### PR TITLE
Move Scala Native linking to runtime fetched scala-native-cli process

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -189,7 +189,7 @@ class Build(val crossScalaVersion: String)
     Deps.dependency,
     Deps.guava, // for coursierJvm / scalaJsEnvNodeJs, see above
     Deps.nativeTestRunner,
-    Deps.nativeTools,
+    Deps.nativeTools, // Used only for discovery methods. For linking, look for scala-native-cli
     Deps.osLib,
     Deps.pprint,
     Deps.scalaJsEnvNodeJs,

--- a/modules/build/src/main/scala/scala/build/Artifacts.scala
+++ b/modules/build/src/main/scala/scala/build/Artifacts.scala
@@ -164,11 +164,10 @@ object Artifacts {
         None
     }
 
-    val scalaNativeCli = fetchedScalaNativeCli match {
-      case Some(fetched) => fetched.fullDetailedArtifacts.collect { case (_, _, _, Some(f)) =>
-          f.toPath
-        }
-      case None => Nil
+    val scalaNativeCli = fetchedScalaNativeCli.toSeq.flatMap { fetched =>
+      fetched.fullDetailedArtifacts.collect { case (_, _, _, Some(f)) =>
+        f.toPath
+      }
     }
 
     val extraStubsJars =

--- a/modules/build/src/main/scala/scala/build/Logger.scala
+++ b/modules/build/src/main/scala/scala/build/Logger.scala
@@ -19,7 +19,8 @@ trait Logger {
 
   def coursierLogger: coursier.cache.CacheLogger
   def bloopRifleLogger: BloopRifleLogger
-  def scalaNativeLogger: sn.Logger
+  def scalaNativeTestLogger: sn.Logger
+  def scalaNativeCliInternalLoggerOptions: List[String]
 
   def compilerOutputStream: PrintStream
 }
@@ -40,8 +41,10 @@ object Logger {
       coursier.cache.CacheLogger.nop
     def bloopRifleLogger: BloopRifleLogger =
       BloopRifleLogger.nop
-    def scalaNativeLogger: sn.Logger =
+    def scalaNativeTestLogger: sn.Logger =
       sn.Logger.nullLogger
+    def scalaNativeCliInternalLoggerOptions: List[String] =
+      List()
 
     def compilerOutputStream: PrintStream =
       new PrintStream(

--- a/modules/build/src/main/scala/scala/build/errors/ScalaNativeBuildError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/ScalaNativeBuildError.scala
@@ -1,0 +1,4 @@
+package scala.build.errors
+
+final class ScalaNativeBuildError()
+    extends BuildException(s"Error compiling with Scala Native")

--- a/modules/build/src/main/scala/scala/build/internal/NativeBuilderHelper.scala
+++ b/modules/build/src/main/scala/scala/build/internal/NativeBuilderHelper.scala
@@ -7,7 +7,7 @@ import scala.build.Build
 
 object NativeBuilderHelper {
 
-  case class SNCacheData(val changed: Boolean, val projectSha: String)
+  case class SNCacheData(changed: Boolean, projectSha: String)
 
   private def resolveProjectShaPath(nativeWorkDir: os.Path) = nativeWorkDir / ".project_sha"
   private def resolveOutputShaPath(nativeWorkDir: os.Path)  = nativeWorkDir / ".output_sha"

--- a/modules/build/src/main/scala/scala/build/internal/Runner.scala
+++ b/modules/build/src/main/scala/scala/build/internal/Runner.scala
@@ -306,7 +306,7 @@ object Runner {
     val config = TestAdapter.Config()
       .withBinaryFile(launcher)
       .withEnvVars(sys.env.toMap)
-      .withLogger(logger.scalaNativeLogger)
+      .withLogger(logger.scalaNativeTestLogger)
 
     var adapter: TestAdapter = null
 

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -335,6 +335,8 @@ final case class BuildOptions(
       compilerPlugins = value(compilerPlugins),
       dependencies = value(dependencies),
       extraClassPath = allExtraJars,
+      scalaNativeCliVersion =
+        if (platform.value == Platform.Native) Some(scalaNativeOptions.finalVersion) else None,
       extraCompileOnlyJars = allExtraCompileOnlyJars,
       extraSourceJars = allExtraSourceJars,
       fetchSources = classPathOptions.fetchSources.getOrElse(false),

--- a/modules/build/src/main/scala/scala/build/options/ScalaNativeOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/ScalaNativeOptions.scala
@@ -27,27 +27,44 @@ final case class ScalaNativeOptions(
 
   private def gc(): sn.GC =
     gcStr.map(_.trim).filter(_.nonEmpty) match {
-      case Some("default") | None => sn.GC.default
+      case Some("default") | None => sn.Discover.GC()
       case Some(other)            => sn.GC(other)
     }
+  private def gcCliOption(): List[String] =
+    List("--gc", gc().name)
+
   private def mode(): sn.Mode =
     modeStr.map(_.trim).filter(_.nonEmpty) match {
       case Some("default") | None => sn.Discover.mode()
       case Some(other)            => sn.Mode(other)
     }
+  private def modeCliOption(): List[String] =
+    List("--mode", mode().name)
 
   private def clangPath() = clang
     .filter(_.nonEmpty)
     .map(Paths.get(_))
     .getOrElse(sn.Discover.clang())
+  private def clangCliOption(): List[String] =
+    List("--clang", clangPath.toString())
+
   private def clangppPath() = clangpp
     .filter(_.nonEmpty)
     .map(Paths.get(_))
     .getOrElse(sn.Discover.clangpp())
-  private def finalLinkingOptions() =
+  private def clangppCliOption(): List[String] =
+    List("--clang-pp", clangppPath().toString())
+
+  private def finalLinkingOptions(): List[String] =
     linkingOptions ++ (if (linkingDefaults.getOrElse(true)) sn.Discover.linkingOptions() else Nil)
-  private def finalCompileOptions() =
+  private def finalCompileOptions(): List[String] =
     compileOptions ++ (if (compileDefaults.getOrElse(true)) sn.Discover.compileOptions() else Nil)
+
+  private def linkingCliOptions(): List[String] =
+    finalLinkingOptions.flatMap(option => List("--linking-option", option))
+
+  private def compileCliOptions(): List[String] =
+    finalCompileOptions.flatMap(option => List("--compile-option", option))
 
   def platformSuffix: String =
     "native" + ScalaVersion.nativeBinary(finalVersion).getOrElse(finalVersion)
@@ -62,7 +79,8 @@ final case class ScalaNativeOptions(
       version = finalVersion,
       // there are more modes than bloop allows, but that setting here shouldn't end up being used anyway
       mode =
-        if (mode().name == "release") BloopConfig.LinkerMode.Release
+        if (mode() == sn.Mode.releaseFast || mode() == sn.Mode.releaseFull)
+          BloopConfig.LinkerMode.Release
         else BloopConfig.LinkerMode.Debug,
       gc = gc().name,
       targetTriple = None,
@@ -79,15 +97,13 @@ final case class ScalaNativeOptions(
       output = None
     )
 
-  def config(): sn.NativeConfig =
-    sn.NativeConfig.empty
-      .withGC(gc())
-      .withMode(mode())
-      .withLinkStubs(false)
-      .withClang(clangPath())
-      .withClangPP(clangppPath())
-      .withLinkingOptions(linkingOptions)
-      .withCompileOptions(compileOptions)
+  def configCliOptions(): List[String] =
+    gcCliOption()
+      .++(modeCliOption())
+      .++(clangCliOption())
+      .++(clangppCliOption())
+      .++(linkingCliOptions())
+      .++(compileCliOptions())
 
 }
 

--- a/modules/build/src/main/scala/scala/build/options/ScalaNativeOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/ScalaNativeOptions.scala
@@ -98,12 +98,12 @@ final case class ScalaNativeOptions(
     )
 
   def configCliOptions(): List[String] =
-    gcCliOption()
-      .++(modeCliOption())
-      .++(clangCliOption())
-      .++(clangppCliOption())
-      .++(linkingCliOptions())
-      .++(compileCliOptions())
+    gcCliOption() ++
+      modeCliOption() ++
+      clangCliOption() ++
+      clangppCliOption() ++
+      linkingCliOptions() ++
+      compileCliOptions()
 
 }
 

--- a/modules/build/src/test/scala/scala/build/tests/BuildProjectTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildProjectTests.scala
@@ -40,8 +40,11 @@ class BuildProjectTests extends munit.FunSuite {
 
     override def bloopRifleLogger: BloopRifleLogger = BloopRifleLogger.nop
 
-    override def scalaNativeLogger: scala.scalanative.build.Logger =
+    override def scalaNativeTestLogger: scala.scalanative.build.Logger =
       scala.scalanative.build.Logger.nullLogger
+
+    override def scalaNativeCliInternalLoggerOptions: List[String] =
+      List()
 
     override def compilerOutputStream: PrintStream = ???
 

--- a/modules/build/src/test/scala/scala/build/tests/NativeBuilderHelperTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/NativeBuilderHelperTests.scala
@@ -42,15 +42,15 @@ class NativeBuilderHelperTests extends munit.FunSuite {
     inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
       val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val nativeConfig  = build.options.scalaNativeOptions.config
+      val config        = build.options.scalaNativeOptions.configCliOptions
       val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
       val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
       // generate dummy output
       os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-      val changed =
-        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
-      expect(changed)
+      val cacheData =
+        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+      expect(cacheData.changed)
     }
   }
 
@@ -58,20 +58,20 @@ class NativeBuilderHelperTests extends munit.FunSuite {
     inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
       val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val nativeConfig  = build.options.scalaNativeOptions.config
+      val config        = build.options.scalaNativeOptions.configCliOptions
       val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
       val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
       // generate dummy output
       os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-      val changed =
-        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
-      NativeBuilderHelper.updateOutputSha(destPath, nativeWorkDir)
-      expect(changed)
+      val cacheData =
+        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+      NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
+      expect(cacheData.changed)
 
-      val changedSameBuild =
-        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
-      expect(!changedSameBuild)
+      val sameBuildCache =
+        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+      expect(!sameBuildCache.changed)
     }
   }
 
@@ -79,21 +79,21 @@ class NativeBuilderHelperTests extends munit.FunSuite {
     inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
       val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val nativeConfig  = build.options.scalaNativeOptions.config
+      val config        = build.options.scalaNativeOptions.configCliOptions
       val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
       val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
       // generate dummy output
       os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-      val changed =
-        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
-      NativeBuilderHelper.updateOutputSha(destPath, nativeWorkDir)
-      expect(changed)
+      val cacheData =
+        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+      NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
+      expect(cacheData.changed)
 
       os.remove(destPath)
-      val changedAfterDelete =
-        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
-      expect(changedAfterDelete)
+      val afterDeleteCache =
+        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+      expect(afterDeleteCache.changed)
     }
   }
 
@@ -101,21 +101,21 @@ class NativeBuilderHelperTests extends munit.FunSuite {
     inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
       val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val nativeConfig  = build.options.scalaNativeOptions.config
+      val config        = build.options.scalaNativeOptions.configCliOptions
       val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
       val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
       // generate dummy output
       os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-      val changed =
-        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
-      NativeBuilderHelper.updateOutputSha(destPath, nativeWorkDir)
-      expect(changed)
+      val cacheData =
+        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+      NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
+      expect(cacheData.changed)
 
       os.write.over(destPath, Random.alphanumeric.take(10).mkString(""))
-      val changedAfterFileUpdate =
-        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
-      expect(changedAfterFileUpdate)
+      val cacheAfterFileUpdate =
+        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+      expect(cacheAfterFileUpdate.changed)
     }
   }
 
@@ -123,20 +123,20 @@ class NativeBuilderHelperTests extends munit.FunSuite {
     inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
       val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val nativeConfig  = build.options.scalaNativeOptions.config
+      val config        = build.options.scalaNativeOptions.configCliOptions
       val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
       val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
       os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-      val changed =
-        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
-      NativeBuilderHelper.updateOutputSha(destPath, nativeWorkDir)
-      expect(changed)
+      val cacheData =
+        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+      NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
+      expect(cacheData.changed)
 
       os.write.append(root / helloFileName, Random.alphanumeric.take(10).mkString(""))
-      val changedAfterFileUpdate =
-        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
-      expect(changedAfterFileUpdate)
+      val cacheAfterFileUpdate =
+        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+      expect(cacheAfterFileUpdate.changed)
     }
   }
 
@@ -144,15 +144,15 @@ class NativeBuilderHelperTests extends munit.FunSuite {
     inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
       val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val nativeConfig  = build.options.scalaNativeOptions.config
+      val config        = build.options.scalaNativeOptions.configCliOptions
       val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
       val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
       os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-      val changed =
-        NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, destPath, nativeWorkDir)
-      NativeBuilderHelper.updateOutputSha(destPath, nativeWorkDir)
-      expect(changed)
+      val cacheData =
+        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+      NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
+      expect(cacheData.changed)
 
       val updatedBuild = build.copy(
         options = build.options.copy(
@@ -161,16 +161,16 @@ class NativeBuilderHelperTests extends munit.FunSuite {
           )
         )
       )
-      val updatedNativeConfig = updatedBuild.options.scalaNativeOptions.config
+      val updatedConfig = updatedBuild.options.scalaNativeOptions.configCliOptions
 
-      val changedAfterConfigUpdate =
-        NativeBuilderHelper.shouldBuildIfChanged(
+      val cacheAfterConfigUpdate =
+        NativeBuilderHelper.getCacheData(
           updatedBuild,
-          updatedNativeConfig,
+          updatedConfig,
           destPath,
           nativeWorkDir
         )
-      expect(changedAfterConfigUpdate)
+      expect(cacheAfterConfigUpdate.changed)
     }
   }
 

--- a/modules/build/src/test/scala/scala/build/tests/NativeBuilderHelperTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/NativeBuilderHelperTests.scala
@@ -42,7 +42,7 @@ class NativeBuilderHelperTests extends munit.FunSuite {
     inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
       val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val config        = build.options.scalaNativeOptions.configCliOptions
+      val config        = build.options.scalaNativeOptions.configCliOptions()
       val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
       val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
       // generate dummy output
@@ -58,7 +58,7 @@ class NativeBuilderHelperTests extends munit.FunSuite {
     inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
       val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val config        = build.options.scalaNativeOptions.configCliOptions
+      val config        = build.options.scalaNativeOptions.configCliOptions()
       val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
       val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
       // generate dummy output
@@ -79,7 +79,7 @@ class NativeBuilderHelperTests extends munit.FunSuite {
     inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
       val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val config        = build.options.scalaNativeOptions.configCliOptions
+      val config        = build.options.scalaNativeOptions.configCliOptions()
       val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
       val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
       // generate dummy output
@@ -101,7 +101,7 @@ class NativeBuilderHelperTests extends munit.FunSuite {
     inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
       val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val config        = build.options.scalaNativeOptions.configCliOptions
+      val config        = build.options.scalaNativeOptions.configCliOptions()
       val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
       val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
       // generate dummy output
@@ -123,7 +123,7 @@ class NativeBuilderHelperTests extends munit.FunSuite {
     inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
       val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val config        = build.options.scalaNativeOptions.configCliOptions
+      val config        = build.options.scalaNativeOptions.configCliOptions()
       val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
       val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
       os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
@@ -144,7 +144,7 @@ class NativeBuilderHelperTests extends munit.FunSuite {
     inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
       val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val config        = build.options.scalaNativeOptions.configCliOptions
+      val config        = build.options.scalaNativeOptions.configCliOptions()
       val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
       val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
       os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
@@ -161,7 +161,7 @@ class NativeBuilderHelperTests extends munit.FunSuite {
           )
         )
       )
-      val updatedConfig = updatedBuild.options.scalaNativeOptions.configCliOptions
+      val updatedConfig = updatedBuild.options.scalaNativeOptions.configCliOptions()
 
       val cacheAfterConfigUpdate =
         NativeBuilderHelper.getCacheData(

--- a/modules/build/src/test/scala/scala/build/tests/TestLogger.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestLogger.scala
@@ -42,8 +42,10 @@ case class TestLogger(info: Boolean = true, debug: Boolean = false) extends Logg
 
   def bloopRifleLogger: BloopRifleLogger =
     BloopRifleLogger.nop
-  def scalaNativeLogger: sn.Logger =
+  def scalaNativeTestLogger: sn.Logger =
     sn.Logger.nullLogger
+  def scalaNativeCliInternalLoggerOptions: List[String] =
+    List()
   def bloopBspStderr        = None
   def bloopBspStdout        = None
   def bloopCliInheritStdout = false

--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -541,7 +541,7 @@ object Package extends ScalaCommand[PackageOptions] {
     logger: Logger
   ): Unit = {
 
-    val cliOptions = build.options.scalaNativeOptions.configCliOptions
+    val cliOptions = build.options.scalaNativeOptions.configCliOptions()
 
     os.makeDir.all(nativeWorkDir)
 
@@ -551,7 +551,7 @@ object Package extends ScalaCommand[PackageOptions] {
         cliOptions,
         dest,
         nativeWorkDir
-      ) // TODO add main class
+      )
 
     if (cacheData.changed)
       withLibraryJar(build, dest.last.stripSuffix(".jar")) { mainJar =>
@@ -581,7 +581,7 @@ object Package extends ScalaCommand[PackageOptions] {
         if (exitCode == 0)
           NativeBuilderHelper.updateProjectAndOutputSha(dest, nativeWorkDir, cacheData.projectSha)
         else
-          throw new ScalaNativeBuildError()
+          throw new ScalaNativeBuildError
       }
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -19,15 +19,13 @@ import java.util.jar.{Attributes => JarAttributes, JarOutputStream}
 import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import scala.build.EitherCps.{either, value}
-import scala.build.errors.BuildException
-import scala.build.internal.{NativeBuilderHelper, ScalaJsConfig}
+import scala.build.errors.{BuildException, ScalaNativeBuildError}
+import scala.build.internal.{NativeBuilderHelper, Runner, ScalaJsConfig}
 import scala.build.options.{PackageType, Platform}
 import scala.build.{Build, Inputs, Logger, Os}
 import scala.cli.CurrentParams
 import scala.cli.commands.OptionsHelper._
 import scala.cli.internal.{GetImageResizer, ScalaJsLinker}
-import scala.scalanative.util.Scope
-import scala.scalanative.{build => sn}
 import scala.util.Properties
 
 object Package extends ScalaCommand[PackageOptions] {
@@ -408,7 +406,7 @@ object Package extends ScalaCommand[PackageOptions] {
     val workDir =
       build.options.scalaNativeOptions.nativeWorkDir(inputs.workspace, inputs.projectName)
 
-    buildNative(build, mainClass, destPath, workDir, logger.scalaNativeLogger)
+    buildNative(build, mainClass, destPath, workDir, logger)
   }
 
   private def bootstrap(
@@ -540,28 +538,50 @@ object Package extends ScalaCommand[PackageOptions] {
     mainClass: String,
     dest: os.Path,
     nativeWorkDir: os.Path,
-    nativeLogger: sn.Logger
+    logger: Logger
   ): Unit = {
 
-    val nativeConfig = build.options.scalaNativeOptions.config()
+    val cliOptions = build.options.scalaNativeOptions.configCliOptions
 
     os.makeDir.all(nativeWorkDir)
-    val changed = NativeBuilderHelper.shouldBuildIfChanged(build, nativeConfig, dest, nativeWorkDir)
 
-    if (changed)
+    val cacheData =
+      NativeBuilderHelper.getCacheData(
+        build,
+        cliOptions,
+        dest,
+        nativeWorkDir
+      ) // TODO add main class
+
+    if (cacheData.changed)
       withLibraryJar(build, dest.last.stripSuffix(".jar")) { mainJar =>
-        val config = sn.Config.empty
-          .withCompilerConfig(nativeConfig)
-          .withMainClass(mainClass + "$")
-          .withClassPath(mainJar +: build.artifacts.classPath)
-          .withWorkdir(nativeWorkDir.toNIO)
-          .withLogger(nativeLogger)
 
-        Scope { implicit scope =>
-          sn.Build.build(config, dest.toNIO)
-        }
+        val classpath = build.fullClassPath.map(_.toString) :+ mainJar.toString()
+        val args =
+          cliOptions ++
+            logger.scalaNativeCliInternalLoggerOptions ++
+            List[String](
+              "--outpath",
+              dest.toString(),
+              "--workdir",
+              nativeWorkDir.toString(),
+              "--main",
+              mainClass
+            ) ++ classpath
 
-        NativeBuilderHelper.updateOutputSha(dest, nativeWorkDir)
+        val exitCode =
+          Runner.runJvm(
+            build.options.javaHome().value.javaCommand,
+            build.options.javaOptions.javaOpts.map(_.value),
+            build.artifacts.scalaNativeCli.map(_.toFile),
+            "scala.scalanative.cli.ScalaNativeLd",
+            args,
+            logger
+          )
+        if (exitCode == 0)
+          NativeBuilderHelper.updateProjectAndOutputSha(dest, nativeWorkDir, cacheData.projectSha)
+        else
+          throw new ScalaNativeBuildError()
       }
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -9,7 +9,6 @@ import scala.build.internal.{Constants, Runner}
 import scala.build.options.Platform
 import scala.build.{Build, Inputs, Logger}
 import scala.cli.CurrentParams
-import scala.scalanative.{build => sn}
 import scala.util.Properties
 
 object Run extends ScalaCommand[RunOptions] {
@@ -162,7 +161,7 @@ object Run extends ScalaCommand[RunOptions] {
           build,
           mainClass,
           build.options.scalaNativeOptions.nativeWorkDir(root, projectName),
-          logger.scalaNativeLogger
+          logger
         ) { launcher =>
           Runner.runNative(
             launcher.toIO,
@@ -214,7 +213,7 @@ object Run extends ScalaCommand[RunOptions] {
     build: Build.Successful,
     mainClass: String,
     workDir: os.Path,
-    logger: sn.Logger
+    logger: Logger
   )(f: os.Path => T): T = {
     val dest = workDir / s"main${if (Properties.isWin) ".exe" else ""}"
     Package.buildNative(build, mainClass, dest, workDir, logger)

--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -152,7 +152,7 @@ object Test extends ScalaCommand[TestOptions] {
             build,
             "scala.scalanative.testinterface.TestMain",
             build.options.scalaNativeOptions.nativeWorkDir(root, projectName),
-            logger.scalaNativeLogger
+            logger
           ) { launcher =>
             Runner.testNative(
               build.fullClassPath,

--- a/modules/cli/src/main/scala/scala/cli/internal/CliLogger.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/CliLogger.scala
@@ -158,10 +158,9 @@ class CliLogger(
     }
 
   val scalaNativeCliInternalLoggerOptions: List[String] = {
-    if (verbosity >= 2) List("-v", "-v", "-v")
-    else if (verbosity >= 1) List("-v", "-v")
-    else if (verbosity == 0) List("-v")
-    else List()
+    if (verbosity >= 1) List("-v", "-v", "-v") // debug
+    else if (verbosity >= 0) List("-v", "-v")  // info
+    else List()                                // error
   }
 
   // Allow to disable that?

--- a/modules/cli/src/main/scala/scala/cli/internal/CliLogger.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/CliLogger.scala
@@ -148,7 +148,7 @@ class CliLogger(
       def bloopCliInheritStderr = verbosity >= 3
     }
 
-  def scalaNativeLogger: sn.Logger =
+  def scalaNativeTestLogger: sn.Logger =
     new sn.Logger {
       def trace(msg: Throwable) = ()
       def debug(msg: String)    = logger.debug(msg)
@@ -156,6 +156,13 @@ class CliLogger(
       def warn(msg: String)     = logger.log(msg)
       def error(msg: String)    = logger.log(msg)
     }
+
+  val scalaNativeCliInternalLoggerOptions: List[String] = {
+    if (verbosity >= 2) List("-v", "-v", "-v")
+    else if (verbosity >= 1) List("-v", "-v")
+    else if (verbosity == 0) List("-v")
+    else List()
+  }
 
   // Allow to disable that?
   def compilerOutputStream = out

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -115,7 +115,9 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     )
     inputs.fromRoot { root =>
       val output =
-        os.proc(TestUtil.cli, extraOptions, fileName, "--native").call(cwd = root).out.text().trim
+        os.proc(TestUtil.cli, extraOptions, fileName, "--native", "-q")
+          .call(cwd = root)
+          .out.text().trim
       expect(output == message)
     }
   }
@@ -205,8 +207,9 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     )
     inputs.fromRoot { root =>
       val output =
-        os.proc(TestUtil.cli, extraOptions, "print.sc", "messages.sc", "--native").call(cwd =
-          root).out.text().trim
+        os.proc(TestUtil.cli, extraOptions, "print.sc", "messages.sc", "--native", "-q")
+          .call(cwd = root)
+          .out.text().trim
       expect(output == message)
     }
   }
@@ -344,7 +347,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     )
     inputs.fromRoot { root =>
       val output =
-        os.proc(TestUtil.cli, extraOptions, "dir", "--native", "--main-class", "print_sc")
+        os.proc(TestUtil.cli, extraOptions, "dir", "--native", "--main-class", "print_sc", "-q")
           .call(cwd = root)
           .out.text().trim
       expect(output == message)


### PR DESCRIPTION
This is a PR meant to showcase changes to Scala Native linking before they have to be finalized so that no grave mistakes will be made on the scala-native-cli side. The most interesting part is in buildNative in Package.scala, where we run the linking process. Other changes concern redesigning Scala Native logging (we move it to scala-native-cli) and adjusted caching to accommodate the new structure.