### PR TITLE
Allow shebangs and using directives in scripts

### DIFF
--- a/modules/build/src/main/scala/scala/build/preprocessing/TemporaryDirectivesParser.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/TemporaryDirectivesParser.scala
@@ -67,9 +67,9 @@ object TemporaryDirectivesParser {
   }
 
   def parseDirectives(content: String): Option[(List[Directive], Option[String])] = {
-
+    val content0 = content.trim()
     def helper(fromIndex: Int, acc: List[Directive]): (List[Directive], Int) =
-      parseDirective(content, fromIndex) match {
+      parseDirective(content0, fromIndex) match {
         case None                  => (acc.reverse, fromIndex)
         case Some((dir, newIndex)) => helper(newIndex, dir.toList ::: acc)
       }
@@ -86,8 +86,8 @@ object TemporaryDirectivesParser {
         if (onlyCommentedDirectives) None
         else
           Some {
-            content.take(codeStartsAt).map(c => if (c.isControl) c else ' ') ++
-              content.drop(codeStartsAt)
+            content0.take(codeStartsAt).map(c => if (c.isControl) c else ' ') ++
+              content0.drop(codeStartsAt)
           }
       Some((directives, updatedContentOpt))
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -234,6 +234,32 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
 
+  test("Scripts may contain whitespace before using directives") {
+    val inputs = TestInputs(
+      Seq(os.rel / "print.sc" ->
+        s"""
+           |using com.lihaoyi::pprint:${Constants.pprintVersion}
+           |println("Foo")""".stripMargin)
+    )
+    inputs.fromRoot { root =>
+      os.proc(TestUtil.cli, extraOptions, root / "print.sc").call(cwd = root)
+    }
+  }
+
+  test("Scripts with shebangs work".only) {
+    val inputs = TestInputs(
+      Seq(os.rel / "print.sc" ->
+        s"""|#!/usr/bin/env ${TestUtil.cli.last}
+            |using com.lihaoyi::pprint:${Constants.pprintVersion}
+            |println("Foo")""".stripMargin)
+    )
+
+    inputs.fromRoot { root =>
+      os.perms.set(root / "print.sc", "r-x------")
+      os.proc(root / "print.sc", extraOptions).call(cwd = root)
+    }
+  }
+
   test("Pass arguments") {
     val inputs = TestInputs(
       Seq(


### PR DESCRIPTION
Previously, shebangs were replaced whith empty strings what resulted
with whitespace lines before the `using` directive. Now, we ignore
whitespaces in the beginning and in the end while running scripts.