### PR TITLE
fix: stick to a tcp connection for Bloop on non standard OS's.

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/SharedCompilationServerOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SharedCompilationServerOptions.scala
@@ -148,8 +148,11 @@ final case class SharedCompilationServerOptions(
         Some(() => BspConnectionAddress.WindowsNamedPipe(bspPipeName()))
       else
         Some(() => BspConnectionAddress.UnixDomainSocket(bspSocketFile(directories)))
+
+    // FreeBSD throws a java.lang.UnsatisfiedLinkError when trying the
+    // UnixDomainSocket, so stick with TCP
     def default =
-      if (isGraalvmNativeImage && arch != "x86_64")
+      if ((isGraalvmNativeImage && arch != "x86_64") || Properties.osName == "FreeBSD")
         None // tcp
       else
         namedSocket

--- a/modules/cli/src/main/scala/scala/cli/commands/SharedCompilationServerOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SharedCompilationServerOptions.scala
@@ -149,10 +149,11 @@ final case class SharedCompilationServerOptions(
       else
         Some(() => BspConnectionAddress.UnixDomainSocket(bspSocketFile(directories)))
 
-    // FreeBSD throws a java.lang.UnsatisfiedLinkError when trying the
-    // UnixDomainSocket, so stick with TCP
+    // FreeBSD and others throw a java.lang.UnsatisfiedLinkError when trying the
+    // UnixDomainSocket, because of the ipcsocket JNI stuff, so stick with TCP for them.
+    def isStandardOs = Properties.isLinux || Properties.isWin || Properties.isMac
     def default =
-      if ((isGraalvmNativeImage && arch != "x86_64") || Properties.osName == "FreeBSD")
+      if ((isGraalvmNativeImage && arch != "x86_64") || !isStandardOs)
         None // tcp
       else
         namedSocket


### PR DESCRIPTION
I'll be honest, I haven't really dug into the JNI/JNA issues, so I'm
unsure if there is a better more appropriate to get domain sockets to
work on FreeBSD in this scenario, but when testing it with --bloop-bsp-protocol
being set to tcp it worked. So this is just a quick fix to ensure that the
default for FreeBSD for now is tcp.

Closes #271 