### PR TITLE
Fix #525: Spuriously duplicate options

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -159,12 +159,13 @@ object Build {
         overrideOptions.orElse(options) // update hash in inputs with options coming from the CLI or cross-building, not from the sources
       )
 
-      val baseOptions = overrideOptions.orElse(sharedOptions)
+      val overridenWithSharedOptions = overrideOptions.orElse(sharedOptions)
+      val overridenOptions           = overrideOptions.orElse(options)
 
-      val crossSources0 = crossSources.withVirtualDir(inputs0, scope, baseOptions)
+      val crossSources0 = crossSources.withVirtualDir(inputs0, scope, overridenWithSharedOptions)
 
-      val sources = value(crossSources0.scopedSources(baseOptions))
-        .sources(scope, baseOptions)
+      val sources = value(crossSources0.scopedSources(overridenWithSharedOptions))
+        .sources(scope, overridenOptions)
 
       val generatedSources = sources.generateSources(inputs0.generatedSrcRoot(scope))
       val buildOptions     = sources.buildOptions

--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -161,11 +161,10 @@ object Build {
 
       val baseOptions = overrideOptions.orElse(sharedOptions)
 
-
       val crossSources0 = crossSources.withVirtualDir(inputs0, scope, baseOptions)
 
       val scopedSources = value(crossSources0.scopedSources(baseOptions))
-      val sources = scopedSources.sources(scope, baseOptions)
+      val sources       = scopedSources.sources(scope, baseOptions)
 
       val generatedSources = sources.generateSources(inputs0.generatedSrcRoot(scope))
       val buildOptions     = sources.buildOptions

--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -164,7 +164,7 @@ object Build {
       val crossSources0 = crossSources.withVirtualDir(inputs0, scope, baseOptions)
 
       val scopedSources = value(crossSources0.scopedSources(baseOptions))
-      val sources       = scopedSources.sources(scope, crossSources0.sharedOptions(baseOptions))
+      val sources       = scopedSources.sources(scope, baseOptions)
 
       val generatedSources = sources.generateSources(inputs0.generatedSrcRoot(scope))
       val buildOptions     = sources.buildOptions

--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -159,13 +159,13 @@ object Build {
         overrideOptions.orElse(options) // update hash in inputs with options coming from the CLI or cross-building, not from the sources
       )
 
-      val overridenWithSharedOptions = overrideOptions.orElse(sharedOptions)
-      val overridenOptions           = overrideOptions.orElse(options)
+      val baseOptions = overrideOptions.orElse(sharedOptions)
 
-      val crossSources0 = crossSources.withVirtualDir(inputs0, scope, overridenWithSharedOptions)
 
-      val sources = value(crossSources0.scopedSources(overridenWithSharedOptions))
-        .sources(scope, overridenOptions)
+      val crossSources0 = crossSources.withVirtualDir(inputs0, scope, baseOptions)
+
+      val scopedSources = value(crossSources0.scopedSources(baseOptions))
+      val sources = scopedSources.sources(scope, baseOptions)
 
       val generatedSources = sources.generateSources(inputs0.generatedSrcRoot(scope))
       val buildOptions     = sources.buildOptions

--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -164,7 +164,7 @@ object Build {
       val crossSources0 = crossSources.withVirtualDir(inputs0, scope, baseOptions)
 
       val scopedSources = value(crossSources0.scopedSources(baseOptions))
-      val sources       = scopedSources.sources(scope, baseOptions)
+      val sources       = scopedSources.sources(scope, crossSources0.sharedOptions(baseOptions))
 
       val generatedSources = sources.generateSources(inputs0.generatedSrcRoot(scope))
       val buildOptions     = sources.buildOptions

--- a/modules/build/src/main/scala/scala/build/CrossSources.scala
+++ b/modules/build/src/main/scala/scala/build/CrossSources.scala
@@ -67,6 +67,7 @@ final case class CrossSources(
         .flatMap(_.withPlatform(platform.value).toSeq)
         .map(_.scopedValue(defaultScope)),
       buildOptions
+        .filter(!_.requirements.isEmpty)
         .flatMap(_.withScalaVersion(retainedScalaVersion).toSeq)
         .flatMap(_.withPlatform(platform.value).toSeq)
         .map(_.scopedValue(defaultScope))

--- a/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
@@ -68,8 +68,8 @@ final class BspImpl(
     if (verbosity >= 3)
       pprint.stderr.log(scopedSources)
 
-    val sourcesMain = scopedSources.sources(Scope.Main, buildOptions)
-    val sourcesTest = scopedSources.sources(Scope.Test, buildOptions)
+    val sourcesMain = scopedSources.sources(Scope.Main, crossSources.sharedOptions(buildOptions))
+    val sourcesTest = scopedSources.sources(Scope.Test, crossSources.sharedOptions(buildOptions))
 
     if (verbosity >= 3)
       pprint.stderr.log(sourcesMain)

--- a/modules/build/src/main/scala/scala/build/options/HasBuildRequirements.scala
+++ b/modules/build/src/main/scala/scala/build/options/HasBuildRequirements.scala
@@ -14,4 +14,6 @@ final case class HasBuildRequirements[+T](
     }
   def scopedValue(defaultScope: Scope): HasScope[T] =
     HasScope(requirements.scope.map(_.scope).getOrElse(defaultScope), value)
+  def map[U](f: T => U): HasBuildRequirements[U] =
+    copy(value = f(value))
 }

--- a/modules/build/src/main/scala/scala/build/options/HasScope.scala
+++ b/modules/build/src/main/scala/scala/build/options/HasScope.scala
@@ -10,4 +10,6 @@ final case class HasScope[+T](
   def valueForInheriting(currentScope: Scope): Option[T] =
     if (currentScope.allScopes.contains(scope)) Some(value)
     else None
+  def map[U](f: T => U): HasScope[U] =
+    copy(value = f(value))
 }

--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -797,7 +797,8 @@ class BuildTests extends munit.FunSuite {
     inputs.withBuild(buildOptions, buildThreads, bloopConfig) { (_, _, maybeBuild) =>
       val expectedOptions =
         Seq("-deprecation", "-feature", "-Xmaxwarns", "1", "-Xdisable-assertions")
-      assert(maybeBuild.toOption.get.options.scalaOptions.scalacOptions == expectedOptions)
+      val scalacOptions = maybeBuild.toOption.get.options.scalaOptions.scalacOptions
+      expect(scalacOptions == expectedOptions)
     }
   }
 }

--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -775,4 +775,29 @@ class BuildTests extends munit.FunSuite {
       assert(maybeBuild.toOption.get.options.scalaNativeOptions.linkingOptions.isEmpty)
     }
   }
+
+  // Issue #525
+  test("scalac options not spuriously duplicating") {
+    val inputs = TestInputs(
+      os.rel / "foo.scala" ->
+        """// using scala "2.13"
+          |// using options "-deprecation", "-feature", "-Xmaxwarns", "1"
+          |// using option "-Xdisable-assertions"
+          |
+          |def foo = "bar"
+          |""".stripMargin
+    )
+
+    val buildOptions: BuildOptions = defaultOptions.copy(
+      internal = defaultOptions.internal.copy(
+        keepDiagnostics = true
+      )
+    )
+
+    inputs.withBuild(buildOptions, buildThreads, bloopConfig) { (_, _, maybeBuild) =>
+      val expectedOptions =
+        Seq("-deprecation", "-feature", "-Xmaxwarns", "1", "-Xdisable-assertions")
+      assert(maybeBuild.toOption.get.options.scalaOptions.scalacOptions == expectedOptions)
+    }
+  }
 }

--- a/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
@@ -44,7 +44,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, BuildOptions())
+      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(_.value) == expectedDeps)
       expect(sources.paths.isEmpty)
@@ -78,7 +78,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, BuildOptions())
+      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(
         _.value
@@ -111,7 +111,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, BuildOptions())
+      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(_.value) == expectedDeps)
       expect(sources.paths.isEmpty)
@@ -140,7 +140,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, BuildOptions())
+      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(_.value) == expectedDeps)
       expect(sources.paths.isEmpty)
@@ -169,7 +169,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, BuildOptions())
+      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(_.value).isEmpty)
       expect(sources.paths.isEmpty)
@@ -203,7 +203,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, BuildOptions())
+      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(_.value) == expectedDeps)
       expect(sources.paths.length == 1)
@@ -236,7 +236,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, BuildOptions())
+      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(_.value) == expectedDeps)
       expect(sources.paths.isEmpty)
@@ -299,7 +299,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, BuildOptions())
+      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       val parsedCodes: Seq[String] = sources.inMemory.map(_._3)
 
@@ -331,7 +331,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, BuildOptions())
+      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(_.value) == expectedDeps)
       expect(sources.paths.isEmpty)
@@ -364,7 +364,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, BuildOptions())
+      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(_.value) == expectedDeps)
       expect(sources.paths.isEmpty)
@@ -388,7 +388,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, BuildOptions())
+      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
       val javaOpts      = sources.buildOptions.javaOptions.javaOpts.sortBy(_.toString())
 
       expect(
@@ -419,7 +419,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, BuildOptions())
+      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
       val jsOptions     = sources.buildOptions.scalaJsOptions
       expect(
         jsOptions.version == Some("1.8.0"),

--- a/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
@@ -44,7 +44,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
+      val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(_.value) == expectedDeps)
       expect(sources.paths.isEmpty)
@@ -78,7 +78,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
+      val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(
         _.value
@@ -111,7 +111,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
+      val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(_.value) == expectedDeps)
       expect(sources.paths.isEmpty)
@@ -140,7 +140,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
+      val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(_.value) == expectedDeps)
       expect(sources.paths.isEmpty)
@@ -169,7 +169,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
+      val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(_.value).isEmpty)
       expect(sources.paths.isEmpty)
@@ -203,7 +203,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
+      val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(_.value) == expectedDeps)
       expect(sources.paths.length == 1)
@@ -236,7 +236,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
+      val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(_.value) == expectedDeps)
       expect(sources.paths.isEmpty)
@@ -299,7 +299,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
+      val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       val parsedCodes: Seq[String] = sources.inMemory.map(_._3)
 
@@ -331,7 +331,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
+      val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(_.value) == expectedDeps)
       expect(sources.paths.isEmpty)
@@ -364,7 +364,7 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
+      val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.map(_.value) == expectedDeps)
       expect(sources.paths.isEmpty)
@@ -388,8 +388,8 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
-      val javaOpts      = sources.buildOptions.javaOptions.javaOpts.sortBy(_.toString())
+      val sources  = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
+      val javaOpts = sources.buildOptions.javaOptions.javaOpts.sortBy(_.toString())
 
       expect(
         javaOpts(0).value == "-Dfoo1",
@@ -419,8 +419,8 @@ class SourcesTests extends munit.FunSuite {
           TestLogger()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
-      val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
-      val jsOptions     = sources.buildOptions.scalaJsOptions
+      val sources   = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
+      val jsOptions = sources.buildOptions.scalaJsOptions
       expect(
         jsOptions.version == Some("1.8.0"),
         jsOptions.mode == Some("mode"),

--- a/modules/cli/src/main/scala/scala/cli/commands/Export.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Export.scala
@@ -33,7 +33,7 @@ object Export extends ScalaCommand[ExportOptions] {
       )
     }
     val scopedSources = value(crossSources.scopedSources(buildOptions))
-    val sources       = scopedSources.sources(Scope.Main, buildOptions)
+    val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(buildOptions))
 
     if (verbosity >= 3)
       pprint.stderr.log(sources)

--- a/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
@@ -38,7 +38,7 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
       }
 
       value(crossSources.scopedSources(options))
-        .sources(Scope.Main, options)
+        .sources(Scope.Main, crossSources.sharedOptions(options))
         .buildOptions
     }
 


### PR DESCRIPTION
This PR fixes the issue and adds a unit test based on the original issue snippet. It is worth noting that I decided to fix only the _spuriously_ duplicate options - users still can duplicate them on will f.e. by providing multiple of the same using directives in different files or by adding an already defined option via cli. On that occasion they will most likely still receive the same warning. 

I did not want to limit users in defining duplicate options as that would require a more strict control of a scalac api, f.e. perhaps one day scalac will have an option that will be able to be defined multiple times (like our verbose) and then our hypothetical assumption would become incorrect.