### PR TITLE
Resolve dependencies in setup-ide step

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -365,8 +365,8 @@ trait CliIntegrationBase extends SbtModule with ScalaCliPublishModule with HasTe
            |  def bloopVersion = "${Deps.bloopConfig.dep.version}"
            |  def oldBloopVersion = "${TestDeps.oldBloopConfig.dep.version}"
            |  def newBloopVersion = "${TestDeps.newBloopConfig.dep.version}"
-           |  def pprintVersion = "${Deps.pprint.dep.version}"
-           |  def munitVersion = "${Deps.munit.dep.version}"
+           |  def pprintVersion = "${TestDeps.pprint.dep.version}"
+           |  def munitVersion = "${TestDeps.munit.dep.version}"
            |  def dockerTestImage = "${Docker.testImage}"
            |  def dockerAlpineTestImage = "${Docker.alpineTestImage}"
            |}

--- a/build.sc
+++ b/build.sc
@@ -365,6 +365,8 @@ trait CliIntegrationBase extends SbtModule with ScalaCliPublishModule with HasTe
            |  def bloopVersion = "${Deps.bloopConfig.dep.version}"
            |  def oldBloopVersion = "${TestDeps.oldBloopConfig.dep.version}"
            |  def newBloopVersion = "${TestDeps.newBloopConfig.dep.version}"
+           |  def pprintVersion = "${Deps.pprint.dep.version}"
+           |  def munitVersion = "${Deps.munit.dep.version}"
            |  def dockerTestImage = "${Docker.testImage}"
            |  def dockerAlpineTestImage = "${Docker.alpineTestImage}"
            |}

--- a/modules/cli/src/main/scala/scala/cli/commands/SetupIdeOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SetupIdeOptions.scala
@@ -1,5 +1,6 @@
 package scala.cli.commands
 
+import scala.build.options.BuildOptions
 import caseapp._
 
 // format: off
@@ -11,9 +12,12 @@ final case class SetupIdeOptions(
   @Name("name")
     bspName: Option[String] = None,
   charset: Option[String] = None
-)
-// format: on
+) {
+  // format: on
+  def buildOptions: BuildOptions =
+    shared.buildOptions(enableJmh = false, jmhVersion = None)
 
+}
 object SetupIdeOptions {
   implicit val parser = Parser[SetupIdeOptions]
   implicit val help   = Help[SetupIdeOptions]

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -148,6 +148,40 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
 
+  val importPprintOnlyProject = TestInputs(
+    Seq(
+      os.rel / "simple.sc" -> s"import $$ivy.`com.lihaoyi::pprint:${Constants.pprintVersion}`"
+    )
+  )
+
+  test("setup-ide should succeed for valid dependencies") {
+    importPprintOnlyProject.fromRoot { root =>
+      val p = os.proc(
+        TestUtil.cli,
+        "setup-ide",
+        ".",
+        extraOptions,
+        "--dependency",
+        s"org.scalameta::munit:${Constants.munitVersion}"
+      ).call(cwd = root, check = false)
+      expect(p.exitCode == 0)
+    }
+  }
+
+  test("setup-ide should fail for invalid dependencies") {
+    importPprintOnlyProject.fromRoot { root =>
+      val p = os.proc(
+        TestUtil.cli,
+        "setup-ide",
+        ".",
+        extraOptions,
+        "--dependency",
+        "org.scalameta::munit:0.7.119999"
+      ).call(cwd = root, check = false)
+      expect(p.exitCode == 1)
+    }
+  }
+
   test("simple") {
     val inputs = TestInputs(
       Seq(

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -163,8 +163,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
         extraOptions,
         "--dependency",
         s"org.scalameta::munit:${Constants.munitVersion}"
-      ).call(cwd = root, check = false)
-      expect(p.exitCode == 0)
+      ).call(cwd = root)
     }
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -156,7 +156,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("setup-ide should succeed for valid dependencies") {
     importPprintOnlyProject.fromRoot { root =>
-      val p = os.proc(
+      os.proc(
         TestUtil.cli,
         "setup-ide",
         ".",
@@ -169,6 +169,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("setup-ide should fail for invalid dependencies") {
     importPprintOnlyProject.fromRoot { root =>
+      val invalidMunitVersion = "0.7.119999"
       val p = os.proc(
         TestUtil.cli,
         "setup-ide",
@@ -176,7 +177,8 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
         extraOptions,
         "--dependency",
         "org.scalameta::munit:0.7.119999"
-      ).call(cwd = root, check = false)
+      ).call(cwd = root, check = false, stderr = os.Pipe)
+      expect(p.err.text().contains(s"Error downloading org.scalameta:munit"))
       expect(p.exitCode == 1)
     }
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -169,7 +169,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("setup-ide should fail for invalid dependencies") {
     importPprintOnlyProject.fromRoot { root =>
-      val invalidMunitVersion = "0.7.119999"
+
       val p = os.proc(
         TestUtil.cli,
         "setup-ide",

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -24,6 +24,8 @@ object TestDeps {
   // used in tests, should be older than the default one
   def oldBloopConfig = ivy"ch.epfl.scala::bloop-config:1.4.8-122-794af022"
   def newBloopConfig = Deps.bloopConfig
+  def pprint         = Deps.pprint
+  def munit          = Deps.munit
 }
 
 object Deps {


### PR DESCRIPTION
Fail only when dependencies passed via CLI cannot be resolved

Fail when someone passes '--dependency <invalid_dependency>
Do not fail when there is an invalid '$ivy.<dep>' in code