### PR TITLE
Do not automatically cancel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 
 concurrency:
   group: ${{ github.head_ref }}
-  cancel-in-progress: true
 
 jobs:
   jvm-tests:


### PR DESCRIPTION
This led to misleading red builds of commits in master branch