### PR TITLE
deps: bump Bloop to 1.4.10.

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -43,7 +43,7 @@ object Deps {
   }
   def ammonite          = ivy"com.lihaoyi:::ammonite:2.4.0-23-76673f7f"
   def asm               = ivy"org.ow2.asm:asm:9.1"
-  def bloopConfig       = ivy"ch.epfl.scala::bloop-config:1.4.8-124-49a6348a"
+  def bloopConfig       = ivy"ch.epfl.scala::bloop-config:1.4.10"
   def bsp4j             = ivy"ch.epfl.scala:bsp4j:2.0.0-M14"
   def caseApp           = ivy"com.github.alexarchambault::case-app:2.1.0-M7"
   def collectionCompat  = ivy"org.scala-lang.modules::scala-collection-compat:2.5.0"


### PR DESCRIPTION
This is mainly to avoid someone running a Snapshot of Metals, which now
needs 1.4.10 after they have ran scala-cli once meaning that scala-cli
started Bloop, which is older, they then opened metals, and then were
greeted with a warning and a message offering to re-start Bloop. I just
had this happen to me and on the Metals side we've been told this can be
confusing for users at times.

All that to say, this just bumps Bloop to the newest release