### PR TITLE
Download inputs each time

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SharedOptions.scala
@@ -12,8 +12,8 @@ import scala.build.blooprifle.BloopRifleConfig
 import scala.build.internal.Constants
 import scala.build.options._
 import scala.build.{Inputs, LocalRepo, Logger, Os, Positioned}
+import scala.concurrent.duration._
 import scala.util.Properties
-
 // format: off
 final case class SharedOptions(
   @Recurse
@@ -193,7 +193,7 @@ final case class SharedOptions(
     val download: String => Either[String, Array[Byte]] = { url =>
       val artifact = Artifact(url).withChanging(true)
       val res = coursierCache.logger.use {
-        coursierCache.file(artifact).run.unsafeRun()(coursierCache.ec)
+        coursierCache.withTtl(0.seconds).file(artifact).run.unsafeRun()(coursierCache.ec)
       }
       res
         .left.map(_.describe)


### PR DESCRIPTION
Not sure yet, but looks like this change causes:
1. Inputs are downloaded each time
2. If download fails, coursier gets input from cache