### PR TITLE
Allow to disable Bloop file content comparison

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -115,6 +115,8 @@ object Build {
     def diagnostics: None.type   = None
   }
 
+  def defaultStrictBloopJsonCheck = true
+
   def updateInputs(
     inputs: Inputs,
     options: BuildOptions,
@@ -724,7 +726,10 @@ object Build {
 
     val project = value(buildProject(inputs, sources, generatedSources, options, scope, logger))
 
-    val updatedBloopConfig = project.writeBloopFile(logger)
+    val updatedBloopConfig = project.writeBloopFile(
+      options.internal.strictBloopJsonCheck.getOrElse(defaultStrictBloopJsonCheck),
+      logger
+    )
 
     if (updatedBloopConfig && os.isDir(classesDir0)) {
       logger.debug(s"Clearing $classesDir0")

--- a/modules/build/src/main/scala/scala/build/Project.scala
+++ b/modules/build/src/main/scala/scala/build/Project.scala
@@ -68,12 +68,16 @@ final case class Project(
   def bloopFile: BloopConfig.File =
     BloopConfig.File(BloopConfig.File.LatestVersion, bloopProject)
 
-  def writeBloopFile(logger: Logger): Boolean = {
-    val bloopFileContent = writeAsJsonToArray(bloopFile)(BloopCodecs.codecFile)
-    val dest             = directory / ".bloop" / s"$projectName.json"
+  def writeBloopFile(strictCheck: Boolean, logger: Logger): Boolean = {
+    lazy val bloopFileContent =
+      writeAsJsonToArray(bloopFile)(BloopCodecs.codecFile)
+    val dest = directory / ".bloop" / s"$projectName.json"
     val doWrite = !os.isFile(dest) || {
-      val currentContent = os.read.bytes(dest)
-      !Arrays.equals(currentContent, bloopFileContent)
+      strictCheck && {
+        logger.debug(s"Checking Bloop project in $dest")
+        val currentContent = os.read.bytes(dest)
+        !Arrays.equals(currentContent, bloopFileContent)
+      }
     }
     if (doWrite) {
       logger.debug(s"Writing bloop project in $dest")

--- a/modules/build/src/main/scala/scala/build/options/InternalOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/InternalOptions.scala
@@ -7,7 +7,8 @@ final case class InternalOptions(
   keepDiagnostics: Boolean = false,
   cache: Option[FileCache[Task]] = None,
   localRepository: Option[String] = None,
-  verbosity: Option[Int] = None
+  verbosity: Option[Int] = None,
+  strictBloopJsonCheck: Option[Boolean] = None
 )
 
 object InternalOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SharedOptions.scala
@@ -101,7 +101,10 @@ final case class SharedOptions(
   @Hidden
     forbid: List[String] = Nil,
   @Recurse
-  helpGroups: HelpGroupOptions = HelpGroupOptions()
+  helpGroups: HelpGroupOptions = HelpGroupOptions(),
+
+  @Hidden
+    strictBloopJsonCheck: Option[Boolean] = None
 ) {
   // format: on
 
@@ -171,7 +174,8 @@ final case class SharedOptions(
       internal = InternalOptions(
         cache = Some(coursierCache),
         localRepository = LocalRepo.localRepo(directories.directories.localRepoDir),
-        verbosity = Some(logging.verbosity)
+        verbosity = Some(logging.verbosity),
+        strictBloopJsonCheck = strictBloopJsonCheck
       )
     )
   }

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1043,6 +1043,8 @@ Generate SemanticDBs
 
 #### `--forbid`
 
+#### `--strict-bloop-json-check`
+
 ## Test options
 
 Available in commands:


### PR DESCRIPTION
~Not sure we should merge that right now.~ While trying to find the origin of some slowdowns when preparing my Scala Love talk, I found that generating Bloop file JSONs and comparing them to their values on disk was quite costly (~200 ms, but I'd like to re-check those benchmarks).

On top of that, they're unnecessary… most of the time. As we write them under `project_-inputs-hash-` directories, we only compute them from the same set of inputs, so they're very unlikely to change.

Yet, they *might* change. They reference many artifacts, and these could change over time. That can be the case for snapshot artifacts, or if users change their coursier cache location. For that reason, I'm not sure we should ~merge that right now~ enable this by default. I'd like to keep refactoring things, so that we know if some artifacts are considered "changing" (snapshots), and we take into account the coursier cache location in the project hash. Maybe that should be enough to make it safe to enable that optimization by default.