### PR TITLE
Remove scalac option prefix from arguments

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/ScalacOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalacOptions.scala
@@ -23,7 +23,7 @@ object ScalacOptions {
     .withExtraNames(Seq(Name("scala-opt"), Name("O")))
     .withValueDescription(Some(ValueDescription("option")))
     .withHelpMessage(Some(HelpMessage(
-      "Add a `scalac` option. All options starts with (-g, -language, -opt, -P, -target, -V, -W, -X, -Y) are assumed to be Scala compiler options"
+      "Add a `scalac` option. Note that options starting with `-g`, `-language`, `-opt`, `-P`, `-target`, `-V`, `-W`, `-X`, and `-Y` are assumed to be Scala compiler options and don't require to be passed after `-O` or `--scalac-option`."
     )))
     .withGroup(Some(Group("Scala")))
     .withOrigin(Some("ScalacOptions"))

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalacOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalacOptions.scala
@@ -22,7 +22,9 @@ object ScalacOptions {
   private val scalacOptionsArg = Arg("scalacOption")
     .withExtraNames(Seq(Name("scala-opt"), Name("O")))
     .withValueDescription(Some(ValueDescription("option")))
-    .withHelpMessage(Some(HelpMessage("Add a `scalac` option")))
+    .withHelpMessage(Some(HelpMessage(
+      "Add a `scalac` option. All options starts with (-g, -language, -opt, -P, -target, -V, -W, -X, -Y) are assumed to be Scala compiler options"
+    )))
     .withGroup(Some(Group("Scala")))
     .withOrigin(Some("ScalacOptions"))
   // .withIsFlag(true) // The scalac options we handle accept no value after the -… argument
@@ -33,9 +35,8 @@ object ScalacOptions {
 
       val underlying = StandardArgument[List[String]](scalacOptionsArg)
 
-      val arg = scalacOptionsArg.withExtraNames(
-        scalacOptionsArg.extraNames ++ scalacOptionsPrefixes.toVector.map(Name(_))
-      )
+      val arg = scalacOptionsArg
+
       def withDefaultOrigin(origin: String) = this
       def init                              = Some(Nil)
       def step(args: List[String], acc: Option[List[String]], formatter: Formatter[Name]) =

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -874,7 +874,7 @@ Available in commands:
 
 Aliases: `--scala-opt`, `-O`
 
-Add a `scalac` option. All options starts with (-g, -language, -opt, -P, -target, -V, -W, -X, -Y) are assumed to be Scala compiler options
+Add a `scalac` option. Note that options starting with `-g`, `-language`, `-opt`, `-P`, `-target`, `-V`, `-W`, `-X`, and `-Y` are assumed to be Scala compiler options and don't require to be passed after `-O` or `--scalac-option`.
 
 ## Setup IDE options
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -872,9 +872,9 @@ Available in commands:
 
 #### `--scalac-option`
 
-Aliases: `--scala-opt`, `-O`, `-P`, `-W`, `-g`, `-X`, `-language`, `-Y`, `-V`, `-target`, `-opt`
+Aliases: `--scala-opt`, `-O`
 
-Add a `scalac` option
+Add a `scalac` option. All options starts with (-g, -language, -opt, -P, -target, -V, -W, -X, -Y) are assumed to be Scala compiler options
 
 ## Setup IDE options
 


### PR DESCRIPTION
resolves #149 

Scalac options prefixes were treated as a normal parameter by case-app, therefore generated help message was confusing:
`  -O, -P, -W, -g, -X, -Y, -V, -opt, -target, -language, --scala-opt, --scalac-option option  Add a `scalac` option`

and ` ./mill cli complete zsh-v1 2 compile -` generates too many hyphens:

```
"----p:Add a `scalac` option"
"----w:Add a `scalac` option"
"---g:Add a `scalac` option"
"----x:Add a `scalac` option"
"---language:Add a `scalac` option"
```

To avoid above problem, I removed scalac options prefixes from arguments and added descriptions to `HelpMessage`.
 
