### PR TITLE
Fix CI - head_ref return empty string on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
`github.head_ref` only returns a non-empty value for pull request events, therefore master was [corrupted](https://github.com/VirtusLab/scala-cli/actions/runs/1294281003) by an empty value for the `group` parameter in `concurrency`.

Using github.ref should fix it because it return the branch name or tag ref that triggered the workflow