### PR TITLE
Allow custom repositories for scala-library in repl

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -414,6 +414,7 @@ trait CliIntegrationBase extends SbtModule with ScalaCliPublishModule with HasTe
            |  def bspVersion = "${Deps.bsp4j.dep.version}"
            |  def scala212 = "${Scala.scala212}"
            |  def scala213 = "${Scala.scala213}"
+           |  def scalaSnapshot213 = "${Scala.scalaSnapshot213}"
            |  def scala3   = "${Scala.scala3}"
            |  def defaultScala = "${Scala.defaultUser}"
            |  def bloopVersion = "${Deps.bloopConfig.dep.version}"

--- a/modules/build/src/main/scala/scala/build/ReplArtifacts.scala
+++ b/modules/build/src/main/scala/scala/build/ReplArtifacts.scala
@@ -67,16 +67,21 @@ object ReplArtifacts {
     dependencies: Seq[AnyDependency],
     extraClassPath: Seq[Path],
     logger: Logger,
-    directories: Directories
+    directories: Directories,
+    repositories: Seq[String]
   ): Either[BuildException, ReplArtifacts] = either {
-    val localRepoOpt = LocalRepo.localRepo(directories.localRepoDir)
-    val isScala2     = scalaParams.scalaVersion.startsWith("2.")
+    val isScala2 = scalaParams.scalaVersion.startsWith("2.")
     val replDep =
       if (isScala2) dep"org.scala-lang:scala-compiler:${scalaParams.scalaVersion}"
       else dep"org.scala-lang::scala3-compiler:${scalaParams.scalaVersion}"
     val allDeps = dependencies ++ Seq(replDep)
     val replArtifacts =
-      Artifacts.artifacts(Positioned.none(allDeps), localRepoOpt.toSeq, scalaParams, logger)
+      Artifacts.artifacts(
+        Positioned.none(allDeps),
+        repositories,
+        scalaParams,
+        logger
+      )
     val mainClass =
       if (isScala2) "scala.tools.nsc.MainGenericRunner"
       else "dotty.tools.repl.Main"

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -245,7 +245,7 @@ final case class BuildOptions(
     JavaHome().withCache(jvmCache)
   }
 
-  private def finalRepositories: Seq[String] =
+  def finalRepositories: Seq[String] =
     classPathOptions.extraRepositories ++ internal.localRepository.toSeq
 
   private def computeScalaVersions(

--- a/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
@@ -136,7 +136,8 @@ object Repl extends ScalaCommand[ReplOptions] {
           artifacts.dependencies,
           artifacts.extraClassPath,
           logger,
-          directories
+          directories,
+          options.finalRepositories
         )
     }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
@@ -17,6 +17,20 @@ abstract class ReplTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
 
+  test("repl custom repositories work") {
+    TestInputs(Nil).fromRoot { root =>
+      os.proc(
+        TestUtil.cli,
+        "repl",
+        "--repl-dry-run",
+        "--scala",
+        Constants.scalaSnapshot213,
+        "--repository",
+        "https://scala-ci.typesafe.com/artifactory/scala-integration"
+      ).call(cwd = root)
+    }
+  }
+
   test("ammonite") {
     TestInputs(Nil).fromRoot { root =>
       val ammArgs = Seq(

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -3,11 +3,12 @@ import mill._, scalalib._
 import scala.util.Properties
 
 object Scala {
-  def scala212  = "2.12.15"
-  def scala213  = "2.13.6"
-  def scala3    = "3.0.2"
-  val allScala2 = Seq(scala213, scala212)
-  val all       = allScala2 ++ Seq(scala3)
+  def scala212         = "2.12.15"
+  def scala213         = "2.13.6"
+  def scalaSnapshot213 = "2.13.8-bin-e814d78"
+  def scala3           = "3.0.2"
+  val allScala2        = Seq(scala213, scala212)
+  val all              = allScala2 ++ Seq(scala3)
 
   def listAll: Seq[String] = {
     def patchVer(sv: String): Int =


### PR DESCRIPTION
It is now possible to run `scala-cli -S 2.13.8-foobar --repository https://<some_repo>`

closes #107 