### PR TITLE
Explicitly pass errors around

### DIFF
--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifle.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifle.scala
@@ -43,22 +43,22 @@ object BloopRifle {
     config: BloopRifleConfig,
     scheduler: ScheduledExecutorService,
     logger: BloopRifleLogger
-  ): Future[Unit] = {
-
-    val classPath = config.classPath().map(_.toPath)
-
-    Operations.startServer(
-      config.host,
-      config.port,
-      config.javaPath,
-      config.javaOpts,
-      classPath,
-      scheduler,
-      config.startCheckPeriod,
-      config.startCheckTimeout,
-      logger
-    )
-  }
+  ): Future[Unit] =
+    config.classPath() match {
+      case Left(ex) => Future.failed(new Exception("Error getting Bloop class path", ex))
+      case Right(cp) =>
+        Operations.startServer(
+          config.host,
+          config.port,
+          config.javaPath,
+          config.javaOpts,
+          cp.map(_.toPath),
+          scheduler,
+          config.startCheckPeriod,
+          config.startCheckTimeout,
+          logger
+        )
+    }
 
   /** Opens a BSP connection to a running bloop server.
     *

--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifleConfig.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifleConfig.scala
@@ -11,7 +11,7 @@ final case class BloopRifleConfig(
   port: Int,
   javaPath: String,
   javaOpts: Seq[String],
-  classPath: () => Seq[File],
+  classPath: () => Either[Throwable, Seq[File]],
   bspSocketOrPort: Option[() => BspConnectionAddress],
   bspStdin: Option[InputStream],
   bspStdout: Option[OutputStream],
@@ -84,7 +84,7 @@ object BloopRifleConfig {
       .getOrElse(hardCodedDefaultVersion)
   }
 
-  def default(bloopClassPath: () => Seq[File]): BloopRifleConfig =
+  def default(bloopClassPath: () => Either[Throwable, Seq[File]]): BloopRifleConfig =
     BloopRifleConfig(
       host = defaultHost,
       port = defaultPort,

--- a/modules/build-macros/src/main/scala/scala/build/AsyncStateMachine.scala
+++ b/modules/build-macros/src/main/scala/scala/build/AsyncStateMachine.scala
@@ -1,0 +1,31 @@
+package scala.build
+
+// from https://github.com/scala/scala/blob/96a666989b6bee067b1029553c6684ef1cb6f6b1/src/partest/scala/tools/partest/async/AsyncStateMachine.scala
+
+// The async phase expects the state machine class to structurally conform to this interface.
+trait AsyncStateMachine[F, R] {
+
+  /** Assign `i` to the state variable */
+  protected def state_=(i: Int): Unit
+
+  /** Retrieve the current value of the state variable */
+  protected def state: Int
+
+  /** Complete the state machine with the given failure. */
+  protected def completeFailure(t: Throwable): Unit
+
+  /** Complete the state machine with the given value. */
+  protected def completeSuccess(value: AnyRef): Unit
+
+  /** Register the state machine as a completion callback of the given future. */
+  protected def onComplete(f: F): Unit
+
+  /** Extract the result of the given future if it is complete, or `null` if it is incomplete. */
+  protected def getCompleted(f: F): R
+
+  /** Extract the success value of the given future. If the state machine detects a failure it may
+    * complete the async block and return `this` as a sentinel value to indicate that the caller
+    * (the state machine dispatch loop) should immediately exit.
+    */
+  protected def tryGet(tr: R): AnyRef
+}

--- a/modules/build-macros/src/main/scala/scala/build/EitherAwait.scala
+++ b/modules/build-macros/src/main/scala/scala/build/EitherAwait.scala
@@ -1,0 +1,62 @@
+package scala.build
+
+// originally adapted from https://github.com/scala/scala/blob/96a666989b6bee067b1029553c6684ef1cb6f6b1/src/partest/scala/tools/partest/async/OptionDsl.scala
+
+import scala.annotation.compileTimeOnly
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+object EitherAwait {
+  final case class Helper[E]() {
+    def apply[T](body: T): Either[E, T] = macro impl
+  }
+  def either[E]: Helper[E] = Helper[E]()
+  @compileTimeOnly("[async] `value` must be enclosed in `optionally`")
+  def value[E, T](option: Either[E, T]): T = ???
+  def impl(c: blackbox.Context)(body: c.Tree): c.Tree = {
+    import c.universe._
+    val awaitSym = typeOf[EitherAwait.type].decl(TermName("value"))
+    def mark(t: DefDef): Tree =
+      c.internal.markForAsyncTransform(c.internal.enclosingOwner, t, awaitSym, Map.empty)
+    val name = TypeName("stateMachine$async")
+    val body0 = mark(
+      q"""override def apply(tr$$async: _root_.scala.Either[_root_.scala.AnyRef, _root_.scala.AnyRef]) = ${body}"""
+    )
+    q"""
+      final class $name extends _root_.scala.build.EitherStateMachine {
+        $body0
+      }
+      new $name().start().asInstanceOf[${c.macroApplication.tpe}]
+    """
+  }
+}
+
+abstract class EitherStateMachine
+    extends AsyncStateMachine[Either[AnyRef, AnyRef], Either[AnyRef, AnyRef]] {
+  var result$async: Either[AnyRef, AnyRef] = _
+
+  // FSM translated method
+  def apply(tr$async: Either[AnyRef, AnyRef]): Unit
+
+  // Required methods
+  private[this] var state$async: Int                        = 0
+  protected def state: Int                                  = state$async
+  protected def state_=(s: Int): Unit                       = state$async = s
+  protected def completeFailure(t: Throwable): Unit         = throw t
+  protected def completeSuccess(value: AnyRef): Unit        = result$async = Right(value)
+  protected def onComplete(f: Either[AnyRef, AnyRef]): Unit = ???
+  protected def getCompleted(f: Either[AnyRef, AnyRef]): Either[AnyRef, AnyRef] = {
+    f
+  }
+  protected def tryGet(tr: Either[AnyRef, AnyRef]): AnyRef = tr match {
+    case Right(value) =>
+      value.asInstanceOf[AnyRef]
+    case Left(e) =>
+      result$async = Left(e)
+      this // sentinel value to indicate the dispatch loop should exit.
+  }
+  def start(): Either[AnyRef, AnyRef] = {
+    apply(Right(null))
+    result$async
+  }
+}

--- a/modules/build-macros/src/main/scala/scala/build/EitherTraverse.scala
+++ b/modules/build-macros/src/main/scala/scala/build/EitherTraverse.scala
@@ -1,0 +1,20 @@
+package scala.build
+
+import scala.collection.mutable.ListBuffer
+
+object EitherTraverse {
+  def traverse[E, T](eithers: Seq[Either[E, T]]): Either[::[E], Seq[T]] = {
+    val errors = new ListBuffer[E]
+    val values = new ListBuffer[T]
+    eithers.foreach {
+      case Left(e) => errors += e
+      case Right(t) =>
+        if (errors.isEmpty)
+          values += t
+    }
+    errors.result() match {
+      case Nil    => Right(values.result())
+      case h :: t => Left(::(h, t))
+    }
+  }
+}

--- a/modules/build-macros/src/main/scala/scala/build/Ops.scala
+++ b/modules/build-macros/src/main/scala/scala/build/Ops.scala
@@ -1,0 +1,17 @@
+package scala.build
+
+object Ops {
+  implicit class EitherSeqOps[E, T](private val seq: Seq[Either[E, T]]) extends AnyVal {
+    def traverse: Either[::[E], Seq[T]] =
+      EitherTraverse.traverse(seq)
+  }
+
+  implicit class EitherThrowOps[E <: Throwable, T](private val either: Either[E, T])
+      extends AnyVal {
+    def orThrow: T =
+      either match {
+        case Left(e)  => throw new Exception(e)
+        case Right(t) => t
+      }
+  }
+}

--- a/modules/build/src/main/scala/scala/build/Logger.scala
+++ b/modules/build/src/main/scala/scala/build/Logger.scala
@@ -5,6 +5,7 @@ import coursier.cache.CacheLogger
 import java.io.{OutputStream, PrintStream}
 
 import scala.build.blooprifle.BloopRifleLogger
+import scala.build.errors.BuildException
 import scala.scalanative.{build => sn}
 
 trait Logger {
@@ -13,6 +14,9 @@ trait Logger {
   def log(s: => String): Unit
   def log(s: => String, debug: => String): Unit
   def debug(s: => String): Unit
+
+  def log(ex: BuildException): Unit
+  def exit(ex: BuildException): Nothing
 
   def coursierLogger: coursier.cache.CacheLogger
   def bloopRifleLogger: BloopRifleLogger
@@ -27,6 +31,10 @@ object Logger {
     def log(s: => String): Unit                   = ()
     def log(s: => String, debug: => String): Unit = ()
     def debug(s: => String): Unit                 = ()
+
+    def log(ex: BuildException): Unit = ()
+    def exit(ex: BuildException): Nothing =
+      throw new Exception(ex)
 
     def coursierLogger: coursier.cache.CacheLogger =
       coursier.cache.CacheLogger.nop

--- a/modules/build/src/main/scala/scala/build/ReplArtifacts.scala
+++ b/modules/build/src/main/scala/scala/build/ReplArtifacts.scala
@@ -4,6 +4,9 @@ import java.nio.file.Path
 
 import dependency._
 
+import scala.build.errors.BuildException
+import scala.build.EitherAwait.{either, value}
+
 final case class ReplArtifacts(
   replArtifacts: Seq[(String, Path)],
   extraJars: Seq[Path],
@@ -37,7 +40,7 @@ object ReplArtifacts {
     extraSourceJars: Seq[Path],
     logger: Logger,
     directories: Directories
-  ): ReplArtifacts = {
+  ): Either[BuildException, ReplArtifacts] = either {
     val localRepoOpt  = LocalRepo.localRepo(directories.localRepoDir)
     val allDeps       = dependencies ++ Seq(dep"com.lihaoyi:::ammonite:$ammoniteVersion")
     val replArtifacts = Artifacts.artifacts(allDeps, localRepoOpt.toSeq, scalaParams, logger)
@@ -49,7 +52,7 @@ object ReplArtifacts {
       classifiersOpt = Some(Set("sources"))
     )
     ReplArtifacts(
-      replArtifacts ++ replSourceArtifacts,
+      value(replArtifacts) ++ value(replSourceArtifacts),
       extraJars,
       extraSourceJars,
       "ammonite.Main",
@@ -64,7 +67,7 @@ object ReplArtifacts {
     extraJars: Seq[Path],
     logger: Logger,
     directories: Directories
-  ): ReplArtifacts = {
+  ): Either[BuildException, ReplArtifacts] = either {
     val localRepoOpt = LocalRepo.localRepo(directories.localRepoDir)
     val isScala2     = scalaParams.scalaVersion.startsWith("2.")
     val replDep =
@@ -76,7 +79,7 @@ object ReplArtifacts {
       if (isScala2) "scala.tools.nsc.MainGenericRunner"
       else "dotty.tools.repl.Main"
     ReplArtifacts(
-      replArtifacts,
+      value(replArtifacts),
       extraJars,
       Nil,
       mainClass,

--- a/modules/build/src/main/scala/scala/build/errors/BuildException.scala
+++ b/modules/build/src/main/scala/scala/build/errors/BuildException.scala
@@ -1,0 +1,6 @@
+package scala.build.errors
+
+abstract class BuildException(
+  val message: String,
+  cause: Throwable = null
+) extends Exception(message, cause)

--- a/modules/build/src/main/scala/scala/build/errors/CompositeBuildException.scala
+++ b/modules/build/src/main/scala/scala/build/errors/CompositeBuildException.scala
@@ -1,0 +1,27 @@
+package scala.build.errors
+
+final class CompositeBuildException private (
+  val mainException: BuildException,
+  val others: Seq[BuildException]
+) extends BuildException(
+      s"${others.length + 1} exceptions, first one: ${mainException.getMessage}",
+      mainException
+    )
+
+object CompositeBuildException {
+  private def flatten(list: ::[BuildException]): ::[BuildException] = {
+    val list0 = list.flatMap {
+      case c: CompositeBuildException => c.mainException :: c.others.toList
+      case e                          => e :: Nil
+    }
+    list0 match {
+      case Nil    => sys.error("Can't happen")
+      case h :: t => ::(h, t)
+    }
+  }
+  def apply(exceptions: ::[BuildException]): BuildException =
+    flatten(exceptions) match {
+      case h :: Nil => h
+      case h :: t   => new CompositeBuildException(h, t)
+    }
+}

--- a/modules/build/src/main/scala/scala/build/errors/ModuleFormatError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/ModuleFormatError.scala
@@ -1,0 +1,7 @@
+package scala.build.errors
+
+final class ModuleFormatError(
+  val moduleString: String,
+  val error: String,
+  val originOpt: Option[String] = None
+) extends BuildException(s"Error parsing ${originOpt.getOrElse("")}module '$moduleString': $error")

--- a/modules/build/src/main/scala/scala/build/errors/RepositoryFormatError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/RepositoryFormatError.scala
@@ -1,0 +1,5 @@
+package scala.build.errors
+
+final class RepositoryFormatError(errors: ::[String]) extends BuildException(
+      s"Error parsing repositories: ${errors.mkString(", ")}"
+    )

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -10,6 +10,8 @@ import java.nio.file.Path
 import java.security.MessageDigest
 
 import scala.build.{Artifacts, Logger, Os}
+import scala.build.EitherAwait.{either, value}
+import scala.build.errors.BuildException
 import scala.build.internal.Constants._
 import scala.build.internal.{Constants, OsLibc, Util}
 import scala.util.Properties
@@ -194,7 +196,7 @@ final case class BuildOptions(
     ScalaParameters(scalaVersion, scalaBinaryVersion, maybePlatformSuffix)
   }
 
-  def artifacts(logger: Logger): Artifacts =
+  def artifacts(logger: Logger): Either[BuildException, Artifacts] =
     Artifacts(
       params = scalaParams,
       compilerPlugins = compilerPlugins,

--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -14,6 +14,7 @@ import scala.util.Properties
 import scala.build.tastylib.TastyData
 import scala.build.Logger
 import scala.build.LocalRepo
+import scala.build.Ops._
 
 class BuildTests extends munit.FunSuite {
 
@@ -54,12 +55,13 @@ class BuildTests extends munit.FunSuite {
           |println(s"n=$n")
           |""".stripMargin
     )
-    testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, build) =>
-      if (checkResults)
-        build.assertGeneratedEquals(
+    testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, maybeBuild) =>
+      if (checkResults) {
+        maybeBuild.orThrow.assertGeneratedEquals(
           "simple.class",
           "simple$.class"
         )
+      }
     }
   }
 
@@ -79,12 +81,13 @@ class BuildTests extends munit.FunSuite {
           |println(s"n=$n")
           |""".stripMargin
     )
-    testInputs.withBuild(defaultScala3Options, buildThreads, bloopConfig) { (root, inputs, build) =>
-      build.assertGeneratedEquals(
-        "simple.class",
-        "simple$.class",
-        "simple.tasty"
-      )
+    testInputs.withBuild(defaultScala3Options, buildThreads, bloopConfig) {
+      (root, inputs, maybeBuild) =>
+        maybeBuild.orThrow.assertGeneratedEquals(
+          "simple.class",
+          "simple$.class",
+          "simple.tasty"
+        )
     }
   }
 
@@ -100,7 +103,8 @@ class BuildTests extends munit.FunSuite {
         generateSemanticDbs = Some(true)
       )
     )
-    testInputs.withBuild(buildOptions, buildThreads, bloopConfig) { (root, inputs, build) =>
+    testInputs.withBuild(buildOptions, buildThreads, bloopConfig) { (root, inputs, maybeBuild) =>
+      val build = maybeBuild.orThrow
       build.assertGeneratedEquals(
         "simple.class",
         "simple$.class",
@@ -127,7 +131,8 @@ class BuildTests extends munit.FunSuite {
         generateSemanticDbs = Some(true)
       )
     )
-    testInputs.withBuild(buildOptions, buildThreads, bloopConfig) { (root, inputs, build) =>
+    testInputs.withBuild(buildOptions, buildThreads, bloopConfig) { (root, inputs, maybeBuild) =>
+      val build = maybeBuild.orThrow
       build.assertGeneratedEquals(
         "simple.class",
         "simple$.class",
@@ -150,8 +155,8 @@ class BuildTests extends munit.FunSuite {
           |""".stripMargin
     )
     testInputs.withBuild(defaultOptions.enableJs, buildThreads, bloopConfig) {
-      (root, inputs, build) =>
-        build.assertGeneratedEquals(
+      (root, inputs, maybeBuild) =>
+        maybeBuild.orThrow.assertGeneratedEquals(
           "simple.class",
           "simple$.class",
           "simple.sjsir",
@@ -168,8 +173,8 @@ class BuildTests extends munit.FunSuite {
           |""".stripMargin
     )
     testInputs.withBuild(defaultOptions.enableNative, buildThreads, bloopConfig) {
-      (root, inputs, build) =>
-        build.assertGeneratedEquals(
+      (root, inputs, maybeBuild) =>
+        maybeBuild.orThrow.assertGeneratedEquals(
           "simple.class",
           "simple$.class",
           // "simple.nir", // not sure why Scala Native doesn't generate this one.
@@ -191,8 +196,8 @@ class BuildTests extends munit.FunSuite {
           |println(g.mkString)
           |""".stripMargin
     )
-    testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, build) =>
-      build.assertGeneratedEquals(
+    testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, maybeBuild) =>
+      maybeBuild.orThrow.assertGeneratedEquals(
         "simple.class",
         "simple$.class"
       )
@@ -207,8 +212,8 @@ class BuildTests extends munit.FunSuite {
           |println(g.mkString)
           |""".stripMargin
     )
-    testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, build) =>
-      build.assertGeneratedEquals(
+    testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, maybeBuild) =>
+      maybeBuild.orThrow.assertGeneratedEquals(
         "simple.class",
         "simple$.class"
       )
@@ -223,8 +228,8 @@ class BuildTests extends munit.FunSuite {
           |println(g.mkString)
           |""".stripMargin
     )
-    testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, build) =>
-      build.assertGeneratedEquals(
+    testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, maybeBuild) =>
+      maybeBuild.orThrow.assertGeneratedEquals(
         "simple.class",
         "simple$.class"
       )
@@ -241,8 +246,8 @@ class BuildTests extends munit.FunSuite {
           |pprint.log(g)
           |""".stripMargin
     )
-    testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, build) =>
-      build.assertGeneratedEquals(
+    testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, maybeBuild) =>
+      maybeBuild.orThrow.assertGeneratedEquals(
         "simple.class",
         "simple$.class"
       )
@@ -259,8 +264,8 @@ class BuildTests extends munit.FunSuite {
           |pprint.log(g)
           |""".stripMargin
     )
-    testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, build) =>
-      build.assertGeneratedEquals(
+    testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, maybeBuild) =>
+      maybeBuild.orThrow.assertGeneratedEquals(
         "simple.class",
         "simple$.class"
       )
@@ -280,7 +285,7 @@ class BuildTests extends munit.FunSuite {
         keepDiagnostics = true
       )
     )
-    testInputs.withBuild(buildOptions, buildThreads, bloopConfig) { (root, inputs, build) =>
+    testInputs.withBuild(buildOptions, buildThreads, bloopConfig) { (root, inputs, maybeBuild) =>
       val expectedDiag = {
         val start = new bsp4j.Position(2, 0)
         val end   = new bsp4j.Position(2, 2)
@@ -290,7 +295,7 @@ class BuildTests extends munit.FunSuite {
         d.setSeverity(bsp4j.DiagnosticSeverity.ERROR)
         d
       }
-      val diagnostics = build.diagnostics
+      val diagnostics = maybeBuild.orThrow.diagnostics
       val expected    = Some(Seq(Right(root / "simple.sc") -> expectedDiag))
       expect(diagnostics == expected)
     }
@@ -309,7 +314,7 @@ class BuildTests extends munit.FunSuite {
         keepDiagnostics = true
       )
     )
-    testInputs.withBuild(buildOptions, buildThreads, bloopConfig) { (root, inputs, build) =>
+    testInputs.withBuild(buildOptions, buildThreads, bloopConfig) { (root, inputs, maybeBuild) =>
       val expectedDiag = {
         val start = new bsp4j.Position(2, 0)
         val end   = new bsp4j.Position(2, 0) // would have expected (2, 2) here :|
@@ -319,7 +324,7 @@ class BuildTests extends munit.FunSuite {
         d.setSeverity(bsp4j.DiagnosticSeverity.ERROR)
         d
       }
-      val diagnostics = build.diagnostics
+      val diagnostics = maybeBuild.orThrow.diagnostics
       val expected    = Some(Seq(Right(root / "simple.sc") -> expectedDiag))
       expect(diagnostics == expected)
     }
@@ -340,8 +345,8 @@ class BuildTests extends munit.FunSuite {
           |}
           |""".stripMargin
     )
-    testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, build) =>
-      build.assertGeneratedEquals(
+    testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, maybeBuild) =>
+      maybeBuild.orThrow.assertGeneratedEquals(
         "Simple.class",
         "Simple$.class"
       )
@@ -362,8 +367,8 @@ class BuildTests extends munit.FunSuite {
           |}
           |""".stripMargin
     )
-    testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, build) =>
-      build.assertGeneratedEquals(
+    testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, maybeBuild) =>
+      maybeBuild.orThrow.assertGeneratedEquals(
         "Simple.class",
         "Simple$.class"
       )
@@ -392,8 +397,8 @@ class BuildTests extends munit.FunSuite {
           |""".stripMargin
     )
     val options = defaultOptions.enableJs
-    testInputs.withBuild(options, buildThreads, bloopConfig) { (root, inputs, build) =>
-      build.assertGeneratedEquals(
+    testInputs.withBuild(options, buildThreads, bloopConfig) { (root, inputs, maybeBuild) =>
+      maybeBuild.orThrow.assertGeneratedEquals(
         "Simple.class",
         "Simple$.class",
         "Simple.sjsir",

--- a/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.ExecutorService
 
 import scala.build.{Build, BuildThreads, Directories, Inputs}
 import scala.build.blooprifle.BloopRifleConfig
+import scala.build.errors.BuildException
 import scala.build.options.BuildOptions
 import scala.util.control.NonFatal
 import scala.util.{Properties, Try}
@@ -31,11 +32,11 @@ final case class TestInputs(
     options: BuildOptions,
     buildThreads: BuildThreads,
     bloopConfig: BloopRifleConfig
-  )(f: (os.Path, Inputs, Build) => T): T =
+  )(f: (os.Path, Inputs, Either[BuildException, Build]) => T): T =
     withInputs { (root, inputs) =>
-      val (build, _) =
+      val res =
         Build.build(inputs, options, buildThreads, bloopConfig, TestLogger(), crossBuilds = false)
-      f(root, inputs, build)
+      f(root, inputs, res.map(_._1))
     }
 }
 

--- a/modules/build/src/test/scala/scala/build/tests/TestLogger.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestLogger.scala
@@ -4,6 +4,7 @@ import coursier.cache.CacheLogger
 import coursier.cache.loggers.{FallbackRefreshDisplay, RefreshLogger}
 
 import scala.build.blooprifle.BloopRifleLogger
+import scala.build.errors.BuildException
 import scala.build.Logger
 import scala.scalanative.{build => sn}
 
@@ -22,6 +23,11 @@ case class TestLogger(info: Boolean = true, debug: Boolean = false) extends Logg
   def debug(s: => String): Unit =
     if (debug)
       System.err.println(s)
+
+  def log(ex: BuildException): Unit =
+    System.err.println(ex.getMessage)
+  def exit(ex: BuildException): Nothing =
+    throw new Exception(ex)
 
   def coursierLogger: CacheLogger =
     RefreshLogger.create(new FallbackRefreshDisplay)

--- a/modules/cli/src/main/scala/scala/cli/commands/LoggingOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/LoggingOptions.scala
@@ -7,6 +7,7 @@ import coursier.cache.loggers.{FallbackRefreshDisplay, ProgressBarRefreshDisplay
 import java.io.PrintStream
 
 import scala.build.blooprifle.BloopRifleLogger
+import scala.build.errors.BuildException
 import scala.build.Logger
 import scala.scalanative.{build => sn}
 
@@ -44,6 +45,19 @@ final case class LoggingOptions(
       def debug(message: => String) =
         if (verbosity >= 2)
           System.err.println(message)
+
+      def log(ex: BuildException): Unit =
+        if (verbosity >= 0)
+          System.err.println(ex.getMessage)
+      def exit(ex: BuildException): Nothing =
+        if (verbosity < 0)
+          sys.exit(1)
+        else if (verbosity == 0) {
+          System.err.println(ex.getMessage)
+          sys.exit(1)
+        }
+        else
+          throw new Exception(ex)
 
       def coursierLogger =
         if (quiet)

--- a/modules/cli/src/main/scala/scala/cli/commands/Metabrowse.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Metabrowse.scala
@@ -35,6 +35,7 @@ object Metabrowse extends ScalaCommand[MetabrowseOptions] {
 
     val (build, _) =
       Build.build(inputs, options.buildOptions, bloopRifleConfig, logger, crossBuilds = false)
+        .orExit(logger)
 
     val successfulBuild = build match {
       case f: Build.Failed =>

--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -43,8 +43,9 @@ object Test extends ScalaCommand[TestOptions] {
         logger,
         crossBuilds = false,
         postAction = () => WatchUtil.printWatchMessage()
-      ) { (build, _) =>
-        maybeTest(build, allowExit = false)
+      ) { res =>
+        for ((build, _) <- res.orReport(logger))
+          maybeTest(build, allowExit = false)
       }
       try WatchUtil.waitForCtrlC()
       finally watcher.dispose()
@@ -52,6 +53,7 @@ object Test extends ScalaCommand[TestOptions] {
     else {
       val (build, _) =
         Build.build(inputs, initialBuildOptions, bloopRifleConfig, logger, crossBuilds = false)
+          .orExit(logger)
       maybeTest(build, allowExit = true)
     }
   }

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -60,6 +60,7 @@ object Deps {
   def scalaPackager              = ivy"org.virtuslab::scala-packager:${Versions.scalaPackager}"
   def scalaPackagerCli           = ivy"org.virtuslab::scala-packager-cli:${Versions.scalaPackager}"
   def scalaparse                 = ivy"com.lihaoyi::scalaparse:2.3.2"
+  def scalaReflect(sv: String)   = ivy"org.scala-lang:scala-reflect:$sv"
   def shapeless                  = ivy"com.chuusai::shapeless:2.3.7"
   def slf4jNop                   = ivy"org.slf4j:slf4j-nop:1.8.0-beta4"
   def snailgun                   = ivy"me.vican.jorge::snailgun-core:0.4.0"


### PR DESCRIPTION
This makes some internal methods (mostly in the `build` module) return errors explicitly via `Either[BuildException, ?]`, rather than throwing an exception. These errors go up to the "leaf" modules (cli, tests), which can then report errors properly (by printing a message to stderr, rather than throwing, which prints a stack trace).