### PR TITLE
Use artifacts from main scope in tests

### DIFF
--- a/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
@@ -75,7 +75,7 @@ final class BspImpl(
       pprint.stderr.log(sourcesMain)
 
     val options0Main = sourcesMain.buildOptions
-    val options0Test = sourcesTest.buildOptions
+    val options0Test = sourcesTest.buildOptions.orElse(options0Main)
 
     val generatedSourcesMain = sourcesMain.generateSources(inputs.generatedSrcRoot(Scope.Main))
     val generatedSourcesTest = sourcesTest.generateSources(inputs.generatedSrcRoot(Scope.Test))

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -772,7 +772,8 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
     val inputs = TestInputs(
       Seq(
         os.rel / "Messages.scala" ->
-          """object Messages {
+          """// using lib "com.lihaoyi::os-lib:0.7.8"
+            |object Messages {
             |  def msg = "Hello"
             |}
             |""".stripMargin,
@@ -826,12 +827,18 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
               uri.drop(idx + 1)
             }
 
-          if (actualScalaVersion.startsWith("2.13"))
+          if (actualScalaVersion.startsWith("2.13")) {
             expect(foundDepSources.exists(_.startsWith("utest_2.13-0.7.10")))
-          else if (actualScalaVersion.startsWith("2.12"))
+            expect(foundDepSources.exists(_.startsWith("os-lib_2.13-0.7.8")))
+          }
+          else if (actualScalaVersion.startsWith("2.12")) {
             expect(foundDepSources.exists(_.startsWith("utest_2.12-0.7.10")))
-          else
+            expect(foundDepSources.exists(_.startsWith("os-lib_2.12-0.7.8")))
+          }
+          else {
             expect(foundDepSources.exists(_.startsWith("utest_3-0.7.10")))
+            expect(foundDepSources.exists(_.startsWith("os-lib_3-0.7.8")))
+          }
 
           expect(foundDepSources.exists(_.startsWith("test-interface-1.0")))
           expect(foundDepSources.forall(_.endsWith("-sources.jar")))


### PR DESCRIPTION
The problem was that scope test didn't include the libraries specified in scope main.

Now, all attached artifacts in scope main should be visible in test scope. I merge `buildOptions` from Main with `testOptions`. 