### PR TITLE
Make scala-cli.sh more reliable

### DIFF
--- a/scala-cli.sh
+++ b/scala-cli.sh
@@ -29,7 +29,13 @@ if [ ! -f "$CACHE_DEST" ]; then
   echo "Downloading $SCALA_CLI_URL"
   curl -fLo "$TMP_DEST" "$SCALA_CLI_URL"
   mv "$TMP_DEST" "$CACHE_DEST"
+fi
+
+if [ ! -f "$SCALA_CLI_BIN_PATH" ]; then
   gunzip -k "$CACHE_DEST"
+fi
+
+if [ ! -x "$SCALA_CLI_BIN_PATH" ]; then
   chmod +x "$SCALA_CLI_BIN_PATH"
 fi
 


### PR DESCRIPTION
The .gz file we download might already be in cache (downloaded manually by users say), while the uncompressed launcher can be missing.

These changes make sure we uncompress the .gz file if needed, even if it was already in cache.