### PR TITLE
Add support for running and debugging main classes in Metals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out/
 .vscode/
 .scala
 .bsp
+.idea/

--- a/modules/bloop-rifle/src/main/scala/scala/build/bloop/BuildServer.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/bloop/BuildServer.scala
@@ -2,4 +2,7 @@ package scala.build.bloop
 
 import ch.epfl.scala.bsp4j
 
+import scala.build.bsp.ScalaDebugServer
+
 trait BuildServer extends bsp4j.BuildServer with bsp4j.ScalaBuildServer with bsp4j.JavaBuildServer
+    with ScalaDebugServer

--- a/modules/bloop-rifle/src/main/scala/scala/build/bloop/ScalaDebugServer.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/bloop/ScalaDebugServer.scala
@@ -1,0 +1,11 @@
+package scala.build.bsp;
+
+import ch.epfl.scala.bsp4j.{DebugSessionAddress, DebugSessionParams}
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
+
+import java.util.concurrent.CompletableFuture;
+
+trait ScalaDebugServer {
+  @JsonRequest("debugSession/start")
+  def buildTargetDebugSession(params: DebugSessionParams): CompletableFuture[DebugSessionAddress]
+}

--- a/modules/bloop-rifle/src/main/scala/scala/build/bloop/ScalaDebugServerForwardStubs.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/bloop/ScalaDebugServerForwardStubs.scala
@@ -1,0 +1,13 @@
+package scala.build.bsp
+
+import ch.epfl.scala.{bsp4j => b}
+
+import java.util.concurrent.CompletableFuture
+
+trait ScalaDebugServerForwardStubs extends ScalaDebugServer {
+  protected def forwardTo: ScalaDebugServer
+  override def buildTargetDebugSession(
+    params: b.DebugSessionParams
+  ): CompletableFuture[b.DebugSessionAddress] =
+    forwardTo.buildTargetDebugSession(params)
+}

--- a/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
@@ -10,10 +10,11 @@ import scala.concurrent.{Future, Promise}
 import scala.jdk.CollectionConverters._
 
 class BspServer(
-  bloopServer: b.BuildServer with b.ScalaBuildServer with b.JavaBuildServer,
+  bloopServer: b.BuildServer with b.ScalaBuildServer with b.JavaBuildServer with ScalaDebugServer,
   compile: (() => CompletableFuture[b.CompileResult]) => CompletableFuture[b.CompileResult],
   logger: Logger
 ) extends b.BuildServer with b.ScalaBuildServer with b.JavaBuildServer with BuildServerForwardStubs
+    with ScalaDebugServerForwardStubs
     with ScalaBuildServerForwardStubs with JavaBuildServerForwardStubs with HasGeneratedSources {
 
   private var extraDependencySources: Seq[os.Path] = Nil
@@ -163,8 +164,9 @@ class BspServer(
       for (target <- res0.getTargets.asScala) {
         val capabilities = target.getCapabilities
         // TODO Re-enable once we support this via BSP
-        capabilities.setCanRun(false)
-        capabilities.setCanTest(false)
+        capabilities.setCanDebug(true)
+        capabilities.setCanRun(true)
+        capabilities.setCanTest(true)
       }
       res0
     }

--- a/modules/build/src/main/scala/scala/build/bsp/BuildServerForwardStubs.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BuildServerForwardStubs.scala
@@ -1,5 +1,6 @@
 package scala.build.bsp
 
+import ch.epfl.scala.bsp4j.{DependencyModulesParams, DependencyModulesResult}
 import ch.epfl.scala.{bsp4j => b}
 
 import java.util.concurrent.CompletableFuture
@@ -36,4 +37,7 @@ trait BuildServerForwardStubs extends b.BuildServer {
     forwardTo.workspaceBuildTargets()
   override def workspaceReload(): CompletableFuture[Object] =
     forwardTo.workspaceReload()
+  override def buildTargetDependencyModules(params: DependencyModulesParams)
+    : CompletableFuture[DependencyModulesResult] =
+    forwardTo.buildTargetDependencyModules(params)
 }

--- a/modules/build/src/main/scala/scala/build/bsp/LoggingBuildServer.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/LoggingBuildServer.scala
@@ -1,5 +1,6 @@
 package scala.build.bsp
 
+import ch.epfl.scala.bsp4j.{DependencyModulesParams, DependencyModulesResult}
 import ch.epfl.scala.{bsp4j => b}
 
 import java.util.concurrent.CompletableFuture
@@ -44,4 +45,7 @@ trait LoggingBuildServer extends b.BuildServer {
     underlying.workspaceBuildTargets().logF
   override def workspaceReload(): CompletableFuture[Object] =
     underlying.workspaceReload().logF
+  override def buildTargetDependencyModules(params: DependencyModulesParams)
+    : CompletableFuture[DependencyModulesResult] =
+    underlying.buildTargetDependencyModules(pprint.stderr.log(params)).logF
 }

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -47,7 +47,7 @@ object Deps {
   def ammonite          = ivy"com.lihaoyi:::ammonite:2.4.0-23-76673f7f"
   def asm               = ivy"org.ow2.asm:asm:9.1"
   def bloopConfig       = ivy"ch.epfl.scala::bloop-config:1.4.8-124-49a6348a"
-  def bsp4j             = ivy"ch.epfl.scala:bsp4j:2.0.0-M13"
+  def bsp4j             = ivy"ch.epfl.scala:bsp4j:2.0.0-M14"
   def caseApp           = ivy"com.github.alexarchambault::case-app:2.1.0-M7"
   def collectionCompat  = ivy"org.scala-lang.modules::scala-collection-compat:2.5.0"
   def coursierJvm       = ivy"io.get-coursier::coursier-jvm:${Versions.coursier}"


### PR DESCRIPTION
We added support for [Debugging Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/). It allows to run and debug main classes in scala-cli project in VSCode. 

There is still missing support for test classes, it will be added in next PR.