### PR TITLE
Print tasty exception from Pretty stacktraces only if verbosity is higher than 1

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -118,9 +118,10 @@ object Run extends ScalaCommand[RunOptions] {
       case Some(cls) => cls
       case None      => value(build.retainedMainClass)
     }
+    val verbosity = build.options.internal.verbosity.getOrElse(0).toString
 
     val (finalMainClass, finalArgs) =
-      if (jvmRunner) (Constants.runnerMainClass, mainClass +: args)
+      if (jvmRunner) (Constants.runnerMainClass, mainClass +: verbosity +: args)
       else (mainClass, args)
     runOnce(
       root,

--- a/modules/runner/src/main/scala-2/scala/cli/runner/Stacktrace.scala
+++ b/modules/runner/src/main/scala-2/scala/cli/runner/Stacktrace.scala
@@ -2,7 +2,7 @@ package scala.cli.runner
 
 object Stacktrace {
 
-  def print(t: Throwable, prefix: String): Boolean =
+  def print(t: Throwable, prefix: String, verbosity: Int): Boolean =
     false
 
 }

--- a/modules/runner/src/main/scala-3-stable/scala/cli/runner/Stacktrace.scala
+++ b/modules/runner/src/main/scala-3-stable/scala/cli/runner/Stacktrace.scala
@@ -6,7 +6,7 @@ object Stacktrace {
 
   private lazy val disable = java.lang.Boolean.getBoolean("scala.cli.runner.Stacktrace.disable")
 
-  def print(t: Throwable, prefix: String): Boolean = !disable && {
+  def print(t: Throwable, prefix: String, verbosity: Int): Boolean = !disable && {
     val e = t match {
       case e: Exception => e
       case _            => new Exception(t) // meh
@@ -18,9 +18,11 @@ object Stacktrace {
       true
     catch
       case e: Throwable => // meh meh
-        Console.out.print("Failed to process exception, failure:")
-        e.printStackTrace()
-        Console.out.println("----\n")
+        if (verbosity >= 1) {
+          Console.out.print("Failed to process exception, failure:")
+          e.printStackTrace()
+          Console.out.println("----\n")
+        }
         false
   }
 

--- a/modules/runner/src/main/scala/scala/cli/runner/Runner.scala
+++ b/modules/runner/src/main/scala/scala/cli/runner/Runner.scala
@@ -6,7 +6,8 @@ object Runner {
   def main(args: Array[String]): Unit = {
     assert(args.nonEmpty)
     val mainClass = args.head
-    val args0     = args.tail
+    val verbosity = args.tail.head.toInt
+    val args0     = args.drop(2)
 
     val loader = Thread.currentThread().getContextClassLoader
     val cls    = loader.loadClass(mainClass)
@@ -19,7 +20,7 @@ object Runner {
           callerClass = Some(getClass.getName),
           cutInvoke = true
         )
-        printer.printException(e.getCause)
+        printer.printException(e.getCause, verbosity)
         System.exit(1)
     }
   }

--- a/modules/runner/src/main/scala/scala/cli/runner/StackTracePrinter.scala
+++ b/modules/runner/src/main/scala/scala/cli/runner/StackTracePrinter.scala
@@ -42,14 +42,18 @@ final case class StackTracePrinter(
   }
 
   @tailrec
-  private def printCause(ex: Throwable, causedStackTrace: Array[StackTraceElement]): Unit =
+  private def printCause(
+    ex: Throwable,
+    causedStackTrace: Array[StackTraceElement],
+    verbosity: Int
+  ): Unit =
     if (ex != null) {
       truncateStackTrace(ex)
-      if (!Stacktrace.print(ex, "Caused by: ")) {
+      if (!Stacktrace.print(ex, "Caused by: ", verbosity)) {
         System.err.println(s"Caused by: $ex")
         printStackTrace(ex.getStackTrace, causedStackTrace)
       }
-      printCause(ex.getCause, ex.getStackTrace)
+      printCause(ex.getCause, ex.getStackTrace, verbosity)
     }
   private def printStackTrace(trace: Array[StackTraceElement]): Unit =
     printStackTrace(trace, Array.empty)
@@ -84,15 +88,15 @@ final case class StackTracePrinter(
       System.err.println(s"\t$gray... $cut more$reset")
   }
 
-  def printException(ex: Throwable): Unit = {
+  def printException(ex: Throwable, verbosity: Int): Unit = {
     val q          = "\""
     val threadName = Thread.currentThread().getName
     truncateStackTrace(ex)
-    if (!Stacktrace.print(ex, "")) {
+    if (!Stacktrace.print(ex, "", verbosity)) {
       System.err.println(s"Exception in thread $q$threadName$q $ex")
       printStackTrace(ex.getStackTrace)
     }
-    printCause(ex.getCause, ex.getStackTrace)
+    printCause(ex.getCause, ex.getStackTrace, verbosity)
   }
 }
 


### PR DESCRIPTION
Pretty stacktraces don't support the latest version of Scala 3.1 yet.
So if user run  applications and an exception are thrown the following message is printed:

```
Compiling project (Scala 3.1.0, JVM)
Compiled project (Scala 3.1.0, JVM)
Failed to process exception, failure:dotty.tools.tasty.UnpickleException: TASTy signature has wrong version.
 expected: {majorVersion: 28, minorVersion: 0}
 found   : {majorVersion: 28, minorVersion: 1}

This TASTy file was produced by a more recent, forwards incompatible release.
To read this TASTy file, please upgrade your tooling.
The TASTy file was produced by Scala 3.1.0.
        at dotty.tools.tasty.TastyHeaderUnpickler.check(TastyHeaderUnpickler.scala:90)
        at dotty.tools.tasty.TastyHeaderUnpickler.readFullHeader(TastyHeaderUnpickler.scala:80)
        at dotty.tools.tasty.TastyHeaderUnpickler.readHeader(TastyHeaderUnpickler.scala:38)
        at dotty.tools.dotc.core.tasty.TastyUnpickler.<init>(TastyUnpickler.scala:89)
        at dotty.tools.dotc.core.tasty.TastyUnpickler.<init>(TastyUnpickler.scala:32)
        at dotty.tools.dotc.core.tasty.TastyClassName.<init>(TastyClassName.scala:19)
        at dotty.tools.dotc.fromtasty.TastyFileUtil$.getClassName(TastyFileUtil.scala:37)
        at dotty.tools.dotc.fromtasty.TastyFileUtil$.getClassPath(TastyFileUtil.scala:19)
        at dotty.tools.dotc.Driver.$anonfun$1(Driver.scala:106)
        at scala.collection.immutable.List.flatMap(List.scala:293)
        at dotty.tools.dotc.Driver.fromTastySetup(Driver.scala:113)
        at dotty.tools.dotc.Driver.setup$$anonfun$1(Driver.scala:90)
        at scala.Option.map(Option.scala:242)
        at dotty.tools.dotc.Driver.setup(Driver.scala:90)
        at dotty.tools.dotc.Driver.process(Driver.scala:197)
        at dotty.tools.dotc.Driver.process(Driver.scala:167)
        at dotty.tools.dotc.Driver.process(Driver.scala:179)
        at scala.tasty.inspector.TastyInspector$.inspectFiles(TastyInspector.scala:103)
        at scala.tasty.inspector.TastyInspector$.inspectAllTastyFiles(TastyInspector.scala:52)
        at scala.tasty.inspector.TastyInspector$.inspectTastyFiles(TastyInspector.scala:27)
        at org.virtuslab.stacktraces.core.StacktracesInspector$.inspectStackTrace(StacktracesInspector.scala:25)
        at scala.cli.runner.Stacktraces$.$anonfun$1(Stacktraces.scala:28)
        at scala.collection.immutable.List.flatMap(List.scala:293)
        at scala.cli.runner.Stacktraces$.convertToPrettyStackTrace(Stacktraces.scala:37)
        at scala.cli.runner.Stacktrace$.liftedTree1$1(Stacktrace.scala:15)
        at scala.cli.runner.Stacktrace$.print(Stacktrace.scala:24)
        at scala.cli.runner.StackTracePrinter.printException(StackTracePrinter.scala:91)
        at scala.cli.runner.Runner$.main(Runner.scala:22)
        at scala.cli.runner.Runner.main(Runner.scala)
----

Exception in thread "main" java.lang.Exception: Caught exception during processing
        at Throws$.main(Hello.scala:8)
        at Throws.main(Hello.scala)

```

IMO we should only display tasty error from level 1 verbosity. It's not very critical functionality of ScalaCLI.