### PR TITLE
Disable checking if the file already exists in docker package

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -242,7 +242,7 @@ object Package extends ScalaCommand[PackageOptions] {
             ).build()
         }
       case PackageType.Docker =>
-        docker(inputs, build, mainClass(), () => alreadyExistsCheck(), logger)
+        docker(inputs, build, mainClass(), logger)
     }
 
     if (!build.options.packageOptions.isDockerEnabled) {
@@ -342,10 +342,9 @@ object Package extends ScalaCommand[PackageOptions] {
     inputs: Inputs,
     build: Build.Successful,
     mainClass: String,
-    alreadyExistsCheck: () => Unit,
     logger: Logger
   ): Unit = {
-    if (Properties.isMac || Properties.isWin) {
+    if (build.options.scalaNativeOptions.enable && (Properties.isMac || Properties.isWin)) {
       System.err.println(
         "Package scala native application to docker image is not supported on MacOs and Windows"
       )
@@ -382,7 +381,7 @@ object Package extends ScalaCommand[PackageOptions] {
     if (build.options.scalaJsOptions.enable) buildJs(build, appPath, mainClass)
     else if (build.options.scalaNativeOptions.enable)
       buildNative(inputs, build, appPath, mainClass, logger)
-    else bootstrap(build, appPath, mainClass, alreadyExistsCheck)
+    else bootstrap(build, appPath, mainClass, () => false)
 
     logger.message(
       "Started building docker image with your application, it would take some time"


### PR DESCRIPTION
We use the `bootstrap` file to generate the docker image. This file is saved in the `tmp` directory, so there is no need to check if the file already exists as this directory is randomly generated each time.