### PR TITLE
Enable the URL protocol gzip+https

### DIFF
--- a/modules/cli/src/main/resources/META-INF/native-image/org.virtuslab/scala-cli-core/native-image.properties
+++ b/modules/cli/src/main/resources/META-INF/native-image/org.virtuslab/scala-cli-core/native-image.properties
@@ -18,4 +18,5 @@ Args = --no-fallback \
        -H:IncludeResources=org/scalajs/linker/backend/emitter/.*.sjsir \
        --allow-incomplete-classpath \
        --report-unsupported-elements-at-runtime \
-       -H:+ReportExceptionStackTraces
+       -H:+ReportExceptionStackTraces \
+       -H:EnableURLProtocols=gzip+https


### PR DESCRIPTION
I think we should add support for protocols gzip+https in building native-image. It should fix the following error during downloading scala-cli using coursier app. 
```
Caused by: java.net.MalformedURLException: Accessing an URL protocol that was not enabled. The URL protocol gzip+https is not tested and might not work as expected. It can be enabled by adding the -H:EnableURLProtocols=gzip+https option to the native-image command.
        at com.oracle.svm.core.jdk.JavaNetSubstitutions.unsupported(JavaNetSubstitutions.java:208)
        at com.oracle.svm.core.jdk.JavaNetSubstitutions.getURLStreamHandler(JavaNetSubstitutions.java:169)
        at java.net.URL.getURLStreamHandler(URL.java:70)
        at java.net.URL.<init>(URL.java:651)
        at coursier.cache.CacheUrl$.url(CacheUrl.scala:103)
        at coursier.cache.CacheUrl$.urlConnectionMaybePartial(CacheUrl.scala:308)
        at coursier.cache.ConnectionBuilder.connectionMaybePartial(ConnectionBuilder.scala:48)
        at coursier.cache.internal.Downloader$Blocking$.doDownload(Downloader.scala:214)
        at coursier.cache.internal.Downloader$Blocking$.$anonfun$remote$2(Downloader.scala:384)
        at coursier.cache.internal.Downloader$.$anonfun$downloading$1(Downloader.scala:682)
        at coursier.cache.CacheLocks$.withUrlLock(CacheLocks.scala:116)
        at coursier.cache.internal.Downloader$.helper$2(Downloader.scala:682)
        ... 18 more
```

More details in this [PR](https://github.com/coursier/apps/pull/115).