### PR TITLE
Do not fall back refresh workspace to bloop

### DIFF
--- a/modules/build/src/main/scala/scala/build/bsp/BuildServerForwardStubs.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BuildServerForwardStubs.scala
@@ -75,8 +75,10 @@ trait BuildServerForwardStubs extends b.BuildServer {
       .handleAsync(fatalExceptionHandler("workspaceBuildTargets"))
 
   override def workspaceReload(): CompletableFuture[Object] =
-    forwardTo.workspaceReload()
-      .handleAsync(fatalExceptionHandler("workspaceReload"))
+    CompletableFuture.completedFuture(new Object)
+  // Bloop does not support workspaceReload and Intellij calls it at the start
+  // forwardTo.workspaceReload()
+  //   .handleAsync(fatalExceptionHandler("workspaceReload"))
 
   override def buildTargetDependencyModules(params: DependencyModulesParams)
     : CompletableFuture[DependencyModulesResult] =


### PR DESCRIPTION
It seems that Intellij calls `workspaceReload` at start and then Scala CLI fails with that comes from Bloop.

```
[Trace - 09:51:29 PM] Received notification 'build/logMessage'
Params: {
  "type": 1,
  "message": "Fatal error has occured within bloop bsp server, method: workspaceReload. Shutting down the server:\n org.eclipse.lsp4j.jsonrpc.ResponseErrorException\n\tat org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.handleResponse(RemoteEndpoint.java:209)\n\tat org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.consume(RemoteEndpoint.java:193)\n\tat org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:194)\n\tat org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:94)\n\tat org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:113)\n\tat java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)\n\tat java.util.concurrent.FutureTask.run(FutureTask.java:264)\n\tat java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)\n\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)\n\tat java.lang.Thread.run(Thread.java:833)\n\tat com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:597)\n\tat com.oracle.svm.core.posix.thread.PosixJavaThreads.pthreadStartRoutine(PosixJavaThreads.java:194)\n"
}


```