### PR TITLE
Always forward Bloop stderr

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/SharedCompilationServerOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SharedCompilationServerOptions.scala
@@ -233,7 +233,7 @@ final case class SharedCompilationServerOptions(
       javaPath = javaPath,
       bspSocketOrPort = defaultBspSocketOrPort(directories),
       bspStdout = if (verbosity >= 3) Some(System.err) else None,
-      bspStderr = if (verbosity >= 3) Some(System.err) else None,
+      bspStderr = Some(System.err),
       period = bloopBspCheckPeriodDuration.getOrElse(baseConfig.period),
       timeout = bloopBspTimeoutDuration.getOrElse(baseConfig.timeout),
       initTimeout = bloopStartupTimeoutDuration.getOrElse(baseConfig.initTimeout),


### PR DESCRIPTION
Usually, Bloop prints nothing to stderr, so there's no difference, but
this could help a lot in cases when it gets lost, for example #452