### PR TITLE
Prepare scala-cli to handle Scala 3 Native correctly

### DIFF
--- a/modules/build/src/main/scala/scala/build/Artifacts.scala
+++ b/modules/build/src/main/scala/scala/build/Artifacts.scala
@@ -112,7 +112,7 @@ object Artifacts {
     val maybeSnapshotRepo = {
       val hasSnapshots = (jvmRunnerDependencies ++ jvmTestRunnerDependencies)
         .exists(_.version.endsWith("SNAPSHOT")) ||
-        scalaNativeCliVersion.map(_.endsWith("SNAPSHOT")).getOrElse(false)
+        scalaNativeCliVersion.exists(_.endsWith("SNAPSHOT"))
       val runnerNeedsSonatypeSnapshots = Constants.runnerNeedsSonatypeSnapshots(params.scalaVersion)
       if (hasSnapshots || runnerNeedsSonatypeSnapshots)
         Seq(coursier.Repositories.sonatype("snapshots").root)

--- a/modules/build/src/main/scala/scala/build/Artifacts.scala
+++ b/modules/build/src/main/scala/scala/build/Artifacts.scala
@@ -111,7 +111,8 @@ object Artifacts {
 
     val maybeSnapshotRepo = {
       val hasSnapshots = (jvmRunnerDependencies ++ jvmTestRunnerDependencies)
-        .exists(_.version.endsWith("SNAPSHOT"))
+        .exists(_.version.endsWith("SNAPSHOT")) ||
+        scalaNativeCliVersion.map(_.endsWith("SNAPSHOT")).getOrElse(false)
       val runnerNeedsSonatypeSnapshots = Constants.runnerNeedsSonatypeSnapshots(params.scalaVersion)
       if (hasSnapshots || runnerNeedsSonatypeSnapshots)
         Seq(coursier.Repositories.sonatype("snapshots").root)
@@ -153,7 +154,7 @@ object Artifacts {
           value {
             fetch(
               Positioned.none(dependency),
-              Nil,
+              allExtraRepositories,
               params,
               logger,
               None

--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -353,9 +353,9 @@ object Build {
         else if (scalaVersion.startsWith("2.13"))
           true
         else if (scalaVersion.startsWith("2.12"))
-          !inputs.sourceFiles().exists {
-            case _: Inputs.AnyScript => true
-            case _                   => false
+          inputs.sourceFiles().forall {
+            case _: Inputs.AnyScript => false
+            case _                   => true
           }
         else false
       case None => false

--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -15,7 +15,7 @@ import scala.build.blooprifle.BloopRifleConfig
 import scala.build.errors._
 import scala.build.internal.{Constants, CustomCodeWrapper, MainClass, Util}
 import scala.build.options.validation.ValidationException
-import scala.build.options.{BuildOptions, ClassPathOptions, Platform, Scope, SNNumeralVersion}
+import scala.build.options.{BuildOptions, ClassPathOptions, Platform, SNNumeralVersion, Scope}
 import scala.build.postprocessing._
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration.DurationInt

--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -349,7 +349,7 @@ object Build {
         else if (scalaVersion.startsWith("3.0"))
           false
         else if (scalaVersion.startsWith("3"))
-          snNumeralVer >= SNNumeralVersion(0, 4, 2)
+          snNumeralVer >= SNNumeralVersion(0, 4, 3)
         else if (scalaVersion.startsWith("2.13"))
           true
         else if (scalaVersion.startsWith("2.12"))

--- a/modules/build/src/main/scala/scala/build/errors/ScalaNativeCompatibilityError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/ScalaNativeCompatibilityError.scala
@@ -2,9 +2,11 @@ package scala.build.errors
 
 final class ScalaNativeCompatibilityError
     extends BuildException(
-      """scala-cli: invalid option: '--native' for scripts is supported only for scala 2.13.*
+      """Used Scala Native version is incompatible the passed options.
         |Please try one of the following combinations:
-        |  scala-cli --native -S 2.13 <...> (for *.sc & *.scala files)
-        |  scala-cli --native -S 2.12 <...> (for *.scala files)
+        |  Scala Native version >= 0.4.3 for Scala 3.1 (*.sc & *.scala files)
+        |  Scala Native version >= 0.4.0 for Scala 2.13 (*.sc & *.scala files)
+        |  Scala Native version >= 0.4.0 for Scala 2.12 (*.scala files)
+        |Windows is supported since Scala Native 0.4.1.
         |""".stripMargin
     )

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -59,11 +59,11 @@ final case class BuildOptions(
       .orElse(if (platform.value == Platform.JVM) None else Some(false))
 
   private def scalaLibraryDependencies: Either[BuildException, Seq[AnyDependency]] = either {
-    if (scalaOptions.addScalaLibrary.getOrElse(true)) {
+    if (platform.value != Platform.Native && scalaOptions.addScalaLibrary.getOrElse(true)) {
       val scalaParams0 = value(scalaParams)
       val lib =
         if (scalaParams0.scalaVersion.startsWith("3."))
-          dep"org.scala-lang::scala3-library:${scalaParams0.scalaVersion}"
+          dep"org.scala-lang::scala3-library::${scalaParams0.scalaVersion}"
         else
           dep"org.scala-lang:scala-library:${scalaParams0.scalaVersion}"
       Seq(lib)

--- a/modules/build/src/main/scala/scala/build/options/SNNumeralVersion.scala
+++ b/modules/build/src/main/scala/scala/build/options/SNNumeralVersion.scala
@@ -1,16 +1,6 @@
 package scala.build.options
 
 case class SNNumeralVersion(major: Int, minor: Int, patch: Int) {
-
-  override def equals(other: Any): Boolean =
-    other match {
-      case that: SNNumeralVersion =>
-        this.major == that.major &&
-          this.minor == that.minor &&
-          this.patch == that.patch
-      case _ => false
-    }
-
   def <(that: SNNumeralVersion): Boolean =
     if (this.major == that.major)
       if (this.minor == that.minor) this.patch < that.patch
@@ -27,7 +17,7 @@ case class SNNumeralVersion(major: Int, minor: Int, patch: Int) {
 object SNNumeralVersion {
   private val VersionPattern = raw"(\d+)\.(\d+)\.(\d+)(\-.*)?".r
 
-  // tags/suffixes are included or not compared since they usually
+  // tags/suffixes are not included or compared since they usually
   // should offer no feature compatibility improvements
   def parse(v: String): Option[SNNumeralVersion] = v match {
     case VersionPattern(major, minor, patch, _) =>

--- a/modules/build/src/main/scala/scala/build/options/SNNumeralVersion.scala
+++ b/modules/build/src/main/scala/scala/build/options/SNNumeralVersion.scala
@@ -3,13 +3,13 @@ package scala.build.options
 case class SNNumeralVersion(major: Int, minor: Int, patch: Int) {
 
   override def equals(other: Any): Boolean =
-    if (other.isInstanceOf[SNNumeralVersion]) {
-      val that = other.asInstanceOf[SNNumeralVersion]
-      this.major == that.major &&
-      this.minor == that.minor &&
-      this.patch == that.patch
+    other match {
+      case that: SNNumeralVersion =>
+        this.major == that.major &&
+          this.minor == that.minor &&
+          this.patch == that.patch
+      case _ => false
     }
-    else false
 
   def <(that: SNNumeralVersion): Boolean =
     if (this.major == that.major)

--- a/modules/build/src/main/scala/scala/build/options/SNNumeralVersion.scala
+++ b/modules/build/src/main/scala/scala/build/options/SNNumeralVersion.scala
@@ -1,0 +1,38 @@
+package scala.build.options
+
+case class SNNumeralVersion(major: Int, minor: Int, patch: Int) {
+
+  override def equals(other: Any): Boolean =
+    if (other.isInstanceOf[SNNumeralVersion]) {
+      val that = other.asInstanceOf[SNNumeralVersion]
+      this.major == that.major &&
+      this.minor == that.minor &&
+      this.patch == that.patch
+    }
+    else false
+
+  def <(that: SNNumeralVersion): Boolean =
+    if (this.major == that.major)
+      if (this.minor == that.minor) this.patch < that.patch
+      else this.minor < that.minor
+    else this.major < that.major
+
+  def <=(that: SNNumeralVersion) = this < that || this == that
+
+  def >(that: SNNumeralVersion) = !(this <= that)
+
+  def >=(that: SNNumeralVersion) = !(this < that)
+}
+
+object SNNumeralVersion {
+  private val VersionPattern = raw"(\d+)\.(\d+)\.(\d+)(\-.*)?".r
+
+  // tags/suffixes are included or not compared since they usually
+  // should offer no feature compatibility improvements
+  def parse(v: String): Option[SNNumeralVersion] = v match {
+    case VersionPattern(major, minor, patch, _) =>
+      Some(SNNumeralVersion(major.toInt, minor.toInt, patch.toInt))
+    case _ =>
+      None
+  }
+}

--- a/modules/build/src/main/scala/scala/build/options/ScalaNativeOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/ScalaNativeOptions.scala
@@ -71,16 +71,11 @@ final case class ScalaNativeOptions(
   def platformSuffix: String =
     "native" + ScalaVersion.nativeBinary(finalVersion).getOrElse(finalVersion)
 
-  private def nativeScalalibDependency(scalaVersion: String): AnyDependency =
-    if (scalaVersion.startsWith("2."))
-      dep"org.scala-native::scalalib::$finalVersion"
-    else
-      dep"org.scala-native::scala3lib::$finalVersion"
-
   def nativeDependencies(scalaVersion: String): Seq[AnyDependency] =
-    Seq("nativelib", "javalib", "auxlib")
-      .map(name => dep"org.scala-native::$name::$finalVersion") :+
-      nativeScalalibDependency(scalaVersion)
+    if (scalaVersion.startsWith("2."))
+      Seq(dep"org.scala-native::scalalib::$finalVersion")
+    else
+      Seq(dep"org.scala-native::scala3lib::$finalVersion")
 
   def compilerPlugins: Seq[AnyDependency] =
     Seq(dep"org.scala-native:::nscplugin:$finalVersion")

--- a/modules/build/src/main/scala/scala/build/options/ScalaNativeOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/ScalaNativeOptions.scala
@@ -8,8 +8,6 @@ import java.nio.file.Paths
 import scala.build.internal.Constants
 import scala.scalanative.{build => sn}
 
-case class ScalaNativeVersion(major: Int, minor: Int, patch: Int, tag: String)
-
 final case class ScalaNativeOptions(
   version: Option[String] = None,
   modeStr: Option[String] = None,
@@ -27,12 +25,7 @@ final case class ScalaNativeOptions(
 
   def finalVersion = version.map(_.trim).filter(_.nonEmpty).getOrElse(Constants.scalaNativeVersion)
 
-  private val VersionPattern = "(\\d+)\\.(\\d+)\\.(\\d+)(\\-.*)?".r
-  def numeralVersion: Option[ScalaNativeVersion] = finalVersion match {
-    case VersionPattern(major, minor, patch, tag) =>
-      Some(ScalaNativeVersion(major.toInt, minor.toInt, patch.toInt, tag))
-    case _ => None
-  }
+  def numeralVersion = SNNumeralVersion.parse(finalVersion)
 
   private def gc(): sn.GC =
     gcStr.map(_.trim).filter(_.nonEmpty) match {

--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -784,7 +784,7 @@ class BuildTests extends munit.FunSuite {
           |// using nativeVersion "0.4.3-RC2"
           |// using scala "3.1.0"
           |def foo(): String = "foo"
-          |""".stripMargin,
+          |""".stripMargin
     )
     val buildOptions = defaultOptions.copy(
       scalaOptions = defaultOptions.scalaOptions.copy(
@@ -803,7 +803,7 @@ class BuildTests extends munit.FunSuite {
           |// using nativeVersion "0.4.3-RC2"
           |// using scala "3.0.2"
           |def foo(): String = "foo"
-          |""".stripMargin,
+          |""".stripMargin
     )
     val buildOptions = defaultOptions.copy(
       scalaOptions = defaultOptions.scalaOptions.copy(

--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -14,6 +14,7 @@ import scala.build.{BuildThreads, Directories, LocalRepo}
 import scala.meta.internal.semanticdb.TextDocuments
 import scala.util.Properties
 import scala.build.preprocessing.directives.SingleValueExpected
+import scala.build.errors.ScalaNativeCompatibilityError
 
 class BuildTests extends munit.FunSuite {
 
@@ -773,6 +774,45 @@ class BuildTests extends munit.FunSuite {
 
     inputs.withBuild(buildOptions, buildThreads, bloopConfig) { (_, _, maybeBuild) =>
       assert(maybeBuild.toOption.get.options.scalaNativeOptions.linkingOptions.isEmpty)
+    }
+  }
+
+  test("Scala Native working with Scala 3.1") {
+    val testInputs = TestInputs(
+      os.rel / "Simple.scala" ->
+        """// using platform "scala-native"
+          |// using nativeVersion "0.4.3-RC2"
+          |// using scala "3.1.0"
+          |def foo(): String = "foo"
+          |""".stripMargin,
+    )
+    val buildOptions = defaultOptions.copy(
+      scalaOptions = defaultOptions.scalaOptions.copy(
+        scalaVersion = None
+      )
+    )
+    testInputs.withBuild(buildOptions, buildThreads, bloopConfig) { (_, _, maybeBuild) =>
+      assert(maybeBuild.isRight)
+    }
+  }
+
+  test("Scala Native not working with Scala 3.0") {
+    val testInputs = TestInputs(
+      os.rel / "Simple.scala" ->
+        """// using platform "scala-native"
+          |// using nativeVersion "0.4.3-RC2"
+          |// using scala "3.0.2"
+          |def foo(): String = "foo"
+          |""".stripMargin,
+    )
+    val buildOptions = defaultOptions.copy(
+      scalaOptions = defaultOptions.scalaOptions.copy(
+        scalaVersion = None
+      )
+    )
+    testInputs.withBuild(buildOptions, buildThreads, bloopConfig) { (_, _, maybeBuild) =>
+      assert(maybeBuild.isLeft)
+      assert(maybeBuild.left.get.isInstanceOf[ScalaNativeCompatibilityError])
     }
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -143,7 +143,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
           check = false,
           stderr = os.Pipe
         ).err.text().trim
-        expect(output.contains("scala-cli: invalid option:"))
+        expect(output.contains("Used Scala Native version is incompatible the passed options"))
       }
     }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -158,14 +158,14 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
         Seq(
           os.rel / fileName ->
             s"""import scala.scalanative.libc._
-              |import scala.scalanative.unsafe._
-              |
-              |@main def main() =
-              |  val message = "$message"
-              |  Zone { implicit z =>
-              |    stdio.printf(toCString(message))
-              |  }
-              |""".stripMargin
+               |import scala.scalanative.unsafe._
+               |
+               |@main def main() =
+               |  val message = "$message"
+               |  Zone { implicit z =>
+               |    stdio.printf(toCString(message))
+               |  }
+               |""".stripMargin
         )
       )
       inputs.fromRoot { root =>

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -30,7 +30,7 @@ object TestUtil {
   // format: on
 
   lazy val canRunJs     = !isNativeCli || !Properties.isWin
-  lazy val canRunNative = !Properties.isWin
+  lazy val canRunNative = true
 
   def fromPath(app: String): Option[String] = {
 

--- a/website/docs/guides/scala-native.md
+++ b/website/docs/guides/scala-native.md
@@ -3,11 +3,29 @@ title: Scala Native
 sidebar_position: 22
 ---
 
-Scala Native only works with Scala `2.13.x` and `2.12.x` however we recommend using `2.13.x`.
+Scala Native works with Scala `3.1.x`, `2.13.x` and `2.12.x`. Scripts are unavailable for Scala `2.12.x`.
 
-This page is currently a work in progress, but here are some initial notes:
+Scala Native requires the LLVM toolchain - see requirements on Scala Native website.
+## Configuration
 
-- Scala Native requires the LLVM toolchain; see requirements on Scala Native website
-- Enable via the command-line using `--native`
+Enable Scala Native support by passing `--native` to `scala-cli`, such as:
+
+```scala
+scala-cli Test.scala --native
+```
+
+A Scala Native version can be set by passing `--native-version` with an argument:
+
+```scala
+scala-cli Test.scala --native --native-version 0.4.3
+```
+
+Platform compatibility and supported Scala language versions depend on this version.  
+It is recommended to use the newest stable version.
+
+## Dependencies
+
+This section is currently a work in progress, but here are some initial notes:
+
 - Beware platform dependencies
 - `compile` / `run` / `test` / `package` should all work


### PR DESCRIPTION
This includes a couple of changes:
* Similarly to a regular Scala or Scala.js, a scala3-library is fetched if Scala 3 is used (here called `scala3lib` for Native)
* Scala Native compatibility checks were updated - now everything is checked against both Scala language version and Scala Native version. The error message was also adjusted.
* If a snapshot version of scala-native-cli is used, now a Sonatype snapshot repository should be also checked for it. This is something I did not take into consideration before, and while up to this point no snapshot version of scala-native-cli was released, this is more of a future-proof than necessary change.

I was testing it with a locally published scala-native-cli 0.4.3-SNAPSHOT and scala-native-cli 0.4.3-RC2 should be released soon. On that release I'll add additional Scala 3 Native integration tests to the CI (either in this PR or separately, however will be more convenient)