### PR TITLE
Enable some scalafmt rewrites

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -14,6 +14,16 @@ newlines.alwaysBeforeElseAfterCurlyIf = true
 
 runner.dialect = scala213
 
+rewrite.rules = [
+  RedundantBraces
+]
+
+rewrite.redundantBraces {
+  ifElseExpressions = true
+  includeUnitMethods = false
+  stringInterpolation = true
+}
+
 fileOverride {
   "glob:**/scala-3-stable/**" {
     runner.dialect = scala3

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -16,6 +16,7 @@ runner.dialect = scala213
 
 rewrite.rules = [
   RedundantBraces
+  RedundantParens
 ]
 
 rewrite.redundantBraces {

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -17,6 +17,7 @@ runner.dialect = scala213
 rewrite.rules = [
   RedundantBraces
   RedundantParens
+  SortModifiers
 ]
 
 rewrite.redundantBraces {
@@ -24,6 +25,11 @@ rewrite.redundantBraces {
   includeUnitMethods = false
   stringInterpolation = true
 }
+
+rewrite.sortModifiers.order = [
+  "private", "final", "override", "protected",
+  "implicit", "sealed", "abstract", "lazy"
+]
 
 fileOverride {
   "glob:**/scala-3-stable/**" {

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -12,6 +12,9 @@ newlines.beforeMultiline = keep
 newlines.afterCurlyLambdaParams = keep
 newlines.alwaysBeforeElseAfterCurlyIf = true
 
+DisableSyntax.noIsInstanceOf = true
+DisableSyntax.noReturns = true
+
 runner.dialect = scala213
 
 rewrite.rules = [

--- a/build.sc
+++ b/build.sc
@@ -325,7 +325,7 @@ trait CliIntegrationBase extends SbtModule with ScalaCliPublishModule with HasTe
     Deps.osLib
   )
 
-  private def mainArtifactName = T { artifactName() }
+  private def mainArtifactName = T(artifactName())
   trait Tests extends super.Tests with ScalaCliScalafixModule {
     def ivyDeps = super.ivyDeps() ++ Agg(
       Deps.bsp4j,
@@ -647,9 +647,8 @@ def copyStaticLauncher(directory: String = "artifacts") = T.command {
   )
 }
 
-private def gitClone(repo: String, branch: String, workDir: os.Path) = {
+private def gitClone(repo: String, branch: String, workDir: os.Path) =
   os.proc("git", "clone", repo, "-q", "-b", branch).call(cwd = workDir)
-}
 private def setupGithubRepo(repoDir: os.Path) = {
   val gitUserName = "gh-actions"
   val gitEmail    = "actions@github.com"
@@ -659,9 +658,8 @@ private def setupGithubRepo(repoDir: os.Path) = {
 }
 
 private def commitChanges(name: String, branch: String, repoDir: os.Path): Unit = {
-  if (os.proc("git", "status").call(cwd = repoDir).out.text().trim.contains("nothing to commit")) {
+  if (os.proc("git", "status").call(cwd = repoDir).out.text().trim.contains("nothing to commit"))
     println("Nothing Changes")
-  }
   else {
     os.proc("git", "add", "-A").call(cwd = repoDir)
     os.proc("git", "commit", "-am", name).call(cwd = repoDir)
@@ -753,8 +751,8 @@ object ci extends Module {
     os.proc("apt-ftparchive", "release", ".").call(cwd = debianDir, stdout = releasePath)
 
     val pgpPassphrase =
-      Option(System.getenv("PGP_PASSPHRASE")).getOrElse { sys.error("PGP_PASSPHRASE not set") }
-    val keyName = Option(System.getenv("GPG_EMAIL")).getOrElse { sys.error("GPG_EMAIL not set") }
+      Option(System.getenv("PGP_PASSPHRASE")).getOrElse(sys.error("PGP_PASSPHRASE not set"))
+    val keyName = Option(System.getenv("GPG_EMAIL")).getOrElse(sys.error("GPG_EMAIL not set"))
     val releaseGpgPath = debianDir / "Release.gpg"
     val inReleasePath  = debianDir / "InRelease"
     os.proc(

--- a/modules/bloop-rifle/src/main/scala/scala/build/bloop/BloopServer.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/bloop/BloopServer.scala
@@ -199,10 +199,12 @@ object BloopServer {
       )
       f(server)
     }
+    // format: off
     finally {
       if (server != null)
         server.shutdown()
     }
+    // format: on
   }
 
 }

--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifle.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifle.scala
@@ -31,13 +31,12 @@ object BloopRifle {
     logger: BloopRifleLogger,
     scheduler: ScheduledExecutorService
   ): Boolean = {
-    def check() = {
+    def check() =
       Operations.check(
         config.host,
         config.port,
         logger
       )
-    }
     check() && {
       !BloopRifle.shutdownBloopIfVersionIncompatible(
         config,
@@ -189,11 +188,10 @@ object BloopRifle {
 
   def nullInputStream() = new FileInputStream(Util.devNull)
 
-  def extractVersionFromBloopAbout(stdoutFromBloopAbout: String): Option[String] = {
+  def extractVersionFromBloopAbout(stdoutFromBloopAbout: String): Option[String] =
     stdoutFromBloopAbout.split("\n").find(_.startsWith("bloop v")).map(
       _.split(" ")(1).trim().drop(1)
     )
-  }
 
   def getCurrentBloopVersion(
     config: BloopRifleConfig,
@@ -232,14 +230,13 @@ object BloopRifle {
     }
     if (bloopExitNeeded) {
       logger.debug(
-        s"Shutting down unsupported bloop v${currentBloopVersion}."
+        s"Shutting down unsupported bloop v$currentBloopVersion."
       )
       val retCode = exit(config, workdir, logger)
       logger.debug(s"Bloop exit return code: $retCode")
     }
-    else {
+    else
       logger.debug("No need to reset bloop")
-    }
     bloopExitNeeded
   }
 }

--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Operations.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Operations.scala
@@ -221,12 +221,14 @@ object Operations {
                 s"BSP connection at $socketFile not found, waiting $period"
             }
             Thread.sleep(period.toMillis)
-            if (socketFile.exists()) {
+            if (socketFile.exists())
               socket =
+                // format: off
                 try {
                   try {
                     (new NamedSocketBuilder).create(socketFile.getAbsolutePath)
                   }
+                // format: on
                   catch {
                     case ex: RuntimeException if ex.getMessage == "NamedSocketBuilder" =>
                       throw ex.getCause
@@ -242,7 +244,6 @@ object Operations {
                     logger.debug(s"Error when connecting to $socketFile: ${e.getMessage}")
                     null
                 }
-            }
             count += 1
           }
           if (socket != null) {
@@ -262,10 +263,12 @@ object Operations {
           while (socket == null && count < maxCount && closed.value.isEmpty) {
             Thread.sleep(period.toMillis)
             socket =
+              // format: off
               try {
                 try {
                   (new NamedSocketBuilder).create(p.name)
                 }
+              // format: on
                 catch {
                   case ex: RuntimeException if ex.getMessage == "NamedSocketBuilder" =>
                     throw ex.getCause

--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Util.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Util.scala
@@ -13,6 +13,7 @@ object Util {
       socket = new Socket
       f(socket)
     }
+    // format: off
     finally {
       if (socket != null)
         try {
@@ -22,6 +23,7 @@ object Util {
         }
         catch { case _: IOException => }
     }
+    // format: on
   }
 
   def devNull: File =

--- a/modules/build-macros/src/main/scala/scala/build/EitherCps.scala
+++ b/modules/build-macros/src/main/scala/scala/build/EitherCps.scala
@@ -20,7 +20,7 @@ object EitherCps {
       c.internal.markForAsyncTransform(c.internal.enclosingOwner, t, awaitSym, Map.empty)
     val name = TypeName("stateMachine$async")
     val body0 = mark(
-      q"""override def apply(tr$$async: _root_.scala.Either[_root_.scala.AnyRef, _root_.scala.AnyRef]) = ${body}"""
+      q"""override def apply(tr$$async: _root_.scala.Either[_root_.scala.AnyRef, _root_.scala.AnyRef]) = $body"""
     )
     q"""
       final class $name extends _root_.scala.build.EitherStateMachine {
@@ -45,9 +45,8 @@ abstract class EitherStateMachine
   protected def completeFailure(t: Throwable): Unit         = throw t
   protected def completeSuccess(value: AnyRef): Unit        = result$async = Right(value)
   protected def onComplete(f: Either[AnyRef, AnyRef]): Unit = ???
-  protected def getCompleted(f: Either[AnyRef, AnyRef]): Either[AnyRef, AnyRef] = {
+  protected def getCompleted(f: Either[AnyRef, AnyRef]): Either[AnyRef, AnyRef] =
     f
-  }
   protected def tryGet(tr: Either[AnyRef, AnyRef]): AnyRef = tr match {
     case Right(value) =>
       value.asInstanceOf[AnyRef]

--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -296,7 +296,7 @@ object Build {
 
     val watcher = new Watcher(ListBuffer(), threads.fileWatcher, run(), bloopServer.shutdown())
 
-    try {
+    def doWatch(): Unit =
       for (elem <- inputs.elements) {
         val depth = elem match {
           case _: Inputs.SingleFile => -1
@@ -328,7 +328,8 @@ object Build {
           }
         }
       }
-    }
+
+    try doWatch()
     catch {
       case NonFatal(e) =>
         watcher.dispose()
@@ -360,7 +361,7 @@ object Build {
     }
 
     val semanticDbScalacOptions =
-      if (options.scalaOptions.generateSemanticDbs.getOrElse(false)) {
+      if (options.scalaOptions.generateSemanticDbs.getOrElse(false))
         if (params.scalaVersion.startsWith("2."))
           Seq(
             "-Yrangepos",
@@ -372,7 +373,6 @@ object Build {
           Seq(
             "-Xsemanticdb"
           )
-      }
       else Nil
 
     val sourceRootScalacOptions =

--- a/modules/build/src/main/scala/scala/build/ConsoleBloopBuildClient.scala
+++ b/modules/build/src/main/scala/scala/build/ConsoleBloopBuildClient.scala
@@ -30,9 +30,8 @@ class ConsoleBloopBuildClient(
 
   private val diagnostics0 = new mutable.ListBuffer[(Either[String, os.Path], bsp4j.Diagnostic)]
 
-  def setGeneratedSources(newGeneratedSources: Seq[GeneratedSource]) = {
+  def setGeneratedSources(newGeneratedSources: Seq[GeneratedSource]) =
     generatedSources = newGeneratedSources
-  }
   def setProjectParams(newParams: Seq[String]): Unit = {
     projectParams = newParams
   }

--- a/modules/build/src/main/scala/scala/build/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/Inputs.scala
@@ -256,9 +256,8 @@ object Inputs {
         val isStdin = (arg == "-.scala" || arg == "_" || arg == "_.scala") &&
           stdinOpt0.nonEmpty
         if (isStdin) Right(Seq(VirtualScalaFile(stdinOpt0.get, "<stdin>")))
-        else if ((arg == "-" || arg == "-.sc" || arg == "_.sc") && stdinOpt0.nonEmpty) {
+        else if ((arg == "-" || arg == "-.sc" || arg == "_.sc") && stdinOpt0.nonEmpty)
           Right(Seq(VirtualScript(stdinOpt0.get, "stdin", os.sub / "stdin.sc")))
-        }
         else if (arg.contains("://")) {
           val url =
             if (githubGistsArchiveRegex.findFirstMatchIn(arg).nonEmpty) s"$arg/download" else arg
@@ -284,10 +283,9 @@ object Inputs {
                       while ({
                         read = zipInputStream.read(buf)
                         read >= 0
-                      }) {
+                      })
                         if (read > 0)
                           baos.write(buf, 0, read)
-                      }
                       baos.toByteArray
                     }
                     readArchive(resolve(entry.getName, content) +: acc)
@@ -296,9 +294,8 @@ object Inputs {
                 }
               readArchive(Nil)
             }
-            else {
+            else
               List(resolve(url, content))
-            }
           }
         }
         else if (arg.endsWith(".sc")) Right(Seq(Script(dir, subPath)))

--- a/modules/build/src/main/scala/scala/build/LocalRepo.scala
+++ b/modules/build/src/main/scala/scala/build/LocalRepo.scala
@@ -38,7 +38,7 @@ object LocalRepo {
             while ({
               ent = zis.getNextEntry()
               ent != null
-            }) {
+            })
               if (!ent.isDirectory) {
                 val baos = new ByteArrayOutputStream
                 var read = -1
@@ -54,7 +54,6 @@ object LocalRepo {
                   createFolders = true
                 )
               }
-            }
           }
           finally {
             if (zis != null) zis.close()
@@ -94,13 +93,9 @@ object LocalRepo {
             channel = null
           }
         }
-        finally {
-          if (lock != null) lock.release()
-        }
+        finally if (lock != null) lock.release()
       }
-      finally {
-        if (channel != null) channel.close()
-      }
+      finally if (channel != null) channel.close()
     }
 
 }

--- a/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
@@ -26,9 +26,7 @@ class BspServer(
       n <- projectNameOpt.iterator
       if n.targetUriOpt.isEmpty
       target <- res.getTargets.asScala.iterator.find(_.getDisplayName == n.name)
-    } {
-      n.targetUriOpt = Some(target.getId.getUri)
-    }
+    } n.targetUriOpt = Some(target.getId.getUri)
 
   private def stripInvalidTargets(params: b.WorkspaceBuildTargetsResult): Unit = {
     val updatedTargets = params

--- a/modules/build/src/main/scala/scala/build/bsp/BspThreads.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspThreads.scala
@@ -22,10 +22,7 @@ object BspThreads {
       threads = create()
       f(threads)
     }
-    finally {
-      if (threads != null)
-        threads.shutdown()
-    }
+    finally if (threads != null) threads.shutdown()
   }
   def create(): BspThreads =
     BspThreads(

--- a/modules/build/src/main/scala/scala/build/bsp/HasGeneratedSources.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/HasGeneratedSources.scala
@@ -17,9 +17,8 @@ trait HasGeneratedSources {
       .map(uri => new b.BuildTargetIdentifier(uri))
 
   def setProjectName(workspace: os.Path, name: String): Unit =
-    if (!projectNameOpt.exists(n => n.bloopWorkspace == workspace && n.name == name)) {
+    if (!projectNameOpt.exists(n => n.bloopWorkspace == workspace && n.name == name))
       projectNameOpt = Some(ProjectName(workspace, name))
-    }
   def setGeneratedSources(sources: Seq[GeneratedSource]): Unit = {
     generatedSources = GeneratedSources(sources)
   }

--- a/modules/build/src/main/scala/scala/build/internal/MainClass.scala
+++ b/modules/build/src/main/scala/scala/build/internal/MainClass.scala
@@ -49,9 +49,7 @@ object MainClass {
           reader.accept(checker, 0)
           checker.mainClassOpt.iterator
         }
-        finally {
-          is.close()
-        }
+        finally is.close()
       }
       .toVector
 }

--- a/modules/build/src/main/scala/scala/build/internal/Name.scala
+++ b/modules/build/src/main/scala/scala/build/internal/Name.scala
@@ -82,16 +82,15 @@ object Name {
     * avoid loading FastParse and ScalaParse entirely if we're running a cached script, which shaves
     * off 200-300ms of startup time.
     */
-  def backtickWrap(s: String) = {
+  def backtickWrap(s: String) =
     if (s.isEmpty) "``"
     else if (s(0) == '`' && s.last == '`') s
     else {
       val chunks = s.split("_", -1)
-      def validOperator(c: Char) = {
+      def validOperator(c: Char) =
         c.getType == Character.MATH_SYMBOL ||
         c.getType == Character.OTHER_SYMBOL ||
         "!#%&*+-/:<=>?@\\^|~".contains(c)
-      }
       val validChunks = chunks.zipWithIndex.forall { case (chunk, index) =>
         chunk.forall(c => c.isLetter || c.isDigit || c == '$') ||
           (
@@ -115,5 +114,4 @@ object Name {
 
       if (valid) s else '`' + s + '`'
     }
-  }
 }

--- a/modules/build/src/main/scala/scala/build/internal/Runner.scala
+++ b/modules/build/src/main/scala/scala/build/internal/Runner.scala
@@ -255,10 +255,7 @@ object Runner {
         if (success) 0 else 1
       }
     }
-    finally {
-      if (adapter != null)
-        adapter.close()
-    }
+    finally if (adapter != null) adapter.close()
   }
 
   def testNative(
@@ -295,9 +292,6 @@ object Runner {
         if (success) 0 else 1
       }
     }
-    finally {
-      if (adapter != null)
-        adapter.close()
-    }
+    finally if (adapter != null) adapter.close()
   }
 }

--- a/modules/build/src/main/scala/scala/build/internal/ScalaParse.scala
+++ b/modules/build/src/main/scala/scala/build/internal/ScalaParse.scala
@@ -43,7 +43,7 @@ object ScalaParse {
     def BulkImport = P(`_`).map(_ => Seq("_" -> None))
     def Prefix     = P(IdParser.rep(1, sep = "."))
     def Suffix     = P("." ~/ (BulkImport | Selectors))
-    def ImportExpr: P[ImportTree] = {
+    def ImportExpr: P[ImportTree] =
       // Manually use `WL0` parser here, instead of relying on WhitespaceApi, as
       // we do not want the whitespace to be consumed even if the WL0 parser parses
       // to the end of the input (which is the default behavior for WhitespaceApi)
@@ -51,7 +51,6 @@ object ScalaParse {
         case (start, idSeq, selectors, end) =>
           ImportTree(idSeq, selectors, start, end)
       }
-    }
     P(`import` ~/ ImportExpr.rep(1, sep = ","./))
   }
 

--- a/modules/build/src/main/scala/scala/build/options/ScalaJsOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/ScalaJsOptions.scala
@@ -21,12 +21,11 @@ final case class ScalaJsOptions(
     if (enable) Some("sjs" + ScalaVersion.jsBinary(finalVersion).getOrElse(finalVersion))
     else None
   def jsDependencies(scalaVersion: String): Seq[AnyDependency] =
-    if (enable) {
+    if (enable)
       if (scalaVersion.startsWith("2."))
         Seq(dep"org.scala-js::scalajs-library:$finalVersion")
       else
         Seq(dep"org.scala-js:scalajs-library_2.13:$finalVersion")
-    }
     else
       Nil
   def compilerPlugins(scalaVersion: String): Seq[AnyDependency] =

--- a/modules/build/src/main/scala/scala/build/postprocessing/AsmPositionUpdater.scala
+++ b/modules/build/src/main/scala/scala/build/postprocessing/AsmPositionUpdater.scala
@@ -63,9 +63,7 @@ object AsmPositionUpdater {
             if (checker.mappedStuff) Some(writer.toByteArray)
             else None
           }
-          finally {
-            is.close()
-          }
+          finally is.close()
         for (b <- updateByteCodeOpt) {
           logger.debug(s"Overwriting ${path.relativeTo(Os.pwd)}")
           os.write.over(path, b)

--- a/modules/build/src/main/scala/scala/build/postprocessing/SemanticdbProcessor.scala
+++ b/modules/build/src/main/scala/scala/build/postprocessing/SemanticdbProcessor.scala
@@ -24,11 +24,9 @@ object SemanticdbProcessor {
         for {
           startLine <- adjust(range.startLine)
           endLine   <- adjust(range.endLine)
-        } yield {
-          range
-            .withStartLine(startLine)
-            .withEndLine(endLine)
-        }
+        } yield range
+          .withStartLine(startLine)
+          .withEndLine(endLine)
     }
 
     def updateTrees(trees: Seq[Tree]): Option[Seq[Tree]] =

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
@@ -61,7 +61,7 @@ object ScriptPreprocessor {
 
   private val sheBangRegex: Regex = s"""(^(#!.*(\\r\\n?|\\n)?)+(\\s*!#.*)?)""".r
 
-  private def ignoreSheBangLines(content: String): String = {
+  private def ignoreSheBangLines(content: String): String =
     if (content.startsWith("#!")) {
       val regexMatch = sheBangRegex.findFirstMatchIn(content)
       regexMatch match {
@@ -73,10 +73,8 @@ object ScriptPreprocessor {
         case None => content
       }
     }
-    else {
+    else
       content
-    }
-  }
 
   private def preprocess(
     reportingPath: Either[String, os.Path],

--- a/modules/build/src/main/scala/scala/build/preprocessing/TemporaryDirectivesParser.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/TemporaryDirectivesParser.scala
@@ -56,10 +56,9 @@ object TemporaryDirectivesParser {
     }
   }
 
-  private def maybeDirective[_: P] = {
+  private def maybeDirective[_: P] =
     // TODO Use some cuts above to also catch malformed directives?
     P(directive.?)
-  }
 
   private def parseDirective(content: String, fromIndex: Int): Option[(Seq[Directive], Int)] = {
     // TODO Don't create a new String here

--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -56,12 +56,11 @@ class BuildTests extends munit.FunSuite {
           |""".stripMargin
     )
     testInputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, inputs, maybeBuild) =>
-      if (checkResults) {
+      if (checkResults)
         maybeBuild.orThrow.assertGeneratedEquals(
           "simple.class",
           "simple$.class"
         )
-      }
     }
   }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/Bsp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Bsp.scala
@@ -40,9 +40,7 @@ object Bsp extends ScalaCommand[BspOptions] {
         val doneFuture = bsp.run()
         Await.result(doneFuture, Duration.Inf)
       }
-      finally {
-        bsp.shutdown()
-      }
+      finally bsp.shutdown()
     }
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/InstallCompletions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/InstallCompletions.scala
@@ -94,7 +94,7 @@ object InstallCompletions extends ScalaCommand[InstallCompletionsOptions] {
         Charset.defaultCharset()
       )
 
-      if (options.logging.verbosity >= 0) {
+      if (options.logging.verbosity >= 0)
         if (updated) {
           System.err.println(s"Updated $rcFile")
           System.err.println(
@@ -104,7 +104,6 @@ object InstallCompletions extends ScalaCommand[InstallCompletionsOptions] {
         }
         else
           System.err.println(s"$rcFile already up-to-date")
-      }
     }
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/InstallHome.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/InstallHome.scala
@@ -13,16 +13,15 @@ object InstallHome extends ScalaCommand[InstallHomeOptions] {
     val binDirPath      = scala.build.Directories.default().binRepoDir
     val scalaCliBinPath = binDirPath / "scala-cli"
 
-    if (os.exists(scalaCliBinPath)) {
+    if (os.exists(scalaCliBinPath))
       if (options.force) os.remove.all(scalaCliBinPath)
       else if (coursier.paths.Util.useAnsiOutput()) {
         println(
           "scala-cli already exists. Do you want to override it [Y/n]"
         )
         val replace = readLine()
-        if (replace == "Y") {
+        if (replace == "Y")
           os.remove.all(scalaCliBinPath)
-        }
         else {
           System.err.println("Abort")
           sys.exit(1)
@@ -34,7 +33,6 @@ object InstallHome extends ScalaCommand[InstallHomeOptions] {
         )
         sys.exit(1)
       }
-    }
 
     os.copy(
       from = os.Path(options.scalaCliBinaryPath, os.pwd),
@@ -56,12 +54,10 @@ object InstallHome extends ScalaCommand[InstallHomeOptions] {
         updater.applyUpdate(update)
       }
 
-    if (didUpdate) {
+    if (didUpdate)
       println("Successfully installed scala-cli")
-    }
-    else {
+    else
       System.err.println(s"scala-cli is already installed")
-    }
 
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/OptionsHelper.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/OptionsHelper.scala
@@ -2,7 +2,7 @@ package scala.cli.commands
 
 object OptionsHelper {
   implicit class Mandatory[A](x: Option[A]) {
-    def mandatory(parameter: String, group: String): A = {
+    def mandatory(parameter: String, group: String): A =
       x match {
         case Some(v) => v
         case None =>
@@ -11,6 +11,5 @@ object OptionsHelper {
           )
           sys.exit(1)
       }
-    }
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -245,7 +245,7 @@ object Package extends ScalaCommand[PackageOptions] {
         docker(inputs, build, mainClass(), logger)
     }
 
-    if (!build.options.packageOptions.isDockerEnabled) {
+    if (!build.options.packageOptions.isDockerEnabled)
       logger.message {
         if (packageType.runnable)
           s"Wrote $dest, run it with" + System.lineSeparator() +
@@ -256,7 +256,6 @@ object Package extends ScalaCommand[PackageOptions] {
         else
           s"Wrote $dest"
       }
-    }
   }
 
   private def libraryJar(build: Build.Successful): Array[Byte] = {
@@ -286,10 +285,7 @@ object Package extends ScalaCommand[PackageOptions] {
         zos.closeEntry()
       }
     }
-    finally {
-      if (zos != null)
-        zos.close()
-    }
+    finally if (zos != null) zos.close()
 
     baos.toByteArray
   }
@@ -330,10 +326,7 @@ object Package extends ScalaCommand[PackageOptions] {
         zos.closeEntry()
       }
     }
-    finally {
-      if (zos != null)
-        zos.close()
-    }
+    finally if (zos != null) zos.close()
 
     baos.toByteArray
   }
@@ -448,9 +441,8 @@ object Package extends ScalaCommand[PackageOptions] {
             val path = os.Path(artifactPath)
             ClassPathEntry.Resource(path.last, os.mtime(path), os.read.bytes(path))
           }
-          else {
+          else
             ClassPathEntry.Url(url)
-          }
       }
     val byteCodeEntry = ClassPathEntry.Resource(s"${destPath.last}-content.jar", 0L, tmpJarContent)
 
@@ -504,9 +496,7 @@ object Package extends ScalaCommand[PackageOptions] {
       Files.write(mainJar, mainJarContent)
       f(mainJar)
     }
-    finally {
-      Files.deleteIfExists(mainJar)
-    }
+    finally Files.deleteIfExists(mainJar)
   }
 
   def withSourceJar[T](
@@ -520,9 +510,7 @@ object Package extends ScalaCommand[PackageOptions] {
       Files.write(jar, jarContent)
       f(jar)
     }
-    finally {
-      Files.deleteIfExists(jar)
-    }
+    finally Files.deleteIfExists(jar)
   }
 
   def linkJs(

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -155,7 +155,7 @@ object Run extends ScalaCommand[RunOptions] {
           allowExecve = allowExecve
         )
 
-    if (retCode != 0) {
+    if (retCode != 0)
       if (exitOnError)
         sys.exit(retCode)
       else {
@@ -164,7 +164,6 @@ object Run extends ScalaCommand[RunOptions] {
         val reset    = Console.RESET
         System.err.println(s"${red}Program exited with return code $lightRed$retCode$red.$reset")
       }
-    }
 
     retCode == 0
   }
@@ -180,10 +179,7 @@ object Run extends ScalaCommand[RunOptions] {
       Package.linkJs(build, dest, mainClassOpt, addTestInitializer, config)
       f(dest)
     }
-    finally {
-      if (os.exists(dest))
-        os.remove(dest)
-    }
+    finally if (os.exists(dest)) os.remove(dest)
   }
 
   def withNativeLauncher[T](
@@ -198,9 +194,6 @@ object Run extends ScalaCommand[RunOptions] {
       Package.buildNative(build, mainClass, dest, config, workDir, logger)
       f(dest)
     }
-    finally {
-      if (os.exists(dest))
-        os.remove(dest)
-    }
+    finally if (os.exists(dest)) os.remove(dest)
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -102,13 +102,12 @@ abstract class ScalaCommand[T](implicit parser: Parser[T], help: Help[T])
         ""
       )))
       .withTerminalWidthOpt {
-        if (Properties.isWin) {
+        if (Properties.isWin)
           if (coursier.paths.Util.useJni()) {
             val size = coursier.jniutils.WindowsAnsiTerminal.terminalSize()
             Some(size.getWidth)
           }
           else None
-        }
         else
           // That's how Ammonite gets the terminal width, but I'd rather not spawn a sub-process upfront in Scala CLI…
           //   val pathedTput = if (os.isFile(os.Path("/usr/bin/tput"))) "/usr/bin/tput" else "tput"

--- a/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
@@ -33,9 +33,8 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
     }
 
     def inputs = options.shared.inputsOrExit(args)
-    if (options.buildOptions.classPathOptions.extraDependencies.nonEmpty) {
+    if (options.buildOptions.classPathOptions.extraDependencies.nonEmpty)
       downloadDeps(inputs, options.buildOptions, options.shared.logger)
-    }
 
     val argv = {
       val commandIndex = rawArgv.indexOf("setup-ide")

--- a/modules/cli/src/main/scala/scala/cli/commands/SharedCompilationServerOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SharedCompilationServerOptions.scala
@@ -91,10 +91,7 @@ final case class SharedCompilationServerOptions(
           case _: FileAlreadyExistsException =>
         }
       }
-      finally {
-        if (os.exists(tmpDir))
-          os.remove(tmpDir)
-      }
+      finally if (os.exists(tmpDir)) os.remove(tmpDir)
     }
     dir
   }
@@ -172,7 +169,7 @@ final case class SharedCompilationServerOptions(
 
   def bloopDefaultJvmOptions(logger: Logger): List[String] = {
     val file = new File(bloopGlobalOptionsFile)
-    if (file.exists() && file.isFile()) {
+    if (file.exists() && file.isFile())
       try {
         val reader = new BufferedReader(new FileReader(file))
         val gson   = new Gson()
@@ -180,12 +177,10 @@ final case class SharedCompilationServerOptions(
         json.javaOptions.toList
       }
       catch {
-        case e: Throwable => {
+        case e: Throwable =>
           e.printStackTrace()
           List.empty
-        }
       }
-    }
     else {
       logger.debug(s"Bloop global options file '${file.toPath().toAbsolutePath()}' not found.")
       List.empty

--- a/modules/cli/src/main/scala/scala/cli/commands/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SharedOptions.scala
@@ -238,10 +238,9 @@ object SharedOptions {
       while ({
         read = in.read(buf)
         read >= 0
-      }) {
+      })
         if (read > 0)
           baos.write(buf, 0, read)
-      }
       val result = baos.toByteArray
       logger.debug(s"Done reading stdin (${result.length} B)")
       Some(result)

--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -112,7 +112,7 @@ object Test extends ScalaCommand[TestOptions] {
         )
       }
 
-    if (retCode != 0) {
+    if (retCode != 0)
       if (exitOnError)
         sys.exit(retCode)
       else {
@@ -121,6 +121,5 @@ object Test extends ScalaCommand[TestOptions] {
         val reset    = Console.RESET
         System.err.println(s"${red}Program exited with return code $lightRed$retCode$red.$reset")
       }
-    }
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/WatchUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/WatchUtil.scala
@@ -11,7 +11,7 @@ object WatchUtil {
     val shortCut = if (isDevMode) "Ctrl+D" else "Ctrl+C"
     val gray     = "\u001b[90m"
     val reset    = Console.RESET
-    s"${gray}$message, press $shortCut to exit.$reset"
+    s"$gray$message, press $shortCut to exit.$reset"
   }
 
   def printWatchMessage(): Unit =

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
@@ -170,7 +170,7 @@ object GenerateReferenceDoc extends CaseApp[Options] {
       val headerPrefix = "#" * additionalIndentation
       val names        = c.names.map(_.mkString(" "))
       b.append(
-        s"""${headerPrefix}## `${names.head}`
+        s"""$headerPrefix## `${names.head}`
            |
            |""".stripMargin
       )

--- a/modules/integration/src/main/scala/scala/cli/integration/TestInputs.scala
+++ b/modules/integration/src/main/scala/scala/cli/integration/TestInputs.scala
@@ -59,14 +59,14 @@ object TestInputs {
     val tmpDir = baseTmpDir / s"test-${tmpCount.incrementAndGet()}"
     os.makeDir.all(tmpDir)
     val tmpDir0 = os.Path(tmpDir.toIO.getCanonicalFile)
-    try f(tmpDir0)
-    finally {
+    def removeAll(): Unit =
       try os.remove.all(tmpDir0)
       catch {
         case ex: IOException =>
           System.err.println(s"Ignoring $ex while removing $tmpDir0")
       }
-    }
+    try f(tmpDir0)
+    finally removeAll()
   }
 
   private def tmpDir: os.Path = {

--- a/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
@@ -236,10 +236,8 @@ class NativePackagerTests extends munit.FunSuite {
           val output = os.proc("docker", "run", expectedImage).call(cwd = os.root).out.text.trim
           expect(output == message)
         }
-        finally {
-          // clear
-          os.proc("docker", "rmi", "-f", expectedImage).call(cwd = os.root)
-        }
+        // clear
+        finally os.proc("docker", "rmi", "-f", expectedImage).call(cwd = os.root)
       }
 
     def runJsTest(): Unit =
@@ -275,10 +273,8 @@ class NativePackagerTests extends munit.FunSuite {
           expect(output == message)
 
         }
-        finally {
-          // clear
-          os.proc("docker", "rmi", "-f", expectedImage).call(cwd = os.root)
-        }
+        // clear
+        finally os.proc("docker", "rmi", "-f", expectedImage).call(cwd = os.root)
       }
 
     def runNativeTest(): Unit =
@@ -315,10 +311,8 @@ class NativePackagerTests extends munit.FunSuite {
           expect(output == message)
 
         }
-        finally {
-          // clear
-          os.proc("docker", "rmi", "-f", expectedImage).call(cwd = os.root)
-        }
+        // clear
+        finally os.proc("docker", "rmi", "-f", expectedImage).call(cwd = os.root)
       }
 
     test("building docker image") {

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -178,10 +178,7 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
         zf = new ZipFile(launcher.toIO)
         expect(zf.getEntry("cats/kernel/Monoid.class") != null)
       }
-      finally {
-        if (zf != null)
-          zf.close()
-      }
+      finally if (zf != null) zf.close()
 
       val runnableLauncher =
         if (Properties.isWin) {

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -431,7 +431,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
              |${tab}at scala.sys.package$$.error(package.scala:30)
              |${tab}at Throws$$.something(Throws.scala:3)
              |${tab}at Throws$$.main(Throws.scala:5)
-             |${tab}... 1 more
+             |$tab... 1 more
              |""".stripMargin.linesIterator.toVector
         else if (actualScalaVersion.startsWith("2.13."))
           s"""Exception in thread "main" java.lang.Exception: Caught exception during processing
@@ -441,7 +441,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
              |${tab}at scala.sys.package$$.error(package.scala:27)
              |${tab}at Throws$$.something(Throws.scala:3)
              |${tab}at Throws$$.main(Throws.scala:5)
-             |${tab}... 1 more
+             |$tab... 1 more
              |""".stripMargin.linesIterator.toVector
         else
           s"""Exception in thread main: java.lang.Exception: Caught exception during processing
@@ -492,24 +492,24 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
              |Caused by: java.lang.Exception: Caught exception during processing
              |${tab}at throws$$.<init>(throws.sc:6)
              |${tab}at throws$$.<clinit>(throws.sc)
-             |${tab}... 1 more
+             |$tab... 1 more
              |Caused by: java.lang.RuntimeException: nope
              |${tab}at scala.sys.package$$.error(package.scala:30)
              |${tab}at throws$$.something(throws.sc:2)
              |${tab}at throws$$.<init>(throws.sc:3)
-             |${tab}... 2 more
+             |$tab... 2 more
              |""".stripMargin.linesIterator.toVector
         else
           s"""Exception in thread "main" java.lang.ExceptionInInitializerError
              |${tab}at throws.main(throws.sc)
              |Caused by: java.lang.Exception: Caught exception during processing
              |${tab}at throws$$.<clinit>(throws.sc:6)
-             |${tab}... 1 more
+             |$tab... 1 more
              |Caused by: java.lang.RuntimeException: nope
              |${tab}at scala.sys.package$$.error(package.scala:27)
              |${tab}at throws$$.something(throws.sc:2)
              |${tab}at throws$$.<clinit>(throws.sc:3)
-             |${tab}... 1 more
+             |$tab... 1 more
              |""".stripMargin.linesIterator.toVector
       if (exceptionLines != expectedLines) {
         pprint.log(exceptionLines)
@@ -556,12 +556,12 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
            |${tab}at throws.main(throws.sc)
            |Caused by: java.lang.Exception: Caught exception during processing
            |${tab}at throws$$.<clinit>(throws.sc:8)
-           |${tab}... 1 more
+           |$tab... 1 more
            |Caused by: java.lang.RuntimeException: nope
            |${tab}at scala.sys.package$$.error(package.scala:27)
            |${tab}at throws$$.something(throws.sc:3)
            |${tab}at throws$$.<clinit>(throws.sc:5)
-           |${tab}... 1 more
+           |$tab... 1 more
            |""".stripMargin.linesIterator.toVector
       expect(exceptionLines == expectedLines)
     }
@@ -951,9 +951,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
         val classDirAfter = os.Path(run(), os.pwd)
         expect(!classDirAfter.startsWith(root))
       }
-      finally {
-        os.perms.set(root / "dir", "rwxr-xr-x")
-      }
+      finally os.perms.set(root / "dir", "rwxr-xr-x")
     }
   }
   if (!Properties.isWin)

--- a/modules/runner/src/main/scala/scala/cli/runner/StackTracePrinter.scala
+++ b/modules/runner/src/main/scala/scala/cli/runner/StackTracePrinter.scala
@@ -73,7 +73,7 @@ final case class StackTracePrinter(
           else if (elem.getFileName == null) "Unknown Source"
           else if (elem.getLineNumber >= 0) s"${elem.getFileName}:${elem.getLineNumber}"
           else elem.getFileName
-        val str = s"${bold}${elem.getClassName}.${elem.getMethodName}$reset" +
+        val str = s"$bold${elem.getClassName}.${elem.getMethodName}$reset" +
           s"$gray($reset$location$gray)$reset"
         System.err.println(s"\t${gray}at$reset $str")
       }

--- a/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyFormat.scala
+++ b/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyFormat.scala
@@ -31,10 +31,9 @@ object TastyFormat {
     compilerExperimental: Int
   ): Boolean =
     fileMajor == compilerMajor && {
-      if (fileExperimental == compilerExperimental) {
+      if (fileExperimental == compilerExperimental)
         if (compilerExperimental == 0) fileMinor <= compilerMinor
         else fileMinor == compilerMinor
-      }
       else
         fileExperimental == 0 && fileMinor < compilerMinor
     }

--- a/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyHeaderUnpickler.scala
+++ b/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyHeaderUnpickler.scala
@@ -62,11 +62,9 @@ class TastyHeaderUnpickler(reader: TastyReader) {
           val producedByAddendum =
             s"\nThe TASTy file was produced by $toolingVersion.$toolingAddendum"
           val msg =
-            (
-              if (fileExperimental != 0) unstableAddendum
-              else if (fileMajor < MajorVersion) backIncompatAddendum
-              else forwardIncompatAddendum
-            )
+            if (fileExperimental != 0) unstableAddendum
+            else if (fileMajor < MajorVersion) backIncompatAddendum
+            else forwardIncompatAddendum
           signature + msg + producedByAddendum
         }
       )

--- a/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyUnpickler.scala
+++ b/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyUnpickler.scala
@@ -47,9 +47,8 @@ private class TastyUnpickler(reader: TastyReader) { self =>
     val ref = readInt()
     if (ref < 0)
       Left(ref.abs)
-    else {
+    else
       Right(ErasedTypeRef(nameTable(NameRef(ref))))
-    }
   }
 
   private def readNameContents(): (TastyName, Bytes) = {

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
@@ -64,10 +64,7 @@ object AsmTestRunner {
       val reader = new asm.ClassReader(is0)
       reader.accept(checker, 0)
     }
-    finally {
-      if (is0 != null)
-        is0.close()
-    }
+    finally if (is0 != null) is0.close()
 
     val isModule              = className.endsWith("$")
     val hasPublicConstructors = checker.publicConstructorCount > 0
@@ -117,10 +114,7 @@ object AsmTestRunner {
           .toVector // fully consume stream before closing it
           .iterator
       }
-      finally {
-        if (stream != null)
-          stream.close()
-      }
+      finally if (stream != null) stream.close()
     }
     else if (keepJars && Files.isRegularFile(classPathEntry)) {
       import java.util.zip._
@@ -146,18 +140,12 @@ object AsmTestRunner {
               def openStream() = new ByteArrayInputStream(baos.toByteArray)
               (clsName, openStream _)
             }
-            finally {
-              if (is != null)
-                is.close()
-            }
+            finally if (is != null) is.close()
           }
           .toVector // fully consume ZipFile before closing it
           .iterator
       }
-      finally {
-        if (zf != null)
-          zf.close()
-      }
+      finally if (zf != null) zf.close()
     }
     else Iterator.empty
 
@@ -191,16 +179,10 @@ object AsmTestRunner {
             }) baos.write(buf, 0, read)
             baos.toByteArray
           }
-          finally {
-            if (is != null)
-              is.close()
-          }
+          finally if (is != null) is.close()
         }
       }
-      finally {
-        if (zf != null)
-          zf.close()
-      }
+      finally if (zf != null) zf.close()
     }
     else None
 
@@ -251,10 +233,7 @@ object AsmTestRunner {
             val reader = new asm.ClassReader(is0)
             reader.accept(checker, 0)
           }
-          finally {
-            if (is0 != null)
-              is0.close()
-          }
+          finally if (is0 != null) is0.close()
           val isFramework = parentInspector.allParents(name).contains("sbt/testing/Framework")
           if (isFramework && !checker.isAbstract && checker.publicConstructorCount == 1)
             Iterator(name)

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
@@ -66,10 +66,7 @@ object DynamicTestRunner {
           .toVector // fully consume stream before closing it
           .iterator
       }
-      finally {
-        if (stream != null)
-          stream.close()
-      }
+      finally if (stream != null) stream.close()
     }
     else if (keepJars && Files.isRegularFile(classPathEntry)) {
       import java.util.zip._
@@ -84,10 +81,7 @@ object DynamicTestRunner {
           .toVector // full consume ZipFile before closing it
           .iterator
       }
-      finally {
-        if (zf != null)
-          zf.close()
-      }
+      finally if (zf != null) zf.close()
     }
     else Iterator.empty
 

--- a/project/publish.sc
+++ b/project/publish.sc
@@ -11,8 +11,8 @@ import scala.concurrent.duration._
 def ghOrg  = "Virtuslab"
 def ghName = "scala-cli"
 
-private def computePublishVersion(state: VcsState, simple: Boolean): String = {
-  if (state.commitsSinceLastTag > 0) {
+private def computePublishVersion(state: VcsState, simple: Boolean): String =
+  if (state.commitsSinceLastTag > 0)
     if (simple) {
       val versionOrEmpty = state.lastTag
         .filter(_ != "latest")
@@ -46,13 +46,11 @@ private def computePublishVersion(state: VcsState, simple: Boolean): String = {
       if (idx >= 0) rawVersion.take(idx) + "+" + rawVersion.drop(idx + 1) + "-SNAPSHOT"
       else rawVersion
     }
-  }
   else
     state
       .lastTag
       .getOrElse(state.format())
       .stripPrefix("v")
-}
 
 def finalPublishVersion = {
   val isCI = System.getenv("CI") != null

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -63,12 +63,11 @@ def platformSuffix: String = {
 
 def localRepoResourcePath = "local-repo.zip"
 
-def getGhToken(): String = {
+def getGhToken(): String =
   Option(System.getenv("UPLOAD_GH_TOKEN"))
     .getOrElse {
       sys.error("UPLOAD_GH_TOKEN not set")
     }
-}
 
 trait CliLaunchers extends SbtModule { self =>
 
@@ -213,7 +212,7 @@ trait CliLaunchers extends SbtModule { self =>
 
     T {
       mill.define.Target.traverse(allModuleDeps(this :: Nil).distinct)(m =>
-        T.task { m.jar() }
+        T.task(m.jar())
       )()
     }
   }
@@ -313,14 +312,13 @@ trait CliLaunchers extends SbtModule { self =>
   def standaloneLauncher = T {
 
     val cachePath = os.Path(coursier.cache.FileCache().location, os.pwd)
-    def urlOf(path: os.Path): Option[String] = {
+    def urlOf(path: os.Path): Option[String] =
       if (path.startsWith(cachePath)) {
         val segments = path.relativeTo(cachePath).segments
         val url      = segments.head + "://" + segments.tail.mkString("/")
         Some(url)
       }
       else None
-    }
 
     import coursier.launcher.{
       AssemblyGenerator,


### PR DESCRIPTION
This enables
- `RedundantBraces`
- `RedundantParens`
- `SortModifiers`

~I'm not too happy with how `RedundantBraces` handles `try`, `finally`, and `yield` blocks, so I'm not sure we want to merge this right now (maybe we can enable only the two other rules first).~ (a few `// format: off` or manual reflowing of the code just do)