### PR TITLE
Fix generate help for shebang

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/ShebangOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ShebangOptions.scala
@@ -3,8 +3,10 @@ package scala.cli.commands
 import caseapp._
 
 @HelpMessage(
-  """|This command is an equivalent of `run`, but it changes the way how
-     |`scala-cli` parses it's command-line arguments in order to be compatibility
+  """|Like 'run', but more handy from shebang scripts
+     |
+     |This command is equivalent to `run`, but it changes the way
+     |`scala-cli` parses its command-line arguments in order to be compatible
      |with shebang scripts.
      |
      |Normally, inputs and scala-cli options can be mixed. Program have to be specified after `--`

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -200,8 +200,10 @@ Accepts options:
 
 ## `shebang`
 
-This command is an equivalent of `run`, but it changes the way how
-`scala-cli` parses it's command-line arguments in order to be compatibility
+Like 'run', but more handy from shebang scripts
+
+This command is equivalent to `run`, but it changes the way
+`scala-cli` parses its command-line arguments in order to be compatible
 with shebang scripts.
 
 Normally, inputs and scala-cli options can be mixed. Program have to be specified after `--`


### PR DESCRIPTION
Add a shorter description for shebang command in `scala-cli --help`

Replace from 
``` 
shebang    This command is an equivalent of `run`, but it changes the way how
```
to
```
shebang   Like 'run', but more handy from shebang scripts
```

Closes #601