### PR TITLE
Don't write stacktraces to files on CIs

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -103,10 +103,12 @@ object ScalaCli extends CommandsEntryPoint {
     baos.toByteArray
   }
 
+  private def isCI = System.getenv("CI") != null
+
   override def main(args: Array[String]): Unit = {
     try main0(args)
     catch {
-      case e: Throwable =>
+      case e: Throwable if !isCI =>
         val workspace = CurrentParams.workspaceOpt.getOrElse(os.pwd)
         val dir       = workspace / ".scala" / "stacktraces"
         os.makeDir.all(dir)


### PR DESCRIPTION
Users usually can't easily read the stacktrace file there.

Plus this was also hiding stack traces in the Scala CLI integration tests, which we don't need.