### PR TITLE
clean .bsp/scala-cli.json when you run clean

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/Clean.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Clean.scala
@@ -20,7 +20,8 @@ object Clean extends ScalaCommand[CleanOptions] {
       case Right(i) => i
     }
 
-    val workDir = inputs.workspace / ".scala"
+    val workDir       = inputs.workspace / ".scala"
+    val (_, bspEntry) = options.bspFile.bspDetails(inputs.workspace)
 
     val logger = options.logging.logger
     if (os.exists(workDir)) {
@@ -32,5 +33,12 @@ object Clean extends ScalaCommand[CleanOptions] {
       else
         logger.log(s"$workDir is not a directory, ignoring it.")
     }
+
+    if (os.exists(bspEntry)) {
+      logger.log(s"Removing $bspEntry")
+      os.remove(bspEntry)
+    }
+    else
+      logger.log(s"No BSP entry found, so ignoring.")
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/CleanOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/CleanOptions.scala
@@ -8,7 +8,9 @@ final case class CleanOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
   @Recurse
-    directories: SharedDirectoriesOptions = SharedDirectoriesOptions()
+    directories: SharedDirectoriesOptions = SharedDirectoriesOptions(),
+  @Recurse
+    bspFile: SharedBspFileOptions = SharedBspFileOptions()
 )
 // format: on
 

--- a/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
@@ -84,14 +84,8 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
     if (options.buildOptions.classPathOptions.extraDependencies.nonEmpty)
       value(downloadDeps(inputs, options.buildOptions, logger))
 
-    val dir = options.bspDirectory
-      .filter(_.nonEmpty)
-      .map(os.Path(_, Os.pwd))
-      .getOrElse(inputs.workspace / ".bsp")
-
-    val bspName            = options.bspName.map(_.trim).filter(_.nonEmpty).getOrElse("scala-cli")
-    val bspJsonDestination = dir / s"$bspName.json"
-    val scalaCliBspJsonDestination = inputs.workspace / ".scala" / "ide-options.json"
+    val (bspName, bspJsonDestination) = options.bspFile.bspDetails(inputs.workspace)
+    val scalaCliBspJsonDestination    = inputs.workspace / ".scala" / "ide-options.json"
 
     // Ensure the path to the CLI is absolute
     val absolutePathToScalaCli: String = {

--- a/modules/cli/src/main/scala/scala/cli/commands/SetupIdeOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SetupIdeOptions.scala
@@ -9,14 +9,8 @@ import scala.build.options.BuildOptions
 final case class SetupIdeOptions(
   @Recurse
     shared: SharedOptions = SharedOptions(),
-  @Name("bspDir")
-  @HelpMessage("Custom BSP configuration location")
-  @Hidden
-    bspDirectory: Option[String] = None,
-  @Name("name")
-  @HelpMessage("Name of BSP")
-  @Hidden
-    bspName: Option[String] = None,
+  @Recurse
+    bspFile: SharedBspFileOptions = SharedBspFileOptions(),
   @Hidden
   charset: Option[String] = None
 ) {
@@ -25,6 +19,7 @@ final case class SetupIdeOptions(
     shared.buildOptions(enableJmh = false, jmhVersion = None)
 
 }
+
 object SetupIdeOptions {
   implicit lazy val parser: Parser[SetupIdeOptions] = Parser.derive
   implicit lazy val help: Help[SetupIdeOptions]     = Help.derive

--- a/modules/cli/src/main/scala/scala/cli/commands/SharedBspFileOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SharedBspFileOptions.scala
@@ -1,0 +1,35 @@
+package scala.cli.commands
+
+import caseapp._
+
+import scala.build.Os
+
+// format: off
+final case class SharedBspFileOptions(
+  @Name("bspDir")
+  @HelpMessage("Custom BSP configuration location")
+  @Hidden
+    bspDirectory: Option[String] = None,
+  @Name("name")
+  @HelpMessage("Name of BSP")
+  @Hidden
+    bspName: Option[String] = None
+) {
+  // format: on
+
+  def bspDetails(workspace: os.Path): (String, os.Path) = {
+    val dir = bspDirectory
+      .filter(_.nonEmpty)
+      .map(os.Path(_, Os.pwd))
+      .getOrElse(workspace / ".bsp")
+    val bspName0 = bspName.map(_.trim).filter(_.nonEmpty).getOrElse("scala-cli")
+
+    (bspName0, dir / s"$bspName0.json")
+  }
+}
+
+object SharedBspFileOptions {
+  lazy val parser: Parser[SharedBspFileOptions]                           = Parser.derive
+  implicit lazy val parserAux: Parser.Aux[SharedBspFileOptions, parser.D] = parser
+  implicit lazy val help: Help[SharedBspFileOptions]                      = Help.derive
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/CleanTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CleanTests.scala
@@ -17,14 +17,17 @@ class CleanTests extends munit.FunSuite {
     )
 
     inputs.fromRoot { root =>
-      val dir = root / ".scala"
+      val dir      = root / ".scala"
+      val bspEntry = root / ".bsp" / "scala-cli.json"
 
       val res = os.proc(TestUtil.cli, "run", ".").call(cwd = root)
       expect(res.out.text().trim == "Hello")
       expect(os.exists(dir))
+      expect(os.exists(bspEntry))
 
       os.proc(TestUtil.cli, "clean", ".").call(cwd = root)
       expect(!os.exists(dir))
+      expect(!os.exists(bspEntry))
     }
   }
 }

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -62,6 +62,7 @@ Command-line options JSON file
 ## Bsp file options
 
 Available in commands:
+- [`clean`](./commands.md#clean)
 - [`setup-ide`](./commands.md#setup-ide)
 
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -59,6 +59,26 @@ Available in commands:
 
 Command-line options JSON file
 
+## Bsp file options
+
+Available in commands:
+- [`setup-ide`](./commands.md#setup-ide)
+
+
+<!-- Automatically generated, DO NOT EDIT MANUALLY -->
+
+#### `--bsp-directory`
+
+Aliases: `--bsp-dir`
+
+Custom BSP configuration location
+
+#### `--bsp-name`
+
+Aliases: `--name`
+
+Name of BSP
+
 ## Compilation server options
 
 Available in commands:
@@ -862,18 +882,6 @@ Available in commands:
 
 
 <!-- Automatically generated, DO NOT EDIT MANUALLY -->
-
-#### `--bsp-directory`
-
-Aliases: `--bsp-dir`
-
-Custom BSP configuration location
-
-#### `--bsp-name`
-
-Aliases: `--name`
-
-Name of BSP
 
 #### `--charset`
 

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -198,6 +198,7 @@ Accepts options:
 Generate a BSP file that you can import into your IDE
 
 Accepts options:
+- [bsp file](./cli-options.md#bsp-file-options)
 - [compilation server](./cli-options.md#compilation-server-options)
 - [coursier](./cli-options.md#coursier-options)
 - [dependency](./cli-options.md#dependency-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -29,6 +29,7 @@ Accepts options:
 Clean the workspace
 
 Accepts options:
+- [bsp file](./cli-options.md#bsp-file-options)
 - [directories](./cli-options.md#directories-options)
 - [logging](./cli-options.md#logging-options)
 


### PR DESCRIPTION
I think it might be best to do this when you run clean. I hit on this a
couple times now where something was out of sync or not working which
caused me to attempt to do a `scala-cli` clean. However, when you clean
it removes the `.scala` dir, but not the entry that was created in
`.bsp/scala-cli.json` which still references the
`.scala/ide-options.json` file which no longer exists after the clean.
Then since the BSP entry still exists, BSP discovery still triggers in
Metals, and then it sends in the initialize request, but scala-cli just
freezes and doesn't respond. This fix just ensures that when you run
`scala-cli` clean, it cleans up both the `.scala/` and also the
`.bsp/scala-json`.