### PR TITLE
Scala Native 0.4.1

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -38,7 +38,7 @@ object Deps {
 
     def scalaJs       = "1.5.1"
     def scalaMeta     = "4.4.28"
-    def scalaNative   = "0.4.0"
+    def scalaNative   = "0.4.1"
     def scalaPackager = "0.1.24"
   }
   def ammonite          = ivy"com.lihaoyi:::ammonite:2.4.0-23-76673f7f"


### PR DESCRIPTION
See #261 for details.

This is only a temporary solution, 0.4.1 will be able to read 0.4.0's IR, but the full solution should remove SN dependency from CLI's own build somehow.
