### PR TITLE
Work around incremental compilation issues in build

### DIFF
--- a/.mill-jvm-opts
+++ b/.mill-jvm-opts
@@ -1,3 +1,4 @@
 -Xmx512m
 -Xms128m
 -Xss8m
+-Dxsbt.skip.cp.lookup=true


### PR DESCRIPTION
Option suggested by @romanowski, feels great to have incremental compilation work again locally 😅

If a Mill daemon is already running, just stop it by removing `out/` for example, so that a new one gets started with that option.