### PR TITLE
Native image: do not filter-out JVM options passed to scala-cli app

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -79,7 +79,9 @@ object ScalaCli extends CommandsEntryPoint {
     systemProps.map(_.stripPrefix("-D")).foreach { prop =>
       prop.split("=", 2) match {
         case Array(key, value) =>
-          System.setProperty(key, value.stripPrefix("=")) // todo log
+          System.setProperty(key, value)
+        case Array(key) =>
+          System.setProperty(key, "")
       }
     }
   }

--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -70,7 +70,23 @@ object ScalaCli extends CommandsEntryPoint {
     }
   }
 
+  private def partitionArgs(args: Array[String]): (Array[String], Array[String]) = {
+    val systemProps = args.takeWhile(_.startsWith("-D"))
+    (systemProps, args.drop(systemProps.size))
+  }
+
+  private def setSystemProps(systemProps: Array[String]): Unit = {
+    systemProps.map(_.stripPrefix("-D")).foreach { prop =>
+      prop.split("=", 2) match {
+        case Array(key, value) =>
+          System.setProperty(key, value.stripPrefix("=")) // todo log
+      }
+    }
+  }
+
   override def main(args: Array[String]): Unit = {
+    val (systemProps, scalaCliArgs) = partitionArgs(args)
+    setSystemProps(systemProps)
 
     if (Properties.isWin && isGraalvmNativeImage)
       // The DLL loaded by LoadWindowsLibrary is statically linked in
@@ -85,18 +101,18 @@ object ScalaCli extends CommandsEntryPoint {
       coursier.jniutils.WindowsAnsiTerminal.enableAnsiOutput()
 
     // quick hack, until the raw args are kept in caseapp.RemainingArgs by case-app
-    actualDefaultCommand.anyArgs = args.nonEmpty
+    actualDefaultCommand.anyArgs = scalaCliArgs.nonEmpty
 
     commands.foreach {
-      case c: NeedsArgvCommand => c.setArgv(progName +: args)
+      case c: NeedsArgvCommand => c.setArgv(progName +: scalaCliArgs)
       case _                   =>
     }
 
     val processedArgs =
-      if (args.lengthCompare(1) > 0 && isShebangFile(args(0)))
-        Array(args(0), "--") ++ args.tail
+      if (scalaCliArgs.lengthCompare(1) > 0 && isShebangFile(scalaCliArgs(0)))
+        Array(scalaCliArgs(0), "--") ++ scalaCliArgs.tail
       else
-        args
+        scalaCliArgs
     super.main(processedArgs)
   }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -1293,4 +1293,21 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
 
+  test("-D.. options passed to the child app") {
+    val inputs = TestInputs(
+      Seq(
+        os.rel / "Hello.scala" -> """
+                                    |import java.lang.System
+                                    |object ClassHello extends App {
+                                    |  println(System.getProperty("foo"))
+                                    |}""".stripMargin
+      )
+    )
+    inputs.fromRoot { root =>
+      val res = os.proc(TestUtil.cli, "Hello.scala", "--java-opt", "-Dfoo=bar").call(
+        cwd = root
+      )
+      expect(res.out.text().contains("bar"))
+    }
+  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -1310,4 +1310,24 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
       expect(res.out.text().contains("bar"))
     }
   }
+
+  test("-X.. options passed to the child app") {
+    val inputs = TestInputs(
+      Seq(
+        os.rel / "Hello.scala" -> "object Hello extends App {}"
+      )
+    )
+    inputs.fromRoot { root =>
+      // Binaries generated with Graal's native-image are run under SubstrateVM
+      // that cuts some -X.. java options, so they're not passed
+      // to the application's main method. This test ensures it is not
+      // cut. "--java-opt" option requires a value, so it would fail
+      // if -Xmx1g is cut
+      val res = os.proc(TestUtil.cli, "Hello.scala", "--java-opt", "-Xmx1g").call(
+        cwd = root,
+        check = false
+      )
+      assert(res.exitCode == 0, clues(res.out.text(), res.err.text()))
+    }
+  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -1296,10 +1296,8 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   test("-D.. options passed to the child app") {
     val inputs = TestInputs(
       Seq(
-        os.rel / "Hello.scala" -> """
-                                    |import java.lang.System
-                                    |object ClassHello extends App {
-                                    |  println(System.getProperty("foo"))
+        os.rel / "Hello.scala" -> """object ClassHello extends App {
+                                    |  print(System.getProperty("foo"))
                                     |}""".stripMargin
       )
     )
@@ -1307,7 +1305,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
       val res = os.proc(TestUtil.cli, "Hello.scala", "--java-opt", "-Dfoo=bar").call(
         cwd = root
       )
-      expect(res.out.text().contains("bar"))
+      expect(res.out.text().trim() == "bar")
     }
   }
 

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -210,6 +210,7 @@ trait CliLaunchers extends SbtModule { self =>
         else staticLibDir().path.toString
       Seq(
         s"-H:IncludeResources=$localRepoResourcePath",
+        s"-H:-ParseRuntimeOptions",
         s"-H:CLibraryPath=$cLibPath"
       )
     }

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -210,7 +210,7 @@ trait CliLaunchers extends SbtModule { self =>
         else staticLibDir().path.toString
       Seq(
         s"-H:IncludeResources=$localRepoResourcePath",
-        s"-H:-ParseRuntimeOptions",
+        "-H:-ParseRuntimeOptions",
         s"-H:CLibraryPath=$cLibPath"
       )
     }

--- a/website/docs/under-the-hood.md
+++ b/website/docs/under-the-hood.md
@@ -37,3 +37,12 @@ The main point to know is that Scala CLI takes care of fetching and starting Blo
 Scala CLI uses [Coursier](https://get-coursier.io/) to manage dependencies.
 It automatically downloads and unpacks a JVM if none is installed on your system, so that all its commands work fine even if a JVM isn't already installed.
 Scala CLI shares Coursier caches with other tools like [sbt](https://www.scala-sbt.org/), [Mill](https://github.com/com-lihaoyi/mill), or [Metals](https://scalameta.org/metals/).
+
+### scala-cli's JVM
+Scala CLI is a JVM application. Although by default it is distributed as a native image, it is still possible to tweak it with java properties.
+In order set them, the `-D` command-line flags must be placed as the first options to scala-cli, for example:
+
+``` bash
+scala-cli -Dfoo1=bar1 -Dfoo2=bar2 run ...
+```
+Please note, that `scala-cli run -Dfoo=bar` wouldn't work

--- a/website/docs/under-the-hood.md
+++ b/website/docs/under-the-hood.md
@@ -39,7 +39,7 @@ It automatically downloads and unpacks a JVM if none is installed on your system
 Scala CLI shares Coursier caches with other tools like [sbt](https://www.scala-sbt.org/), [Mill](https://github.com/com-lihaoyi/mill), or [Metals](https://scalameta.org/metals/).
 
 ### scala-cli's JVM
-Scala CLI is a JVM application. Although by default it is distributed as a native image, it is still possible to tweak it with java properties.
+Scala CLI is a JVM application. Although by default it is distributed as a GraalVM native image, it is still possible to set Java properties.
 In order set them, the `-D` command-line flags must be placed as the first options to scala-cli, for example:
 
 ``` bash


### PR DESCRIPTION
Graal's native image bulids a native application that has embedded
runtime named SubstrateVM. SubstrateVM processes and filters command line
arguments before passing them to the actual application. For example
it catches all `-X` arguments and uses them to configure itself. In
scala-cli we sometimes need this kind of arguments, for example when
we call `scala-cli --java-opt "-Xmx1g"`.

This commit disables the parsing by setting `-H:-ParseRuntimeOptions`
build option

The graal's parsing logic is defined here: https://github.com/oracle/graal/blob/6773ebc7dcd59ec7185ba5f5db70b714aa43e108/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/RuntimeOptionParser.java#L81