### PR TITLE
Set explicitly name of branch to merge with stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,6 +314,7 @@ jobs:
       with:
         type: now
         message: 'Back port of documentation changes to stable'
+        from_branch: master
         target_branch: stable
         github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
We can't use the default for `from_branch`, where the value is set to current branch. 

This can cause errors during a release, where the CI is running in reaction of created tag.