### PR TITLE
Hide commend for integration tests

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/InstallHomeOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/InstallHomeOptions.scala
@@ -11,10 +11,12 @@ final case class InstallHomeOptions(
   @Name("f")
   @HelpMessage("Overwrite `scala-cli`, if it exists")
     force: Boolean = false,
+  @Hidden
   @HelpMessage("Binary name")
     binaryName: String = "scala-cli",
   @HelpMessage("Print the update to `env` variable")
     env: Boolean = false,
+  @Hidden
   @HelpMessage("Binary directory")
     binDir: Option[String] = None
 ) {

--- a/modules/cli/src/main/scala/scala/cli/commands/Update.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Update.scala
@@ -12,7 +12,7 @@ object Update extends ScalaCommand[UpdateOptions] {
     if (coursier.paths.Util.useAnsiOutput()) {
       println(s"Do you want to update scala-cli to version $newVersion [Y/n]")
       val response = readLine()
-      if (response != "Y") {
+      if (response.toLowerCase != "y") {
         System.err.println("Abort")
         sys.exit(1)
       }

--- a/modules/cli/src/main/scala/scala/cli/commands/UpdateOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/UpdateOptions.scala
@@ -5,14 +5,16 @@ import caseapp._
 // format: off
 @HelpMessage("Update scala-cli - it works only for installation script")
 final case class UpdateOptions(
+  @Hidden
   @Group("Update")
   @HelpMessage("Binary name")
     binaryName: String = "scala-cli",
+  @Hidden
   @Group("Update")
   @HelpMessage("Binary directory")
     binDir: Option[String] = None,
   @Name("f")
-  @HelpMessage("Update scala-cli if is outdated")
+  @HelpMessage("Force update scala-cli if is outdated")
     force: Boolean = false,
   @Hidden
     isInternalRun: Boolean = false

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1006,7 +1006,7 @@ Binary directory
 
 Aliases: `-f`
 
-Update scala-cli if is outdated
+Force update scala-cli if is outdated
 
 #### `--is-internal-run`
 


### PR DESCRIPTION
Some options parameters were added for testing purposes and the user doesn't should to use them. 

If there are cases that these commands will be needed, we will make them visible. Now, I don't see any such cases.