### PR TITLE
Change community link to discord.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -108,8 +108,8 @@ module.exports = {
           title: 'Community',
           items: [
             {
-              label: 'Gitter',
-              href: 'https://gitter.im/Virtuslab/scala-cli',
+              label: 'Discord',
+              href: 'https://discord.gg/ScreHFr957',
             },
           ],
         },


### PR DESCRIPTION
I'm not sure you still plan to have a gitter channel or not, but right
now it just leads to a 404. This changes the community link to instead
point towards the scala-cli channel on the Scala discord. The link is a
non-expiring one.