### PR TITLE
Don't unnecessarily pass native config around

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -549,7 +549,7 @@ object Build {
         if (options.platform == Platform.JS) Some(options.scalaJsOptions.config)
         else None,
       scalaNativeOptions =
-        if (options.platform == Platform.Native) Some(options.scalaNativeOptions.bloopConfig)
+        if (options.platform == Platform.Native) Some(options.scalaNativeOptions.bloopConfig())
         else None,
       projectName = inputs.scopeProjectName(scope),
       classPath = artifacts.compileClassPath ++ mainClassesPath,

--- a/modules/build/src/main/scala/scala/build/options/ScalaNativeOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/ScalaNativeOptions.scala
@@ -25,28 +25,28 @@ final case class ScalaNativeOptions(
 
   def finalVersion = version.map(_.trim).filter(_.nonEmpty).getOrElse(Constants.scalaNativeVersion)
 
-  private def gc: sn.GC =
+  private def gc(): sn.GC =
     gcStr.map(_.trim).filter(_.nonEmpty) match {
       case Some("default") | None => sn.GC.default
       case Some(other)            => sn.GC(other)
     }
-  private def mode: sn.Mode =
+  private def mode(): sn.Mode =
     modeStr.map(_.trim).filter(_.nonEmpty) match {
       case Some("default") | None => sn.Discover.mode()
       case Some(other)            => sn.Mode(other)
     }
 
-  private def clangPath = clang
+  private def clangPath() = clang
     .filter(_.nonEmpty)
     .map(Paths.get(_))
     .getOrElse(sn.Discover.clang())
-  private def clangppPath = clangpp
+  private def clangppPath() = clangpp
     .filter(_.nonEmpty)
     .map(Paths.get(_))
     .getOrElse(sn.Discover.clangpp())
-  private def finalLinkingOptions =
+  private def finalLinkingOptions() =
     linkingOptions ++ (if (linkingDefaults.getOrElse(true)) sn.Discover.linkingOptions() else Nil)
-  private def finalCompileOptions =
+  private def finalCompileOptions() =
     compileOptions ++ (if (compileDefaults.getOrElse(true)) sn.Discover.compileOptions() else Nil)
 
   def platformSuffix: String =
@@ -57,21 +57,21 @@ final case class ScalaNativeOptions(
   def compilerPlugins: Seq[AnyDependency] =
     Seq(dep"org.scala-native:::nscplugin:$finalVersion")
 
-  private def bloopConfigUnsafe: BloopConfig.NativeConfig =
+  def bloopConfig(): BloopConfig.NativeConfig =
     BloopConfig.NativeConfig(
       version = finalVersion,
       // there are more modes than bloop allows, but that setting here shouldn't end up being used anyway
       mode =
-        if (mode.name == "release") BloopConfig.LinkerMode.Release
+        if (mode().name == "release") BloopConfig.LinkerMode.Release
         else BloopConfig.LinkerMode.Debug,
-      gc = gc.name,
+      gc = gc().name,
       targetTriple = None,
-      clang = clangPath,
-      clangpp = clangppPath,
+      clang = clangPath(),
+      clangpp = clangppPath(),
       toolchain = Nil,
       options = BloopConfig.NativeOptions(
-        linker = finalLinkingOptions,
-        compiler = finalCompileOptions
+        linker = finalLinkingOptions(),
+        compiler = finalCompileOptions()
       ),
       linkStubs = false,
       check = false,
@@ -79,21 +79,15 @@ final case class ScalaNativeOptions(
       output = None
     )
 
-  def bloopConfig: BloopConfig.NativeConfig =
-    bloopConfigUnsafe
-
-  private def configUnsafe: sn.NativeConfig =
+  def config(): sn.NativeConfig =
     sn.NativeConfig.empty
-      .withGC(gc)
-      .withMode(mode)
+      .withGC(gc())
+      .withMode(mode())
       .withLinkStubs(false)
-      .withClang(clangPath)
-      .withClangPP(clangppPath)
+      .withClang(clangPath())
+      .withClangPP(clangppPath())
       .withLinkingOptions(linkingOptions)
       .withCompileOptions(compileOptions)
-
-  def config: sn.NativeConfig =
-    configUnsafe
 
 }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -402,11 +402,10 @@ object Package extends ScalaCommand[PackageOptions] {
     mainClass: String,
     logger: Logger
   ): Unit = {
-    val config = build.options.scalaNativeOptions.config
     val workDir =
       build.options.scalaNativeOptions.nativeWorkDir(inputs.workspace, inputs.projectName)
 
-    buildNative(build, mainClass, destPath, config, workDir, logger.scalaNativeLogger)
+    buildNative(build, mainClass, destPath, workDir, logger.scalaNativeLogger)
   }
 
   private def bootstrap(
@@ -537,10 +536,11 @@ object Package extends ScalaCommand[PackageOptions] {
     build: Build.Successful,
     mainClass: String,
     dest: os.Path,
-    nativeConfig: sn.NativeConfig,
     nativeWorkDir: os.Path,
     nativeLogger: sn.Logger
   ): Unit = {
+
+    val nativeConfig = build.options.scalaNativeOptions.config
 
     os.makeDir.all(nativeWorkDir)
     val changed = NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, dest, nativeWorkDir)

--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -540,7 +540,7 @@ object Package extends ScalaCommand[PackageOptions] {
     nativeLogger: sn.Logger
   ): Unit = {
 
-    val nativeConfig = build.options.scalaNativeOptions.config
+    val nativeConfig = build.options.scalaNativeOptions.config()
 
     os.makeDir.all(nativeWorkDir)
     val changed = NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, dest, nativeWorkDir)

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -145,7 +145,6 @@ object Run extends ScalaCommand[RunOptions] {
         withNativeLauncher(
           build,
           mainClass,
-          build.options.scalaNativeOptions.config,
           build.options.scalaNativeOptions.nativeWorkDir(root, projectName),
           logger.scalaNativeLogger
         ) { launcher =>
@@ -198,12 +197,11 @@ object Run extends ScalaCommand[RunOptions] {
   def withNativeLauncher[T](
     build: Build.Successful,
     mainClass: String,
-    config: sn.NativeConfig,
     workDir: os.Path,
     logger: sn.Logger
   )(f: os.Path => T): T = {
     val dest = workDir / s"main${if (Properties.isWin) ".exe" else ""}"
-    Package.buildNative(build, mainClass, dest, config, workDir, logger)
+    Package.buildNative(build, mainClass, dest, workDir, logger)
     f(dest)
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -144,7 +144,6 @@ object Test extends ScalaCommand[TestOptions] {
           Run.withNativeLauncher(
             build,
             "scala.scalanative.testinterface.TestMain",
-            build.options.scalaNativeOptions.config,
             build.options.scalaNativeOptions.nativeWorkDir(root, projectName),
             logger.scalaNativeLogger
           ) { launcher =>


### PR DESCRIPTION
The native config can be obtained from the BuildOptions, no need to compute it early and pass it around this way.