### PR TITLE
Fix compilation error in files.scala example

### DIFF
--- a/website/docs/getting_started.md
+++ b/website/docs/getting_started.md
@@ -119,7 +119,7 @@ cd scala-cli-getting-started
 Now we can write our logic in a file named `files.scala`:
 
 ```scala title=files.scala
-//> using lib com.lihaoyi::os-lib:0.7.8
+//> using lib "com.lihaoyi::os-lib:0.7.8"
 
 def filesByExtension(
   extension: String, 


### PR DESCRIPTION
Had trouble copy/pasting one of the getting started examples because of missing quotes.

Here's the error without the quotes :
```
❯ scala-cli compile .
Compiling project (Scala 3.1.1, JVM)
[error] ./files.scala:5:18: Not found: os
[error]   dir: os.Path = os.pwd): Seq[os.Path] = 
[error]                  ^^
[error] ./files.scala:6:5: Not found: os
[error]     os.walk(dir).filter { f =>
[error]     ^^
[error] ./files.scala:5:31: Not found: os
[error]   dir: os.Path = os.pwd): Seq[os.Path] = 
[error]                               ^^
[error] ./files.scala:5:8: Not found: os
[error]   dir: os.Path = os.pwd): Seq[os.Path] = 
[error]        ^^
[error] ./files.scala:1:1: Illegal start of toplevel definition
[error] using lib "com.lihaoyi::os-lib:0.7.8"
[error] ^^^^^
```