### PR TITLE
Tweak build for aarch64 (raspberrypi 4)

### DIFF
--- a/modules/cli/src/main/java/scala/cli/internal/IpcsocketUnixFeature.java
+++ b/modules/cli/src/main/java/scala/cli/internal/IpcsocketUnixFeature.java
@@ -1,5 +1,7 @@
 package scala.cli.internal;
 
+import java.util.Locale;
+
 import com.oracle.svm.core.annotate.AutomaticFeature;
 import com.oracle.svm.core.jdk.NativeLibrarySupport;
 import com.oracle.svm.core.jdk.PlatformNativeLibrarySupport;
@@ -15,9 +17,13 @@ public class IpcsocketUnixFeature implements Feature {
 
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {
-        NativeLibrarySupport.singleton().preregisterUninitializedBuiltinLibrary("ipcsocket");
-        PlatformNativeLibrarySupport.singleton().addBuiltinPkgNativePrefix("org_scalasbt_ipcsocket_JNIUnixDomainSocketLibraryProvider");
-        NativeLibraries nativeLibraries = ((FeatureImpl.BeforeAnalysisAccessImpl) access).getNativeLibraries();
-        nativeLibraries.addStaticJniLibrary("ipcsocket");
+        String arch = System.getProperty("os.arch").toLowerCase(Locale.ROOT);
+        boolean isX86_64 = arch.equals("x86_64") || arch.equals("amd64");
+        if (isX86_64) {
+            NativeLibrarySupport.singleton().preregisterUninitializedBuiltinLibrary("ipcsocket");
+            PlatformNativeLibrarySupport.singleton().addBuiltinPkgNativePrefix("org_scalasbt_ipcsocket_JNIUnixDomainSocketLibraryProvider");
+            NativeLibraries nativeLibraries = ((FeatureImpl.BeforeAnalysisAccessImpl) access).getNativeLibraries();
+            nativeLibraries.addStaticJniLibrary("ipcsocket");
+        }
     }
 }

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -48,11 +48,11 @@ def platformExecutableJarExtension: String =
   if (Properties.isWin) ".bat"
   else ""
 
+lazy val arch = sys.props("os.arch").toLowerCase(java.util.Locale.ROOT) match {
+  case "amd64" => "x86_64"
+  case other   => other
+}
 def platformSuffix: String = {
-  val arch = sys.props("os.arch").toLowerCase(java.util.Locale.ROOT) match {
-    case "amd64" => "x86_64"
-    case other   => other
-  }
   val os =
     if (Properties.isWin) "pc-win32"
     else if (Properties.isLinux) "pc-linux"
@@ -156,7 +156,7 @@ trait CliLaunchers extends SbtModule { self =>
       if (Properties.isMac)
         copyIpcsocketMacATo(dir)
 
-      if (Properties.isLinux)
+      if (Properties.isLinux && arch == "x86_64")
         copyIpcsocketLinuxATo(dir)
 
       PathRef(dir)

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -224,7 +224,7 @@ trait CliLaunchers extends SbtModule { self =>
   }
 
   def nativeImage =
-    if (Properties.isLinux)
+    if (Properties.isLinux && arch == "x86_64")
       `linux-docker-image`.nativeImage
     else
       `base-image`.nativeImage


### PR DESCRIPTION
With these changes, building a native image on a Raspberry pi 4 with 8 GB of memory works (albeit slowly).