### PR TITLE
`scala-cli` script for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,8 @@ To debug failing document, Sclicheck has build-in following options: `--step` (s
 ## Scala CLI logos
 
 Package with various logos for scala-cli can be found on [google drive](https://drive.google.com/drive/u/1/folders/1M6JeQXmO4DTBeRBKAFJ5HH2p_hbfQnqS)
+
+## Launcher script
+
+There is a script `scala-cli-src` in the repository root that is intended to work exactly like released scala-cli, but using a binary compiled the worktree.
+Just add it to your PATH to get the already-released-scala-cli experience.

--- a/scala-cli-src
+++ b/scala-cli-src
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 ROOT_DIR="$SCRIPT_DIR"
 (

--- a/scala-cli-src
+++ b/scala-cli-src
@@ -1,0 +1,8 @@
+#!/bin/bash
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+ROOT_DIR="$SCRIPT_DIR"
+(
+   cd "$ROOT_DIR" || exit
+   ./mill cli.standaloneLauncher
+)
+"$ROOT_DIR/out/cli/standaloneLauncher/dest/launcher" "$@"

--- a/scala-cli-src
+++ b/scala-cli-src
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 ROOT_DIR="$SCRIPT_DIR"
 (

--- a/scala-cli-src
+++ b/scala-cli-src
@@ -5,4 +5,4 @@ ROOT_DIR="$SCRIPT_DIR"
    cd "$ROOT_DIR" || exit
    ./mill cli.standaloneLauncher
 )
-"$ROOT_DIR/out/cli/standaloneLauncher/dest/launcher" "$@"
+exec "$ROOT_DIR/out/cli/standaloneLauncher/dest/launcher" "$@"


### PR DESCRIPTION
For scala-cli developers. Useful if you need a scala-cli exec that builds and runs code