### PR TITLE
Use the newest scala version if is not specified

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -184,6 +184,7 @@ class Build(val crossScalaVersion: String)
     Deps.scalaparse,
     Deps.shapeless,
     Deps.swoval,
+    Deps.upickle,
     Deps.usingDirectives
   )
 

--- a/build.sc
+++ b/build.sc
@@ -247,6 +247,8 @@ class Build(val crossScalaVersion: String)
          |  def defaultScalafmtVersion = "${Deps.scalafmtCli.dep.version}"
          |
          |  def defaultScalaVersion = "${Scala.defaultUser}"
+         |  def defaultScala212Version = "${Scala.scala212}"
+         |  def defaultScala213Version = "${Scala.scala213}"
          |}
          |""".stripMargin
     if (!os.isFile(dest) || os.read(dest) != code)

--- a/modules/build/src/main/scala/scala/build/errors/InvalidBinaryScalaVersionError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/InvalidBinaryScalaVersionError.scala
@@ -2,4 +2,4 @@ package scala.build.errors
 
 final class InvalidBinaryScalaVersionError(
   val binaryVersion: String
-) extends BuildException(s"Cannot find matching Scala version for '$binaryVersion'")
+) extends ScalaVersionError(s"Cannot find matching Scala version for '$binaryVersion'")

--- a/modules/build/src/main/scala/scala/build/errors/NoValidScalaVersionFoundError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/NoValidScalaVersionFoundError.scala
@@ -2,4 +2,6 @@ package scala.build.errors
 
 final class NoValidScalaVersionFoundError(
   val foundVersions: Seq[String]
-) extends ScalaVersionError(s"Cannot find valid Scala version among ${foundVersions.mkString(", ")}")
+) extends ScalaVersionError(
+      s"Cannot find valid Scala version among ${foundVersions.mkString(", ")}"
+    )

--- a/modules/build/src/main/scala/scala/build/errors/NoValidScalaVersionFoundError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/NoValidScalaVersionFoundError.scala
@@ -1,0 +1,5 @@
+package scala.build.errors
+
+final class NoValidScalaVersionFoundError(
+  val foundVersions: Seq[String]
+) extends ScalaVersionError(s"Cannot find valid Scala version among ${foundVersions.mkString(", ")}")

--- a/modules/build/src/main/scala/scala/build/errors/ScalaVersionError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/ScalaVersionError.scala
@@ -3,4 +3,4 @@ package scala.build.errors
 import scala.build.Position
 
 class ScalaVersionError(message: String, positions: Seq[Position] = Nil)
-  extends BuildException(message, positions = positions)
+    extends BuildException(message, positions = positions)

--- a/modules/build/src/main/scala/scala/build/errors/ScalaVersionError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/ScalaVersionError.scala
@@ -1,0 +1,6 @@
+package scala.build.errors
+
+import scala.build.Position
+
+class ScalaVersionError(message: String, positions: Seq[Position] = Nil)
+  extends BuildException(message, positions = positions)

--- a/modules/build/src/main/scala/scala/build/errors/UnsupportedScalaVersionError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/UnsupportedScalaVersionError.scala
@@ -1,0 +1,5 @@
+package scala.build.errors
+
+final class UnsupportedScalaVersionError(
+  val binaryVersion: String
+) extends ScalaVersionError(s"Unsupported Scala version: $binaryVersion")

--- a/modules/build/src/main/scala/scala/build/internal/StableScalaVersion.scala
+++ b/modules/build/src/main/scala/scala/build/internal/StableScalaVersion.scala
@@ -2,7 +2,7 @@ package scala.build.internal
 
 import upickle.default.{ReadWriter, macroRW}
 
-case class StableScalaVersion(scalaCliVersion: String, supportedScalaVersion: Seq[String])
+case class StableScalaVersion(scalaCliVersion: String, supportedScalaVersions: Seq[String])
 
 case object StableScalaVersion {
   implicit lazy val jsonCodec: ReadWriter[StableScalaVersion] = macroRW

--- a/modules/build/src/main/scala/scala/build/internal/StableScalaVersion.scala
+++ b/modules/build/src/main/scala/scala/build/internal/StableScalaVersion.scala
@@ -4,6 +4,6 @@ import upickle.default.{ReadWriter, macroRW}
 
 case class StableScalaVersion(scalaCliVersion: String, supportedScalaVersions: Seq[String])
 
-case object StableScalaVersion {
+object StableScalaVersion {
   implicit lazy val jsonCodec: ReadWriter[StableScalaVersion] = macroRW
 }

--- a/modules/build/src/main/scala/scala/build/internal/StableScalaVersion.scala
+++ b/modules/build/src/main/scala/scala/build/internal/StableScalaVersion.scala
@@ -1,0 +1,9 @@
+package scala.build.internal
+
+import upickle.default.{ReadWriter, macroRW}
+
+case class StableScalaVersion(scalaCliVersion: String, supportedScalaVersion: Seq[String])
+
+case object StableScalaVersion {
+  implicit lazy val jsonCodec: ReadWriter[StableScalaVersion] = macroRW
+}

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -13,20 +13,17 @@ import java.security.MessageDigest
 
 import scala.build.EitherCps.{either, value}
 import scala.build.blooprifle.VersionUtil.parseJavaVersion
-import scala.build.errors.{BuildException, Diagnostic, InvalidBinaryScalaVersionError}
 import scala.build.errors.{
   BuildException,
+  Diagnostic,
   InvalidBinaryScalaVersionError,
   NoValidScalaVersionFoundError,
   UnsupportedScalaVersionError
 }
 import scala.build.internal.Constants._
-import scala.build.internal.{Constants, OsLibc, Util}
+import scala.build.internal.{OsLibc, StableScalaVersion, Util}
 import scala.build.options.validation.BuildOptionsRule
 import scala.build.{Artifacts, Logger, Os, Position, Positioned}
-import scala.util.Properties
-import scala.build.internal.{OsLibc, StableScalaVersion, Util}
-import scala.build.{Artifacts, Logger, Os, Positioned}
 import scala.util.Properties
 
 final case class BuildOptions(

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -204,12 +204,12 @@ final case class BuildOptions(
     //  it uses stable scala versions from Deps.sc
     val supportedScalaVersions =
       launchersTask.attempt.unsafeRun()(finalCache.ec) match {
-        case Left(ex) =>
-          // FIXME Log ex
+        case Left(_) =>
+          // FIXME Log the exception
           defaultStableScalaVersions
         case Right(versions) =>
           versions
-            .find(_ == scalaCliVersion)
+            .find(_.scalaCliVersion == scalaCliVersion)
             .map(_.supportedScalaVersions)
             .getOrElse {
               // FIXME Log that: logger.debug(s"Couldn't find Scala CLI version $scalaCliVersion in $versions")

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -14,6 +14,12 @@ import java.security.MessageDigest
 import scala.build.EitherCps.{either, value}
 import scala.build.blooprifle.VersionUtil.parseJavaVersion
 import scala.build.errors.{BuildException, Diagnostic, InvalidBinaryScalaVersionError}
+import scala.build.errors.{
+  BuildException,
+  InvalidBinaryScalaVersionError,
+  NoValidScalaVersionFoundError,
+  UnsupportedScalaVersionError
+}
 import scala.build.internal.Constants._
 import scala.build.internal.{Constants, OsLibc, Util}
 import scala.build.options.validation.BuildOptionsRule

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -25,6 +25,9 @@ import scala.build.internal.{Constants, OsLibc, Util}
 import scala.build.options.validation.BuildOptionsRule
 import scala.build.{Artifacts, Logger, Os, Position, Positioned}
 import scala.util.Properties
+import scala.build.internal.{OsLibc, StableScalaVersion, Util}
+import scala.build.{Artifacts, Logger, Os, Positioned}
+import scala.util.Properties
 
 final case class BuildOptions(
   scalaOptions: ScalaOptions = ScalaOptions(),

--- a/modules/build/src/main/scala/scala/build/options/ScalaOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/ScalaOptions.scala
@@ -13,8 +13,14 @@ final case class ScalaOptions(
   extraScalaVersions: Set[String] = Set.empty,
   compilerPlugins: Seq[Positioned[AnyDependency]] = Nil,
   platform: Option[Positioned[Platform]] = None,
-  extraPlatforms: Map[Platform, Positioned[Unit]] = Map.empty
+  extraPlatforms: Map[Platform, Positioned[Unit]] = Map.empty,
+  supportedScalaVersionsUrl: Option[String] = None
 ) {
+
+  lazy val scalaVersionsUrl = supportedScalaVersionsUrl.getOrElse(
+    "https://raw.githubusercontent.com/VirtusLab/scala-cli/master/scala-version.scala"
+  )
+
   def normalize: ScalaOptions = {
     var opt = this
     for (sv <- opt.scalaVersion if opt.extraScalaVersions.contains(sv))

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -1,8 +1,12 @@
 package scala.build.tests
 
 import com.eed3si9n.expecty.Expecty.{assert => expect}
+import dependency.ScalaParameters
 
-import scala.build.options.{BuildOptions, BuildRequirements}
+import scala.build.Ops._
+import scala.build.internal.Constants._
+import scala.build.options.{BuildOptions, BuildRequirements, ScalaOptions}
+import scala.util.Random
 
 class BuildOptionsTests extends munit.FunSuite {
 
@@ -23,5 +27,75 @@ class BuildOptionsTests extends munit.FunSuite {
       "Unexpected Option / Seq / Set / Boolean with a non-empty / non-false default value"
     )
   }
+
+  val expectedScalaVersions = Seq(
+    Some("3")      -> defaultScalaVersion,
+    None           -> defaultScalaVersion,
+    Some("2.13")   -> defaultScala213Version,
+    Some("2.12")   -> defaultScala212Version,
+    Some("2")      -> defaultScala213Version,
+    Some("2.13.2") -> "2.13.2",
+    Some("3.0.1")  -> "3.0.1"
+  )
+
+  for ((prefix, expectedScalaVersion) <- expectedScalaVersions)
+    test(
+      s"use expected default scala version for prefix scala version: ${prefix.getOrElse("empty")}"
+    ) {
+      val options = BuildOptions(
+        scalaOptions = ScalaOptions(
+          scalaVersion = prefix,
+          scalaBinaryVersion = None,
+          supportedScalaVersionsUrl =
+            Some(
+              Random.alphanumeric.take(10).mkString("")
+            ) // invalid url, it should use defaults from Deps.sc
+        )
+      )
+      val scalaParams = options.scalaParams.orThrow
+
+      val expectedScalaParams = ScalaParameters(expectedScalaVersion)
+
+      expect(scalaParams == expectedScalaParams)
+    }
+
+  val expectedScalaConfVersions = Seq(
+    Some("3")      -> "3.0.1",
+    None           -> "3.0.1",
+    Some("2.13")   -> "2.13.4",
+    Some("2.12")   -> "2.12.13",
+    Some("2")      -> "2.13.4",
+    Some("2.13.2") -> "2.13.2"
+  )
+
+  val confFile = s"""[
+                    | {
+                    |  "scalaCliVersion": "$version",
+                    |  "supportedScalaVersions": ["3.0.1", "2.13.4", "2.12.13"]
+                    | }
+                    |]""".stripMargin
+
+  for ((prefix, expectedScalaVersion) <- expectedScalaConfVersions)
+    test(s"use expected scala version from conf file, prefix: ${prefix.getOrElse("empty")}") {
+      TestInputs.withTmpDir("conf-scala-versions") { dirPath =>
+
+        val confFilePath = dirPath / "conf-file.json"
+        os.write(confFilePath, confFile)
+
+        val options = BuildOptions(
+          scalaOptions = ScalaOptions(
+            scalaVersion = prefix,
+            scalaBinaryVersion = None,
+            supportedScalaVersionsUrl = Some(s"file://${confFilePath.toString()}")
+          )
+        )
+
+        val scalaParams         = options.scalaParams.orThrow
+        val expectedScalaParams = ScalaParameters(expectedScalaVersion)
+
+        expect(scalaParams == expectedScalaParams)
+      }
+
+    }
 
 }

--- a/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
@@ -1,9 +1,8 @@
 package scala.build.tests
 
 import java.nio.charset.StandardCharsets
-
-import scala.build.{Build, BuildThreads, Directories, Inputs}
 import scala.build.blooprifle.BloopRifleConfig
+import scala.build.{Build, BuildThreads, Directories, Inputs}
 import scala.build.errors.BuildException
 import scala.build.options.BuildOptions
 import scala.util.control.NonFatal

--- a/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
@@ -51,7 +51,7 @@ object TestInputs {
   def apply(files: (os.RelPath, String)*): TestInputs =
     TestInputs(files, Nil)
 
-  private def withTmpDir[T](prefix: String)(f: os.Path => T): T = {
+  def withTmpDir[T](prefix: String)(f: os.Path => T): T = {
     val tmpDir = os.temp.dir(prefix = prefix)
     try f(tmpDir)
     finally tryRemoveAll(tmpDir)

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -135,7 +135,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
           check = false,
           stderr = os.Pipe
         ).err.text().trim
-        expect(output.startsWith("scala-cli: invalid option:"))
+        expect(output.contains("scala-cli: invalid option:"))
       }
     }
 

--- a/scala-version.json
+++ b/scala-version.json
@@ -1,6 +1,6 @@
 [
  {
   "scalaCliVersion":  "0.0.9",
-  "supportedScalaVersion": ["3.0.2", "2.13.7", "2.12.15"]
+  "supportedScalaVersions": ["3.0.2", "2.13.7", "2.12.15"]
  }
 ]

--- a/scala-version.json
+++ b/scala-version.json
@@ -1,0 +1,6 @@
+[
+ {
+  "scalaCliVersion":  "0.0.9",
+  "supportedScalaVersion": ["3.0.2", "2.13.7", "2.12.15"]
+ }
+]

--- a/website/docs/commands/compile.md
+++ b/website/docs/commands/compile.md
@@ -40,7 +40,7 @@ scala-cli compile --watch Hello.scala
 
 ## Scala version
 
-Scala CLI uses the latest stable version of Scala by default (`3.1.0` when this guide was written). You can specify the Scala version you'd like to use with `--scala`:
+Scala CLI uses the latest stable version of Scala which was tested in `scala-cli` (see our list of [Supported Scala Versions](../reference/scala-versions)). You can specify the Scala version you'd like to use with `--scala`:
 
 ```bash ignore
 scala-cli compile --scala 2.13.6 Hello.scala

--- a/website/docs/cookbooks/scala-versions.md
+++ b/website/docs/cookbooks/scala-versions.md
@@ -3,7 +3,7 @@ title: Picking the Scala version with scala-cli
 sidebar_position: 2
 ---
 
-By default, `scala-cli` runs the latest stable Scala version.
+By default, `scala-cli` runs the latest supported scala version by ScalaCLI. See our list of [Supported Scala Versions](../reference/scala-versions) in ScalaCLI.
 
 To demonstrate how this works, here’s a universal piece of code that detects the Scala version at runtime.
 The code is a bit complicated, so we suggest that you skip reading the whole file, and just focus on what it prints:
@@ -78,7 +78,7 @@ scala-cli -S 2.12 ScalaVersion.scala
 Scala: 2\.12\.15
 -->
 
-In the first example (`-S 2`), the application picks up the latest Scala 2 stable release (`2.13.6` at the time of this writing).
+In the first example (`-S 2`), the application picks up the latest Scala 2 stable release (`2.13.7` at the time of this writing).
 In the second example, the application picks up the latest stable release of `2.12` (which is `2.12.15` at the time of this writing).
 
 You can also pin the version of the language within a `.scala` file with `using` directives.

--- a/website/docs/getting_started.md
+++ b/website/docs/getting_started.md
@@ -72,7 +72,7 @@ Hello Jenny, Jake!
 
 </ChainedSnippets>
 
-You may wonder, what kind of Scala version was used under the hood in that example? The answer is the latest stable one. If we want to specify the Scala version, we can use the `-S` (or `--scala`) option. You can read more about setting the Scala version in our dedicated [Scala Versions cookbook](./cookbooks/scala-versions.md).
+You may wonder what kind of Scala version was used under the hood. The answer is the latest stable version which was tested in Scala CLI. If we want to specify the Scala version we can use `-S` or `--scala` option. More about setting Scala version in a dedicated [cookbook](./cookbooks/scala-versions.md).
 
 Scala CLI offers many more features dedicated for scripting, as described in the [dedicated guide](./guides/scripts.md).
 

--- a/website/docs/reference/scala-versions.md
+++ b/website/docs/reference/scala-versions.md
@@ -1,0 +1,11 @@
+---
+title: Supported scala versions
+sidebar_position: 7
+---
+
+Current ScalaCLI versions support Scala 3, 2.13 and 2.12. The table below lists the last supported version of scala in ScalaCLI. If you want to use newer scala, update scala-cli.
+
+| ScalaCLI versions   |      Scala 3      |  Scala 2.13 | Scala 2.12 |
+|---------------------|:-----------------:|------------:|-----------:|
+| 0.0.9               |   3.0.2           |    2.13.7   | 2.12.7     |
+    


### PR DESCRIPTION
resolves #401 

Instead of using `Constants.defaultScalaVersion`, we should search the newest stable version of scala.