### PR TITLE
Workaround issue with empty JAVA_HOME

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/OsLibc.scala
+++ b/modules/build/src/main/scala/scala/build/internal/OsLibc.scala
@@ -57,8 +57,15 @@ object OsLibc {
     else default
   }
 
-  lazy val defaultJvm: String =
-    if (jvmIndexOs == "linux-musl") s"${JavaHome.systemId}|liberica" // zulu could work too
-    else JavaHome.defaultId
+  lazy val defaultJvm: String = {
+    val hasEmptyJavaHome = Option(System.getenv("JAVA_HOME")).exists(_.trim.isEmpty)
+    if (hasEmptyJavaHome)
+      // Not using the system JVM if JAVA_HOME is set to an empty string
+      // (workaround for https://github.com/coursier/coursier/issues/2292)
+      if (jvmIndexOs == "linux-musl") "liberica" // zulu could work too
+      else JavaHome.defaultJvm
+    else if (jvmIndexOs == "linux-musl") s"${JavaHome.systemId}|liberica" // zulu could work too
+    else s"${JavaHome.systemId}|${JavaHome.defaultJvm}"
+  }
 
 }


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/pull/437.