### PR TITLE
Fix Scala Native directory project caching

### DIFF
--- a/modules/build/src/main/scala/scala/build/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/Inputs.scala
@@ -26,26 +26,10 @@ final case class Inputs(
 
   def singleFiles(): Seq[Inputs.SingleFile] =
     elements.flatMap {
-      case f: Inputs.SingleFile => Seq(f)
-      case d: Inputs.Directory =>
-        os.walk.stream(d.path)
-          .filter { p =>
-            !p.relativeTo(d.path).segments.exists(_.startsWith("."))
-          }
-          .filter(os.isFile(_))
-          .collect {
-            case p if p.last.endsWith(".java") =>
-              Inputs.JavaFile(d.path, p.subRelativeTo(d.path))
-            case p if p.last.endsWith(".scala") =>
-              Inputs.ScalaFile(d.path, p.subRelativeTo(d.path))
-            case p if p.last.endsWith(".sc") =>
-              Inputs.Script(d.path, p.subRelativeTo(d.path))
-          }
-          .toVector
-      case _: Inputs.ResourceDirectory =>
-        Nil
-      case _: Inputs.Virtual =>
-        Nil
+      case f: Inputs.SingleFile        => Seq(f)
+      case d: Inputs.Directory         => singleFilesFromDirectory(d)
+      case _: Inputs.ResourceDirectory => Nil
+      case _: Inputs.Virtual           => Nil
     }
 
   def sourceFiles(): Seq[Inputs.SourceFile] =
@@ -63,26 +47,10 @@ final case class Inputs(
 
   def flattened(): Seq[Inputs.SingleElement] =
     elements.flatMap {
-      case f: Inputs.SingleFile => Seq(f)
-      case d: Inputs.Directory =>
-        os.walk.stream(d.path)
-          .filter { p =>
-            !p.relativeTo(d.path).segments.exists(_.startsWith("."))
-          }
-          .filter(os.isFile(_))
-          .collect {
-            case p if p.last.endsWith(".java") =>
-              Inputs.JavaFile(d.path, p.subRelativeTo(d.path))
-            case p if p.last.endsWith(".scala") =>
-              Inputs.ScalaFile(d.path, p.subRelativeTo(d.path))
-            case p if p.last.endsWith(".sc") =>
-              Inputs.Script(d.path, p.subRelativeTo(d.path))
-          }
-          .toVector
-      case _: Inputs.ResourceDirectory =>
-        Nil
-      case v: Inputs.Virtual =>
-        Seq(v)
+      case f: Inputs.SingleFile        => Seq(f)
+      case d: Inputs.Directory         => singleFilesFromDirectory(d)
+      case _: Inputs.ResourceDirectory => Nil
+      case v: Inputs.Virtual           => Seq(v)
     }
 
   private lazy val inputsHash: String =
@@ -137,11 +105,16 @@ final case class Inputs(
     val it = elements.iterator.flatMap {
       case elem: Inputs.OnDisk =>
         val content = elem match {
-          case _: Inputs.Directory         => "dir:"
-          case _: Inputs.ResourceDirectory => "resource-dir:"
-          case _                           => os.read(elem.path)
+          case dirInput: Inputs.Directory =>
+            Seq("dir:") ++ singleFilesFromDirectory(dirInput)
+              .map(file => s"${file.path}:" + os.read(file.path))
+          case resDirInput: Inputs.ResourceDirectory =>
+            // Resource changes for SN require relinking, so they should also be hashed
+            Seq("resource-dir:") ++ os.walk(resDirInput.path)
+              .map(filePath => s"$filePath:" + os.read(filePath))
+          case _ => Seq(os.read(elem.path))
         }
-        Iterator(elem.path.toString, content, "\n").map(bytes)
+        Iterator((elem.path.toString +: content :+ "\n"): _*).map(bytes)
       case v: Inputs.Virtual =>
         Iterator(v.content, bytes("\n"))
     }
@@ -151,6 +124,22 @@ final case class Inputs(
     val calculatedSum = new BigInteger(1, digest)
     String.format(s"%040x", calculatedSum)
   }
+
+  private def singleFilesFromDirectory(d: Inputs.Directory): Seq[Inputs.SingleFile] =
+    os.walk.stream(d.path)
+      .filter { p =>
+        !p.relativeTo(d.path).segments.exists(_.startsWith("."))
+      }
+      .filter(os.isFile(_))
+      .collect {
+        case p if p.last.endsWith(".java") =>
+          Inputs.JavaFile(d.path, p.subRelativeTo(d.path))
+        case p if p.last.endsWith(".scala") =>
+          Inputs.ScalaFile(d.path, p.subRelativeTo(d.path))
+        case p if p.last.endsWith(".sc") =>
+          Inputs.Script(d.path, p.subRelativeTo(d.path))
+      }
+      .toVector
 }
 
 object Inputs {

--- a/modules/build/src/main/scala/scala/build/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/Inputs.scala
@@ -114,7 +114,7 @@ final case class Inputs(
               .map(filePath => s"$filePath:" + os.read(filePath))
           case _ => Seq(os.read(elem.path))
         }
-        Iterator((elem.path.toString +: content :+ "\n"): _*).map(bytes)
+        (Iterator(elem.path.toString) ++ content.iterator ++ Iterator("\n")).map(bytes)
       case v: Inputs.Virtual =>
         Iterator(v.content, bytes("\n"))
     }

--- a/modules/build/src/test/scala/scala/build/tests/NativeBuilderHelperTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/NativeBuilderHelperTests.scala
@@ -37,141 +37,148 @@ class NativeBuilderHelperTests extends munit.FunSuite {
     )
   )
 
-  test("should build native app at first time") {
+  private def helperTests(fromDirectory: Boolean) = {
+    val additionalMessage = if (fromDirectory) "built from a directory" else "built from a set of files"
 
-    inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
-      val build = maybeBuild.toOption.get.successfulOpt.get
+    test(s"should build native app at first time ($additionalMessage)") {
 
-      val config        = build.options.scalaNativeOptions.configCliOptions()
-      val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
-      val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
-      // generate dummy output
-      os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) { (root, _, maybeBuild) =>
+        val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val cacheData =
-        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-      expect(cacheData.changed)
+        val config        = build.options.scalaNativeOptions.configCliOptions()
+        val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+        val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+        // generate dummy output
+        os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+
+        val cacheData =
+          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+        expect(cacheData.changed)
+      }
     }
-  }
 
-  test("should not rebuild the second time") {
-    inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
-      val build = maybeBuild.toOption.get.successfulOpt.get
+    test(s"should not rebuild the second time ($additionalMessage)") {
+      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) { (root, _, maybeBuild) =>
+        val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val config        = build.options.scalaNativeOptions.configCliOptions()
-      val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
-      val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
-      // generate dummy output
-      os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+        val config        = build.options.scalaNativeOptions.configCliOptions()
+        val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+        val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+        // generate dummy output
+        os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-      val cacheData =
-        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-      NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
-      expect(cacheData.changed)
+        val cacheData =
+          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+        NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
+        expect(cacheData.changed)
 
-      val sameBuildCache =
-        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-      expect(!sameBuildCache.changed)
+        val sameBuildCache =
+          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+        expect(!sameBuildCache.changed)
+      }
     }
-  }
 
-  test("should build native if output file was deleted") {
-    inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
-      val build = maybeBuild.toOption.get.successfulOpt.get
+    test(s"should build native if output file was deleted ($additionalMessage)") {
+      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) { (root, _, maybeBuild) =>
+        val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val config        = build.options.scalaNativeOptions.configCliOptions()
-      val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
-      val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
-      // generate dummy output
-      os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+        val config        = build.options.scalaNativeOptions.configCliOptions()
+        val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+        val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+        // generate dummy output
+        os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-      val cacheData =
-        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-      NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
-      expect(cacheData.changed)
+        val cacheData =
+          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+        NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
+        expect(cacheData.changed)
 
-      os.remove(destPath)
-      val afterDeleteCache =
-        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-      expect(afterDeleteCache.changed)
+        os.remove(destPath)
+        val afterDeleteCache =
+          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+        expect(afterDeleteCache.changed)
+      }
     }
-  }
 
-  test("should build native if output file was changed") {
-    inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
-      val build = maybeBuild.toOption.get.successfulOpt.get
+    test(s"should build native if output file was changed ($additionalMessage)") {
+      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) { (root, _, maybeBuild) =>
+        val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val config        = build.options.scalaNativeOptions.configCliOptions()
-      val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
-      val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
-      // generate dummy output
-      os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+        val config        = build.options.scalaNativeOptions.configCliOptions()
+        val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+        val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+        // generate dummy output
+        os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-      val cacheData =
-        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-      NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
-      expect(cacheData.changed)
+        val cacheData =
+          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+        NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
+        expect(cacheData.changed)
 
-      os.write.over(destPath, Random.alphanumeric.take(10).mkString(""))
-      val cacheAfterFileUpdate =
-        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-      expect(cacheAfterFileUpdate.changed)
+        os.write.over(destPath, Random.alphanumeric.take(10).mkString(""))
+        val cacheAfterFileUpdate =
+          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+        expect(cacheAfterFileUpdate.changed)
+      }
     }
-  }
 
-  test("should build native if input file was changed") {
-    inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
-      val build = maybeBuild.toOption.get.successfulOpt.get
+    test(s"should build native if input file was changed ($additionalMessage)") {
+      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) { (root, _, maybeBuild) =>
+        val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val config        = build.options.scalaNativeOptions.configCliOptions()
-      val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
-      val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
-      os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+        val config        = build.options.scalaNativeOptions.configCliOptions()
+        val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+        val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+        os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-      val cacheData =
-        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-      NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
-      expect(cacheData.changed)
+        val cacheData =
+          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+        NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
+        expect(cacheData.changed)
 
-      os.write.append(root / helloFileName, Random.alphanumeric.take(10).mkString(""))
-      val cacheAfterFileUpdate =
-        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-      expect(cacheAfterFileUpdate.changed)
+        os.write.append(root / helloFileName, Random.alphanumeric.take(10).mkString(""))
+        val cacheAfterFileUpdate =
+          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+        expect(cacheAfterFileUpdate.changed)
+      }
     }
-  }
 
-  test("should build native if native config was changed") {
-    inputs.withBuild(defaultOptions, buildThreads, bloopConfig) { (root, _, maybeBuild) =>
-      val build = maybeBuild.toOption.get.successfulOpt.get
+    test(s"should build native if native config was changed ($additionalMessage)") {
+      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) { (root, _, maybeBuild) =>
+        val build = maybeBuild.toOption.get.successfulOpt.get
 
-      val config        = build.options.scalaNativeOptions.configCliOptions()
-      val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
-      val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
-      os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+        val config        = build.options.scalaNativeOptions.configCliOptions()
+        val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+        val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+        os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-      val cacheData =
-        NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-      NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
-      expect(cacheData.changed)
+        val cacheData =
+          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+        NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
+        expect(cacheData.changed)
 
-      val updatedBuild = build.copy(
-        options = build.options.copy(
-          scalaNativeOptions = build.options.scalaNativeOptions.copy(
-            clang = Some(Random.alphanumeric.take(10).mkString(""))
+        val updatedBuild = build.copy(
+          options = build.options.copy(
+            scalaNativeOptions = build.options.scalaNativeOptions.copy(
+              clang = Some(Random.alphanumeric.take(10).mkString(""))
+            )
           )
         )
-      )
-      val updatedConfig = updatedBuild.options.scalaNativeOptions.configCliOptions()
+        val updatedConfig = updatedBuild.options.scalaNativeOptions.configCliOptions()
 
-      val cacheAfterConfigUpdate =
-        NativeBuilderHelper.getCacheData(
-          updatedBuild,
-          updatedConfig,
-          destPath,
-          nativeWorkDir
-        )
-      expect(cacheAfterConfigUpdate.changed)
+        val cacheAfterConfigUpdate =
+          NativeBuilderHelper.getCacheData(
+            updatedBuild,
+            updatedConfig,
+            destPath,
+            nativeWorkDir
+          )
+        expect(cacheAfterConfigUpdate.changed)
+      }
     }
   }
+
+  helperTests(fromDirectory = false)
+  helperTests(fromDirectory = true)
 
 }

--- a/modules/build/src/test/scala/scala/build/tests/NativeBuilderHelperTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/NativeBuilderHelperTests.scala
@@ -38,142 +38,169 @@ class NativeBuilderHelperTests extends munit.FunSuite {
   )
 
   private def helperTests(fromDirectory: Boolean) = {
-    val additionalMessage = if (fromDirectory) "built from a directory" else "built from a set of files"
+    val additionalMessage =
+      if (fromDirectory) "built from a directory" else "built from a set of files"
 
     test(s"should build native app at first time ($additionalMessage)") {
 
-      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) { (root, _, maybeBuild) =>
-        val build = maybeBuild.toOption.get.successfulOpt.get
+      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) {
+        (root, _, maybeBuild) =>
+          val build = maybeBuild.toOption.get.successfulOpt.get
 
-        val config        = build.options.scalaNativeOptions.configCliOptions()
-        val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
-        val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
-        // generate dummy output
-        os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+          val config        = build.options.scalaNativeOptions.configCliOptions()
+          val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+          val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+          // generate dummy output
+          os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-        val cacheData =
-          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-        expect(cacheData.changed)
+          val cacheData =
+            NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+          expect(cacheData.changed)
       }
     }
 
     test(s"should not rebuild the second time ($additionalMessage)") {
-      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) { (root, _, maybeBuild) =>
-        val build = maybeBuild.toOption.get.successfulOpt.get
+      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) {
+        (root, _, maybeBuild) =>
+          val build = maybeBuild.toOption.get.successfulOpt.get
 
-        val config        = build.options.scalaNativeOptions.configCliOptions()
-        val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
-        val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
-        // generate dummy output
-        os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+          val config        = build.options.scalaNativeOptions.configCliOptions()
+          val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+          val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+          // generate dummy output
+          os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-        val cacheData =
-          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-        NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
-        expect(cacheData.changed)
+          val cacheData =
+            NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+          NativeBuilderHelper.updateProjectAndOutputSha(
+            destPath,
+            nativeWorkDir,
+            cacheData.projectSha
+          )
+          expect(cacheData.changed)
 
-        val sameBuildCache =
-          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-        expect(!sameBuildCache.changed)
+          val sameBuildCache =
+            NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+          expect(!sameBuildCache.changed)
       }
     }
 
     test(s"should build native if output file was deleted ($additionalMessage)") {
-      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) { (root, _, maybeBuild) =>
-        val build = maybeBuild.toOption.get.successfulOpt.get
+      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) {
+        (root, _, maybeBuild) =>
+          val build = maybeBuild.toOption.get.successfulOpt.get
 
-        val config        = build.options.scalaNativeOptions.configCliOptions()
-        val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
-        val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
-        // generate dummy output
-        os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+          val config        = build.options.scalaNativeOptions.configCliOptions()
+          val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+          val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+          // generate dummy output
+          os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-        val cacheData =
-          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-        NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
-        expect(cacheData.changed)
+          val cacheData =
+            NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+          NativeBuilderHelper.updateProjectAndOutputSha(
+            destPath,
+            nativeWorkDir,
+            cacheData.projectSha
+          )
+          expect(cacheData.changed)
 
-        os.remove(destPath)
-        val afterDeleteCache =
-          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-        expect(afterDeleteCache.changed)
+          os.remove(destPath)
+          val afterDeleteCache =
+            NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+          expect(afterDeleteCache.changed)
       }
     }
 
     test(s"should build native if output file was changed ($additionalMessage)") {
-      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) { (root, _, maybeBuild) =>
-        val build = maybeBuild.toOption.get.successfulOpt.get
+      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) {
+        (root, _, maybeBuild) =>
+          val build = maybeBuild.toOption.get.successfulOpt.get
 
-        val config        = build.options.scalaNativeOptions.configCliOptions()
-        val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
-        val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
-        // generate dummy output
-        os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+          val config        = build.options.scalaNativeOptions.configCliOptions()
+          val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+          val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+          // generate dummy output
+          os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-        val cacheData =
-          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-        NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
-        expect(cacheData.changed)
+          val cacheData =
+            NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+          NativeBuilderHelper.updateProjectAndOutputSha(
+            destPath,
+            nativeWorkDir,
+            cacheData.projectSha
+          )
+          expect(cacheData.changed)
 
-        os.write.over(destPath, Random.alphanumeric.take(10).mkString(""))
-        val cacheAfterFileUpdate =
-          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-        expect(cacheAfterFileUpdate.changed)
+          os.write.over(destPath, Random.alphanumeric.take(10).mkString(""))
+          val cacheAfterFileUpdate =
+            NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+          expect(cacheAfterFileUpdate.changed)
       }
     }
 
     test(s"should build native if input file was changed ($additionalMessage)") {
-      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) { (root, _, maybeBuild) =>
-        val build = maybeBuild.toOption.get.successfulOpt.get
+      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) {
+        (root, _, maybeBuild) =>
+          val build = maybeBuild.toOption.get.successfulOpt.get
 
-        val config        = build.options.scalaNativeOptions.configCliOptions()
-        val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
-        val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
-        os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+          val config        = build.options.scalaNativeOptions.configCliOptions()
+          val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+          val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+          os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-        val cacheData =
-          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-        NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
-        expect(cacheData.changed)
+          val cacheData =
+            NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+          NativeBuilderHelper.updateProjectAndOutputSha(
+            destPath,
+            nativeWorkDir,
+            cacheData.projectSha
+          )
+          expect(cacheData.changed)
 
-        os.write.append(root / helloFileName, Random.alphanumeric.take(10).mkString(""))
-        val cacheAfterFileUpdate =
-          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-        expect(cacheAfterFileUpdate.changed)
+          os.write.append(root / helloFileName, Random.alphanumeric.take(10).mkString(""))
+          val cacheAfterFileUpdate =
+            NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+          expect(cacheAfterFileUpdate.changed)
       }
     }
 
     test(s"should build native if native config was changed ($additionalMessage)") {
-      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) { (root, _, maybeBuild) =>
-        val build = maybeBuild.toOption.get.successfulOpt.get
+      inputs.withBuild(defaultOptions, buildThreads, bloopConfig, fromDirectory) {
+        (root, _, maybeBuild) =>
+          val build = maybeBuild.toOption.get.successfulOpt.get
 
-        val config        = build.options.scalaNativeOptions.configCliOptions()
-        val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
-        val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
-        os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
+          val config        = build.options.scalaNativeOptions.configCliOptions()
+          val nativeWorkDir = build.options.scalaNativeOptions.nativeWorkDir(root, "native-test")
+          val destPath      = nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
+          os.write(destPath, Random.alphanumeric.take(10).mkString(""), createFolders = true)
 
-        val cacheData =
-          NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
-        NativeBuilderHelper.updateProjectAndOutputSha(destPath, nativeWorkDir, cacheData.projectSha)
-        expect(cacheData.changed)
+          val cacheData =
+            NativeBuilderHelper.getCacheData(build, config, destPath, nativeWorkDir)
+          NativeBuilderHelper.updateProjectAndOutputSha(
+            destPath,
+            nativeWorkDir,
+            cacheData.projectSha
+          )
+          expect(cacheData.changed)
 
-        val updatedBuild = build.copy(
-          options = build.options.copy(
-            scalaNativeOptions = build.options.scalaNativeOptions.copy(
-              clang = Some(Random.alphanumeric.take(10).mkString(""))
+          val updatedBuild = build.copy(
+            options = build.options.copy(
+              scalaNativeOptions = build.options.scalaNativeOptions.copy(
+                clang = Some(Random.alphanumeric.take(10).mkString(""))
+              )
             )
           )
-        )
-        val updatedConfig = updatedBuild.options.scalaNativeOptions.configCliOptions()
+          val updatedConfig = updatedBuild.options.scalaNativeOptions.configCliOptions()
 
-        val cacheAfterConfigUpdate =
-          NativeBuilderHelper.getCacheData(
-            updatedBuild,
-            updatedConfig,
-            destPath,
-            nativeWorkDir
-          )
-        expect(cacheAfterConfigUpdate.changed)
+          val cacheAfterConfigUpdate =
+            NativeBuilderHelper.getCacheData(
+              updatedBuild,
+              updatedConfig,
+              destPath,
+              nativeWorkDir
+            )
+          expect(cacheAfterConfigUpdate.changed)
       }
     }
   }

--- a/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
@@ -13,13 +13,16 @@ final case class TestInputs(
   inputArgs: Seq[String]
 ) {
   def withInputs[T](f: (os.Path, Inputs) => T): T =
+    withInputs(false)(f)
+  
+  private def withInputs[T](viaDirectory: Boolean)(f: (os.Path, Inputs) => T): T =
     TestInputs.withTmpDir("scala-cli-tests-") { tmpDir =>
       for ((relPath, content) <- files) {
         val path = tmpDir / relPath
         os.write(path, content.getBytes(StandardCharsets.UTF_8), createFolders = true)
       }
 
-      val inputArgs0 = if (inputArgs.isEmpty) files.map(_._1.toString) else inputArgs
+      val inputArgs0 = if (viaDirectory) Seq(tmpDir.toString) else if (inputArgs.isEmpty) files.map(_._1.toString) else inputArgs
       Inputs(inputArgs0, tmpDir, Directories.under(tmpDir / ".data")) match {
         case Left(err)     => sys.error(err)
         case Right(inputs) => f(tmpDir, inputs)
@@ -29,9 +32,10 @@ final case class TestInputs(
   def withBuild[T](
     options: BuildOptions,
     buildThreads: BuildThreads,
-    bloopConfig: BloopRifleConfig
+    bloopConfig: BloopRifleConfig,
+    fromDirectory: Boolean = false
   )(f: (os.Path, Inputs, Either[BuildException, Build]) => T): T =
-    withInputs { (root, inputs) =>
+    withInputs(fromDirectory) { (root, inputs) =>
       val res =
         Build.build(
           inputs,

--- a/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
@@ -14,7 +14,7 @@ final case class TestInputs(
 ) {
   def withInputs[T](f: (os.Path, Inputs) => T): T =
     withInputs(false)(f)
-  
+
   private def withInputs[T](viaDirectory: Boolean)(f: (os.Path, Inputs) => T): T =
     TestInputs.withTmpDir("scala-cli-tests-") { tmpDir =>
       for ((relPath, content) <- files) {
@@ -22,7 +22,10 @@ final case class TestInputs(
         os.write(path, content.getBytes(StandardCharsets.UTF_8), createFolders = true)
       }
 
-      val inputArgs0 = if (viaDirectory) Seq(tmpDir.toString) else if (inputArgs.isEmpty) files.map(_._1.toString) else inputArgs
+      val inputArgs0 =
+        if (viaDirectory) Seq(tmpDir.toString)
+        else if (inputArgs.isEmpty) files.map(_._1.toString)
+        else inputArgs
       Inputs(inputArgs0, tmpDir, Directories.under(tmpDir / ".data")) match {
         case Left(err)     => sys.error(err)
         case Right(inputs) => f(tmpDir, inputs)


### PR DESCRIPTION
Previously if `scala-cli run srcDir --native` was run, only the initial project would be cached and used, with following changes to the codebase being ignored.