### PR TITLE
Run native linker only if project was changed

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/NativeBuilderHelper.scala
+++ b/modules/build/src/main/scala/scala/build/internal/NativeBuilderHelper.scala
@@ -1,0 +1,65 @@
+package scala.build.internal
+
+import java.math.BigInteger
+import java.security.MessageDigest
+
+import scala.build.Build
+import scala.scalanative.{build => sn}
+
+case object NativeBuilderHelper {
+
+  private def resolveProjectShaPath(nativeWorkDir: os.Path) = nativeWorkDir / ".project_sha"
+  private def resolveOutputShaPath(nativeWorkDir: os.Path)  = nativeWorkDir / ".output_sha"
+
+  private def fileSha(filePath: os.Path): String = {
+    val md = MessageDigest.getInstance("SHA-1")
+    md.update(os.read.bytes(filePath))
+
+    val digest        = md.digest()
+    val calculatedSum = new BigInteger(1, digest)
+    String.format(s"%040x", calculatedSum)
+  }
+
+  private def projectSha(build: Build.Successful, nativeConfig: sn.NativeConfig) = {
+    val md = MessageDigest.getInstance("SHA-1")
+    md.update(build.inputs.sourceHash().getBytes)
+    md.update(nativeConfig.toString.getBytes)
+    md.update(build.options.hash.getOrElse("").getBytes)
+
+    val digest        = md.digest()
+    val calculatedSum = new BigInteger(1, digest)
+    String.format(s"%040x", calculatedSum)
+  }
+
+  def updateOutputSha(dest: os.Path, nativeWorkDir: os.Path) = {
+    val outputShaPath = resolveOutputShaPath(nativeWorkDir)
+    val sha           = fileSha(dest)
+    os.write.over(outputShaPath, sha)
+  }
+
+  def shouldBuildIfChanged(
+    build: Build.Successful,
+    nativeConfig: sn.NativeConfig,
+    dest: os.Path,
+    nativeWorkDir: os.Path
+  ): Boolean = {
+    val projectShaPath = resolveProjectShaPath(nativeWorkDir)
+    val outputShaPath  = resolveOutputShaPath(nativeWorkDir)
+
+    val currentProjectSha = projectSha(build, nativeConfig)
+    val currentOutputSha  = if (os.exists(dest)) Some(fileSha(dest)) else None
+
+    val previousProjectSha = if (os.exists(projectShaPath)) Some(os.read(projectShaPath)) else None
+    val previousOutputSha  = if (os.exists(outputShaPath)) Some(os.read(outputShaPath)) else None
+
+    val changed =
+      !previousProjectSha.contains(currentProjectSha) ||
+      previousOutputSha != currentOutputSha ||
+      !os.exists(dest)
+
+    // update sha in .projectShaPath
+    if (changed) os.write.over(projectShaPath, currentProjectSha, createFolders = true)
+
+    changed
+  }
+}

--- a/modules/build/src/main/scala/scala/build/internal/NativeBuilderHelper.scala
+++ b/modules/build/src/main/scala/scala/build/internal/NativeBuilderHelper.scala
@@ -6,7 +6,7 @@ import java.security.MessageDigest
 import scala.build.Build
 import scala.scalanative.{build => sn}
 
-case object NativeBuilderHelper {
+object NativeBuilderHelper {
 
   private def resolveProjectShaPath(nativeWorkDir: os.Path) = nativeWorkDir / ".project_sha"
   private def resolveOutputShaPath(nativeWorkDir: os.Path)  = nativeWorkDir / ".output_sha"
@@ -24,6 +24,7 @@ case object NativeBuilderHelper {
     val md = MessageDigest.getInstance("SHA-1")
     md.update(build.inputs.sourceHash().getBytes)
     md.update(nativeConfig.toString.getBytes)
+    md.update(Constants.version.getBytes)
     md.update(build.options.hash.getOrElse("").getBytes)
 
     val digest        = md.digest()

--- a/modules/build/src/test/scala/scala/build/tests/NativeBuilderHelperTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/NativeBuilderHelperTests.scala
@@ -1,0 +1,178 @@
+package scala.build.tests
+
+import com.eed3si9n.expecty.Expecty.{assert => expect}
+
+import scala.build.Ops.EitherThrowOps
+import scala.build.blooprifle.BloopRifleConfig
+import scala.build.internal.NativeBuilderHelper
+import scala.build.{Bloop, BuildThreads, Directories, LocalRepo, Logger}
+import scala.build.options.{BuildOptions, InternalOptions, ScalaOptions}
+import scala.util.{Properties, Random}
+
+class NativeBuilderHelperTests extends munit.FunSuite {
+
+  val buildThreads = BuildThreads.create()
+  val bloopConfig  = BloopRifleConfig.default(v => Bloop.bloopClassPath(Logger.nop, v))
+
+  val helloFileName = "Hello.scala"
+
+  val inputs = TestInputs(
+    os.rel / helloFileName ->
+      s"""object Hello extends App {
+         |  println("Hello")
+         |}
+         |""".stripMargin,
+    os.rel / "main" / "Main.scala" ->
+      s"""object Main extends App {
+         |  println("Hello")
+         |}
+         |""".stripMargin
+  )
+
+  val extraRepoTmpDir = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
+  val directories     = Directories.under(extraRepoTmpDir)
+
+  val defaultOptions = BuildOptions(
+    internal = InternalOptions(
+      localRepository = LocalRepo.localRepo(directories.localRepoDir)
+    )
+  )
+
+  test("should build native app at first time") {
+
+    inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
+      val build = maybeBuild.toOption.get.successfulOpt.get
+
+      val nativeConfig  = build.options.scalaNativeOptions.config
+      val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+      val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+      // generate dummy output
+      os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+
+      val changed =
+        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
+      expect(changed)
+    }
+  }
+
+  test("should not rebuild the second time") {
+    inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
+      val build = maybeBuild.toOption.get.successfulOpt.get
+
+      val nativeConfig  = build.options.scalaNativeOptions.config
+      val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+      val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+      // generate dummy output
+      os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+
+      val changed =
+        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
+      NativeBuilderHelper.updateOutputSha(destPath, nativeWorkDir)
+      expect(changed)
+
+      val changedSameBuild =
+        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
+      expect(!changedSameBuild)
+    }
+  }
+
+  test("should build native if output file was deleted") {
+    inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
+      val build = maybeBuild.toOption.get.successfulOpt.get
+
+      val nativeConfig  = build.options.scalaNativeOptions.config
+      val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+      val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+      // generate dummy output
+      os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+
+      val changed =
+        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
+      NativeBuilderHelper.updateOutputSha(destPath, nativeWorkDir)
+      expect(changed)
+
+      os.remove(destPath)
+      val changedAfterDelete =
+        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
+      expect(changedAfterDelete)
+    }
+  }
+
+  test("should build native if output file was changed") {
+    inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
+      val build = maybeBuild.toOption.get.successfulOpt.get
+
+      val nativeConfig  = build.options.scalaNativeOptions.config
+      val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+      val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+      // generate dummy output
+      os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+
+      val changed =
+        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
+      NativeBuilderHelper.updateOutputSha(destPath, nativeWorkDir)
+      expect(changed)
+
+      os.write.over(destPath, Random.alphanumeric.take(10).mkString(""))
+      val changedAfterFileUpdate =
+        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
+      expect(changedAfterFileUpdate)
+    }
+  }
+
+  test("should build native if input file was changed") {
+    inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
+      val build = maybeBuild.toOption.get.successfulOpt.get
+
+      val nativeConfig  = build.options.scalaNativeOptions.config
+      val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+      val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+      os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+
+      val changed =
+        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
+      NativeBuilderHelper.updateOutputSha(destPath, nativeWorkDir)
+      expect(changed)
+
+      os.write.append(root / helloFileName, Random.alphanumeric.take(10).mkString(""))
+      val changedAfterFileUpdate =
+        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
+      expect(changedAfterFileUpdate)
+    }
+  }
+
+  test("should build native if native config was changed") {
+    inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
+      val build = maybeBuild.toOption.get.successfulOpt.get
+
+      val nativeConfig  = build.options.scalaNativeOptions.config
+      val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+      val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+      os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+
+      val changed =
+        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
+      NativeBuilderHelper.updateOutputSha(destPath, nativeWorkDir)
+      expect(changed)
+
+      val updatedBuild = build.copy(
+        options = build.options.copy(
+          scalaNativeOptions = build.options.scalaNativeOptions.copy(
+            clang = Some(Random.alphanumeric.take(10).mkString(""))
+          )
+        )
+      )
+      val updatedNativeConfig = updatedBuild.options.scalaNativeOptions.config
+
+      val changedAfterConfigUpdate =
+        NativeBuilderHelper.shouldBuildIfChanged(
+          updatedBuild,
+          updatedNativeConfig,
+          destPath,
+          nativeWorkDir
+        )
+      expect(changedAfterConfigUpdate)
+    }
+  }
+
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -202,11 +202,8 @@ object Run extends ScalaCommand[RunOptions] {
     workDir: os.Path,
     logger: sn.Logger
   )(f: os.Path => T): T = {
-    val dest = os.temp(prefix = "main", suffix = if (Properties.isWin) ".exe" else "")
-    try {
-      Package.buildNative(build, mainClass, dest, config, workDir, logger)
-      f(dest)
-    }
-    finally if (os.exists(dest)) os.remove(dest)
+    val dest = workDir / s"main${if (Properties.isWin) ".exe" else ""}"
+    Package.buildNative(build, mainClass, dest, config, workDir, logger)
+    f(dest)
   }
 }


### PR DESCRIPTION
closes #281 

To avoid long waiting for executing linker,  we calculate the sha of the project, and only when something has changed we run a linker.
We count sha for the following variable:
-  output (was changed or deleted)
-  native config
-  all files in the project
-  build options
-  ScalaCLI version