### PR TITLE
Ignore main scope in test command

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -42,11 +42,8 @@ object Test extends ScalaCommand[TestOptions] {
 
     def maybeTest(builds: Builds, allowExit: Boolean): Unit = {
       val optionsKeys = builds.map.keys.toVector.map(_.optionsKey).distinct
-      val builds0 = optionsKeys.map { optionsKey =>
+      val builds0 = optionsKeys.flatMap { optionsKey =>
         builds.map.get(CrossKey(optionsKey, Scope.Test))
-          .orElse(builds.map.get(CrossKey(optionsKey, Scope.Main)))
-          // Can this happen in practice now?
-          .getOrElse(sys.error(s"Main build not found for $optionsKey"))
       }
       val buildsLen = builds0.length
       val printBeforeAfterMessages =


### PR DESCRIPTION
```
$ cat ZioTest.test.scala
// using scala "3.1.0"

// using lib "dev.zio::zio::2.0.0-M6-2"
// using lib "dev.zio::zio-test-sbt::2.0.0-M6-2"

import zio.*
import zio.test.*
import zio.test.Assertion.equalTo

object ExampleSpec extends DefaultRunnableSpec {
  def spec = suite("ExampleSpec")(
    testM("integer addition is associative") {
      val left = 2
      UIO(assert(left)(equalTo[Int](2)))
    }
  )
}

$ ./mill scala test ZioTest.test.scala

Compiling project (test, Scala 3.1.0, JVM)
Compiled project (test, Scala 3.1.0, JVM)
[E] BSP server cancelled, closing socket...
Running tests for Scala 3.0.2, JVM

No test framework found

Running tests for Scala 3.1.0, JVM

+ ExampleSpec
  + integer addition is associative
Ran 1 test in 188 ms: 1 succeeded, 0 ignored, 0 failed
Done
```

it seems, that scala-cli run test for Scala 3.0.2 and 3.1.0

```
val optionsKeys = builds.map.keys.toVector.map(_.optionsKey).distinct
// Vector(CrossKey(3.0.2,JVM), CrossKey(3.1.0,JVM))
```

because Scala CLI found two different Scala version in main (default version) and test (version from using directives) scope. 
The first time it doesn't find the framework because there are no test libraries on the `classPath` in main scope. To avoid this situation, I ignore scope main in test command.

I think another problem is that there may be two versions of Scala in main and test scope. And scala-cli doesn't throw any exception. 

