### PR TITLE
Renaming default branch to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-    - master
+    - main
     tags:
     - "v*"
   pull_request:
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: ${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   bloop-memory-footprint:
@@ -320,7 +320,7 @@ jobs:
       with:
         type: now
         message: 'Back port of documentation changes to stable'
-        from_branch: master
+        from_branch: main
         target_branch: stable
         github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -21,11 +21,11 @@ jobs:
         DEPLOYMENT_BRANCH: gh-pages
         GIT_PASS: ${{ secrets.GITHUB_TOKEN }}
     # after the release the PR should be empty
-    - name: Open PR with changes back to master
+    - name: Open PR with changes back to main
       uses: repo-sync/pull-request@v2
       with:
-        destination_branch: "master"
+        destination_branch: "main"
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        pr_title: "Back port of documentation changes to master"
+        pr_title: "Back port of documentation changes to main"
         name: Update stable branch
         branch: backport/stable

--- a/README.md
+++ b/README.md
@@ -174,4 +174,4 @@ Just add it to your PATH to get the already-released-scala-cli experience.
 
 ## Releases
 
-Instructions on how to release - [Release Procedure](https://github.com/VirtusLab/scala-cli/blob/master/.github/release/release-procedure.md)
+Instructions on how to release - [Release Procedure](https://github.com/VirtusLab/scala-cli/blob/main/.github/release/release-procedure.md)

--- a/build.sc
+++ b/build.sc
@@ -779,7 +779,7 @@ object ci extends Module {
     if (os.exists(scalaCliDir)) os.remove.all(scalaCliDir)
     if (!os.exists(targetDir)) os.makeDir.all(targetDir)
 
-    val branch = "master"
+    val branch = "main"
     val repo   = s"https://oauth2:${ghToken()}@github.com/VirtusLab/scala-cli.git"
 
     // Cloning
@@ -862,7 +862,7 @@ object ci extends Module {
 
     os.makeDir.all(targetDir)
 
-    val branch = "master"
+    val branch = "main"
     val repo   = s"git@github.com:Virtuslab/scala-cli-packages.git"
 
     // Cloning
@@ -889,7 +889,7 @@ object ci extends Module {
 
     os.makeDir.all(targetDir)
 
-    val branch = "master"
+    val branch = "main"
     val repo   = s"git@github.com:Virtuslab/scala-cli-packages.git"
 
     // Cloning
@@ -943,7 +943,7 @@ object ci extends Module {
     )
       .call(cwd = debianDir, stdin = pgpPassphrase, stdout = inReleasePath)
 
-    commitChanges(s"Update Debian packages for $version", "master", packagesDir)
+    commitChanges(s"Update Debian packages for $version", branch, packagesDir)
   }
   def updateCentOsPackages() = T.command {
     val version = cli.publishVersion()
@@ -957,7 +957,7 @@ object ci extends Module {
 
     os.makeDir.all(targetDir)
 
-    val branch = "master"
+    val branch = "main"
     val repo   = s"git@github.com:Virtuslab/scala-cli-packages.git"
 
     // Cloning

--- a/modules/build/src/main/scala/scala/build/options/ScalaOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/ScalaOptions.scala
@@ -18,7 +18,7 @@ final case class ScalaOptions(
 ) {
 
   lazy val scalaVersionsUrl = supportedScalaVersionsUrl.getOrElse(
-    "https://github.com/VirtuslabRnD/scala-cli-scala-versions/raw/master/scala-versions-v1.json"
+    "https://github.com/VirtusLab/scala-cli-scala-versions/raw/main/scala-versions-v1.json"
   )
 
   def normalize: ScalaOptions = {

--- a/modules/cli/src/main/scala/scala/cli/commands/Fmt.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Fmt.scala
@@ -32,8 +32,7 @@ object Fmt extends ScalaCommand[FmtOptions] {
     }
 
   // Based on scalafmt comment:
-  // https://github.com/scalameta/scalafmt/blob/master/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
-  // commit d0c11e98898334969f5f4dfc4bd511630cf00ab9
+  // https://github.com/scalameta/scalafmt/blob/d0c11e98898334969f5f4dfc4bd511630cf00ab9/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
   // First we look for the file in the cwd.
   // If not found or could not read, we go to the git root and look there.
   // If not found or could not read, we use the default version.

--- a/scala-cli.bat
+++ b/scala-cli.bat
@@ -3,7 +3,7 @@
 rem This is the launcher script of Scala CLI (https://github.com/VirtusLab/scala-cli).
 rem This script downloads and runs the Scala CLI version set by SCALA_CLI_VERSION below.
 rem
-rem Download the latest version of this script at https://github.com/VirtusLab/scala-cli/raw/master/scala-cli.bat
+rem Download the latest version of this script at https://github.com/VirtusLab/scala-cli/raw/main/scala-cli.bat
 
 setlocal enabledelayedexpansion
 

--- a/scala-cli.sh
+++ b/scala-cli.sh
@@ -3,7 +3,7 @@
 # This is the launcher script of Scala CLI (https://github.com/VirtusLab/scala-cli).
 # This script downloads and runs the Scala CLI version set by SCALA_CLI_VERSION below.
 #
-# Download the latest version of this script at https://github.com/VirtusLab/scala-cli/raw/master/scala-cli.sh
+# Download the latest version of this script at https://github.com/VirtusLab/scala-cli/raw/main/scala-cli.sh
 
 set -eu
 

--- a/website/docs/_advanced_install.mdx
+++ b/website/docs/_advanced_install.mdx
@@ -291,12 +291,12 @@ Script to automatically download and cache standalone `scala-cli` launcher.
         ]}>
 <TabItem value="macOS/Linux">
 
-<DownloadButton desc= 'ScalaCLI launcher for macOs/Linux' href='https://github.com/VirtusLab/scala-cli/blob/master/scala-cli.sh' width = '250px' ></DownloadButton>
+<DownloadButton desc= 'ScalaCLI launcher for macOs/Linux' href='https://github.com/VirtusLab/scala-cli/blob/main/scala-cli.sh' width = '250px' ></DownloadButton>
 
 </TabItem>
 <TabItem value="windows">
 
-<DownloadButton desc= 'ScalaCLI launcher for Windows' href='https://github.com/VirtusLab/scala-cli/blob/master/scala-cli.bat' width = '250px' ></DownloadButton>
+<DownloadButton desc= 'ScalaCLI launcher for Windows' href='https://github.com/VirtusLab/scala-cli/blob/main/scala-cli.bat' width = '250px' ></DownloadButton>
 
 </TabItem>
 </Tabs>

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -134,7 +134,7 @@ module.exports = {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           editUrl:
-            'https://github.com/Virtuslab/scala-cli/edit/master/website/',
+            'https://github.com/Virtuslab/scala-cli/edit/main/website/',
         },
         theme: {
          // customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
- [x] renaming default branch to main in [scala-packager](https://github.com/VirtusLab/scala-packager)
- [x] renaming default branch to main in [scala-cli-scala-versions](https://github.com/VirtuslabRnD/scala-cli-scala-versions)
- [x] renaming default branch to main in [scala-cli-packages](https://github.com/VirtusLab/scala-cli-packages)