### PR TITLE
Integration with Scala Snippet Checker

### DIFF
--- a/.github/workflows/snippet-checker.yml
+++ b/.github/workflows/snippet-checker.yml
@@ -1,0 +1,13 @@
+name: Scala Snippet Checker
+on:
+  issue_comment:
+    types: [created, edited]
+  issues:
+    types: [opened, edited]
+
+jobs:
+  snippet-runner:
+    timeout-minutes: 2
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: virtuslab/scala-snippet-checker@196b2db3aa878bb84fc54fe083f681797fd4e1dd


### PR DESCRIPTION
A Github Action to run Scala Script snippet code in issues.

It detects scala code in issues and comments. Each snippet must be annotated with `scala-cli` after backtick.