### PR TITLE
Better musl handling

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/OsLibc.scala
+++ b/modules/build/src/main/scala/scala/build/internal/OsLibc.scala
@@ -57,14 +57,14 @@ object OsLibc {
     else default
   }
 
-  lazy val defaultJvm: String = {
+  def defaultJvm(os: String): String = {
     val hasEmptyJavaHome = Option(System.getenv("JAVA_HOME")).exists(_.trim.isEmpty)
     if (hasEmptyJavaHome)
       // Not using the system JVM if JAVA_HOME is set to an empty string
       // (workaround for https://github.com/coursier/coursier/issues/2292)
-      if (jvmIndexOs == "linux-musl") "liberica" // zulu could work too
+      if (os == "linux-musl") "liberica" // zulu could work too
       else JavaHome.defaultJvm
-    else if (jvmIndexOs == "linux-musl") s"${JavaHome.systemId}|liberica" // zulu could work too
+    else if (os == "linux-musl") s"${JavaHome.systemId}|liberica" // zulu could work too
     else s"${JavaHome.systemId}|${JavaHome.defaultJvm}"
   }
 

--- a/modules/build/src/main/scala/scala/build/internal/OsLibc.scala
+++ b/modules/build/src/main/scala/scala/build/internal/OsLibc.scala
@@ -57,15 +57,19 @@ object OsLibc {
     else default
   }
 
+  private def defaultJvmVersion = "8"
+
   def defaultJvm(os: String): String = {
     val hasEmptyJavaHome = Option(System.getenv("JAVA_HOME")).exists(_.trim.isEmpty)
+    val defaultJvm0 =
+      if (os == "linux-musl") s"liberica:$defaultJvmVersion" // zulu could work too
+      else s"adopt:$defaultJvmVersion"
     if (hasEmptyJavaHome)
       // Not using the system JVM if JAVA_HOME is set to an empty string
       // (workaround for https://github.com/coursier/coursier/issues/2292)
-      if (os == "linux-musl") "liberica" // zulu could work too
-      else JavaHome.defaultJvm
-    else if (os == "linux-musl") s"${JavaHome.systemId}|liberica" // zulu could work too
-    else s"${JavaHome.systemId}|${JavaHome.defaultJvm}"
+      defaultJvm0
+    else
+      s"${JavaHome.systemId}|$defaultJvm0"
   }
 
 }

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -172,7 +172,8 @@ final case class BuildOptions(
     javaHomeLocationOpt().getOrElse {
       implicit val ec = finalCache.ec
       finalCache.logger.use {
-        val path = javaHomeManager.get(OsLibc.defaultJvm).unsafeRun()
+        val jvmIndexOs = javaOptions.jvmIndexOs.getOrElse(OsLibc.jvmIndexOs)
+        val path       = javaHomeManager.get(OsLibc.defaultJvm(jvmIndexOs)).unsafeRun()
         Positioned(Position.Custom("OsLibc.defaultJvm"), os.Path(path))
       }
     }

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -149,6 +149,8 @@ final case class BuildOptions(
     Positioned(javaHome.positions, JavaHomeInfo(javaCmd, javaVersion))
   }
 
+  private def jvmIndexOs = javaOptions.jvmIndexOs.getOrElse(OsLibc.jvmIndexOs)
+
   def javaHomeLocationOpt(): Option[Positioned[os.Path]] =
     javaOptions.javaHomeOpt
       .orElse {
@@ -162,7 +164,14 @@ final case class BuildOptions(
         javaOptions.jvmIdOpt.map { jvmId =>
           implicit val ec = finalCache.ec
           finalCache.logger.use {
-            val path = javaHomeManager.get(jvmId).unsafeRun()
+            val enforceLiberica =
+              jvmIndexOs == "linux-musl" && jvmId.forall(c => c.isDigit || c == '.' || c == '-')
+            val jvmId0 =
+              if (enforceLiberica)
+                s"liberica:$jvmId" // FIXME Workaround, until this is automatically handled by coursier-jvm
+              else
+                jvmId
+            val path = javaHomeManager.get(jvmId0).unsafeRun()
             Positioned(Position.CommandLine("--jvm"), os.Path(path))
           }
         }
@@ -172,8 +181,7 @@ final case class BuildOptions(
     javaHomeLocationOpt().getOrElse {
       implicit val ec = finalCache.ec
       finalCache.logger.use {
-        val jvmIndexOs = javaOptions.jvmIndexOs.getOrElse(OsLibc.jvmIndexOs)
-        val path       = javaHomeManager.get(OsLibc.defaultJvm(jvmIndexOs)).unsafeRun()
+        val path = javaHomeManager.get(OsLibc.defaultJvm(jvmIndexOs)).unsafeRun()
         Positioned(Position.Custom("OsLibc.defaultJvm"), os.Path(path))
       }
     }
@@ -232,7 +240,7 @@ final case class BuildOptions(
     val jvmCache = JvmCache()
       .withIndex(indexTask)
       .withArchiveCache(ArchiveCache().withCache(finalCache))
-      .withOs(javaOptions.jvmIndexOs.getOrElse(OsLibc.jvmIndexOs))
+      .withOs(jvmIndexOs)
       .withArchitecture(javaOptions.jvmIndexArch.getOrElse(JvmIndex.defaultArchitecture()))
     JavaHome().withCache(jvmCache)
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -982,7 +982,10 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     )
     inputs.fromRoot { root =>
       os.copy(os.Path(TestUtil.cli.head), root / "scala")
-      os.proc("docker", "build", "-t", "scala-cli-distroless-it", ".").call(cwd = root)
+      os.proc("docker", "build", "-t", "scala-cli-distroless-it", ".").call(
+        cwd = root,
+        stdout = os.Inherit
+      )
       os.remove(root / "scala")
       os.remove(root / "Dockerfile")
       val termOpt   = if (System.console() == null) Nil else Seq("-t")


### PR DESCRIPTION
~This should allow to spot musl-related bugs more easily (those in the Linux "static" launcher), by not defaulting to glibc from the static launcher, even when it's available when we're running (when we pick a JVM, when we download scalafmt or metabrowse external binaries, …)~