### PR TITLE
Should not re-compile project after catching exception

### DIFF
--- a/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
@@ -222,7 +222,6 @@ final class BspImpl(
               preBuildDataTest.generatedSources
             ))
           case Left((ex, scope)) =>
-            notifyBuildChange(actualLocalServer)
             Left((ex, scope))
         },
       executor


### PR DESCRIPTION
When a compile exception was caught, the function `notifyBuildChange ` was called. This caused the project to recompile and so on forever, because it never compiled properly.


