### PR TITLE
Ignore NoClassDefFoundError exception in test runner

### DIFF
--- a/modules/build/src/main/scala/scala/build/options/InternalOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/InternalOptions.scala
@@ -6,7 +6,8 @@ import coursier.util.Task
 final case class InternalOptions(
   keepDiagnostics: Boolean = false,
   cache: Option[FileCache[Task]] = None,
-  localRepository: Option[String] = None
+  localRepository: Option[String] = None,
+  verbosity: Option[Int] = None
 )
 
 object InternalOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SharedOptions.scala
@@ -171,7 +171,8 @@ final case class SharedOptions(
       ),
       internal = InternalOptions(
         cache = Some(coursierCache),
-        localRepository = LocalRepo.localRepo(directories.directories.localRepoDir)
+        localRepository = LocalRepo.localRepo(directories.directories.localRepoDir),
+        verbosity = Some(logging.verbosity)
       )
     )
   }

--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -160,6 +160,7 @@ object Test extends ScalaCommand[TestOptions] {
       case Platform.JVM =>
         val extraArgs =
           (if (requireTests) Seq("--require-tests") else Nil) ++
+            build.options.internal.verbosity.map(v => s"--verbosity=$v") ++
             testFrameworkOpt.map(fw => s"--test-framework=$fw").toSeq ++
             Seq("--") ++ args
 

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
@@ -116,7 +116,7 @@ object DynamicTestRunner {
         val it: Iterator[Class[_]] =
           try Iterator(loader.loadClass(name))
           catch {
-            case _: ClassNotFoundException | _: UnsupportedClassVersionError =>
+            case _: ClassNotFoundException | _: UnsupportedClassVersionError | _: NoClassDefFoundError =>
               Iterator.empty
           }
         it
@@ -175,7 +175,10 @@ object DynamicTestRunner {
     val framework = testFrameworkOpt.map(loadFramework(classLoader, _))
       .orElse(findFrameworkService(classLoader))
       .orElse(findFramework(classPath0, classLoader, TestRunner.commonTestFrameworks))
-      .getOrElse(sys.error("No test framework found"))
+      .getOrElse {
+        System.err.println("No test framework found")
+        sys.exit(1)
+      }
     def classes = {
       val keepJars = false // look into dependencies, much slower
       listClasses(classPath0, keepJars).map(name => classLoader.loadClass(name))


### PR DESCRIPTION
ScalaCli throws unexpected exception when someone was trying to run test for `Main` classes. 
```
$ cat HelloWorld.scala
object HelloWorld extends App {
  println("Hello World")
}
$ scala-cli test HelloWorld.scala
Exception in thread "main" java.lang.NoClassDefFoundError: module-info is not a class because access_flag ACC_MODULE is set
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1010)
        at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
        at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:855)
        at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:753)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:676)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:634)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:182)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:519)
        at scala.build.testrunner.DynamicTestRunner$.liftedTree1$1(DynamicTestRunner.scala:117)
        at scala.build.testrunner.DynamicTestRunner$.findFramework$$anonfun$2(DynamicTestRunner.scala:121)
        at scala.collection.Iterator$$anon$10.nextCur(Iterator.scala:585)
        at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:599)
        at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:592)
        at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:592)
        at scala.collection.Iterator$SliceIterator.hasNext(Iterator.scala:1228)
        at scala.collection.immutable.List.prependedAll(List.scala:152)
        at scala.collection.IterableOnceOps.toList(IterableOnce.scala:1251)
        at scala.collection.IterableOnceOps.toList$(IterableOnce.scala:1251)
        at scala.collection.AbstractIterator.toList(Iterator.scala:1288)
        at scala.build.testrunner.DynamicTestRunner$.findFramework(DynamicTestRunner.scala:146)
        at scala.build.testrunner.DynamicTestRunner$.$anonfun$4(DynamicTestRunner.scala:177)
```

If we added new ignored exception in `DynamicTestRunner.scala`, scala-cli return more friendly user error message:
```
scala-cli test HelloWorld.scala
No test framework found
```