### PR TITLE
Use 'ng-stop' instead of 'exit' to quit bloop

### DIFF
--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Operations.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Operations.scala
@@ -311,7 +311,7 @@ object Operations {
     val streams        = Streams(in, out, err)
 
     nailgunClient0.run(
-      "exit",
+      "ng-stop",
       Array.empty,
       workingDir,
       sys.env.toMap,

--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -106,12 +106,11 @@ class BloopTests extends munit.FunSuite {
       BloopUtil.killBloop()
       TestUtil.retry()(assert(!bloopRunning()))
 
-      val res = runScalaCli("bloop", "start").call(check=false)
+      val res = runScalaCli("bloop", "start").call(check = false)
       assert(res.exitCode == 0, clues(res.out.text()))
       assert(bloopRunning(), clues(res.out.text()))
 
-
-      val resExit = runScalaCli("bloop", "exit").call(check=false)
+      val resExit = runScalaCli("bloop", "exit").call(check = false)
       assert(resExit.exitCode == 0, clues(resExit.out.text()))
       assert(!bloopRunning())
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -98,7 +98,7 @@ class BloopTests extends munit.FunSuite {
   test("bloop exit works") {
     def assertBloopNotRunning(): Unit = {
       val javaProcesses = os.proc("jps", "-l").call().out.text()
-      expect(!javaProcesses.contains("bloop.Server"))
+      expect(!javaProcesses.contains("bloop.Bloop"))
     }
 
     val inputs = TestInputs(Seq.empty)

--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -11,9 +11,6 @@ class BloopTests extends munit.FunSuite {
   private lazy val bloopDaemonDir =
     BloopUtil.bloopDaemonDir(runScalaCli("directories").call().out.text())
 
-  // temporary, bleep exit does exit, but is having issues later on…
-  private def exitCheck = false
-
   val dummyInputs = TestInputs(
     Seq(
       os.rel / "Test.scala" ->
@@ -31,9 +28,9 @@ class BloopTests extends munit.FunSuite {
     shouldRestart: Boolean
   ): Unit = TestUtil.retryOnCi() {
     dummyInputs.fromRoot { root =>
+      BloopUtil.killBloop()
 
       val bloop = BloopUtil.bloop(currentBloopVersion, bloopDaemonDir)
-      bloop("exit").call(cwd = root, stdout = os.Inherit, check = exitCheck)
       bloop("about").call(cwd = root, stdout = os.Inherit)
 
       val output = os.proc(TestUtil.cli, "run", ".")
@@ -61,7 +58,7 @@ class BloopTests extends munit.FunSuite {
 
   test("invalid bloop options passed via cli cause bloop start failure") {
     TestInputs(Seq()).fromRoot { root =>
-      runScalaCli("bloop", "exit").call(cwd = root, check = exitCheck)
+      runScalaCli("bloop", "exit").call(cwd = root)
       val res = runScalaCli("bloop", "start", "--bloop-java-opt", "-zzefhjzl").call(
         cwd = root,
         stderr = os.Pipe,
@@ -84,7 +81,7 @@ class BloopTests extends munit.FunSuite {
     )
 
     inputs.fromRoot { root =>
-      runScalaCli("bloop", "exit").call(check = exitCheck)
+      runScalaCli("bloop", "exit").call()
       val res = runScalaCli(
         "bloop",
         "start",
@@ -98,4 +95,23 @@ class BloopTests extends munit.FunSuite {
     }
   }
 
+  test("bloop exit works") {
+    def assertBloopNotRunning(): Unit = {
+      val javaProcesses = os.proc("jps", "-l").call().out.text()
+      expect(!javaProcesses.contains("bloop.Server"))
+    }
+
+    val inputs = TestInputs(Seq.empty)
+    inputs.fromRoot { _ =>
+      BloopUtil.killBloop()
+      TestUtil.retry()(assertBloopNotRunning())
+
+      val res = runScalaCli("bloop", "start").call()
+      assert(res.exitCode == 0, clues(res.out.text()))
+
+      val resExit = runScalaCli("bloop", "exit").call()
+      assert(resExit.exitCode == 0, clues(resExit.out.text()))
+      assertBloopNotRunning()
+    }
+  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -96,22 +96,24 @@ class BloopTests extends munit.FunSuite {
   }
 
   test("bloop exit works") {
-    def assertBloopNotRunning(): Unit = {
+    def bloopRunning(): Boolean = {
       val javaProcesses = os.proc("jps", "-l").call().out.text()
-      expect(!javaProcesses.contains("bloop.Bloop"))
+      javaProcesses.contains("bloop.Bloop")
     }
 
     val inputs = TestInputs(Seq.empty)
     inputs.fromRoot { _ =>
       BloopUtil.killBloop()
-      TestUtil.retry()(assertBloopNotRunning())
+      TestUtil.retry()(assert(!bloopRunning()))
 
-      val res = runScalaCli("bloop", "start").call()
+      val res = runScalaCli("bloop", "start").call(check=false)
       assert(res.exitCode == 0, clues(res.out.text()))
+      assert(bloopRunning(), clues(res.out.text()))
 
-      val resExit = runScalaCli("bloop", "exit").call()
+
+      val resExit = runScalaCli("bloop", "exit").call(check=false)
       assert(resExit.exitCode == 0, clues(resExit.out.text()))
-      assertBloopNotRunning()
+      assert(!bloopRunning())
     }
   }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -107,7 +107,7 @@ object TestUtil {
 
   def retryOnCi[T](maxAttempts: Int = 3, waitDuration: FiniteDuration = 5.seconds)(
     run: => T
-  ) = retry((if (isCI) 1 else maxAttempts), waitDuration)(run)
+  ) = retry((if (isCI) maxAttempts else 1), waitDuration)(run)
 
   // Same as os.RelPath.toString, but for the use of File.separator instead of "/"
   def relPathStr(relPath: os.RelPath): String =

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -83,7 +83,7 @@ object TestUtil {
     if (uri.startsWith("file:///")) "file:/" + uri.stripPrefix("file:///")
     else uri
 
-  def retryOnCi[T](
+  def retry[T](
     maxAttempts: Int = 3,
     waitDuration: FiniteDuration = 5.seconds
   )(
@@ -102,10 +102,21 @@ object TestUtil {
             helper(count + 1)
           }
       }
-    helper(if (isCI) 1 else maxAttempts)
+    helper(1)
   }
+
+  def retryOnCi[T](maxAttempts: Int = 3, waitDuration: FiniteDuration = 5.seconds)(
+    run: => T
+  ) = retry((if (isCI) 1 else maxAttempts), waitDuration)(run)
 
   // Same as os.RelPath.toString, but for the use of File.separator instead of "/"
   def relPathStr(relPath: os.RelPath): String =
     (Seq.fill(relPath.ups)("..") ++ relPath.segments).mkString(File.separator)
+
+  def kill(pid: Int) =
+    if (Properties.isWin)
+      os.proc("taskkill", "/PID", pid).call()
+    else
+      os.proc("kill", pid).call()
+
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -115,7 +115,7 @@ object TestUtil {
 
   def kill(pid: Int) =
     if (Properties.isWin)
-      os.proc("taskkill", "/PID", pid).call()
+      os.proc("taskkill", "/F", "/PID", pid).call()
     else
       os.proc("kill", pid).call()
 

--- a/modules/integration/src/test/scala/scala/cli/integration/util/BloopUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/util/BloopUtil.scala
@@ -73,7 +73,7 @@ object BloopUtil {
     }
   def killBloop() = {
     val javaProcesses = os.proc("jps", "-l").call().out.text().linesIterator
-    val bloopPidReg   = "(\\d+).*bloop[.]Server".r
+    val bloopPidReg   = "(\\d+).*bloop[.]Bloop".r
     val bloopPids = javaProcesses.flatMap { l =>
       l match {
         case bloopPidReg(pid) => Some(pid.toInt)

--- a/modules/integration/src/test/scala/scala/cli/integration/util/BloopUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/util/BloopUtil.scala
@@ -71,5 +71,15 @@ object BloopUtil {
           args
         )
     }
-
+  def killBloop() = {
+    val javaProcesses = os.proc("jps", "-l").call().out.text().linesIterator
+    val bloopPidReg   = "(\\d+).*bloop[.]Server".r
+    val bloopPids = javaProcesses.flatMap { l =>
+      l match {
+        case bloopPidReg(pid) => Some(pid.toInt)
+        case _                => None
+      }
+    }.toList
+    bloopPids.foreach(TestUtil.kill _)
+  }
 }


### PR DESCRIPTION
Seems that `ng-stop` has some special behavior in snailgun and returns different
exit code

https://github.com/jvican/snailgun/blob/1c6ba5cfbd948aaf055a729cc481d6292c661f7a/core/src/main/scala/snailgun/protocol/Protocol.scala#L113