### PR TITLE
Fix issue with missing stubs when using snapshot scala-cli

### DIFF
--- a/modules/build/src/main/scala/scala/build/Artifacts.scala
+++ b/modules/build/src/main/scala/scala/build/Artifacts.scala
@@ -113,7 +113,8 @@ object Artifacts {
       val hasSnapshots = (jvmRunnerDependencies ++ jvmTestRunnerDependencies)
         .exists(_.version.endsWith("SNAPSHOT"))
       val runnerNeedsSonatypeSnapshots = Constants.runnerNeedsSonatypeSnapshots(params.scalaVersion)
-      if (hasSnapshots || runnerNeedsSonatypeSnapshots)
+      val stubsNeedSonatypeSnapshots   = addStubs && stubsVersion.endsWith("SNAPSHOT")
+      if (hasSnapshots || runnerNeedsSonatypeSnapshots || stubsNeedSonatypeSnapshots)
         Seq(coursier.Repositories.sonatype("snapshots").root)
       else
         Nil


### PR DESCRIPTION
I have come across this issue when trying to compile in Scala Native using scala-cli on SNAPSHOT, like this:
```
cs launch -r sonatype:snapshots org.virtuslab.scala-cli:cli_2.12:0.0.9+132-g6d303d24-SNAPSHOT -M scala.cli.ScalaCli
```
I would get:
```
Error downloading org.virtuslab.scala-cli:stubs:0.0.9+132-g6d303d24-SNAPSHOT
  not found: /Users/jchyb/.ivy2/local/org.virtuslab.scala-cli/stubs/0.0.9+132-g6d303d24-SNAPSHOT/ivys/ivy.xml
  not found: https://repo1.maven.org/maven2/org/virtuslab/scala-cli/stubs/0.0.9+132-g6d303d24-SNAPSHOT/stubs-0.0.9+132-g6d303d24-SNAPSHOT.pom
```
This was not the case when compiling to JVM.
Fixed by additionally checking if snapshot stubs are used and adding the Sonatype snapshot repository based on that. No real way to test this outside of merging and trying out again manually I think.