### PR TITLE
Don't compute "hash data" for options that are not used by Bloop

### DIFF
--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -38,8 +38,7 @@ final case class BuildOptions(
   internal: InternalOptions = InternalOptions(),
   mainClass: Option[String] = None,
   testOptions: TestOptions = TestOptions(),
-  packageOptions: PackageOptions = PackageOptions(),
-  replOptions: ReplOptions = ReplOptions()
+  notForBloopOptions: PostBuildOptions = PostBuildOptions()
 ) {
 
   lazy val platform: Positioned[Platform] =
@@ -381,13 +380,6 @@ final case class BuildOptions(
     )
     value(maybeArtifacts)
   }
-
-  // FIXME We'll probably need more refined rules if we start to support extra Scala.JS or Scala Native specific types
-  def packageTypeOpt: Option[PackageType] =
-    if (packageOptions.isDockerEnabled) Some(PackageType.Docker)
-    else if (platform.value == Platform.JS) Some(PackageType.Js)
-    else if (platform.value == Platform.Native) Some(PackageType.Native)
-    else packageOptions.packageTypeOpt
 
   private def allCrossScalaVersionOptions: Seq[BuildOptions] = {
     val scalaOptions0 = scalaOptions.normalize

--- a/modules/build/src/main/scala/scala/build/options/PackageOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/PackageOptions.scala
@@ -31,7 +31,5 @@ final case class PackageOptions(
 }
 
 object PackageOptions {
-  /* Using HasHashData.nop here (PublishOptions values are not used during compilation) */
-  implicit val hasHashData: HasHashData[PackageOptions] = HasHashData.nop
-  implicit val monoid: ConfigMonoid[PackageOptions]     = ConfigMonoid.derive
+  implicit val monoid: ConfigMonoid[PackageOptions] = ConfigMonoid.derive
 }

--- a/modules/build/src/main/scala/scala/build/options/PostBuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/PostBuildOptions.scala
@@ -1,0 +1,12 @@
+package scala.build.options
+
+final case class PostBuildOptions(
+  packageOptions: PackageOptions = PackageOptions(),
+  replOptions: ReplOptions = ReplOptions()
+)
+
+object PostBuildOptions {
+  /* Using HasHashData.nop here (PostBuildOptions values are not used during compilation) */
+  implicit val hasHashData: HasHashData[PostBuildOptions] = HasHashData.nop
+  implicit val monoid: ConfigMonoid[PostBuildOptions]     = ConfigMonoid.derive
+}

--- a/modules/build/src/main/scala/scala/build/options/ReplOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/ReplOptions.scala
@@ -14,7 +14,5 @@ final case class ReplOptions(
 }
 
 object ReplOptions {
-  /* Using HasHashData.nop here (PublishOptions values are not used during compilation) */
-  implicit val hasHashData: HasHashData[ReplOptions] = HasHashData.nop
-  implicit val monoid: ConfigMonoid[ReplOptions]     = ConfigMonoid.derive
+  implicit val monoid: ConfigMonoid[ReplOptions] = ConfigMonoid.derive
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -88,8 +88,17 @@ object Package extends ScalaCommand[PackageOptions] {
     build: Build.Successful
   ): Either[BuildException, Unit] = either {
 
-    val packageType = build.options.packageTypeOpt
-      .getOrElse(PackageType.Bootstrap)
+    // FIXME We'll probably need more refined rules if we start to support extra Scala.JS or Scala Native specific types
+    val packageType =
+      if (build.options.notForBloopOptions.packageOptions.isDockerEnabled)
+        PackageType.Docker
+      else if (build.options.platform.value == Platform.JS)
+        PackageType.Js
+      else if (build.options.platform.value == Platform.Native)
+        PackageType.Native
+      else
+        build.options.notForBloopOptions.packageOptions.packageTypeOpt
+          .getOrElse(PackageType.Bootstrap)
 
     // TODO When possible, call alreadyExistsCheck() before compiling stuff
 
@@ -149,6 +158,8 @@ object Package extends ScalaCommand[PackageOptions] {
         case None      => build.retainedMainClass
       }
 
+    val packageOptions = build.options.notForBloopOptions.packageOptions
+
     packageType match {
       case PackageType.Bootstrap =>
         bootstrap(build, destPath, value(mainClass), () => alreadyExistsCheck())
@@ -170,13 +181,12 @@ object Package extends ScalaCommand[PackageOptions] {
         bootstrap(build, bootstrapPath, value(mainClass), () => alreadyExistsCheck())
         val sharedSettings = SharedSettings(
           sourceAppPath = bootstrapPath,
-          version = build.options.packageOptions.packageVersion,
+          version = packageOptions.packageVersion,
           force = force,
           outputPath = destPath,
-          logoPath = build.options.packageOptions.logoPath,
-          launcherApp = build.options.packageOptions.launcherApp
+          logoPath = packageOptions.logoPath,
+          launcherApp = packageOptions.launcherApp
         )
-        val packageOptions = build.options.packageOptions
 
         lazy val debianSettings = DebianSettings(
           shared = sharedSettings,
@@ -244,7 +254,7 @@ object Package extends ScalaCommand[PackageOptions] {
         docker(inputs, build, value(mainClass), logger)
     }
 
-    if (!build.options.packageOptions.isDockerEnabled)
+    if (!packageOptions.isDockerEnabled)
       logger.message {
         if (packageType.runnable)
           s"Wrote $dest, run it with" + System.lineSeparator() +
@@ -336,6 +346,8 @@ object Package extends ScalaCommand[PackageOptions] {
     mainClass: String,
     logger: Logger
   ): Unit = {
+    val packageOptions = build.options.notForBloopOptions.packageOptions
+
     if (build.options.platform.value == Platform.Native && (Properties.isMac || Properties.isWin)) {
       System.err.println(
         "Package scala native application to docker image is not supported on MacOs and Windows"
@@ -348,22 +360,22 @@ object Package extends ScalaCommand[PackageOptions] {
       case Platform.JS     => Some("node")
       case Platform.Native => None
     }
-    val from = build.options.packageOptions.dockerOptions.from.getOrElse {
+    val from = packageOptions.dockerOptions.from.getOrElse {
       build.options.platform.value match {
         case Platform.JVM    => "openjdk:17-slim"
         case Platform.JS     => "node"
         case Platform.Native => "debian:stable-slim"
       }
     }
-    val repository = build.options.packageOptions.dockerOptions.imageRepository.mandatory(
+    val repository = packageOptions.dockerOptions.imageRepository.mandatory(
       "--docker-image-repository",
       "docker"
     )
-    val tag = build.options.packageOptions.dockerOptions.imageTag.getOrElse("latest")
+    val tag = packageOptions.dockerOptions.imageTag.getOrElse("latest")
 
     val dockerSettings = DockerSettings(
       from = from,
-      registry = build.options.packageOptions.dockerOptions.imageRegistry,
+      registry = packageOptions.dockerOptions.imageRegistry,
       repository = repository,
       tag = Some(tag),
       exec = exec
@@ -441,7 +453,7 @@ object Package extends ScalaCommand[PackageOptions] {
     def dependencyEntries =
       build.artifacts.artifacts.map {
         case (url, artifactPath) =>
-          if (build.options.packageOptions.isStandalone) {
+          if (build.options.notForBloopOptions.packageOptions.isStandalone) {
             val path = os.Path(artifactPath)
             ClassPathEntry.Resource(path.last, os.mtime(path), os.read.bytes(path))
           }

--- a/modules/cli/src/main/scala/scala/cli/commands/PackageOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/PackageOptions.scala
@@ -71,40 +71,42 @@ final case class PackageOptions(
     val baseOptions = shared.buildOptions(enableJmh = false, jmhVersion = None)
     baseOptions.copy(
       mainClass = mainClass.mainClass.filter(_.nonEmpty),
-      packageOptions = baseOptions.packageOptions.copy(
-        standalone = standalone,
-        version = Some(packager.version),
-        launcherApp = packager.launcherApp,
-        maintainer = packager.maintainer,
-        description = packager.description,
-        packageTypeOpt = packageTypeOpt,
-        logoPath = packager.logoPath.map(os.Path(_, os.pwd)),
-        macOSidentifier = packager.identifier,
-        debianOptions = DebianOptions(
-          conflicts = packager.debianConflicts,
-          dependencies = packager.debianDependencies,
-          architecture = Some(packager.debArchitecture)
-        ),
-        redHatOptions = RedHatOptions(
-          license = packager.license,
-          release = Some(packager.release),
-          architecture = Some(packager.rpmArchitecture)
-        ),
-        windowsOptions = WindowsOptions(
-          licensePath = packager.licensePath.map(os.Path(_, os.pwd)),
-          productName = Some(packager.productName),
-          exitDialog = packager.exitDialog,
-          suppressValidation = packager.suppressValidation,
-          extraConfig = packager.extraConfig,
-          is64Bits = Some(packager.is64Bits),
-          installerVersion = packager.installerVersion
-        ),
-        dockerOptions = DockerOptions(
-          from = packager.dockerFrom,
-          imageRegistry = packager.dockerImageRegistry,
-          imageRepository = packager.dockerImageRepository,
-          imageTag = packager.dockerImageTag,
-          isDockerEnabled = Some(docker)
+      notForBloopOptions = baseOptions.notForBloopOptions.copy(
+        packageOptions = baseOptions.notForBloopOptions.packageOptions.copy(
+          standalone = standalone,
+          version = Some(packager.version),
+          launcherApp = packager.launcherApp,
+          maintainer = packager.maintainer,
+          description = packager.description,
+          packageTypeOpt = packageTypeOpt,
+          logoPath = packager.logoPath.map(os.Path(_, os.pwd)),
+          macOSidentifier = packager.identifier,
+          debianOptions = DebianOptions(
+            conflicts = packager.debianConflicts,
+            dependencies = packager.debianDependencies,
+            architecture = Some(packager.debArchitecture)
+          ),
+          redHatOptions = RedHatOptions(
+            license = packager.license,
+            release = Some(packager.release),
+            architecture = Some(packager.rpmArchitecture)
+          ),
+          windowsOptions = WindowsOptions(
+            licensePath = packager.licensePath.map(os.Path(_, os.pwd)),
+            productName = Some(packager.productName),
+            exitDialog = packager.exitDialog,
+            suppressValidation = packager.suppressValidation,
+            extraConfig = packager.extraConfig,
+            is64Bits = Some(packager.is64Bits),
+            installerVersion = packager.installerVersion
+          ),
+          dockerOptions = DockerOptions(
+            from = packager.dockerFrom,
+            imageRegistry = packager.dockerImageRegistry,
+            imageRepository = packager.dockerImageRepository,
+            imageTag = packager.dockerImageTag,
+            isDockerEnabled = Some(docker)
+          )
         )
       )
     )

--- a/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
@@ -120,10 +120,10 @@ object Repl extends ScalaCommand[ReplOptions] {
   ): Either[BuildException, Unit] = either {
 
     val replArtifacts = value {
-      if (options.replOptions.useAmmonite)
+      if (options.notForBloopOptions.replOptions.useAmmonite)
         ReplArtifacts.ammonite(
           artifacts.params,
-          options.replOptions.ammoniteVersion,
+          options.notForBloopOptions.replOptions.ammoniteVersion,
           artifacts.dependencies,
           artifacts.extraClassPath,
           artifacts.extraSourceJars,
@@ -154,7 +154,9 @@ object Repl extends ScalaCommand[ReplOptions] {
       .filter(os.isFile(_)) // just in case
       .map(_.last.stripSuffix(".class"))
       .sorted
-    if (rootClasses.nonEmpty && options.replOptions.useAmmoniteOpt.exists(_ == true))
+    val warnRootClasses = rootClasses.nonEmpty &&
+      options.notForBloopOptions.replOptions.useAmmoniteOpt.exists(_ == true)
+    if (warnRootClasses)
       logger.message(
         s"Warning: found classes defined in the root package (${rootClasses.mkString(", ")})." +
           " These will not be accessible from the REPL."
@@ -169,12 +171,12 @@ object Repl extends ScalaCommand[ReplOptions] {
         classDir.map(_.toIO).toSeq ++ replArtifacts.replClassPath.map(_.toFile),
         replArtifacts.replMainClass,
         if (Properties.isWin)
-          options.replOptions.ammoniteArgs.map { a =>
+          options.notForBloopOptions.replOptions.ammoniteArgs.map { a =>
             if (a.contains(" ")) "\"" + a.replace("\"", "\\\"") + "\""
             else a
           }
         else
-          options.replOptions.ammoniteArgs,
+          options.notForBloopOptions.replOptions.ammoniteArgs,
         logger,
         allowExecve = allowExit
       )

--- a/modules/cli/src/main/scala/scala/cli/commands/ReplOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ReplOptions.scala
@@ -48,10 +48,12 @@ final case class ReplOptions(
           baseOptions.javaOptions.javaOpts ++
             sharedJava.allJavaOpts.map(JavaOpt(_)).map(Positioned.commandLine _)
       ),
-      replOptions = baseOptions.replOptions.copy(
-        useAmmoniteOpt = ammonite,
-        ammoniteVersionOpt = ammoniteVersionOpt,
-        ammoniteArgs = ammoniteArg
+      notForBloopOptions = baseOptions.notForBloopOptions.copy(
+        replOptions = baseOptions.notForBloopOptions.replOptions.copy(
+          useAmmoniteOpt = ammonite,
+          ammoniteVersionOpt = ammoniteVersionOpt,
+          ammoniteArgs = ammoniteArg
+        )
       ),
       internalDependencies = baseOptions.internalDependencies.copy(
         addRunnerDependencyOpt = baseOptions.internalDependencies.addRunnerDependencyOpt


### PR DESCRIPTION
This PR makes that more explicit via `notForBloopOptions: PostBuildOptions` in `BuildOptions`.

This hash is only used to make Bloop directories unique, so it doesn't need to take package or repl options into account.