### PR TITLE
Fix separator typo when installing shell completions

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/InstallCompletions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/InstallCompletions.scala
@@ -28,7 +28,7 @@ object InstallCompletions extends ScalaCommand[InstallCompletionsOptions] {
 
     val name = options.name.getOrElse {
       val baseName = (new Argv0).get("scala-cli")
-      val idx      = baseName.lastIndexOf(File.pathSeparator)
+      val idx      = baseName.lastIndexOf(File.separator)
       if (idx < 0) baseName
       else baseName.drop(idx + 1)
     }


### PR DESCRIPTION
This appears to be a minor typo in calling `File.pathSeparator` vs `File.separator`. 


```bash
> scala-cli repl --amm
Loading...
Welcome to the Ammonite Repl 2.4.0-23-76673f7f (Scala 3.0.2 Java 1.8.0_144)
@ import java.io.File 
import java.io.File

@ File.separator 
res1: String = "/"

@ File.pathSeparator 
res2: String = ":"
```

Fixes VirtusLab/scala-cli#513