### PR TITLE
For -S 3.x input use latest release from 3.x versions

### DIFF
--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -284,15 +284,17 @@ final case class BuildOptions(
       sv match {
         case Some(sv0) =>
           val prefix           = if (sv0.endsWith(".")) sv0 else sv0 + "."
-          val matchingVersions = allVersions.filter(_.startsWith(prefix))
+          val matchingVersions = allVersions.filter(_.startsWith(prefix)).map(Version(_))
           if (matchingVersions.isEmpty)
             Left(new InvalidBinaryScalaVersionError(sv0))
           else {
             val validMaxVersions = maxSupportedScalaVersions
               .filter(_.repr.startsWith(prefix))
-            val validMatchingVersions = matchingVersions
-              .map(Version(_))
-              .filter(v => validMaxVersions.exists(v <= _))
+            val validMatchingVersions = {
+              val filtered = matchingVersions.filter(v => validMaxVersions.exists(v <= _))
+              if (filtered.isEmpty) matchingVersions
+              else filtered
+            }
             if (validMatchingVersions.isEmpty)
               Left(new UnsupportedScalaVersionError(sv0))
             else

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -35,7 +35,8 @@ class BuildOptionsTests extends munit.FunSuite {
     Some("2.12")   -> defaultScala212Version,
     Some("2")      -> defaultScala213Version,
     Some("2.13.2") -> "2.13.2",
-    Some("3.0.1")  -> "3.0.1"
+    Some("3.0.1")  -> "3.0.1",
+    Some("3.0")    -> "3.0.2"
   )
 
   for ((prefix, expectedScalaVersion) <- expectedScalaVersions)
@@ -61,6 +62,7 @@ class BuildOptionsTests extends munit.FunSuite {
 
   val expectedScalaConfVersions = Seq(
     Some("3")      -> "3.0.1",
+    Some("3.0")    -> "3.0.1",
     None           -> "3.0.1",
     Some("2.13")   -> "2.13.4",
     Some("2.12")   -> "2.12.13",


### PR DESCRIPTION
For now, If someone pass -S 3.1 parameter to scala-cli, it throws error:
```
VL-D-0317:scala-cli lwronski$ scala-cli hello.sc -S 3.1
Unsupported Scala version: 3.1
```
My expectation is, that scala-cli use latest version from 3.1.

There are two ways to solve this problem:
- If someone pass 3.x, we use latest scala version for 3.x (I have already done it in this PR).
- we have to add entries to [scala-versions-v1.json](https://raw.githubusercontent.com/VirtuslabRnD/scala-cli-scala-versions/master/scala-versions-v1.json) such as: { "3.0.2", "3.1.0", "3.2.x", ..., "3.x.x"}. Mechanism search the latest supported version for prefix "3.1", but it doesn't exists in scala-versions-v1.json, therefore the error was throw. 

Is the first option good enough?