### PR TITLE
Bump coursier to 2.1.0-M2

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -34,7 +34,7 @@ object TestDeps {
 object Deps {
   object Versions {
     // jni-utils version may need to be sync-ed when bumping the coursier version
-    def coursier = "2.0.16-200-ge888c6dea"
+    def coursier = "2.1.0-M2"
 
     def scalaJs       = "1.8.0"
     def scalaMeta     = "4.4.31"


### PR DESCRIPTION
This is mainly to pull in https://github.com/coursier/coursier/pull/2242
which allows for a user to be able to set `COURSIER_CREDENTIALS` and get it
correctly pulled in to resolve deps. (trying to use this for some works scripts
and currently hitting on this).