### PR TITLE
More lightweight coursier logging

### DIFF
--- a/modules/build/src/main/scala/scala/build/Bloop.scala
+++ b/modules/build/src/main/scala/scala/build/Bloop.scala
@@ -1,6 +1,8 @@
 package scala.build
 
 import ch.epfl.scala.bsp4j
+import coursier.cache.FileCache
+import coursier.util.Task
 import dependency.parser.ModuleParser
 import dependency.{AnyDependency, DependencyLike, ScalaParameters, ScalaVersion}
 
@@ -45,18 +47,20 @@ object Bloop {
   def bloopClassPath(
     dep: AnyDependency,
     params: ScalaParameters,
-    logger: Logger
+    logger: Logger,
+    cache: FileCache[Task]
   ): Either[BuildException, Seq[File]] =
     either {
-      value(Artifacts.artifacts(Positioned.none(Seq(dep)), Nil, params, logger))
+      value(Artifacts.artifacts(Positioned.none(Seq(dep)), Nil, params, logger, cache))
         .map(_._2.toFile)
     }
 
-  def bloopClassPath(logger: Logger): Either[BuildException, Seq[File]] =
-    bloopClassPath(logger, BloopRifleConfig.defaultVersion)
+  def bloopClassPath(logger: Logger, cache: FileCache[Task]): Either[BuildException, Seq[File]] =
+    bloopClassPath(logger, cache, BloopRifleConfig.defaultVersion)
 
   def bloopClassPath(
     logger: Logger,
+    cache: FileCache[Task],
     bloopVersion: String
   ): Either[BuildException, Seq[File]] = either {
     val moduleStr = BloopRifleConfig.defaultModule
@@ -68,6 +72,6 @@ object Bloop {
     val sv     = BloopRifleConfig.defaultScalaVersion
     val sbv    = ScalaVersion.binary(sv)
     val params = ScalaParameters(sv, sbv)
-    value(bloopClassPath(dep, params, logger))
+    value(bloopClassPath(dep, params, logger, cache))
   }
 }

--- a/modules/build/src/main/scala/scala/build/Bloop.scala
+++ b/modules/build/src/main/scala/scala/build/Bloop.scala
@@ -11,6 +11,7 @@ import java.io.File
 import scala.build.EitherCps.{either, value}
 import scala.build.blooprifle.BloopRifleConfig
 import scala.build.errors.{BuildException, ModuleFormatError}
+import scala.build.internal.CsLoggerUtil._
 import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters._
 
@@ -51,8 +52,16 @@ object Bloop {
     cache: FileCache[Task]
   ): Either[BuildException, Seq[File]] =
     either {
-      value(Artifacts.artifacts(Positioned.none(Seq(dep)), Nil, params, logger, cache))
-        .map(_._2.toFile)
+      val res = value {
+        Artifacts.artifacts(
+          Positioned.none(Seq(dep)),
+          Nil,
+          params,
+          logger,
+          cache.withMessage(s"Downloading compilation server ${dep.version}")
+        )
+      }
+      res.map(_._2.toFile)
     }
 
   def bloopClassPath(logger: Logger, cache: FileCache[Task]): Either[BuildException, Seq[File]] =

--- a/modules/build/src/main/scala/scala/build/Logger.scala
+++ b/modules/build/src/main/scala/scala/build/Logger.scala
@@ -26,7 +26,7 @@ trait Logger {
   def log(ex: BuildException): Unit
   def exit(ex: BuildException): Nothing
 
-  def coursierLogger: coursier.cache.CacheLogger
+  def coursierLogger(printBefore: String): coursier.cache.CacheLogger
   def bloopRifleLogger: BloopRifleLogger
   def scalaJsLogger: ScalaJsLogger
   def scalaNativeTestLogger: sn.Logger
@@ -47,7 +47,7 @@ object Logger {
     def exit(ex: BuildException): Nothing =
       throw new Exception(ex)
 
-    def coursierLogger: coursier.cache.CacheLogger =
+    def coursierLogger(printBefore: String): coursier.cache.CacheLogger =
       coursier.cache.CacheLogger.nop
     def bloopRifleLogger: BloopRifleLogger =
       BloopRifleLogger.nop

--- a/modules/build/src/main/scala/scala/build/PersistentDiagnosticLogger.scala
+++ b/modules/build/src/main/scala/scala/build/PersistentDiagnosticLogger.scala
@@ -27,7 +27,8 @@ class PersistentDiagnosticLogger(parent: Logger) extends Logger {
   def log(ex: BuildException): Unit     = parent.log(ex)
   def exit(ex: BuildException): Nothing = parent.exit(ex)
 
-  def coursierLogger: coursier.cache.CacheLogger        = parent.coursierLogger
+  def coursierLogger(printBefore: String): coursier.cache.CacheLogger =
+    parent.coursierLogger(printBefore)
   def bloopRifleLogger: BloopRifleLogger                = parent.bloopRifleLogger
   def scalaJsLogger: ScalaJsLogger                      = parent.scalaJsLogger
   def scalaNativeTestLogger: sn.Logger                  = parent.scalaNativeTestLogger

--- a/modules/build/src/main/scala/scala/build/ReplArtifacts.scala
+++ b/modules/build/src/main/scala/scala/build/ReplArtifacts.scala
@@ -8,6 +8,7 @@ import java.nio.file.Path
 
 import scala.build.EitherCps.{either, value}
 import scala.build.errors.BuildException
+import scala.build.internal.CsLoggerUtil._
 
 final case class ReplArtifacts(
   replArtifacts: Seq[(String, Path)],
@@ -46,14 +47,19 @@ object ReplArtifacts {
   ): Either[BuildException, ReplArtifacts] = either {
     val localRepoOpt = LocalRepo.localRepo(directories.localRepoDir)
     val allDeps      = dependencies ++ Seq(dep"com.lihaoyi:::ammonite:$ammoniteVersion")
-    val replArtifacts =
-      Artifacts.artifacts(Positioned.none(allDeps), localRepoOpt.toSeq, scalaParams, logger, cache)
+    val replArtifacts = Artifacts.artifacts(
+      Positioned.none(allDeps),
+      localRepoOpt.toSeq,
+      scalaParams,
+      logger,
+      cache.withMessage(s"Downloading Ammonite $ammoniteVersion")
+    )
     val replSourceArtifacts = Artifacts.artifacts(
       Positioned.none(allDeps),
       localRepoOpt.toSeq,
       scalaParams,
       logger,
-      cache,
+      cache.withMessage(s"Downloading Ammonite $ammoniteVersion sources"),
       classifiersOpt = Some(Set("sources"))
     )
     ReplArtifacts(
@@ -85,7 +91,7 @@ object ReplArtifacts {
         repositories,
         scalaParams,
         logger,
-        cache
+        cache.withMessage(s"Downloading Scala compiler ${scalaParams.scalaVersion}")
       )
     val mainClass =
       if (isScala2) "scala.tools.nsc.MainGenericRunner"

--- a/modules/build/src/main/scala/scala/build/internal/CsLoggerUtil.scala
+++ b/modules/build/src/main/scala/scala/build/internal/CsLoggerUtil.scala
@@ -1,0 +1,42 @@
+package scala.build.internal
+
+import coursier.cache.FileCache
+import coursier.cache.loggers.RefreshLogger
+import coursier.jvm.JavaHome
+import coursier.util.Task
+
+object CsLoggerUtil {
+
+  // All of these methods are a bit flaky…
+
+  implicit class CsCacheExtensions(private val cache: FileCache[Task]) extends AnyVal {
+    def withMessage(message: String): FileCache[Task] =
+      cache.logger match {
+        case _: RefreshLogger =>
+          var displayed = false
+          val logger = RefreshLogger.create(
+            CustomProgressBarRefreshDisplay.create(
+              keepOnScreen = false,
+              if (!displayed) {
+                System.err.println(message)
+                displayed = true
+              },
+              ()
+            )
+          )
+          cache.withLogger(logger)
+        case _ => cache
+      }
+  }
+  implicit class CsJavaHomeExtensions(private val javaHome: JavaHome) extends AnyVal {
+    def withMessage(message: String): JavaHome =
+      javaHome.cache.map(_.archiveCache.cache) match {
+        case Some(f: FileCache[Task]) =>
+          val cache0 = f.withMessage(message)
+          javaHome.withCache(
+            javaHome.cache.map(c => c.withArchiveCache(c.archiveCache.withCache(cache0)))
+          )
+        case _ => javaHome
+      }
+  }
+}

--- a/modules/build/src/main/scala/scala/build/internal/CustomProgressBarRefreshDisplay.scala
+++ b/modules/build/src/main/scala/scala/build/internal/CustomProgressBarRefreshDisplay.scala
@@ -1,0 +1,206 @@
+package scala.build.internal
+
+// Same as ProgressBarRefreshDisplay in coursier, but allowing not to keep progress
+// bars on screen
+
+import coursier.cache.internal.ConsoleDim
+import coursier.cache.loggers._
+
+import java.io.Writer
+import java.sql.Timestamp
+
+import scala.concurrent.duration.{Duration, DurationInt}
+
+class CustomProgressBarRefreshDisplay(
+  /** Whether to keep details on screen after this display is stopped */
+  keepOnScreen: Boolean,
+  beforeOutput: => Unit,
+  afterOutput: => Unit
+) extends RefreshDisplay {
+
+  import coursier.cache.internal.Terminal.Ansi
+  import CustomProgressBarRefreshDisplay.display
+
+  val refreshInterval: Duration =
+    20.millis
+
+  private var printedAnything0 = false
+  private var currentHeight    = 0
+
+  override def stop(out: Writer): Unit = {
+
+    for (_ <- 1 to 2; _ <- 0 until currentHeight) {
+      out.clearLine(2)
+      out.down(1)
+    }
+    for (_ <- 0 until currentHeight)
+      out.up(2)
+
+    out.flush()
+
+    if (printedAnything0) {
+      afterOutput
+      printedAnything0 = false
+    }
+
+    currentHeight = 0
+  }
+
+  private def truncatedPrintln(out: Writer, s: String, width: Int): Unit = {
+    out.clearLine(2)
+    out.write(RefreshDisplay.truncated(s, width))
+    out.write('\n')
+  }
+
+  def update(
+    out: Writer,
+    done: Seq[(String, RefreshInfo)],
+    downloads: Seq[(String, RefreshInfo)],
+    changed: Boolean
+  ): Unit =
+    if (changed) {
+
+      val width = ConsoleDim.width()
+
+      val done0 = done
+        .filter {
+          case (url, _) =>
+            !url.endsWith(".sha1") &&
+              !url.endsWith(".sha256") &&
+              !url.endsWith(".md5") &&
+              !url.endsWith("/")
+        }
+
+      val elems = done0.iterator.map((_, true)) ++ downloads.iterator.map((_, false))
+      for (((url, info), isDone) <- elems) {
+        assert(info != null, s"Incoherent state ($url)")
+
+        if (!printedAnything0) {
+          beforeOutput
+          printedAnything0 = true
+        }
+
+        truncatedPrintln(out, url, width)
+        out.clearLine(2)
+        out.write(s"  ${display(info, isDone)}" + System.lineSeparator())
+      }
+
+      val displayedCount = done0.length + downloads.length
+
+      if (displayedCount < currentHeight) {
+        for (_ <- 1 to 2; _ <- displayedCount until currentHeight) {
+          out.clearLine(2)
+          out.down(1)
+        }
+
+        for (_ <- displayedCount until currentHeight)
+          out.up(2)
+      }
+
+      for (_ <- downloads.indices)
+        out.up(2)
+      if (!keepOnScreen)
+        for (_ <- done0.indices)
+          out.up(2)
+
+      out.left(10000)
+
+      out.flush()
+
+      currentHeight =
+        if (keepOnScreen) downloads.length
+        else displayedCount
+    }
+
+}
+
+object CustomProgressBarRefreshDisplay {
+
+  def create(): CustomProgressBarRefreshDisplay =
+    new CustomProgressBarRefreshDisplay(keepOnScreen = true, (), ())
+
+  def create(
+    beforeOutput: => Unit,
+    afterOutput: => Unit
+  ): CustomProgressBarRefreshDisplay =
+    new CustomProgressBarRefreshDisplay(keepOnScreen = true, beforeOutput, afterOutput)
+
+  def create(
+    keepOnScreen: Boolean,
+    beforeOutput: => Unit,
+    afterOutput: => Unit
+  ): CustomProgressBarRefreshDisplay =
+    new CustomProgressBarRefreshDisplay(keepOnScreen, beforeOutput, afterOutput)
+
+  // Scala version of http://stackoverflow.com/questions/3758606/how-to-convert-byte-size-into-human-readable-format-in-java/3758880#3758880
+  def byteCount(bytes: Long, si: Boolean = false) = {
+    val unit = if (si) 1000 else 1024
+    if (bytes < unit)
+      bytes.toString + "B"
+    else {
+      val prefixes = if (si) "kMGTPE" else "KMGTPE"
+      val exp      = (math.log(bytes.toDouble) / math.log(unit.toDouble)).toInt min prefixes.length
+      val pre      = prefixes.charAt(exp - 1).toString + (if (si) "" else "i")
+      f"${bytes / math.pow(unit.toDouble, exp.toDouble)}%.1f ${pre}B"
+    }
+  }
+
+  private val format =
+    new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+  private def formatTimestamp(ts: Long): String =
+    format.format(new Timestamp(ts))
+
+  private def display(info: RefreshInfo, isDone: Boolean): String =
+    info match {
+      case d: RefreshInfo.DownloadInfo =>
+        val actualFraction = d.fraction
+          .orElse(if (isDone) Some(1.0) else None)
+          .orElse(if (d.downloaded == 0L) Some(0.0) else None)
+
+        val start =
+          actualFraction match {
+            case None =>
+              "       [          ] "
+            case Some(frac) =>
+              val elem = if (d.watching) "." else "#"
+
+              val decile = (10.0 * frac).toInt
+              assert(decile >= 0)
+              assert(decile <= 10)
+
+              f"${100.0 * frac}%5.1f%%" +
+                " [" + (elem * decile) + (" " * (10 - decile)) + "] "
+          }
+
+        start +
+          byteCount(d.downloaded) +
+          d.rate().fold("")(r => s" (${byteCount(r.toLong)} / s)")
+
+      case c: RefreshInfo.CheckUpdateInfo =>
+        if (isDone)
+          (c.currentTimeOpt, c.remoteTimeOpt) match {
+            case (Some(current), Some(remote)) =>
+              if (current < remote)
+                s"Updated since ${formatTimestamp(current)} (${formatTimestamp(remote)})"
+              else if (current == remote)
+                s"No new update since ${formatTimestamp(current)}"
+              else
+                s"Warning: local copy newer than remote one (${formatTimestamp(current)} > ${formatTimestamp(remote)})"
+            case (Some(_), None) =>
+              // FIXME Likely a 404 Not found, that should be taken into account by the cache
+              "No modified time in response"
+            case (None, Some(remote)) =>
+              s"Last update: ${formatTimestamp(remote)}"
+            case (None, None) =>
+              "" // ???
+          }
+        else
+          c.currentTimeOpt match {
+            case Some(current) =>
+              s"Checking for updates since ${formatTimestamp(current)}"
+            case None =>
+              "" // ???
+          }
+    }
+
+}

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -376,6 +376,7 @@ final case class BuildOptions(
       addNativeTestInterface = addNativeTestInterface,
       addJmhDependencies = jmhOptions.addJmhDependencies,
       extraRepositories = finalRepositories,
+      cache = finalCache,
       logger = logger
     )
     value(maybeArtifacts)

--- a/modules/build/src/test/scala/scala/build/tests/BuildProjectTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildProjectTests.scala
@@ -42,7 +42,7 @@ class BuildProjectTests extends munit.FunSuite {
 
     override def exit(ex: BuildException): Nothing = ???
 
-    override def coursierLogger: CacheLogger = CacheLogger.nop
+    override def coursierLogger(message: String): CacheLogger = CacheLogger.nop
 
     override def bloopRifleLogger: BloopRifleLogger = BloopRifleLogger.nop
     override def scalaJsLogger: ScalaJsLogger       = NullLogger

--- a/modules/build/src/test/scala/scala/build/tests/TestLogger.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestLogger.scala
@@ -38,7 +38,7 @@ case class TestLogger(info: Boolean = true, debug: Boolean = false) extends Logg
   def exit(ex: BuildException): Nothing =
     throw new Exception(ex)
 
-  def coursierLogger: CacheLogger =
+  def coursierLogger(message: String): CacheLogger =
     RefreshLogger.create(new FallbackRefreshDisplay)
 
   def bloopRifleLogger: BloopRifleLogger =

--- a/modules/build/src/test/scala/scala/build/tests/util/BloopServer.scala
+++ b/modules/build/src/test/scala/scala/build/tests/util/BloopServer.scala
@@ -1,5 +1,7 @@
 package scala.build.tests.util
 
+import coursier.cache.FileCache
+
 import scala.build.{Bloop, Logger}
 import scala.build.blooprifle.BloopRifleConfig
 import scala.util.Properties
@@ -19,7 +21,7 @@ object BloopServer {
 
   val bloopConfig = BloopRifleConfig.default(
     bloopAddress,
-    v => Bloop.bloopClassPath(Logger.nop, v),
+    v => Bloop.bloopClassPath(Logger.nop, FileCache(), v),
     directories.bloopWorkingDir.toIO
   )
 

--- a/modules/cli/src/main/scala/scala/cli/commands/BloopExitOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/BloopExitOptions.scala
@@ -20,7 +20,7 @@ final case class BloopExitOptions(
   def bloopRifleConfig(): BloopRifleConfig =
     compilationServer.bloopRifleConfig(
       logging.logger,
-      coursier.coursierCache(logging.logger.coursierLogger),
+      coursier.coursierCache(logging.logger.coursierLogger("Downloading Bloop")),
       logging.verbosity,
       "java", // shouldn't be used…
       directories.directories

--- a/modules/cli/src/main/scala/scala/cli/commands/BloopExitOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/BloopExitOptions.scala
@@ -12,12 +12,15 @@ final case class BloopExitOptions(
     compilationServer: SharedCompilationServerOptions = SharedCompilationServerOptions(),
   @Recurse
     directories: SharedDirectoriesOptions = SharedDirectoriesOptions(),
+  @Recurse
+    coursier: CoursierOptions = CoursierOptions()
 ) {
   // format: on
 
   def bloopRifleConfig(): BloopRifleConfig =
     compilationServer.bloopRifleConfig(
       logging.logger,
+      coursier.coursierCache(logging.logger.coursierLogger),
       logging.verbosity,
       "java", // shouldn't be used…
       directories.directories

--- a/modules/cli/src/main/scala/scala/cli/commands/BloopStartOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/BloopStartOptions.scala
@@ -33,6 +33,7 @@ final case class BloopStartOptions(
   def bloopRifleConfig(): BloopRifleConfig =
     compilationServer.bloopRifleConfig(
       logging.logger,
+      coursier.coursierCache(logging.logger.coursierLogger),
       logging.verbosity,
       buildOptions.javaHome().value.javaCommand,
       directories.directories

--- a/modules/cli/src/main/scala/scala/cli/commands/BloopStartOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/BloopStartOptions.scala
@@ -26,14 +26,14 @@ final case class BloopStartOptions(
     BuildOptions(
       javaOptions = jvm.javaOptions,
       internal = InternalOptions(
-        cache = Some(coursier.coursierCache(logging.logger.coursierLogger))
+        cache = Some(coursier.coursierCache(logging.logger.coursierLogger("")))
       )
     )
 
   def bloopRifleConfig(): BloopRifleConfig =
     compilationServer.bloopRifleConfig(
       logging.logger,
-      coursier.coursierCache(logging.logger.coursierLogger),
+      coursier.coursierCache(logging.logger.coursierLogger("Downloading Bloop")),
       logging.verbosity,
       buildOptions.javaHome().value.javaCommand,
       directories.directories

--- a/modules/cli/src/main/scala/scala/cli/commands/CoursierOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/CoursierOptions.scala
@@ -12,15 +12,22 @@ final case class CoursierOptions(
   @HelpMessage("Specify a TTL for changing dependencies, such as snapshots")
   @ValueDescription("duration|Inf")
   @Hidden
-    ttl: Option[String] = None
+    ttl: Option[String] = None,
+  @Group("Dependency")
+  @HelpMessage("Set the coursier cache location")
+  @ValueDescription("path")
+  @Hidden
+    cache: Option[String] = None
 ) {
   // format: on
   def coursierCache(logger: CacheLogger) = {
-    val baseCache = FileCache()
-    val ttl0      = ttl.map(_.trim).filter(_.nonEmpty).map(Duration(_)).orElse(baseCache.ttl)
+    var baseCache = FileCache().withLogger(logger)
+    val ttlOpt    = ttl.map(_.trim).filter(_.nonEmpty).map(Duration(_))
+    for (ttl0 <- ttlOpt)
+      baseCache = baseCache.withTtl(ttl0)
+    for (loc <- cache.filter(_.trim.nonEmpty))
+      baseCache = baseCache.withLocation(loc)
     baseCache
-      .withTtl(ttl0)
-      .withLogger(logger)
   }
 }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands
 
 import caseapp._
+import coursier.cache.FileCache
 
 import scala.build.EitherCps.{either, value}
 import scala.build.errors.BuildException
@@ -127,6 +128,7 @@ object Repl extends ScalaCommand[ReplOptions] {
     dryRun: Boolean
   ): Either[BuildException, Unit] = either {
 
+    val cache = options.internal.cache.getOrElse(FileCache())
     val replArtifacts = value {
       if (options.notForBloopOptions.replOptions.useAmmonite)
         ReplArtifacts.ammonite(
@@ -136,6 +138,7 @@ object Repl extends ScalaCommand[ReplOptions] {
           artifacts.extraClassPath,
           artifacts.extraSourceJars,
           logger,
+          cache,
           directories
         )
       else
@@ -144,6 +147,7 @@ object Repl extends ScalaCommand[ReplOptions] {
           artifacts.dependencies,
           artifacts.extraClassPath,
           logger,
+          cache,
           options.finalRepositories
         )
     }

--- a/modules/cli/src/main/scala/scala/cli/commands/SharedCompilationServerOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SharedCompilationServerOptions.scala
@@ -1,7 +1,9 @@
 package scala.cli.commands
 
 import caseapp._
+import coursier.cache.FileCache
 import coursier.core.{Version => Ver}
+import coursier.util.Task
 import upickle.default.{ReadWriter, macroRW}
 
 import java.io.File
@@ -209,6 +211,7 @@ final case class SharedCompilationServerOptions(
 
   def bloopRifleConfig(
     logger: Logger,
+    cache: FileCache[Task],
     verbosity: Int,
     javaPath: String,
     directories: => scala.build.Directories,
@@ -250,7 +253,7 @@ final case class SharedCompilationServerOptions(
       .getOrElse(directories.bloopWorkingDir)
     val baseConfig = BloopRifleConfig.default(
       address,
-      v => Bloop.bloopClassPath(logger, v),
+      v => Bloop.bloopClassPath(logger, cache, v),
       workingDir.toIO
     )
 

--- a/modules/cli/src/main/scala/scala/cli/commands/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SharedOptions.scala
@@ -10,11 +10,13 @@ import upickle.default.{ReadWriter, macroRW}
 import java.io.{ByteArrayOutputStream, File, InputStream}
 
 import scala.build.blooprifle.BloopRifleConfig
+import scala.build.internal.CsLoggerUtil._
 import scala.build.internal.{Constants, OsLibc}
 import scala.build.options.{Platform, ScalacOpt, ShadowingSeq}
 import scala.build.{Inputs, LocalRepo, Logger, Os, Position, Positioned, options => bo}
 import scala.concurrent.duration._
 import scala.util.Properties
+import scala.util.control.NonFatal
 // format: off
 final case class SharedOptions(
   @Recurse
@@ -187,11 +189,21 @@ final case class SharedOptions(
     val jvmId = compilationServer.bloopJvm.getOrElse {
       OsLibc.baseDefaultJvm(OsLibc.jvmIndexOs, "17")
     }
-    val logger = options.javaHomeManager.cache
+    val javaHomeManager = options.javaHomeManager
+      .withMessage(s"Downloading JVM $jvmId")
+    val logger = javaHomeManager.cache
       .flatMap(_.archiveCache.cache.loggerOpt)
       .getOrElse(_root_.coursier.cache.CacheLogger.nop)
-    val command = os.Path(logger.use(options.javaHomeManager.get(jvmId).unsafeRun()))
-    val ext     = if (Properties.isWin) ".exe" else ""
+    val command = {
+      val path = logger.use {
+        try javaHomeManager.get(jvmId).unsafeRun()
+        catch {
+          case NonFatal(e) => throw new Exception(e)
+        }
+      }
+      os.Path(path)
+    }
+    val ext = if (Properties.isWin) ".exe" else ""
     compilationServer.bloopRifleConfig(
       logging.logger,
       coursierCache,
@@ -202,7 +214,7 @@ final case class SharedOptions(
     )
   }
 
-  lazy val coursierCache = coursier.coursierCache(logging.logger.coursierLogger)
+  lazy val coursierCache = coursier.coursierCache(logging.logger.coursierLogger(""))
 
   def inputsOrExit(
     args: RemainingArgs,
@@ -216,7 +228,10 @@ final case class SharedOptions(
     val download: String => Either[String, Array[Byte]] = { url =>
       val artifact = Artifact(url).withChanging(true)
       val res = coursierCache.logger.use {
-        coursierCache.withTtl(0.seconds).file(artifact).run.unsafeRun()(coursierCache.ec)
+        try coursierCache.withTtl(0.seconds).file(artifact).run.unsafeRun()(coursierCache.ec)
+        catch {
+          case NonFatal(e) => throw new Exception(e)
+        }
       }
       res
         .left.map(_.describe)

--- a/modules/cli/src/main/scala/scala/cli/commands/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SharedOptions.scala
@@ -194,6 +194,7 @@ final case class SharedOptions(
     val ext     = if (Properties.isWin) ".exe" else ""
     compilationServer.bloopRifleConfig(
       logging.logger,
+      coursierCache,
       logging.verbosity,
       (command / "bin" / s"java$ext").toString,
       directories.directories,

--- a/modules/cli/src/main/scala/scala/cli/internal/FetchExternalBinary.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/FetchExternalBinary.scala
@@ -10,6 +10,7 @@ import java.util.{Locale, UUID}
 import scala.build.Logger
 import scala.build.internal.OsLibc
 import scala.util.Properties
+import scala.util.control.NonFatal
 
 object FetchExternalBinary {
 
@@ -23,10 +24,16 @@ object FetchExternalBinary {
 
     val f = cache.logger.use {
       logger.log(s"Getting $url")
-      cache.file(Artifact(url).withChanging(changing)).run.flatMap {
-        case Left(e)  => Task.fail(e)
-        case Right(f) => Task.point(os.Path(f, os.pwd))
-      }.unsafeRun()(cache.ec)
+      try cache.file(Artifact(url).withChanging(changing))
+        .run
+        .flatMap {
+          case Left(e)  => Task.fail(e)
+          case Right(f) => Task.point(os.Path(f, os.pwd))
+        }
+        .unsafeRun()(cache.ec)
+      catch {
+        case NonFatal(e) => throw new Exception(e)
+      }
     }
     logger.debug(s"$url is available locally at $f")
 

--- a/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
@@ -3,6 +3,7 @@ package scala.cli.launcher
 import coursier.Repositories
 import dependency._
 
+import scala.build.internal.CsLoggerUtil._
 import scala.build.internal.{OsLibc, Runner}
 import scala.build.options.{BuildOptions, JavaOptions}
 import scala.build.{Artifacts, Positioned}
@@ -14,7 +15,7 @@ object LauncherCli {
   def runAndExit(version: String, options: LauncherOptions, remainingArgs: Seq[String]): Nothing = {
 
     val logger       = LoggingOptions().logger
-    val cache        = CoursierOptions().coursierCache(logger.coursierLogger)
+    val cache        = CoursierOptions().coursierCache(logger.coursierLogger(""))
     val scalaVersion = options.cliScalaVersion.getOrElse(Properties.versionNumberString)
 
     val scalaCliDependency = Seq(dep"org.virtuslab.scala-cli::cli:$version")
@@ -29,7 +30,7 @@ object LauncherCli {
         snapshotsRepo,
         ScalaParameters(scalaVersion),
         logger,
-        cache,
+        cache.withMessage(s"Fetching Scala CLI $version"),
         None
       ) match {
         case Right(value) => value

--- a/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
@@ -6,7 +6,7 @@ import dependency._
 import scala.build.internal.{OsLibc, Runner}
 import scala.build.options.{BuildOptions, JavaOptions}
 import scala.build.{Artifacts, Positioned}
-import scala.cli.commands.LoggingOptions
+import scala.cli.commands.{CoursierOptions, LoggingOptions}
 import scala.util.Properties
 
 object LauncherCli {
@@ -14,6 +14,7 @@ object LauncherCli {
   def runAndExit(version: String, options: LauncherOptions, remainingArgs: Seq[String]): Nothing = {
 
     val logger       = LoggingOptions().logger
+    val cache        = CoursierOptions().coursierCache(logger.coursierLogger)
     val scalaVersion = options.cliScalaVersion.getOrElse(Properties.versionNumberString)
 
     val scalaCliDependency = Seq(dep"org.virtuslab.scala-cli::cli:$version")
@@ -28,6 +29,7 @@ object LauncherCli {
         snapshotsRepo,
         ScalaParameters(scalaVersion),
         logger,
+        cache,
         None
       ) match {
         case Right(value) => value

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -213,6 +213,10 @@ Available in commands:
 
 Specify a TTL for changing dependencies, such as snapshots
 
+#### `--cache`
+
+Set the coursier cache location
+
 ## Cross options
 
 Available in commands:

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -192,6 +192,7 @@ Cross-compile sources
 ## Coursier options
 
 Available in commands:
+- [`bloop exit`](./commands.md#bloop-exit)
 - [`bloop start`](./commands.md#bloop-start)
 - [`bsp`](./commands.md#bsp)
 - [`compile`](./commands.md#compile)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -294,6 +294,7 @@ Accepts options:
 
 Accepts options:
 - [compilation server](./cli-options.md#compilation-server-options)
+- [coursier](./cli-options.md#coursier-options)
 - [directories](./cli-options.md#directories-options)
 - [logging](./cli-options.md#logging-options)
 - [verbosity](./cli-options.md#verbosity-options)


### PR DESCRIPTION
This is the logging that was enabled in my Scala Love talk earlier today. This basically:
- prints a message if and only if anything is being downloaded (so if all artifacts are in cache, nothing is printed)
- this doesn't keep on screen the progress bars usually printed by coursier, so that these don't flood the screen

To specify the message to be printed, see the `cache.withMessage` calls. The message is somehow passed to the coursier cache, that passes it to its logger (`withMessage` is an extension method, added in this PR too).