### PR TITLE
Align coursier launcher used in mill with the one used in scala-cli

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1,5 +1,5 @@
 import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`
-import $ivy.`io.get-coursier::coursier-launcher:2.0.16+73-gddc6d9cc9`
+import $ivy.`io.get-coursier::coursier-launcher:2.1.0-M2`
 import $ivy.`io.github.alexarchambault.mill::mill-native-image-upload:0.1.13`
 import $file.project.deps, deps.{Deps, Docker, Scala, TestDeps}
 import $file.project.publish, publish.{ghOrg, ghName, ScalaCliPublishModule}
@@ -477,7 +477,7 @@ trait NativeIntegrationMostlyStatic extends CliIntegration {
 }
 
 trait JvmIntegration extends CliIntegration {
-  def testLauncher = cli.launcher()
+  def testLauncher = cli.standaloneLauncher()
   def cliKind      = "jvm"
 }
 


### PR DESCRIPTION
Both are partially included in the final standalone launcher, so the
code there might conflict