### PR TITLE
Bump ASM API version

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/MainClass.scala
+++ b/modules/build/src/main/scala/scala/build/internal/MainClass.scala
@@ -6,7 +6,7 @@ object MainClass {
 
   private def stringArrayDescriptor = "([Ljava/lang/String;)V"
 
-  private class MainMethodChecker extends asm.ClassVisitor(asm.Opcodes.ASM4) {
+  private class MainMethodChecker extends asm.ClassVisitor(asm.Opcodes.ASM9) {
     private var foundMainClass = false
     private var nameOpt        = Option.empty[String]
     def found: Boolean         = foundMainClass

--- a/modules/build/src/main/scala/scala/build/postprocessing/AsmPositionUpdater.scala
+++ b/modules/build/src/main/scala/scala/build/postprocessing/AsmPositionUpdater.scala
@@ -9,7 +9,7 @@ object AsmPositionUpdater {
   private class LineNumberTableMethodVisitor(
     lineShift: Int,
     delegate: asm.MethodVisitor
-  ) extends asm.MethodVisitor(asm.Opcodes.ASM5, delegate) {
+  ) extends asm.MethodVisitor(asm.Opcodes.ASM9, delegate) {
     override def visitLineNumber(line: Int, start: asm.Label): Unit =
       super.visitLineNumber(line + lineShift, start)
   }
@@ -17,7 +17,7 @@ object AsmPositionUpdater {
   private class LineNumberTableClassVisitor(
     mappings: Map[String, (String, Int)],
     cw: asm.ClassWriter
-  ) extends asm.ClassVisitor(asm.Opcodes.ASM4, cw) {
+  ) extends asm.ClassVisitor(asm.Opcodes.ASM9, cw) {
     private var lineShiftOpt = Option.empty[Int]
     def mappedStuff          = lineShiftOpt.nonEmpty
     override def visitSource(source: String, debug: String): Unit =


### PR DESCRIPTION
Ran into that kind of error while trying to compile a Java project with Scala CLI, the changes here might help:
```text
$ scala-cli compile . --jvm temurin:17
Compiling project (Scala 3.0.2, JVM)
Compiled project (Scala 3.0.2, JVM)
Exception in thread "main" java.lang.UnsupportedOperationException: NestHost requires ASM7
	at org.objectweb.asm.ClassVisitor.visitNestHost(ClassVisitor.java:165)
	at org.objectweb.asm.ClassReader.accept(ClassReader.java:563)
	at org.objectweb.asm.ClassReader.accept(ClassReader.java:401)
	at scala.build.postprocessing.AsmPositionUpdater$.$anonfun$postProcess$3(AsmPositionUpdater.scala:62)
	at scala.build.postprocessing.AsmPositionUpdater$.$anonfun$postProcess$3$adapted(AsmPositionUpdater.scala:55)
```