### PR TITLE
Remove deprecated bottle :unneeded

### DIFF
--- a/.github/scripts/scala-cli.rb.template
+++ b/.github/scripts/scala-cli.rb.template
@@ -9,7 +9,6 @@ class ScalaCli < Formula
   version "@LAUNCHER_VERSION@"
   sha256 "@LAUNCHER_SHA256@"
   license "Apache-2.0"
-  bottle :unneeded
 
   depends_on java: "1.8+" if MacOS.version < :catalina
   depends_on "openjdk" if MacOS.version >= :catalina


### PR DESCRIPTION
It fixes following warn in brew:
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the virtuslab/scala-cli tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/virtuslab/homebrew-scala-cli/scala-cli.rb:12
```

Based on discussion in [official brew repository](https://github.com/Homebrew/discussions/discussions/2311) we remove bottle :unneeded