### PR TITLE
Fix add-path sub-command on Windows

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -232,7 +232,7 @@ trait Cli extends SbtModule with CliLaunchers with ScalaCliPublishModule with Fo
   object test extends Tests
 }
 
-trait CliCore extends SbtModule with CliLaunchers with ScalaCliPublishModule with FormatNativeImageConf {
+trait CliCore extends SbtModule with CliLaunchers with ScalaCliPublishModule with FormatNativeImageConf with HasMacroAnnotations {
   def scalaVersion = Scala.defaultInternal
   def moduleDeps = Seq(
     build(Scala.defaultInternal),
@@ -241,6 +241,7 @@ trait CliCore extends SbtModule with CliLaunchers with ScalaCliPublishModule wit
   def ivyDeps = super.ivyDeps() ++ Agg(
     Deps.caseApp,
     Deps.coursierLauncher,
+    Deps.dataClass,
     Deps.jimfs, // scalaJsEnvNodeJs pulls jimfs:1.1, whose class path seems borked (bin compat issue with the guava version it depends on)
     Deps.jniUtils,
     Deps.scalaJsLinker,

--- a/build.sc
+++ b/build.sc
@@ -1,6 +1,6 @@
 import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`
 import $ivy.`io.get-coursier::coursier-launcher:2.0.16+73-gddc6d9cc9`
-import $ivy.`io.github.alexarchambault.mill::mill-native-image-upload:0.1.5`
+import $ivy.`io.github.alexarchambault.mill::mill-native-image-upload:0.1.8`
 import $file.project.deps, deps.{Deps, Docker, Scala}
 import $file.project.publish, publish.{ghOrg, ghName, ScalaCliPublishModule}
 import $file.project.settings, settings.{CliLaunchers, FormatNativeImageConf, HasMacroAnnotations, HasTests, LocalRepo, PublishLocalNoFluff, localRepoResourcePath, platformExecutableJarExtension}

--- a/build.sc
+++ b/build.sc
@@ -3,7 +3,7 @@ import $ivy.`io.get-coursier::coursier-launcher:2.0.16+73-gddc6d9cc9`
 import $ivy.`io.github.alexarchambault.mill::mill-native-image-upload:0.1.5`
 import $file.project.deps, deps.{Deps, Docker, Scala}
 import $file.project.publish, publish.{ghOrg, ghName, ScalaCliPublishModule}
-import $file.project.settings, settings.{CliLaunchers, FormatNativeImageConf, HasTests, LocalRepo, PublishLocalNoFluff, localRepoResourcePath, platformExecutableJarExtension}
+import $file.project.settings, settings.{CliLaunchers, FormatNativeImageConf, HasMacroAnnotations, HasTests, LocalRepo, PublishLocalNoFluff, localRepoResourcePath, platformExecutableJarExtension}
 
 import java.io.File
 

--- a/modules/cli-core/src/main/scala/scala/cli/commands/AddPath.scala
+++ b/modules/cli-core/src/main/scala/scala/cli/commands/AddPath.scala
@@ -1,7 +1,7 @@
 package scala.cli.commands
 
 import caseapp._
-import coursier.env.{EnvironmentUpdate, ProfileUpdater, WindowsEnvVarUpdater}
+import coursier.env.{EnvironmentUpdate, ProfileUpdater}
 
 import java.io.File
 
@@ -18,7 +18,7 @@ object AddPath extends ScalaCommand[AddPathOptions] {
       val update = EnvironmentUpdate(Nil, Seq("PATH" -> args.all.mkString(File.pathSeparator)))
       val didUpdate =
         if (Properties.isWin) {
-          val updater = WindowsEnvVarUpdater().withUseJni(Some(coursier.paths.Util.useJni()))
+          val updater = CustomWindowsEnvVarUpdater().withUseJni(Some(coursier.paths.Util.useJni()))
           updater.applyUpdate(update)
         } else {
           val updater = ProfileUpdater()

--- a/modules/cli-core/src/main/scala/scala/cli/commands/CustomWindowsEnvVarUpdater.scala
+++ b/modules/cli-core/src/main/scala/scala/cli/commands/CustomWindowsEnvVarUpdater.scala
@@ -1,0 +1,133 @@
+package scala.cli.commands
+
+import coursier.env._
+import dataclass._
+
+// Only using this instead of coursier.env.WindowsEnvVarUpdater for the "\u0000" striping thing,
+// that earlier version of the Scala CLI may have left behind.
+// We should be able to switch back to coursier.env.WindowsEnvVarUpdater
+// after a bit of time (once super early users used this code more).
+
+@data class CustomWindowsEnvVarUpdater(
+  powershellRunner: PowershellRunner = PowershellRunner(),
+  target: String = "User",
+  @since
+  useJni: Option[Boolean] = None
+) extends EnvVarUpdater {
+
+  private lazy val useJni0 = useJni.getOrElse {
+    // FIXME Should be coursier.paths.Util.useJni(), but it's not available from here.
+    !System.getProperty("coursier.jni", "").equalsIgnoreCase("false")
+  }
+
+  // https://stackoverflow.com/questions/9546324/adding-directory-to-path-environment-variable-in-windows/29109007#29109007
+  // https://docs.microsoft.com/fr-fr/dotnet/api/system.environment.getenvironmentvariable?view=netframework-4.8#System_Environment_GetEnvironmentVariable_System_String_System_EnvironmentVariableTarget_
+  // https://docs.microsoft.com/fr-fr/dotnet/api/system.environment.setenvironmentvariable?view=netframework-4.8#System_Environment_SetEnvironmentVariable_System_String_System_String_System_EnvironmentVariableTarget_
+
+  private def getEnvironmentVariable(name: String): Option[String] =
+    if (useJni0)
+      Option(coursier.jniutils.WindowsEnvironmentVariables.get(name))
+    else {
+      val output = powershellRunner.runScript(CustomWindowsEnvVarUpdater.getEnvVarScript(name)).stripSuffix(System.lineSeparator())
+      if (output == "null") // if ever the actual value is "null", we'll miss it
+        None
+      else
+        Some(output)
+    }
+
+  private def setEnvironmentVariable(name: String, value: String): Unit =
+    if (useJni0) {
+      val value0 = 
+        if (value.contains("\u0000")) value.split(';').filter(!_.contains("\u0000")).mkString(";")
+        else value
+      coursier.jniutils.WindowsEnvironmentVariables.set(name, value0)
+    } else
+      powershellRunner.runScript(CustomWindowsEnvVarUpdater.setEnvVarScript(name, value))
+
+  private def clearEnvironmentVariable(name: String): Unit =
+    if (useJni0)
+      coursier.jniutils.WindowsEnvironmentVariables.delete(name)
+    else
+      powershellRunner.runScript(CustomWindowsEnvVarUpdater.clearEnvVarScript(name))
+
+  def applyUpdate(update: EnvironmentUpdate): Boolean = {
+
+    // Beware, these are not an atomic operation overall
+    // (we might discard values added by others between our get and our set)
+
+    var setSomething = false
+
+    for ((k, v) <- update.set) {
+      val formerValueOpt = getEnvironmentVariable(k)
+      val needsUpdate = formerValueOpt.forall(_ != v)
+      if (needsUpdate) {
+        setEnvironmentVariable(k, v)
+        setSomething = true
+      }
+    }
+
+    for ((k, v) <- update.pathLikeAppends) {
+      val formerValueOpt = getEnvironmentVariable(k)
+      val alreadyInList = formerValueOpt.exists(_.split(CustomWindowsEnvVarUpdater.windowsPathSeparator).contains(v))
+      if (!alreadyInList) {
+        val newValue = formerValueOpt.fold(v)(_ + CustomWindowsEnvVarUpdater.windowsPathSeparator + v)
+        setEnvironmentVariable(k, newValue)
+        setSomething = true
+      }
+    }
+
+    setSomething
+  }
+
+  def tryRevertUpdate(update: EnvironmentUpdate): Boolean = {
+
+    // Beware, these are not an atomic operation overall
+    // (we might discard values added by others between our get and our set)
+
+    var setSomething = false
+
+    for ((k, v) <- update.set) {
+      val formerValueOpt = getEnvironmentVariable(k)
+      val wasUpdated = formerValueOpt.exists(_ == v)
+      if (wasUpdated) {
+        clearEnvironmentVariable(k)
+        setSomething = true
+      }
+    }
+
+    for ((k, v) <- update.pathLikeAppends; formerValue <- getEnvironmentVariable(k)) {
+      val parts = formerValue.split(CustomWindowsEnvVarUpdater.windowsPathSeparator)
+      val isInList = parts.contains(v)
+      if (isInList) {
+        val newValue = parts.filter(_ != v)
+        if (newValue.isEmpty)
+          clearEnvironmentVariable(k)
+        else
+          setEnvironmentVariable(k, newValue.mkString(CustomWindowsEnvVarUpdater.windowsPathSeparator))
+        setSomething = true
+      }
+    }
+
+    setSomething
+  }
+
+}
+
+object CustomWindowsEnvVarUpdater {
+
+  private def getEnvVarScript(name: String): String =
+    s"""[Environment]::GetEnvironmentVariable("$name", "User")
+       |""".stripMargin
+  private def setEnvVarScript(name: String, value: String): String =
+    // FIXME value might need some escaping here
+    s"""[Environment]::SetEnvironmentVariable("$name", "$value", "User")
+       |""".stripMargin
+  private def clearEnvVarScript(name: String): String =
+    // FIXME value might need some escaping here
+    s"""[Environment]::SetEnvironmentVariable("$name", $$null, "User")
+       |""".stripMargin
+
+  private def windowsPathSeparator: String =
+    ";"
+
+}

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -40,6 +40,7 @@ object Deps {
   def ipcSocket = ivy"org.scala-sbt.ipcsocket:ipcsocket:1.4.0"
   def jimfs = ivy"com.google.jimfs:jimfs:1.2"
   def jniUtils = ivy"io.get-coursier.jniutils:windows-jni-utils:0.2.1"
+  def macroParadise = ivy"org.scalamacros:::paradise:2.1.1"
   def munit = ivy"org.scalameta::munit:0.7.25"
   def nativeTestRunner = ivy"org.scala-native::test-runner:${Versions.scalaNative}"
   def nativeTools = ivy"org.scala-native::tools:${Versions.scalaNative}"

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -39,7 +39,7 @@ object Deps {
   def guava = ivy"com.google.guava:guava:18.0"
   def ipcSocket = ivy"org.scala-sbt.ipcsocket:ipcsocket:1.4.0"
   def jimfs = ivy"com.google.jimfs:jimfs:1.2"
-  def jniUtils = ivy"io.get-coursier.jniutils:windows-jni-utils:0.2.1"
+  def jniUtils = ivy"io.get-coursier.jniutils:windows-jni-utils:0.2.5"
   def macroParadise = ivy"org.scalamacros:::paradise:2.1.1"
   def munit = ivy"org.scalameta::munit:0.7.25"
   def nativeTestRunner = ivy"org.scala-native::test-runner:${Versions.scalaNative}"

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -34,6 +34,7 @@ object Deps {
   def caseApp = ivy"com.github.alexarchambault::case-app:2.1.0-M5"
   def coursierJvm = ivy"io.get-coursier::coursier-jvm:${Versions.coursier}"
   def coursierLauncher = ivy"io.get-coursier::coursier-launcher:${Versions.coursier}"
+  def dataClass = ivy"io.github.alexarchambault::data-class:0.2.5"
   def dependency = ivy"io.get-coursier::dependency:0.2.0"
   def expecty = ivy"com.eed3si9n.expecty::expecty:0.15.1"
   def guava = ivy"com.google.guava:guava:18.0"

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -380,6 +380,23 @@ trait LocalRepo extends Module {
 
 }
 
+trait HasMacroAnnotations extends ScalaModule {
+  def scalacOptions = T{
+    val sv = scalaVersion()
+    val extra =
+      if (sv.startsWith("2.") && !sv.startsWith("2.13.")) Nil
+      else Seq("-Ymacro-annotations")
+    super.scalacOptions() ++ extra
+  }
+  def scalacPluginIvyDeps = T{
+    val sv = scalaVersion()
+    val extra =
+      if (sv.startsWith("2.") && !sv.startsWith("2.13.")) Agg(Deps.macroParadise)
+      else Agg.empty[Dep]
+    super.scalacPluginIvyDeps() ++ extra
+  }
+}
+
 private def doFormatNativeImageConf(dir: os.Path, format: Boolean): List[os.Path] = {
   val sortByName = Set("jni-config.json", "reflect-config.json")
   val files = Seq("jni-config.json", "proxy-config.json", "reflect-config.json", "resource-config.json")

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -1,4 +1,4 @@
-import $ivy.`io.github.alexarchambault.mill::mill-native-image_mill0.9:0.1.5`
+import $ivy.`io.github.alexarchambault.mill::mill-native-image_mill0.9:0.1.8`
 import $file.deps, deps.{Deps, Docker}
 
 import io.github.alexarchambault.millnativeimage.NativeImage


### PR DESCRIPTION
This command is used in the manual installation instructions for Windows, and had issues (it was adding null-characters in the env vars it was editing, leading to weird behaviors...)