### PR TITLE
Generate zip supported by sdk

### DIFF
--- a/.github/scripts/generate-os-packages.sh
+++ b/.github/scripts/generate-os-packages.sh
@@ -94,6 +94,36 @@ generate_msi() {
   rm -f "$ARTIFACTS_DIR/"*.wixpdb || true
 }
 
+generate_sdk() {
+  local sdkDirectory
+  local binName
+
+  if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    sdkDirectory="scala-cli-x86_64-pc-linux-static-sdk"
+    binName="scala-cli"
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    sdkDirectory="scala-cli-x86_64-apple-darwin-sdk"
+    binName="scala-cli"
+  elif [[ "$OSTYPE" == "msys" ]]; then
+    sdkDirectory="scala-cli-x86_64-pc-win32-sdk"
+    binName="scala-cli.exe"
+  else
+    echo "Unrecognized operating system: $OSTYPE" 1>&2
+    exit 1
+  fi
+
+  mkdir -p "$sdkDirectory"/bin
+  cp "$(launcher)" "$sdkDirectory"/bin/"$binName"
+
+  if [[ "$OSTYPE" == "msys" ]]; then
+    7z a "$sdkDirectory".zip "$sdkDirectory"
+  else
+    zip -r "$sdkDirectory".zip "$sdkDirectory"
+  fi
+
+  mv "$sdkDirectory".zip "$ARTIFACTS_DIR/"/"$sdkDirectory".zip
+}
+
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   generate_deb
   generate_rpm
@@ -102,6 +132,8 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
 elif [[ "$OSTYPE" == "msys" ]]; then
   generate_msi
 else
-  echo "Unrecognized operating system: $OSTYPE" 1&2
+  echo "Unrecognized operating system: $OSTYPE" 1>&2
   exit 1
 fi
+
+generate_sdk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,9 @@ jobs:
     - name: Generate native launcher
       run: .github/scripts/generate-native-image.sh
       shell: bash
+    - run: ./mill -i ci.setShouldPublish
     - name: Build OS packages
+      if: env.SHOULD_PUBLISH == 'true'
       run: .github/scripts/generate-os-packages.sh
       shell: bash
     - name: Copy artifacts


### PR DESCRIPTION
- _SDKMAN requires that a package has a top-level directory after extraction, and a bin folder directly underneath it_  -  more info [here](https://github.com/sdkman/sdkman-db-migrations/pull/585#issuecomment-1026969744)
- generate os packages only when release CI is running