### PR TITLE
Add scalafix, remove unused imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,13 @@ jobs:
       run: ./mill -i __.checkNativeImageConfFormat
     - name: Check Ammonite availability
       run: ./mill -i 'dummy.amm[_].resolvedRunIvyDeps.'
+    - name: Scalafix check
+      run: |
+        ./mill -i scalafix --check || (
+          echo "To remove unused import run"
+          echo "  ./mill -i scalafix"
+          exit 1
+        )
 
   format:
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       run: ./mill -i 'dummy.amm[_].resolvedRunIvyDeps.'
     - name: Scalafix check
       run: |
-        ./mill -i scalafix --check || (
+        ./mill -i __.fix --check || (
           echo "To remove unused import run"
           echo "  ./mill -i scalafix"
           exit 1

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,10 @@
+rules  = [
+  DisableSyntax,
+  RemoveUnused
+]
+DisableSyntax.noFinalize = true
+
+// `rules` on compilation
+triggered.rules = [
+  DisableSyntax
+]

--- a/.scalafix3.conf
+++ b/.scalafix3.conf
@@ -1,0 +1,11 @@
+# Same as .scalafix.conf, but for RemoveUnused commented out
+rules  = [
+  DisableSyntax,
+  # RemoveUnused
+]
+DisableSyntax.noFinalize = true
+
+// `rules` on compilation
+triggered.rules = [
+  DisableSyntax
+]

--- a/modules/bloop-rifle/src/main/scala/scala/build/bloop/BloopServer.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/bloop/BloopServer.scala
@@ -1,6 +1,6 @@
 package scala.build.bloop
 
-import java.io.{ByteArrayInputStream, InputStream, IOException}
+import java.io.IOException
 import java.net.{ConnectException, Socket}
 import java.nio.file.{Files, Path}
 import java.util.concurrent.{Future => JFuture, ScheduledExecutorService, TimeoutException}
@@ -13,7 +13,7 @@ import scala.build.bloop.bloop4j.BloopExtraBuildParams
 import scala.build.blooprifle.internal.Constants
 import scala.collection.JavaConverters._
 import scala.concurrent.Await
-import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
+import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.build.blooprifle.{BloopRifle, BloopRifleConfig, BloopRifleLogger, BspConnection}
 
 trait BloopServer {
@@ -36,9 +36,6 @@ object BloopServer {
       socket.close()
     }
   }
-
-  private def emptyInputStream: InputStream =
-    new ByteArrayInputStream(Array.emptyByteArray)
 
   private def ensureBloopRunning(
     config: BloopRifleConfig,

--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifle.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifle.scala
@@ -132,10 +132,6 @@ object BloopRifle {
     logger: BloopRifleLogger
   ): Int = {
 
-    config.bspSocketOrPort.map(_()).getOrElse {
-      BspConnectionAddress.Tcp(Util.randomPort())
-    }
-
     val in = config.bspStdin.getOrElse {
       new InputStream {
         def read(): Int = -1

--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifle.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifle.scala
@@ -1,15 +1,13 @@
 package scala.build.blooprifle
 
 import java.io.{FileOutputStream, InputStream, OutputStream}
-import java.nio.file.{Files, Path}
+import java.nio.file.Path
 import java.util.concurrent.ScheduledExecutorService
 
 import scala.build.blooprifle.internal.{Operations, Util}
-import scala.collection.JavaConverters._
 import scala.concurrent.Future
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
-import scala.util.Properties
 
 object BloopRifle {
 
@@ -134,7 +132,7 @@ object BloopRifle {
     logger: BloopRifleLogger
   ): Int = {
 
-    val bspSocketOrPort = config.bspSocketOrPort.map(_()).getOrElse {
+    config.bspSocketOrPort.map(_()).getOrElse {
       BspConnectionAddress.Tcp(Util.randomPort())
     }
 

--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Operations.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Operations.scala
@@ -2,19 +2,17 @@ package scala.build.blooprifle.internal
 
 import java.io.{File, InputStream, IOException, OutputStream}
 import java.net.{ConnectException, InetSocketAddress, Socket}
-import java.nio.file.{Path, Paths}
+import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.{ScheduledExecutorService, ScheduledFuture}
 
 import scala.build.blooprifle.{BloopRifleLogger, BspConnection, BspConnectionAddress}
-import scala.collection.JavaConverters._
 import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration.{Duration, FiniteDuration}
-import scala.util.{Failure, Properties, Success, Try}
+import scala.util.{Failure, Success, Try}
 
 import org.scalasbt.ipcsocket.NativeErrorException
 import snailgun.TcpClient
-import snailgun.logging.{Logger => SnailgunLogger}
 import snailgun.protocol.Streams
 
 object Operations {

--- a/modules/build/src/main/scala/pprint/better.scala
+++ b/modules/build/src/main/scala/pprint/better.scala
@@ -9,13 +9,8 @@ object better {
     tag: String = "",
     width: Int = defaultWidth,
     height: Int = defaultHeight,
-    indent: Int = defaultIndent,
-    initialOffset: Int = 0
+    indent: Int = defaultIndent
   )(implicit line: sourcecode.Line, fileName: sourcecode.FileName): T = {
-
-    def joinSeq[T](seq: Seq[T], sep: T): Seq[T] = {
-      seq.flatMap(x => Seq(x, sep)).dropRight(1)
-    }
 
     val tagStrs =
       if (tag.isEmpty) Seq()

--- a/modules/build/src/main/scala/scala/build/Bloop.scala
+++ b/modules/build/src/main/scala/scala/build/Bloop.scala
@@ -1,17 +1,14 @@
 package scala.build
 
 import ch.epfl.scala.bsp4j
-import dependency.{AnyDependency, Dependency, DependencyLike, ScalaParameters, ScalaVersion}
+import dependency.{AnyDependency, DependencyLike, ScalaParameters, ScalaVersion}
 import dependency.parser.ModuleParser
 
 import java.io.File
-import java.nio.file.Path
 
 import scala.build.blooprifle.BloopRifleConfig
 import scala.build.EitherCps.{either, value}
 import scala.build.errors.ModuleFormatError
-import scala.build.internal.Util.ScalaDependencyOps
-import scala.build.Ops._
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Properties
@@ -21,7 +18,6 @@ object Bloop {
 
   def compile(
     projectName: String,
-    buildClient: bsp4j.BuildClient,
     bloopServer: bloop.BloopServer,
     logger: Logger,
     buildTargetsTimeout: FiniteDuration

--- a/modules/build/src/main/scala/scala/build/ConsoleBloopBuildClient.scala
+++ b/modules/build/src/main/scala/scala/build/ConsoleBloopBuildClient.scala
@@ -28,7 +28,7 @@ class ConsoleBloopBuildClient(
   private val gray         = "\u001b[90m"
   private val reset        = Console.RESET
 
-  private var diagnostics0 = new mutable.ListBuffer[(Either[String, os.Path], bsp4j.Diagnostic)]
+  private val diagnostics0 = new mutable.ListBuffer[(Either[String, os.Path], bsp4j.Diagnostic)]
 
   def setGeneratedSources(newGeneratedSources: Seq[GeneratedSource]) = {
     generatedSources = newGeneratedSources

--- a/modules/build/src/main/scala/scala/build/CrossSources.scala
+++ b/modules/build/src/main/scala/scala/build/CrossSources.scala
@@ -2,7 +2,6 @@ package scala.build
 
 import scala.build.EitherCps.{either, value}
 import scala.build.errors.BuildException
-import scala.build.internal.CodeWrapper
 import scala.build.Ops._
 import scala.build.options.{BuildOptions, BuildRequirements, HasBuildRequirements, Platform}
 import scala.build.preprocessing._

--- a/modules/build/src/main/scala/scala/build/Logger.scala
+++ b/modules/build/src/main/scala/scala/build/Logger.scala
@@ -1,7 +1,5 @@
 package scala.build
 
-import coursier.cache.CacheLogger
-
 import java.io.{OutputStream, PrintStream}
 
 import scala.build.blooprifle.BloopRifleLogger

--- a/modules/build/src/main/scala/scala/build/Project.scala
+++ b/modules/build/src/main/scala/scala/build/Project.scala
@@ -5,7 +5,7 @@ import com.github.plokhotnyuk.jsoniter_scala.core.{writeToArray => writeAsJsonTo
 import _root_.coursier.{Dependency => CsDependency, core => csCore, util => csUtil}
 import coursier.core.Classifier
 
-import java.nio.file.{Path, Paths}
+import java.nio.file.Path
 import java.util.Arrays
 
 final case class Project(
@@ -89,12 +89,12 @@ object Project {
     val modules = detailedArtifacts
       .groupBy(_._1.moduleVersion)
       .toVector
-      .sortBy { case (modVer, values) => indices.getOrElse(modVer, Int.MaxValue) }
+      .sortBy { case (modVer, _) => indices.getOrElse(modVer, Int.MaxValue) }
       .iterator
       .map {
         case ((mod, ver), values) =>
           val artifacts = values.toList.map {
-            case (dep, pub, art, f) =>
+            case (_, pub, _, f) =>
               val classifier =
                 if (pub.classifier == Classifier.empty) None
                 else Some(pub.classifier.value)

--- a/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
@@ -8,7 +8,7 @@ import java.io.{InputStream, OutputStream}
 import java.util.concurrent.{CompletableFuture, Executor}
 
 import scala.build.{BloopBuildClient, Build, GeneratedSource, Inputs, Logger, Sources}
-import scala.build.bloop.{BloopServer, BuildServer}
+import scala.build.bloop.BloopServer
 import scala.build.blooprifle.BloopRifleConfig
 import scala.build.CrossSources
 import scala.build.EitherCps.{either, value}
@@ -87,7 +87,7 @@ final class BspImpl(
     bloopServer: BloopServer,
     notifyChanges: Boolean
   ): Either[BuildException, Unit] = either {
-    val (sources, buildOptions, classesDir0, artifacts, project, generatedSources, buildChanged) =
+    val (sources, buildOptions, _, _, _, generatedSources, buildChanged) =
       value(prepareBuild(actualLocalServer))
     if (notifyChanges && buildChanged)
       notifyBuildChange(actualLocalServer)
@@ -252,17 +252,6 @@ final class BspImpl(
         "Listening to incoming JSONRPC BSP requests."
     }
     val f = launcher.startListening()
-
-    val f0 = threads.prepareBuildExecutor.submit {
-      new Runnable {
-        def run(): Unit =
-          try build(actualLocalServer, remoteServer, notifyChanges = false, logger)
-          catch {
-            case t: Throwable =>
-              logger.debug(s"Caught $t during initial BSP build, ignoring it")
-          }
-      }
-    }
 
     registerWatchInputs(watcher)
 

--- a/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
@@ -253,6 +253,15 @@ final class BspImpl(
     }
     val f = launcher.startListening()
 
+    val initiateFirstBuild: Runnable = { () =>
+      try build(actualLocalServer, remoteServer, notifyChanges = false, logger)
+      catch {
+        case t: Throwable =>
+          logger.debug(s"Caught $t during initial BSP build, ignoring it")
+      }
+    }
+    threads.prepareBuildExecutor.submit(initiateFirstBuild)
+
     registerWatchInputs(watcher)
 
     val es = ExecutionContext.fromExecutorService(threads.buildThreads.bloop.jsonrpc)

--- a/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
@@ -8,7 +8,6 @@ import scala.build.internal.Constants
 import scala.collection.JavaConverters._
 import scala.concurrent.Promise
 import scala.concurrent.Future
-import scala.build.GeneratedSource
 import scala.build.Logger
 
 class BspServer(

--- a/modules/build/src/main/scala/scala/build/bsp/HasGeneratedSources.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/HasGeneratedSources.scala
@@ -37,7 +37,7 @@ object HasGeneratedSources {
     lazy val uriMap: Map[String, GeneratedSource] =
       sources
         .flatMap { g =>
-          g.reportingPath.toOption.toSeq.map { reportingPath =>
+          g.reportingPath.toOption.toSeq.map { _ =>
             g.generated.toNIO.toUri.toASCIIString -> g
           }
         }

--- a/modules/build/src/main/scala/scala/build/bsp/package.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/package.scala
@@ -10,7 +10,7 @@ package object bsp {
 
   implicit class Ext[T](private val f: CompletableFuture[T]) extends AnyVal {
     def logF: CompletableFuture[T] =
-      f.handle { (res, ex) =>
+      f.handle { (res, _) =>
         pprint.better.log(res)
         res
       }

--- a/modules/build/src/main/scala/scala/build/internal/CustomClassCodeWrapper.scala
+++ b/modules/build/src/main/scala/scala/build/internal/CustomClassCodeWrapper.scala
@@ -18,9 +18,9 @@ case object CustomCodeClassWrapper extends CodeWrapper {
    * themselves processed by macros (definitions in objects are easier to process from
    * macros).
    */
-  private val userCodeNestingLevel    = 2
-  private val q                       = "\""
-  private val tq                      = "\"\"\""
+  private val userCodeNestingLevel = 2
+  private val q                    = "\""
+
   override val wrapperPath: Seq[Name] = Seq(Name("instance"))
   def apply(
     code: String,

--- a/modules/build/src/main/scala/scala/build/internal/OsLibc.scala
+++ b/modules/build/src/main/scala/scala/build/internal/OsLibc.scala
@@ -5,8 +5,6 @@ import coursier.jvm.{JavaHome, JvmIndex}
 import java.io.IOException
 import java.nio.charset.Charset
 
-import scala.util.Properties
-
 object OsLibc {
 
   lazy val isMusl: Option[Boolean] = {

--- a/modules/build/src/main/scala/scala/build/internal/Runner.scala
+++ b/modules/build/src/main/scala/scala/build/internal/Runner.scala
@@ -5,7 +5,6 @@ import sbt.testing.{Framework, Status}
 
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
-import java.util.Locale
 
 import scala.build.Logger
 import scala.build.testrunner.{AsmTestRunner, TestRunner}
@@ -265,7 +264,6 @@ object Runner {
   def testNative(
     classPath: Seq[Path],
     launcher: File,
-    logger: Logger,
     frameworkNameOpt: Option[String],
     args: Seq[String],
     nativeLogger: sn.Logger

--- a/modules/build/src/main/scala/scala/build/internal/Util.scala
+++ b/modules/build/src/main/scala/scala/build/internal/Util.scala
@@ -4,10 +4,6 @@ import java.io.PrintStream
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.collection.JavaConverters._
-import java.util.AbstractMap.SimpleEntry
-import java.util.Map.Entry
-
 object Util {
 
   def printException(t: Throwable, out: PrintStream = System.err): Unit =

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -10,7 +10,6 @@ import java.nio.file.Path
 import java.security.MessageDigest
 
 import scala.build.{Artifacts, Logger, Os}
-import scala.build.EitherCps.{either, value}
 import scala.build.errors.BuildException
 import scala.build.internal.Constants._
 import scala.build.internal.{Constants, OsLibc, Util}

--- a/modules/build/src/main/scala/scala/build/options/ScalaJsOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/ScalaJsOptions.scala
@@ -42,12 +42,6 @@ final case class ScalaJsOptions(
       case "nomodule" | "none"   => ModuleKind.NoModule
       case _                     => ModuleKind.CommonJSModule
     }
-  private def moduleKindName: String =
-    moduleKind match {
-      case ModuleKind.CommonJSModule => "commonjs"
-      case ModuleKind.ESModule       => "esmodule"
-      case ModuleKind.NoModule       => "nomodule"
-    }
 
   def finalVersion = version.map(_.trim).filter(_.nonEmpty).getOrElse(Constants.scalaJsVersion)
 

--- a/modules/build/src/main/scala/scala/build/postprocessing/SemanticDbPostProcessor.scala
+++ b/modules/build/src/main/scala/scala/build/postprocessing/SemanticDbPostProcessor.scala
@@ -32,7 +32,6 @@ case object SemanticDbPostProcessor extends PostProcessor {
         SemanticdbProcessor.postProcess(
           os.read(originalSource),
           originalSource.relativeTo(workspace),
-          None,
           if (source.topWrapperLen == 0) n => Some(n)
           else
             LineConversion.scalaLineToScLine(

--- a/modules/build/src/main/scala/scala/build/postprocessing/SemanticdbProcessor.scala
+++ b/modules/build/src/main/scala/scala/build/postprocessing/SemanticdbProcessor.scala
@@ -14,7 +14,6 @@ object SemanticdbProcessor {
   def postProcess(
     originalCode: String,
     originalPath: os.RelPath,
-    wd: Option[os.Path],
     adjust: Int => Option[Int],
     orig: os.Path,
     dest: os.Path

--- a/modules/build/src/main/scala/scala/build/preprocessing/PreprocessedSource.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/PreprocessedSource.scala
@@ -54,9 +54,9 @@ object PreprocessedSource {
             case (a0: InMemory, b0: InMemory) =>
               (a0.reportingPath, b0.reportingPath) match {
                 case (Left(ap), Left(bp))   => ap.compareTo(bp)
-                case (Left(ap), Right(bp))  => -1
+                case (Left(_), Right(_))    => -1
                 case (Right(ap), Right(bp)) => ap.toString.compareTo(bp.toString)
-                case (Right(ap), Left(bp))  => 1
+                case (Right(_), Left(_))    => 1
               }
             case (a0: OnDisk, b0: OnDisk) => a0.path.toString.compareTo(b0.path.toString)
             case _                        => ???

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -15,11 +15,7 @@ import scala.build.errors.{
 }
 import scala.build.internal.AmmUtil
 import scala.build.Ops._
-import scala.build.options.{
-  BuildOptions,
-  BuildRequirements,
-  ClassPathOptions
-}
+import scala.build.options.{BuildOptions, BuildRequirements, ClassPathOptions}
 import scala.build.preprocessing.directives._
 
 case object ScalaPreprocessor extends Preprocessor {
@@ -102,7 +98,7 @@ case object ScalaPreprocessor extends Preprocessor {
   ): Either[BuildException, Option[(BuildRequirements, BuildOptions, String)]] = either {
 
     val afterUsing = value {
-      processUsing(content, printablePath)
+      processUsing(content)
         .sequence
     }
     val afterProcessImports =
@@ -181,11 +177,10 @@ case object ScalaPreprocessor extends Preprocessor {
   }
 
   private def processUsing(
-    content: String,
-    printablePath: String
+    content: String
   ): Option[Either[BuildException, (BuildRequirements, BuildOptions, String)]] =
     TemporaryDirectivesParser.parseDirectives(content).flatMap {
-      case (directives, updatedContent) =>
+      case (_, _) =>
         // TODO Warn about unrecognized directives
         // TODO Report via some diagnostics malformed directives
 

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -4,10 +4,9 @@ import dependency.AnyDependency
 import dependency.parser.DependencyParser
 
 import java.nio.charset.StandardCharsets
-import java.util.Locale
 
 import scala.build.EitherCps.{either, value}
-import scala.build.{Inputs, Os, Sources}
+import scala.build.{Inputs, Os}
 import scala.build.errors.{
   BuildException,
   CompositeBuildException,
@@ -19,14 +18,9 @@ import scala.build.Ops._
 import scala.build.options.{
   BuildOptions,
   BuildRequirements,
-  ClassPathOptions,
-  Platform,
-  ScalaJsOptions,
-  ScalaNativeOptions,
-  ScalaOptions
+  ClassPathOptions
 }
 import scala.build.preprocessing.directives._
-import scala.collection.JavaConverters._
 
 case object ScalaPreprocessor extends Preprocessor {
 
@@ -214,7 +208,6 @@ case object ScalaPreprocessor extends Preprocessor {
   ): Option[(BuildRequirements, BuildOptions, String)] = {
 
     import fastparse._
-    import scalaparse._
     import scala.build.internal.ScalaParse._
 
     val res = parse(content, Header(_))

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
@@ -1,8 +1,5 @@
 package scala.build.preprocessing
 
-import dependency.AnyDependency
-import dependency.parser.DependencyParser
-import scalaparse.Scala.Pattern
 import scala.util.matching.Regex
 
 import java.nio.charset.StandardCharsets
@@ -10,8 +7,8 @@ import java.nio.charset.StandardCharsets
 import scala.build.{Inputs, Os}
 import scala.build.EitherCps.{either, value}
 import scala.build.errors.BuildException
-import scala.build.internal.{AmmUtil, CodeWrapper, Name}
-import scala.build.options.{BuildOptions, ClassPathOptions}
+import scala.build.internal.{AmmUtil, CodeWrapper}
+import scala.build.options.BuildOptions
 import scala.build.options.BuildRequirements
 
 final case class ScriptPreprocessor(codeWrapper: CodeWrapper) extends Preprocessor {

--- a/modules/build/src/main/scala/scala/build/preprocessing/TemporaryDirectivesParser.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/TemporaryDirectivesParser.scala
@@ -55,7 +55,7 @@ object TemporaryDirectivesParser {
   private def parseDirective(content: String, fromIndex: Int): Option[(Seq[Directive], Int)] = {
     // TODO Don't create a new String here
     val res = parse(content.drop(fromIndex), maybeDirective(_))
-    res.fold((err, idx, _) => sys.error(err), (dirOpt, idx) => dirOpt.map((_, idx + fromIndex)))
+    res.fold((err, _, _) => sys.error(err), (dirOpt, idx) => dirOpt.map((_, idx + fromIndex)))
   }
 
   def parseDirectives(content: String): Option[(List[Directive], String)] = {

--- a/modules/build/src/main/scala/scala/build/preprocessing/directives/DirectiveHandler.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/directives/DirectiveHandler.scala
@@ -1,6 +1,5 @@
 package scala.build.preprocessing.directives
 
-
 trait DirectiveHandler {
   def name: String
   def description: String

--- a/modules/build/src/main/scala/scala/build/preprocessing/directives/DirectiveHandler.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/directives/DirectiveHandler.scala
@@ -1,6 +1,5 @@
 package scala.build.preprocessing.directives
 
-import scala.build.options.BuildOptions
 
 trait DirectiveHandler {
   def name: String

--- a/modules/cli/src/main/scala/scala/cli/commands/AddPath.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/AddPath.scala
@@ -5,7 +5,6 @@ import coursier.env.{EnvironmentUpdate, ProfileUpdater}
 
 import java.io.File
 
-import scala.cli.internal.ProfileFileUpdater
 import scala.util.Properties
 
 object AddPath extends ScalaCommand[AddPathOptions] {

--- a/modules/cli/src/main/scala/scala/cli/commands/BloopExit.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/BloopExit.scala
@@ -2,7 +2,7 @@ package scala.cli.commands
 
 import caseapp._
 
-import scala.build.{Bloop, Os}
+import scala.build.Os
 import scala.build.blooprifle.BloopRifle
 
 object BloopExit extends ScalaCommand[BloopExitOptions] {

--- a/modules/cli/src/main/scala/scala/cli/commands/Compile.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Compile.scala
@@ -4,7 +4,7 @@ import caseapp._
 
 import java.io.File
 
-import scala.build.{Build, Inputs, Os}
+import scala.build.Build
 
 object Compile extends ScalaCommand[CompileOptions] {
   override def group                                  = "Main"

--- a/modules/cli/src/main/scala/scala/cli/commands/CustomWindowsEnvVarUpdater.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/CustomWindowsEnvVarUpdater.scala
@@ -10,7 +10,6 @@ import dataclass._
 
 @data class CustomWindowsEnvVarUpdater(
   powershellRunner: PowershellRunner = PowershellRunner(),
-  target: String = "User",
   @since
   useJni: Option[Boolean] = None
 ) extends EnvVarUpdater {

--- a/modules/cli/src/main/scala/scala/cli/commands/Export.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Export.scala
@@ -2,12 +2,11 @@ package scala.cli.commands
 
 import caseapp._
 
-import scala.build.{BloopBuildClient, Build, CrossSources, Inputs, Logger, Sources}
+import scala.build.{CrossSources, Inputs, Logger, Sources}
 import scala.build.EitherCps.{either, value}
 import scala.build.errors.BuildException
 import scala.build.internal.CustomCodeWrapper
 import scala.build.options.BuildOptions
-import scala.build.GeneratedSource
 
 import scala.cli.export._
 

--- a/modules/cli/src/main/scala/scala/cli/commands/InstallHome.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/InstallHome.scala
@@ -3,7 +3,6 @@ package scala.cli.commands
 import caseapp._
 import coursier.env.{EnvironmentUpdate, ProfileUpdater}
 import scala.io.StdIn.readLine
-
 import scala.util.Properties
 
 object InstallHome extends ScalaCommand[InstallHomeOptions] {

--- a/modules/cli/src/main/scala/scala/cli/commands/LoggingOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/LoggingOptions.scala
@@ -4,8 +4,6 @@ import caseapp._
 import coursier.cache.CacheLogger
 import coursier.cache.loggers.{FallbackRefreshDisplay, ProgressBarRefreshDisplay, RefreshLogger}
 
-import java.io.PrintStream
-
 import scala.build.blooprifle.BloopRifleLogger
 import scala.build.errors.BuildException
 import scala.build.Logger

--- a/modules/cli/src/main/scala/scala/cli/commands/Metabrowse.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Metabrowse.scala
@@ -1,21 +1,13 @@
 package scala.cli.commands
 
-import java.io.{IOException, File, FileInputStream, FileOutputStream}
-import java.net.ServerSocket
+import java.io.File
 import java.nio.file.Path
-import java.util.UUID
-import java.util.zip.GZIPInputStream
 
 import caseapp._
-import coursier.jvm.ArchiveType
-import coursier.util.{Artifact, Task}
 
-import scala.build.{Build, BuildThreads, Inputs, Logger, Os}
+import scala.build.{Build, Logger}
 import scala.build.internal.Runner
-import scala.build.options.BuildOptions
 import scala.cli.internal.FetchExternalBinary
-import scala.concurrent.ExecutionContext.{global => ec}
-import scala.util.Properties
 
 object Metabrowse extends ScalaCommand[MetabrowseOptions] {
   override def group = "Miscellaneous"
@@ -39,7 +31,7 @@ object Metabrowse extends ScalaCommand[MetabrowseOptions] {
         .orExit(logger)
 
     val successfulBuild = build match {
-      case f: Build.Failed =>
+      case _: Build.Failed =>
         System.err.println("Build failed")
         sys.exit(1)
       case s: Build.Successful => s
@@ -150,10 +142,4 @@ object Metabrowse extends ScalaCommand[MetabrowseOptions] {
     Runner.run("metabrowse", command, logger, allowExecve = true)
   }
 
-  private def randomPort(): Int = {
-    val s    = new ServerSocket(0)
-    val port = s.getLocalPort
-    s.close()
-    port
-  }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -33,7 +33,6 @@ import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import scala.util.Properties
 
-import java.nio.charset.Charset
 import packager.docker.DockerPackage
 
 object Package extends ScalaCommand[PackageOptions] {
@@ -65,7 +64,7 @@ object Package extends ScalaCommand[PackageOptions] {
         res.orReport(logger).map(_._1).foreach {
           case s: Build.Successful =>
             doPackage(inputs, logger, options.output.filter(_.nonEmpty), options.force, s)
-          case f: Build.Failed =>
+          case _: Build.Failed =>
             System.err.println("Compilation failed")
         }
       }
@@ -79,7 +78,7 @@ object Package extends ScalaCommand[PackageOptions] {
       build match {
         case s: Build.Successful =>
           doPackage(inputs, logger, options.output.filter(_.nonEmpty), options.force, s)
-        case f: Build.Failed =>
+        case _: Build.Failed =>
           System.err.println("Compilation failed")
           sys.exit(1)
       }

--- a/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
@@ -32,7 +32,7 @@ object Repl extends ScalaCommand[ReplOptions] {
       Build.build(inputs, initialBuildOptions, bloopRifleConfig, logger, crossBuilds = false)
         .orExit(logger)
 
-    val successfulBuild = build.successfulOpt.getOrElse {
+    build.successfulOpt.getOrElse {
       System.err.println("Compilation failed")
       sys.exit(1)
     }
@@ -45,7 +45,7 @@ object Repl extends ScalaCommand[ReplOptions] {
       allowExit: Boolean
     ): Unit =
       build match {
-        case s: Build.Successful =>
+        case _: Build.Successful =>
           val res = runRepl(
             buildOptions,
             artifacts,
@@ -61,7 +61,7 @@ object Repl extends ScalaCommand[ReplOptions] {
               else logger.log(ex)
             case Right(()) =>
           }
-        case f: Build.Failed =>
+        case _: Build.Failed =>
           System.err.println("Compilation failed")
           if (allowExit)
             sys.exit(1)

--- a/modules/cli/src/main/scala/scala/cli/commands/ReplOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ReplOptions.scala
@@ -2,7 +2,6 @@ package scala.cli.commands
 
 import caseapp._
 
-import scala.build.internal.Constants
 import scala.build.options.BuildOptions
 
 // format: off

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -3,11 +3,8 @@ package scala.cli.commands
 import caseapp._
 import org.scalajs.linker.interface.StandardConfig
 
-import java.nio.file.Path
-
-import scala.build.{Build, Inputs, Logger, Os}
+import scala.build.{Build, Inputs, Logger}
 import scala.build.internal.{Constants, Runner}
-import scala.build.options.BuildOptions
 import scala.scalanative.{build => sn}
 import scala.util.Properties
 
@@ -53,7 +50,7 @@ object Run extends ScalaCommand[RunOptions] {
         res.orReport(logger).map(_._1).foreach {
           case s: Build.Successful =>
             maybeRun(s, allowTerminate = false)
-          case f: Build.Failed =>
+          case _: Build.Failed =>
             System.err.println("Compilation failed")
         }
       }
@@ -67,7 +64,7 @@ object Run extends ScalaCommand[RunOptions] {
       build match {
         case s: Build.Successful =>
           maybeRun(s, allowTerminate = true)
-        case f: Build.Failed =>
+        case _: Build.Failed =>
           System.err.println("Compilation failed")
           sys.exit(1)
       }

--- a/modules/cli/src/main/scala/scala/cli/commands/RunOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RunOptions.scala
@@ -3,7 +3,6 @@ package scala.cli.commands
 import caseapp._
 import caseapp.core.help.Help
 
-import scala.build.Build
 import scala.build.options.BuildOptions
 
 // format: off

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalacOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalacOptions.scala
@@ -3,7 +3,7 @@ package scala.cli.commands
 import caseapp._
 import caseapp.core.parser.NilParser
 import caseapp.core.parser.Argument
-import caseapp.core.{Arg, Error}
+import caseapp.core.Arg
 import caseapp.core.util.Formatter
 import caseapp.core.parser.StandardArgument
 

--- a/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
@@ -7,7 +7,7 @@ import com.google.gson.GsonBuilder
 import java.io.File
 import java.nio.charset.Charset
 
-import scala.build.{Inputs, Os}
+import scala.build.Os
 import scala.build.internal.Constants
 import scala.collection.JavaConverters._
 

--- a/modules/cli/src/main/scala/scala/cli/commands/SharedCompilationServerOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SharedCompilationServerOptions.scala
@@ -9,7 +9,7 @@ import java.util.Random
 import scala.build.blooprifle.{BloopRifleConfig, BspConnectionAddress}
 import scala.build.{Bloop, Logger, Os}
 import scala.cli.internal.Pid
-import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
+import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.Properties
 
 // format: off

--- a/modules/cli/src/main/scala/scala/cli/commands/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SharedOptions.scala
@@ -3,25 +3,22 @@ package scala.cli.commands
 import java.io.{ByteArrayOutputStream, File, InputStream}
 import caseapp._
 import caseapp.core.help.Help
-import coursier.cache.FileCache
 import coursier.util.Artifact
 import dependency.AnyDependency
 import dependency.parser.DependencyParser
 
 import scala.build.blooprifle.BloopRifleConfig
-import scala.build.{Bloop, Inputs, LocalRepo, Logger, Os}
+import scala.build.{Inputs, LocalRepo, Logger, Os}
 import scala.build.internal.{CodeWrapper, Constants, CustomCodeClassWrapper}
 import scala.build.options.{
   BuildOptions,
   ClassPathOptions,
   InternalDependenciesOptions,
   InternalOptions,
-  JavaOptions,
   JmhOptions,
   ScalaOptions,
   ScriptOptions
 }
-import scala.concurrent.duration.Duration
 import scala.util.Properties
 
 // format: off

--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -2,7 +2,7 @@ package scala.cli.commands
 
 import caseapp._
 
-import scala.build.{Build, Inputs, Os}
+import scala.build.Build
 import scala.build.internal.{Constants, Runner}
 import scala.build.Logger
 
@@ -29,7 +29,7 @@ object Test extends ScalaCommand[TestOptions] {
             allowExecve = allowExit,
             exitOnError = allowExit
           )
-        case f: Build.Failed =>
+        case _: Build.Failed =>
           System.err.println("Compilation failed")
           if (allowExit)
             sys.exit(1)
@@ -93,7 +93,6 @@ object Test extends ScalaCommand[TestOptions] {
           Runner.testNative(
             build.fullClassPath,
             launcher.toIO,
-            logger,
             testFrameworkOpt,
             args,
             logger.scalaNativeLogger

--- a/modules/cli/src/main/scala/scala/cli/export/Sbt.scala
+++ b/modules/cli/src/main/scala/scala/cli/export/Sbt.scala
@@ -68,11 +68,11 @@ final case class Sbt(sbtVersion: String) {
           .map(repo => (repo, RepositoryParser.repository(repo)))
           .zipWithIndex
           .map {
-            case ((repoStr, Right(repo: IvyRepository)), idx) =>
+            case ((_, Right(repo: IvyRepository)), idx) =>
               // TODO repo.authentication?
               // TODO repo.metadataPatternOpt
               s"""Resolver.url("repo-$idx") artifacts "${repo.pattern.string}""""
-            case ((repoStr, Right(repo: MavenRepository)), idx) =>
+            case ((_, Right(repo: MavenRepository)), idx) =>
               // TODO repo.authentication?
               s""""repo-$idx" at "${repo.root}""""
             case _ =>

--- a/modules/cli/src/main/scala/scala/cli/internal/GetImageResizer.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/GetImageResizer.scala
@@ -1,7 +1,5 @@
 package scala.cli.internal
 
-import java.lang.management.ManagementFactory
-
 import packager.windows._
 
 class GetImageResizer {

--- a/modules/cli/src/main/scala/scala/cli/internal/ScalaJsLinker.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/ScalaJsLinker.scala
@@ -1,13 +1,6 @@
 package scala.cli.internal
 
-import org.scalajs.linker.interface.{
-  ESFeatures,
-  LinkerOutput,
-  ModuleInitializer,
-  ModuleKind,
-  Semantics,
-  StandardConfig
-}
+import org.scalajs.linker.interface.{LinkerOutput, ModuleInitializer}
 import org.scalajs.linker.{PathIRContainer, PathOutputFile, StandardImpl}
 import org.scalajs.logging.{Level, ScalaConsoleLogger}
 import org.scalajs.testing.adapter.{TestAdapterInitializer => TAI}

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
@@ -148,7 +148,7 @@ object GenerateReferenceDoc extends CaseApp[Options] {
     b.toString
   }
 
-  private def commandsContent(commands: Seq[Command[_]], allArgs: Seq[Arg]): String = {
+  private def commandsContent(commands: Seq[Command[_]]): String = {
 
     val b = new StringBuilder
 
@@ -286,7 +286,7 @@ object GenerateReferenceDoc extends CaseApp[Options] {
     val nameFormatter = ScalaCli.actualDefaultCommand.nameFormatter
 
     val cliOptionsContent0 = cliOptionsContent(commands, allArgs, nameFormatter)
-    val commandsContent0   = commandsContent(commands, allArgs)
+    val commandsContent0   = commandsContent(commands)
     val usingContent0 = usingContent(
       ScalaPreprocessor.usingDirectiveHandlers,
       ScalaPreprocessor.requireDirectiveHandlers

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
@@ -2,7 +2,6 @@ package scala.cli.doc
 
 import caseapp._
 import caseapp.core.Arg
-import caseapp.core.parser.ParserWithNameFormatter
 import caseapp.core.util.Formatter
 import munit.internal.difflib.Diff
 

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/Options.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/Options.scala
@@ -1,7 +1,5 @@
 package scala.cli.doc
 
-import caseapp._
-
 final case class Options(
   outputDir: String = "docs/reference",
   check: Boolean = false

--- a/modules/integration/src/main/scala/scala/cli/integration/TestInputs.scala
+++ b/modules/integration/src/main/scala/scala/cli/integration/TestInputs.scala
@@ -18,12 +18,12 @@ final case class TestInputs(
       os.write(path, content.getBytes(StandardCharsets.UTF_8), createFolders = true)
     }
   def root(): os.Path = {
-    val tmpDir = TestInputs.tmpDir("scala-cli-tests-")
+    val tmpDir = TestInputs.tmpDir
     writeIn(tmpDir)
     tmpDir
   }
   def fromRoot[T](f: os.Path => T): T =
-    TestInputs.withTmpDir("scala-cli-tests-") { tmpDir =>
+    TestInputs.withTmpDir { tmpDir =>
       writeIn(tmpDir)
       f(tmpDir)
     }
@@ -32,7 +32,7 @@ final case class TestInputs(
 object TestInputs {
 
   private lazy val baseTmpDir = {
-    val fromEnv = Option(System.getenv("SCALA_CLI_TMP")).getOrElse {
+    Option(System.getenv("SCALA_CLI_TMP")).getOrElse {
       sys.error("SCALA_CLI_TMP not set")
     }
     val base = os.Path(System.getenv("SCALA_CLI_TMP"), os.pwd)
@@ -45,7 +45,7 @@ object TestInputs {
         override def run(): Unit =
           try os.remove.all(d)
           catch {
-            case NonFatal(e) =>
+            case NonFatal(_) =>
               System.err.println(s"Could not remove $d, ignoring it.")
           }
       }
@@ -55,7 +55,7 @@ object TestInputs {
 
   private val tmpCount = new AtomicInteger
 
-  private def withTmpDir[T](prefix: String)(f: os.Path => T): T = {
+  private def withTmpDir[T](f: os.Path => T): T = {
     val tmpDir = baseTmpDir / s"test-${tmpCount.incrementAndGet()}"
     os.makeDir.all(tmpDir)
     val tmpDir0 = os.Path(tmpDir.toIO.getCanonicalFile)
@@ -69,7 +69,7 @@ object TestInputs {
     }
   }
 
-  private def tmpDir(prefix: String): os.Path = {
+  private def tmpDir: os.Path = {
     val tmpDir = baseTmpDir / s"test-${tmpCount.incrementAndGet()}"
     os.makeDir.all(tmpDir)
     os.Path(tmpDir.toIO.getCanonicalFile)

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -60,7 +60,8 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
   def withBsp[T](
     inputs: TestInputs,
     args: Seq[String],
-    attempts: Int = 3
+    attempts: Int = 3,
+    pauseDuration: FiniteDuration = 5.seconds
   )(
     f: (
       os.Path,
@@ -99,18 +100,17 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
     @tailrec
     def helper(count: Int): T =
-      if (count <= 1)
-        attempt() match {
-          case Success(t)  => t
-          case Failure(ex) => throw new Exception(ex)
-        }
-      else
-        attempt() match {
-          case Success(t) => t
-          case Failure(ex) =>
-            System.err.println(s"Caught $ex, trying again…")
+      attempt() match {
+        case Success(t)  => t
+        case Failure(ex) =>
+          if (count <= 1)
+            throw new Exception(ex)
+          else {
+            System.err.println(s"Caught $ex, trying again in $pauseDuration…")
+            Thread.sleep(pauseDuration.toMillis)
             helper(count - 1)
-        }
+          }
+      }
 
     helper(attempts)
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -101,7 +101,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
     @tailrec
     def helper(count: Int): T =
       attempt() match {
-        case Success(t)  => t
+        case Success(t) => t
         case Failure(ex) =>
           if (count <= 1)
             throw new Exception(ex)

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -6,7 +6,6 @@ import com.eed3si9n.expecty.Expecty.expect
 import java.net.URI
 import java.nio.charset.Charset
 import java.nio.file.Paths
-import java.util.concurrent.TimeoutException
 
 import scala.annotation.tailrec
 import scala.async.Async.{async, await}
@@ -78,7 +77,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
       var remoteServer: b.BuildServer with b.ScalaBuildServer with b.JavaBuildServer = null
 
       try {
-        val (localClient, remoteServer0, shutdownFuture) =
+        val (localClient, remoteServer0, _) =
           TestBspClient.connect(proc.stdout, proc.stdin, pool)
         remoteServer = remoteServer0
         Await.result(remoteServer.buildInitialize(initParams(root)).asScala, 3.minutes)
@@ -159,7 +158,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
       )
     )
 
-    withBsp(inputs, Seq(".")) { (root, localClient, remoteServer) =>
+    withBsp(inputs, Seq(".")) { (root, _, remoteServer) =>
       async {
         val buildTargetsResp = await(remoteServer.workspaceBuildTargets().asScala)
         val target = {
@@ -173,7 +172,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
         val targets = List(target).asJava
 
-        val depSourcesResp = {
+        {
           val resp = await {
             remoteServer
               .buildTargetDependencySources(new b.DependencySourcesParams(targets))
@@ -198,10 +197,9 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
             expect(foundDepSources.exists(_.startsWith("scala3-library_3-3")))
           }
           expect(foundDepSources.forall(_.endsWith("-sources.jar")))
-          resp
         }
 
-        val sourcesResp = {
+        {
           val resp = await(remoteServer.buildTargetSources(new b.SourcesParams(targets)).asScala)
           val foundTargets = resp.getItems.asScala.map(_.getTarget.getUri).toSeq
           expect(foundTargets == Seq(targetUri))
@@ -215,7 +213,6 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
             )
           )
           expect(foundSources == expectedSources)
-          resp
         }
 
         val scalacOptionsResp = {
@@ -240,7 +237,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
           resp
         }
 
-        val javacOptionsResp = {
+        {
           val resp = await {
             remoteServer.buildTargetJavacOptions(new b.JavacOptionsParams(targets)).asScala
           }
@@ -250,17 +247,15 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
             .map(_.getTarget.getUri)
             .map(TestUtil.normalizeUri)
           expect(foundTargets == Seq(targetUri))
-          resp
         }
 
         val classDir = os.Path(
           Paths.get(new URI(scalacOptionsResp.getItems.asScala.head.getClassDirectory))
         )
 
-        val compileResp = {
+        {
           val resp = await(remoteServer.buildTargetCompile(new b.CompileParams(targets)).asScala)
           expect(resp.getStatusCode == b.StatusCode.OK)
-          resp
         }
 
         val compileProducts = os.walk(classDir).filter(os.isFile(_)).map(_.relativeTo(classDir))
@@ -438,13 +433,12 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
         val targets = List(target).asJava
 
-        val compileResp = {
+        {
           val resp = await(remoteServer.buildTargetCompile(new b.CompileParams(targets)).asScala)
           expect(resp.getStatusCode == b.StatusCode.OK)
-          resp
         }
 
-        val depSourcesResp = {
+        {
           val resp = await {
             remoteServer
               .buildTargetDependencySources(new b.DependencySourcesParams(targets))
@@ -469,7 +463,6 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
             expect(foundDepSources.exists(_.startsWith("scala3-library_3-3")))
           }
           expect(foundDepSources.forall(_.endsWith("-sources.jar")))
-          resp
         }
 
         val didChangeParamsFuture = localClient.buildTargetDidChange()
@@ -480,10 +473,9 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
             |""".stripMargin
         os.write.over(root / "simple.sc", updatedContent)
 
-        val secondCompileResp = {
+        {
           val resp = await(remoteServer.buildTargetCompile(new b.CompileParams(targets)).asScala)
           expect(resp.getStatusCode == b.StatusCode.OK)
-          resp
         }
 
         val didChangeParamsOptFuture = Future.firstCompletedOf(Seq(
@@ -501,7 +493,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
         expect(change.getTarget.getUri == targetUri)
         expect(change.getKind == b.BuildTargetEventKind.CHANGED)
 
-        val secondDepSourcesResp = {
+        {
           val resp = await {
             remoteServer
               .buildTargetDependencySources(new b.DependencySourcesParams(targets))
@@ -552,13 +544,12 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
         val targets = List(target).asJava
 
-        val compileResp = {
+        {
           val resp = await(remoteServer.buildTargetCompile(new b.CompileParams(targets)).asScala)
           expect(resp.getStatusCode == b.StatusCode.OK)
-          resp
         }
 
-        val depSourcesResp = {
+        {
           val resp = await {
             remoteServer
               .buildTargetDependencySources(new b.DependencySourcesParams(targets))
@@ -583,7 +574,6 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
             expect(foundDepSources.exists(_.startsWith("scala3-library_3-3")))
           }
           expect(foundDepSources.forall(_.endsWith("-sources.jar")))
-          resp
         }
 
         val didChangeParamsFuture = localClient.buildTargetDidChange()
@@ -601,10 +591,9 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
             |""".stripMargin
         os.write.over(root / "Test.scala", updatedContent)
 
-        val secondCompileResp = {
+        {
           val resp = await(remoteServer.buildTargetCompile(new b.CompileParams(targets)).asScala)
           expect(resp.getStatusCode == b.StatusCode.OK)
-          resp
         }
 
         val didChangeParamsOptFuture = Future.firstCompletedOf(Seq(

--- a/modules/integration/src/test/scala/scala/cli/integration/CleanTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CleanTests.scala
@@ -23,7 +23,7 @@ class CleanTests extends munit.FunSuite {
       expect(res.out.text.trim == "Hello")
       expect(os.exists(dir))
 
-      val cleanRes = os.proc(TestUtil.cli, "clean", ".").call(cwd = root)
+      os.proc(TestUtil.cli, "clean", ".").call(cwd = root)
       expect(!os.exists(dir))
     }
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -1,7 +1,5 @@
 package scala.cli.integration
 
-import com.eed3si9n.expecty.Expecty.expect
-
 abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
     extends munit.FunSuite with TestScalaVersionArgs {
 

--- a/modules/integration/src/test/scala/scala/cli/integration/TestBspClient.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestBspClient.scala
@@ -16,7 +16,7 @@ import scala.concurrent.ExecutionContext
 class TestBspClient extends b.BuildClient {
 
   private val lock      = new Object
-  private var messages0 = new mutable.ListBuffer[Object]
+  private val messages0 = new mutable.ListBuffer[Object]
   private def addMessage(params: Object): Unit =
     lock.synchronized {
       messages0.append(params)

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -62,7 +62,7 @@ object TestUtil {
   }
 
   def threadPool(prefix: String, size: Int): ExecutorService =
-    Executors.newFixedThreadPool(4, daemonThreadFactory(prefix))
+    Executors.newFixedThreadPool(size, daemonThreadFactory(prefix))
 
   def scheduler(prefix: String): ScheduledExecutorService =
     Executors.newSingleThreadScheduledExecutor(daemonThreadFactory(prefix))

--- a/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyData.scala
+++ b/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyData.scala
@@ -2,11 +2,9 @@ package scala.build.tastylib
 
 import java.util.UUID
 
-import scala.build.tastylib.TastyBuffer.NameRef
 import scala.build.tastylib.TastyReader.Bytes
 import scala.build.tastylib.TastyFormat.NameTags._
 import java.io.ByteArrayOutputStream
-import java.util.Arrays
 import java.nio.charset.StandardCharsets
 
 final case class TastyData(

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
@@ -1,10 +1,9 @@
 package scala.build.testrunner
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, File, InputStream, PrintStream}
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.{Files, Path}
 import java.util.concurrent.ConcurrentHashMap
-import java.util.ServiceLoader
 
 import org.objectweb.asm
 import sbt.testing._
@@ -85,7 +84,7 @@ object AsmTestRunner {
             parentInspector.allParents(checker.name)
               .contains(f.superclassName().replace('.', '/'))
 
-        case f: AnnotatedFingerprint =>
+        case _: AnnotatedFingerprint =>
           // val annotationCls = loader.loadClass(f.annotationName())
           //   .asInstanceOf[Class[Annotation]]
           // f.isModule == isModule && (

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
@@ -105,9 +105,8 @@ object DynamicTestRunner {
     loader: ClassLoader,
     className: String
   ): Framework = {
-    val frameworkCls = classOf[Framework]
-    val cls          = loader.loadClass(className)
-    val constructor  = cls.getConstructor()
+    val cls         = loader.loadClass(className)
+    val constructor = cls.getConstructor()
     constructor.newInstance().asInstanceOf[Framework]
   }
 

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/TestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/TestRunner.scala
@@ -1,7 +1,6 @@
 package scala.build.testrunner
 
 import java.io.{File, PrintStream}
-import java.net.URLClassLoader
 import java.nio.file.{Path, Paths}
 
 import sbt.testing._

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -1,6 +1,8 @@
+import $ivy.`com.goyeau::mill-scalafix:0.2.5`
 import $ivy.`io.github.alexarchambault.mill::mill-native-image_mill0.9:0.1.9`
 import $file.deps, deps.{Deps, Docker}
 
+import com.goyeau.mill.scalafix.ScalafixModule
 import io.github.alexarchambault.millnativeimage.NativeImage
 import java.io.File
 import mill._, scalalib._
@@ -584,5 +586,12 @@ trait FormatNativeImageConf extends JavaModule {
       formattedCount += doFormatNativeImageConf(dir, format = true).length
     System.err.println(s"Formatted $formattedCount file(s).")
     ()
+  }
+}
+
+trait ScalaCliScalafixModule extends ScalafixModule {
+  def scalafixConfig = T {
+    if (scalaVersion().startsWith("2.")) super.scalafixConfig()
+    else Some(os.pwd / ".scalafix3.conf")
   }
 }


### PR DESCRIPTION
The final solution should be to run `./mill all __. fix`.  There is a problem that several modules are compiling to scala 3 and in this version there is no flag `-Ywarn-unused `yet. 

If we run `./mill all __. fix`,it tries to run scalafix on all modules in the defined scala version, but there are modules that compile to every scala version, so it throws an error that `-Ywarn-unused` flag not exists in scala 3. 

I haven't found a solution that can easily exclude scalafix from running for modules compiling to scala 3, therefore I created a scalafix () method in which I explicitly run fix() on each module.

