### PR TITLE
Finished reviewing the Cookbook docs

### DIFF
--- a/website/docs/cookbooks/gists.md
+++ b/website/docs/cookbooks/gists.md
@@ -3,14 +3,12 @@ title: Sharing and testing code with GitHub gists
 sidebar_position: 6
 ---
 
-# Sharing and testing code with GitHub gists
-
 ## Running code from gists
 
-`scala-cli` allows running Scala code straight from GitHub gists, without the need for manually downloading them first.
-This is done by just passing the link to a gist as an argument to `scala-cli`.
+`scala-cli` lets you run Scala code straight from GitHub gists, without the need to manually download them first.
+This is done by passing the link to a gist as an argument to `scala-cli`:
 
-For example, having a given gist `https://gist.github.com/alexarchambault/7b4ec20c4033690dd750ffd601e540ec`:
+For example, given the gist `https://gist.github.com/alexarchambault/7b4ec20c4033690dd750ffd601e540ec`, which contains these two files:
 ```scala title=Messages.scala
 object Messages {
   def hello = "Hello"
@@ -19,29 +17,31 @@ object Messages {
 ```scala title=run.sc
 println(Messages.hello)
 ```
-Running in terminal
+
+You can run them with `scala-cli` like this:
 ```bash
 scala-cli https://gist.github.com/alexarchambault/7b4ec20c4033690dd750ffd601e540ec
 ```
 <!-- Expected:
 Hello
 -->
-Will print `Hello` to the standard output.
+
+This example prints `Hello` to the standard output.
 
 :::note
-Note that the gist doesn't necessarily have to be one file.
-`scala-cli` downloads the gist's archive and unzips it, so the gist can contain multiple files depending on each other.
+As shown in this example, the gist isn't limited to just one file.
+`scala-cli` downloads the gist's archive and unzips it, so the gist can contain multiple files that depend on each other.
 
-`scala-cli` also caches the project sources using `coursier`'s cache.
+`scala-cli` also caches the project sources using Coursier's cache.
 :::
 
 ## Sharing code snippets
 
 Together with the GitHub CLI (`gh`), it becomes really easy to share Scala code.
+If you want to share a code file named `file.scala`, just run this command to create the gist:
 
-If you wants to share a code file, just run:
 ```sh
 gh gist create file.scala
 ```
 
-And to run it quickly like shown above.
+Then you (and others) can run it quickly, using the `scala-cli` approach shown above.

--- a/website/docs/cookbooks/intro.md
+++ b/website/docs/cookbooks/intro.md
@@ -5,6 +5,7 @@ sidebar_position: 1
 
 # Cookbook
 
-This part contains a set of recipes how to use scala-cli in certain situations. The cookbooks are intended to provide a solution to task at hand without providing too many details.
+This section of the documentation contains a set of recipes that show how to use `scala-cli` in certain situations.
+The recipes are intended to provide a solution to the task at hand, but also without going into great detail.
 
-For more in-depth analysis please check out provided [Guides](../guides/intro.md)
+For more in-depth analysis, please check out our [Guides](../guides/intro.md)

--- a/website/docs/cookbooks/scala-docker.md
+++ b/website/docs/cookbooks/scala-docker.md
@@ -1,13 +1,11 @@
 ---
-title: Package Scala application as a docker image
+title: Packaging Scala applications as Docker images
 sidebar_position: 5
 ---
 
-# Package Scala application as a docker image
+Scala CLI can create an executable application and package it into a Docker image.
 
-ScalaCLI can create an executable application and package it into a docker image.
-
-Here is a simple piece of code that will be executed in the docker container.
+For example, here's a simple piece of code that will be executed in a Docker container:
 
 ```scala title=HelloDocker.scala
 object HelloDocker extends App {
@@ -15,9 +13,9 @@ object HelloDocker extends App {
 }
 ```
 
-Passing `--docker` to the `package` sub-command generates a docker image. The docker image name parameter `--docker-image-repository` is mandatory.
+Passing `--docker` to the `package` sub-command generates a Docker image. When creating a Docker image, the `--docker-image-repository` parameter is mandatory.
 
-The following command will generate `hello-docker` image with `latest` tag:
+The following command generates a `hello-docker` image with the `latest` tag:
 
 ```bash
 scala-cli package --docker HelloDocker.scala --docker-image-repository hello-docker
@@ -38,7 +36,8 @@ docker run hello-docker
 Hello from Docker
 -->
 
-It is also supported to package your app in `JS` or `Native` environments.
+You can also package your app in the Scala.JS or Scala Native environments.
+For example, this command creates a Scala.JS Docker image:
 
 ```bash
 scala-cli package --js --docker HelloDocker.scala --docker-image-repository hello-docker
@@ -49,8 +48,15 @@ Built docker image, run it with
   docker run hello-docker:latest
 -->
 
-Package scala native application to docker image is supported only on Linux.
+This command creates a Scala Native Docker image:
 
 ```bash ignore
 scala-cli package --native --docker HelloDocker.scala --docker-image-repository hello-docker
 ```
+
+:::note
+Packaging a Scala Native application to a Docker image is supported only on Linux.
+:::
+
+
+

--- a/website/docs/cookbooks/scala-jvm.md
+++ b/website/docs/cookbooks/scala-jvm.md
@@ -1,13 +1,12 @@
 ---
-title: Test your code with different Java versions
+title: Testing your code with different Java versions
 sidebar_position: 4
 ---
 
-# Test your code with different Java versions
+You can use Scala CLI to test your code compatibility with various versions of `java`, with a key point being that manual installation of a JDK/SDK is not required(!).
+Scala CLI automatically downloads the Java version you specify.
 
-You can use Scala CLI to test your code compatibility with various versions of `java` (no manual installation of jdk or sdk is required). It automatically downloads the specified version of Java.
-
-The following snippet uses the new method `Files.writeString` from Java 11.
+As an example, the following snippet uses the new method `Files.writeString` from Java 11:
 
 ```scala title=Main.scala
 import java.nio.file.Files
@@ -21,7 +20,7 @@ object Main extends App {
 }
 ```
 
-Pass `--jvm` to the `scala-cli` command to run your application with the specified java version.
+To use Java 11 to run this application, pass the following `--jvm` option to the `scala-cli` command:
 
 ```bash ignore
 scala-cli --jvm adopt:11 Main.scala
@@ -31,7 +30,7 @@ scala-cli --jvm adopt:11 Main.scala
 Hello from ScalaCli
 -->
 
-To test your application with Java 8, change the value of `--jvm` parameter.
+To attempt to compile the application with Java 8, change the value of the `--jvm` parameter:
 ```bash ignore fail
 scala-cli --jvm 8 Main.scala
 # In this case, it raises an error because the `Files.createTempFile` method is not available in java 8

--- a/website/docs/cookbooks/scala-package.md
+++ b/website/docs/cookbooks/scala-package.md
@@ -1,12 +1,12 @@
 ---
-title: Package Scala application as an executable file
+title: Packaging Scala applications as executable files
 sidebar_position: 2
 ---
 
-Scala CLI allows you to package your application into a lightweight JAR file, that can be easily run.
-It only contains the byte code of your sources, and automatically downloads its dependencies on its first run.
+Scala CLI lets you package your application into a lightweight JAR file that can be easily run.
+The JAR file only contains the byte code that’s generated from your source code files, and automatically downloads its dependencies on its first run.
 
-The following snippet contains a short application to detect the OS:
+As an example, the following snippet contains a short application to detect the OS:
 ```scala title=DetectOsApp.scala
 object DetectOSApp extends App  {
     def getOperatingSystem(): String = {
@@ -19,7 +19,7 @@ object DetectOSApp extends App  {
 
 ### Default format (lightweight launcher)
 
-By default, the `package` sub-command generates a lightweight JAR.
+By default, the `package` sub-command generates a lightweight JAR that contains only your bytecode. This is how you create a lightweight JAR named `DetectOsApp.jar`:
 
 ```bash
 scala-cli package DetectOsApp.scala
@@ -30,15 +30,15 @@ Wrote DetectOsApp, run it with
   ./DetectOsApp
 -->
 
-Lightweight JARs require the `java` command to be available, and access to internet if dependencies need to be downloaded.
+Lightweight JARs require the `java` command to be available, and access to the internet, if dependencies need to be downloaded. This is how you run it on macOS:
 
 ```bash
-# Run DetectOsApp on MacOs
+# Run DetectOsApp on macOS
 ./DetectOsApp
 # os: Mac OS X
 ```
 
-In the previous example, a Lightweight JAR that was built in a MacOs environment could also run on Linux.
+The lightweight JAR that was just built on macOS can also run on Linux:
 
 ```bash
 # Run DetectOsApp on Linux
@@ -46,21 +46,22 @@ In the previous example, a Lightweight JAR that was built in a MacOs environment
 # os: Linux
 ```
 
-Scala-cli supports building Lightweight JARs in the MacOS, Linux, and Windows environments.
-JARs built on macOS and Linux are portable between these two OSs. The Lightweight JARs built on Windows can only be run on Windows.
+`scala-cli` supports building Lightweight JARs in the macOS, Linux, and Windows environments.
+JARs built on macOS and Linux are portable between these two operating systems.
+Lightweight JARs built on Windows can only be run on Windows.
 
 
 ### Assemblies
-Passing `--assembly` to the `package` sub-command generates so-called "assemblies" or "fat JARs".
+Passing `--assembly` to the `package` sub-command generates so-called "assemblies," or "fat JARs":
 
 ```bash
 scala-cli package --assembly DetectOsApp.scala
 ```
 
-Assemblies also require the `java` command to be available in the `PATH`. As all dependencies are packaged into the assembly, nothing gets downloaded upon the first run and no internet access is required.
+Assemblies also require the `java` command to be available in the `PATH`. But in this case, all of the dependencies that are needed are packaged into the assembly, so nothing gets downloaded upon the first run, and no internet access is required.
 
 ```bash
-# Run DetectOsApp on MacOs
+# Run DetectOsApp on macOS
 ./DetectOsApp
 # os: Mac OS X
 ```

--- a/website/docs/cookbooks/scala-scripts.md
+++ b/website/docs/cookbooks/scala-scripts.md
@@ -1,15 +1,17 @@
 ---
-title: Use scala-cli to run Scala Scripts
+title: Using scala-cli to run Scala Scripts
 sidebar_position: 3
 ---
 
 ## Scala Scripts
 
-Scala Scripts are files containing Scala code without main method required. These codes of Scala do not require build-tools configurations. To run Scala Scripts very quickly without waiting for warn-up build-tools, you can use `scala-cli`.
+Scala scripts are files that contain Scala code without a main method.
+These source code files don't require build-tool configurations.
+To run Scala scripts very quickly without waiting the need for build tools, use `scala-cli`.
 
 ### Run
 
-You can use `scala-cli` to run Scala scripts (no further setup is required):
+For example, given this simple script:
 
 ```scala title=HelloScript.sc
 val sv = scala.util.Properties.versionNumberString
@@ -17,6 +19,8 @@ val sv = scala.util.Properties.versionNumberString
 val message = s"Hello from Scala ${sv}, Java ${System.getProperty("java.version")}"
 println(message)
 ```
+
+You can run it directly with `scala-cli` — there's no need for a build tool or additional configuration:
 
 ```bash
 scala-cli run HelloScript.sc
@@ -26,8 +30,7 @@ scala-cli run HelloScript.sc
 Hello from Scala .*, Java .*
 -->
 
-
-Alternatively, add a "shebang" header to your script, make your script executable, and execute it directly. `scala-cli` needs to be installed for this to work.
+Alternatively, you can add a "shebang" header to your script, make it executable, and execute it directly with `scala-cli`. For example, given this script with a header that invokes `scala-cli`:
 
 ```scala title=HelloScriptSheBang.sc
 #!/usr/bin/env scala-cli
@@ -41,6 +44,7 @@ def printMessage(): Unit =
 printMessage()
 ```
 
+You can make it executable and then run it like this:
 
 ```bash
 chmod +x HelloScriptSheBang.sc
@@ -52,7 +56,7 @@ chmod +x HelloScriptSheBang.sc
 Hello from Scala .*, Java .*
 -->
 
-It is also possible to pass command-line arguments to the script
+You can also pass command line arguments to Scala scripts:
 
 ```scala title=ScriptArguments.sc
 #!/usr/bin/env scala-cli
@@ -69,14 +73,16 @@ chmod +x ScriptArguments.sc
 bar
 -->
 
+As shown, command line arguments are accessed through the special `args` variable.
+
 
 ## Features
 
-All the features from non-scripts work for Scala scripts too, such as waiting for changes (watch mode), dependencies menagement, packaging, compiling and many others.
+All of the features shown for non-scripts work for Scala scripts as well, such as waiting for changes (watch mode), dependency menagement, packaging, compiling, etc.
 
 ### Package
 
-Run `package` to the Scala CLI to package your script to a lightweight executable JAR file.
+For example, run the `package` sub-command to package your script as a lightweight executable JAR file:
 
 ```bash
 scala-cli package HelloScript.sc
@@ -89,7 +95,7 @@ Hello from Scala .*, Java .*
 
 ### Watch mode
 
-Pass `--watch` to the Scala CLI to watch all sources for changes, and re-run them upon changes.
+As another example, pass `--watch` to `scala-cli` to watch all source files for changes, and then re-run them when there is a change:
 
 ```bash ignore
 scala-cli --watch HelloScript.sc

--- a/website/docs/cookbooks/scala-versions.md
+++ b/website/docs/cookbooks/scala-versions.md
@@ -1,13 +1,12 @@
 ---
-title: Picking Scala version with scala-cli
+title: Picking the Scala version with scala-cli
 sidebar_position: 2
 ---
 
-# Picking Scala version with scala-cli
+By default, `scala-cli` runs the latest stable Scala version.
 
-Scala cli by default runs latest stable Scala version.
-
-Here is an universal piece of code that detects Scala version at runtime. Code is a bit complicated so we suggest to skip reading the whole file and just focus on what it prints.
+To demonstrate how this works, here’s a universal piece of code that detects the Scala version at runtime.
+The code is a bit complicated, so we suggest that you skip reading the whole file, and just focus on what it prints:
 
 ```scala title=ScalaVersion.scala
 object ScalaVersion extends App {
@@ -41,7 +40,7 @@ object ScalaVersion extends App {
 }
 ```
 
-When run without any version provided:
+When this application is run without specifying a Scala version, it uses the latest stable release of Scala — 3.1.0 at the time of writing this doc:
 
 ```bash
 scala-cli ScalaVersion.scala
@@ -51,10 +50,7 @@ scala-cli ScalaVersion.scala
 Scala: 3\..*
 -->
 
-
-It will run using latest stable release of Scala (3.1.0 at the time of writing this doc.)
-
-Scala version can be also provided from command line using `--scala` (with `-S` and `--scala-version` aliases)
+When you want to control the Scala version, you can control it from the command line using the `--scala` option (with `-S` and `--scala-version` aliases):
 
 ```bash
 scala-cli -S 2.13.5 ScalaVersion.scala
@@ -63,9 +59,8 @@ scala-cli -S 2.13.5 ScalaVersion.scala
 Scala: 2\.13\.5
 -->
 
-In most cases we do not care for a precise Scala version and 'any Scala 2' or `2.13` is good enough for us.
-
-Scala cli accepts version prefixes so:
+In many cases you won't care for a precise Scala version and will want "any Scala 2" or "any 2.13 release."
+For this situation, `scala-cli` accepts version prefixes like this:
 
 ```bash
 scala-cli -S 2 ScalaVersion.scala
@@ -74,7 +69,7 @@ scala-cli -S 2 ScalaVersion.scala
 Scala: 2\..+
 -->
 
-will result in picking up a latest stable release for Scala 2 (`2.13.6` as of when this doc is written) and
+and this:
 
 ```bash
 scala-cli -S 2.12 ScalaVersion.scala
@@ -83,16 +78,16 @@ scala-cli -S 2.12 ScalaVersion.scala
 Scala: 2\.12\.15
 -->
 
-will use latest stable release of `2.12` `2.12.15`.
+In the first example (`-S 2`), the application picks up the latest Scala 2 stable release (`2.13.6` at the time of this writing).
+In the second example, the application picks up the latest stable release of `2.12` (which is `2.12.15` at the time of this writing).
 
-
-We can also pin the version of the language within the .scala file with `using directives`. You can read our more how using directives works in documentation and examples.
+You can also pin the version of the language within a `.scala` file with `using` directives.
 
 :::info
-Using directives syntax is still experimental and may change in future versions of scala-cli
+The `using` directives syntax is still experimental, and may change in future versions of `scala-cli`.
 :::
 
-So when we will have:
+Here’s an example of a source code file named `version.scala` that contains a `using` directive:
 
 ```scala title=version.scala
 // using scala 2.12.5
@@ -101,7 +96,7 @@ object OldCode
 //rest of the config
 ```
 
-and run
+Now when you compile that code along with the previous `ScalaVersion.scala` file:
 
 ```bash
 scala-cli ScalaVersion.scala version.scala
@@ -111,24 +106,27 @@ scala-cli ScalaVersion.scala version.scala
 Scala: 2\.12\.5
 -->
 
-We will results in using `2.12.5`.
+The output at the time of this writing is "`2.12.5`".
 
-scala-cli is command-line first so any configuration pass to command line will override using directives.
-
-So, running
+The `scala-cli` philosophy is “command line first,” so any configuration information that’s passed to the command line will override `using` directives. So when you run this command with the `-S` option:
 
 ```bash
 scala-cli -S 2.13.5 ScalaVersion.scala version.scala
 ```
 
-Will result in using `2.13.5`
+the result is "`2.13.5`" (as opposed to "`2.12.5`" in the previous example).
 
 <!-- Expected-regex:
 Scala: 2\.13\.5
 -->
 
+:::note
+See our [Using Directives Guide](../guides/using-directives.md) for more details on `using` directives.
+:::
+
+
 ## When should I provide a full version of Scala?
 
-For prototyping, scripting and other use cases that does not require to run code multiple times in the future proving version is not required.
+For prototyping, scripting, and other use cases that won’t need to be run multiple times in the future, providing a Scala version generally isn’t necessary.
 
-Scala is source and binary compatible within each major version (e.g. `2.12.x` or `3.1.x`) so providing version in `eopch.major` form (e.g. `2.12`, `2.13` or `3.1`) should be perfectly fine for most use cases. When your Scala code contains more advanced features that may be more sensitive for changes in minor version (e.g. from `2.13.4` to `2.13.5`) we recommend using complete Scala version.
+Scala is source and binary compatible within each major version (e.g., `2.12.x` or `3.1.x`) so specifying the version in `epoch.major` form (e.g., `2.12`, `2.13`, or `3.1`) should be perfectly fine for most use cases. When your Scala code contains more advanced features that may be more sensitive for changes in minor version (e.g., from `2.13.4` to `2.13.5`) we recommend specifying the complete Scala version.


### PR DESCRIPTION
Here are a few notes to go along with this review:

- scala-scripts.md: I made all occurrences of "Scala scripts" outside of the first header lowercase. I did this to be consistent, because some of them were "Scala Scripts" and others were "Scala scripts".
- Some of the files had a `#` tag for a title, and others did not. Because the `#` titles were duplicates of the `title` attribute in the header section, I removed all of the `#` title declarations, except for the one in `intro.md`, which uses `#` to have a different title than the `title` tag in the header. (I hope that’s okay, I was just trying to avoid the duplication there.)

I also find that I want to see the output of the commands. I was going to run them on my computer and add the output, but it looks like you might be planning to run the code samples with mdoc or something else, so I didn’t do that.

Thanks again, and just let me know if you have any questions or comments!