### PR TITLE
Update nix instructions

### DIFF
--- a/website/docs/_advanced_install.mdx
+++ b/website/docs/_advanced_install.mdx
@@ -138,10 +138,8 @@ This method is provided and supported by the community, not the core team of Sca
 Scala CLI can be installed with [Nix](https://nixos.org) with
 
 ```bash
-nix-env -if https://github.com/kubukoz/scala-cli.nix/archive/refs/heads/main.tar.gz
+nix-env -if https://github.com/NixOS/nixpkgs/archive/refs/heads/master.tar.gz -A scala-cli
 ```
-
-or other methods listed in [the unofficial package's README](https://github.com/kubukoz/scala-cli.nix).
 
 </TabItem>
 
@@ -255,10 +253,8 @@ This method is provided and supported by the community, not the core team of Sca
 Scala CLI can be installed with [Nix](https://nixos.org) with
 
 ```bash
-nix-env -if https://github.com/kubukoz/scala-cli.nix/archive/refs/heads/main.tar.gz
+nix-env -if https://github.com/NixOS/nixpkgs/archive/refs/heads/master.tar.gz -A scala-cli
 ```
-
-or other methods listed in [the unofficial package's README](https://github.com/kubukoz/scala-cli.nix).
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
scala-cli was added to Nixpkgs in https://github.com/NixOS/nixpkgs/pull/142850 so there's no need to link to my repository anymore.

After a stable Nixpkgs release (21.11) is out, I'll update these one more time to be just `nix-env -i scala-cli`.