### PR TITLE
Post processors can now report warning.

### DIFF
--- a/modules/build/src/main/scala/scala/build/postprocessing/ByteCodePostProcessor.scala
+++ b/modules/build/src/main/scala/scala/build/postprocessing/ByteCodePostProcessor.scala
@@ -1,6 +1,7 @@
 package scala.build.postprocessing
 
 import scala.build.{GeneratedSource, Logger}
+import scala.util.{Either, Right}
 
 case object ByteCodePostProcessor extends PostProcessor {
   def postProcess(
@@ -8,7 +9,8 @@ case object ByteCodePostProcessor extends PostProcessor {
     mappings: Map[String, (String, Int)],
     workspace: os.Path,
     output: os.Path,
-    logger: Logger
-  ): Unit =
-    AsmPositionUpdater.postProcess(mappings, output, logger)
+    logger: Logger,
+    scalaVersion: String
+  ): Either[String, Unit] =
+    Right(AsmPositionUpdater.postProcess(mappings, output, logger))
 }

--- a/modules/build/src/main/scala/scala/build/postprocessing/PostProcessor.scala
+++ b/modules/build/src/main/scala/scala/build/postprocessing/PostProcessor.scala
@@ -8,6 +8,7 @@ trait PostProcessor {
     mappings: Map[String, (String, Int)],
     workspace: os.Path,
     output: os.Path,
-    logger: Logger
-  ): Unit
+    logger: Logger,
+    scalaVersion: String
+  ): Either[String, Unit]
 }

--- a/modules/build/src/main/scala/scala/build/postprocessing/SemanticDbPostProcessor.scala
+++ b/modules/build/src/main/scala/scala/build/postprocessing/SemanticDbPostProcessor.scala
@@ -4,15 +4,16 @@ import java.nio.file.FileSystemException
 
 import scala.annotation.tailrec
 import scala.build.{GeneratedSource, Logger}
-
+import scala.util.{Either, Right}
 case object SemanticDbPostProcessor extends PostProcessor {
   def postProcess(
     generatedSources: Seq[GeneratedSource],
     mappings: Map[String, (String, Int)],
     workspace: os.Path,
     output: os.Path,
-    logger: Logger
-  ): Unit = {
+    logger: Logger,
+    scalaVersion: String
+  ): Either[String, Unit] = Right {
     logger.debug("Moving semantic DBs around")
     val semDbRoot = output / "META-INF" / "semanticdb"
     for (source <- generatedSources; originalSource <- source.reportingPath) {

--- a/modules/build/src/main/scala/scala/build/postprocessing/TastyPostProcessor.scala
+++ b/modules/build/src/main/scala/scala/build/postprocessing/TastyPostProcessor.scala
@@ -1,18 +1,21 @@
 package scala.build.postprocessing
 
-import scala.build.tastylib.TastyData
+import scala.build.internal.Constants
+import scala.build.tastylib.{TastyData, TastyVersions}
 import scala.build.{GeneratedSource, Logger}
 
 case object TastyPostProcessor extends PostProcessor {
+
   def postProcess(
     generatedSources: Seq[GeneratedSource],
     mappings: Map[String, (String, Int)],
     workspace: os.Path,
     output: os.Path,
-    logger: Logger
-  ): Unit = {
+    logger: Logger,
+    scalaVersion: String
+  ): Either[String, Unit] = {
 
-    val updatedPaths = generatedSources
+    def updatedPaths = generatedSources
       .flatMap { source =>
         source.reportingPath.toOption.toSeq.map { originalSource =>
           val fromSourceRoot = source.generated.relativeTo(workspace)
@@ -22,32 +25,45 @@ case object TastyPostProcessor extends PostProcessor {
       }
       .toMap
 
-    if (updatedPaths.nonEmpty)
-      os.walk(output)
-        .filter(os.isFile(_))
-        .filter(_.last.endsWith(".tasty")) // make that case-insensitive just in case?
-        .foreach { f =>
-          logger.debug(s"Reading TASTy file $f")
-          val content = os.read.bytes(f)
-          val data    = TastyData.read(content)
-          logger.debug(s"Parsed TASTy file $f")
-          var updatedOne = false
-          val updatedData = data.mapNames { n =>
-            updatedPaths.get(n) match {
-              case Some(newName) =>
-                updatedOne = true
-                newName
-              case None =>
-                n
-            }
-          }
-          if (updatedOne) {
-            logger.debug(
-              s"Overwriting ${if (f.startsWith(os.pwd)) f.relativeTo(os.pwd) else f}"
-            )
-            val updatedContent = TastyData.write(updatedData)
-            os.write.over(f, updatedContent)
-          }
-        }
+    TastyVersions.shouldRunPreprocessor(scalaVersion, Constants.version) match {
+      case Right(false) => Right(())
+      case Left(msg)    => if (updatedPaths.isEmpty) Right(()) else Left(msg)
+      case Right(true) =>
+        val paths = updatedPaths
+        if (paths.isEmpty) Right(())
+        else Right(
+          os.walk(output)
+            .filter(os.isFile(_))
+            .filter(_.last.endsWith(".tasty")) // make that case-insensitive just in case?
+            .foreach(updateTastyFile(logger, paths))
+        )
+    }
+  }
+
+  private def updateTastyFile(
+    logger: Logger,
+    updatedPaths: Map[String, String]
+  )(f: os.Path): Unit = {
+    logger.debug(s"Reading TASTy file $f")
+    val content = os.read.bytes(f)
+    val data    = TastyData.read(content)
+    logger.debug(s"Parsed TASTy file $f")
+    var updatedOne = false
+    val updatedData = data.mapNames { n =>
+      updatedPaths.get(n) match {
+        case Some(newName) =>
+          updatedOne = true
+          newName
+        case None =>
+          n
+      }
+    }
+    if (updatedOne) {
+      logger.debug(
+        s"Overwriting ${if (f.startsWith(os.pwd)) f.relativeTo(os.pwd) else f}"
+      )
+      val updatedContent = TastyData.write(updatedData)
+      os.write.over(f, updatedContent)
+    }
   }
 }

--- a/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyFormat.scala
+++ b/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyFormat.scala
@@ -18,10 +18,6 @@ object TastyFormat {
 
   final val header: Array[Int] = Array(0x5c, 0xa1, 0xab, 0x1f)
 
-  final val MajorVersion: Int        = 28
-  final val MinorVersion: Int        = 1
-  final val ExperimentalVersion: Int = 0
-
   def isVersionCompatible(
     fileMajor: Int,
     fileMinor: Int,

--- a/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyHeaderUnpickler.scala
+++ b/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyHeaderUnpickler.scala
@@ -16,7 +16,8 @@ package scala.build.tastylib
 
 import java.util.UUID
 
-import scala.build.tastylib.TastyFormat.{ExperimentalVersion, MajorVersion, MinorVersion, header}
+import scala.build.tastylib.TastyFormat.header
+import scala.build.tastylib.TastyVersions.{ExperimentalVersion, MajorVersion, MinorVersion}
 
 class TastyHeaderUnpickler(reader: TastyReader) {
   import TastyHeaderUnpickler._

--- a/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyVersions.scala
+++ b/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyVersions.scala
@@ -16,7 +16,7 @@ object TastyVersions {
     scalaVersion: String,
     scalaCliVersion: String
   ): Either[String, Boolean] =
-    if (!scalaVersion.startsWith("3.")) Right(false)
+    if (!scalaVersion.startsWith("3.") && scalaVersion != "3" ) Right(false)
     else
       scalaVersion.split('.')(1).toInt match {
         case scalaMinor if scalaMinor > LatestSupportedScala.MinorVersion =>

--- a/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyVersions.scala
+++ b/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyVersions.scala
@@ -1,0 +1,32 @@
+package scala.build.tastylib
+
+object TastyVersions {
+
+  // Every time tasty version is updated, please update LatestSupportedScala as well!
+  final val MajorVersion: Int        = 28
+  final val MinorVersion: Int        = 1
+  final val ExperimentalVersion: Int = 0
+
+  object LatestSupportedScala {
+    final val MajorVersion: Int = 3
+    final val MinorVersion: Int = 1
+  }
+
+  def shouldRunPreprocessor(
+    scalaVersion: String,
+    scalaCliVersion: String
+  ): Either[String, Boolean] =
+    if (!scalaVersion.startsWith("3.")) Right(false)
+    else
+      scalaVersion.split('.')(1).toInt match {
+        case scalaMinor if scalaMinor > LatestSupportedScala.MinorVersion =>
+          Left(
+            s"Scala CLI (v. $scalaCliVersion) cannot post process TASTY files from Scala $scalaVersion.\n" +
+              s"This is not a fatal error since post processing only cleans up source paths in TASTY file " +
+              s"and it should not affect your application.\n" +
+              s"To get rid of this message, please update Scala CLI version."
+          )
+        case _ =>
+          Right(true)
+      }
+}


### PR DESCRIPTION
We report such warnings and skip processing of TASTY files when we face a Scala Version with newer Tasty than we know we support.