### PR TITLE
Skip set posix file permissions in windows

### DIFF
--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Operations.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Operations.scala
@@ -5,28 +5,17 @@ import snailgun.protocol.Streams
 import snailgun.{Client, TcpClient}
 
 import java.io.{File, InputStream, OutputStream}
-import java.net.{
-  ConnectException,
-  InetSocketAddress,
-  Socket,
-  StandardProtocolFamily,
-  UnixDomainSocketAddress
-}
+import java.net.{ConnectException, InetSocketAddress, Socket, StandardProtocolFamily, UnixDomainSocketAddress}
 import java.nio.channels.SocketChannel
 import java.nio.file.attribute.PosixFilePermissions
 import java.nio.file.{Files, Path}
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.{ExecutorService, ScheduledExecutorService, ScheduledFuture}
 
-import scala.build.blooprifle.{
-  BloopRifleConfig,
-  BloopRifleLogger,
-  BspConnection,
-  BspConnectionAddress
-}
+import scala.build.blooprifle.{BloopRifleConfig, BloopRifleLogger, BspConnection, BspConnectionAddress}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future, Promise}
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Properties, Success, Try}
 
 object Operations {
 
@@ -35,7 +24,7 @@ object Operations {
     if (!Files.exists(path)) {
       // FIXME Small change of race condition here between createDirectories and setPosixFilePermissions
       Files.createDirectories(path)
-      Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rwx------"))
+      if(!Properties.isWin) Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rwx------"))
     }
     LockFiles.under(path)
   }


### PR DESCRIPTION
I noticed this bug while preparing Github actions for scala-cli. 
After running HelloWorld application, I got following error:
```
Run scala-cli hello.sc
[4](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:4)
Downloading https://github.com/coursier/jvm-index/raw/master/index.json
[5](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:5)
Downloaded https://github.com/coursier/jvm-index/raw/master/index.json
[6](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:6)
Downloading https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_x64_windows_hotspot_17_35.zip
[7](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:7)
Still downloading:
[8](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:8)
https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_x64_windows_hotspot_17_35.zip (61.85 %, 116710400 / 1886[9](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:9)0370)
9

[10](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:10)
Downloaded https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_x64_windows_hotspot_17_35.zip
[11](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:11)
Exception in thread "main" java.lang.UnsupportedOperationException
[12](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:12)
	at java.nio.file.Files.setPosixFilePermissions(Files.java:2166)
[13](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:13)
	at scala.build.blooprifle.internal.Operations$.lockFiles(Operations.scala:38)
[14](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:14)
	at scala.build.blooprifle.internal.Operations$.check(Operations.scala:75)
[15](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:15)
	at scala.build.blooprifle.BloopRifle$.check$1(BloopRifle.scala:29)
[16](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:16)
	at scala.build.blooprifle.BloopRifle$.check(BloopRifle.scala:31)
[17](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:17)
	at scala.build.blooprifle.BloopRifle$.getCurrentBloopVersion(BloopRifle.scala:[18](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:18)1)
18
	at scala.build.bloop.BloopServer$.ensureBloopRunning(BloopServer.scala:85)
[19](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:19)
	at scala.build.bloop.BloopServer$.bsp(BloopServer.scala:153)
[20](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:20)
	at scala.build.bloop.BloopServer$.buildServer(BloopServer.scala:183)
[21](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:21)
	at scala.build.bloop.BloopServer$.withBuildServer(BloopServer.scala:248)
[22](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:22)
	at scala.build.Build$.build(Build.scala:408)
[23](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:23)
	at scala.build.Build$.build(Build.scala:432)
[24](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:24)
	at scala.cli.commands.Run$.run(Run.scala:87)
[25](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:25)
	at scala.cli.commands.Run$.run(Run.scala:25)
[26](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:26)
	at scala.cli.commands.Default.run(Default.scala:38)
[27](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:27)
	at scala.cli.commands.Default.run(Default.scala:10)
[28](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:28)
	at caseapp.core.app.CaseApp.main(CaseApp.scala:149)
[29](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:29)
	at caseapp.core.app.CommandsEntryPoint.main(CommandsEntryPoint.scala:116)
[30](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:30)
	at scala.cli.ScalaCliCommands.main(ScalaCliCommands.scala:89)
[31](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:31)
	at scala.cli.ScalaCli$.main0(ScalaCli.scala:148)
[32](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:32)
	at scala.cli.ScalaCli$.main(ScalaCli.scala:71)
[33](https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true#step:9:33)
	at scala.cli.ScalaCli.main(ScalaCli.scala)
```
https://github.com/lwronski/scala-cli-setup/runs/5266884042?check_suite_focus=true