### PR TITLE
Tweaking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,33 +13,6 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  bloop-memory-footprint:
-    timeout-minutes: 120
-    runs-on: ${{ matrix.OS }}
-    strategy:
-      fail-fast: false
-      matrix:
-        OS: ["ubuntu-latest"]
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        submodules: true
-    - uses: coursier/cache-action@v6.3
-    - uses: coursier/setup-action@v1.2.0-M2
-      with:
-        jvm: "temurin:17"
-    - name: Java Version
-      run: java -version
-    - name: Java Home
-      run: echo "$JAVA_HOME"
-    - name: Build Scala CLI
-      run: ./mill copyJvmLauncher build
-    - name: Build Benchmark
-      run: java -jar ./build/scala-cli package --standalone gcbenchmark/gcbenchmark.scala -o gc
-    - name: Run Benchmark
-      run: ./gc $(realpath ./build/scala-cli)
-
   jvm-tests:
     timeout-minutes: 120
     runs-on: ${{ matrix.OS }}
@@ -268,6 +241,33 @@ jobs:
           echo "to update it, then commit the result."
           exit 1
         )
+
+  bloop-memory-footprint:
+    timeout-minutes: 120
+    runs-on: ${{ matrix.OS }}
+    strategy:
+      fail-fast: false
+      matrix:
+        OS: ["ubuntu-latest"]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: coursier/setup-action@v1.2.0-M2
+      with:
+        jvm: "temurin:17"
+    - name: Java Version
+      run: java -version
+    - name: Java Home
+      run: echo "$JAVA_HOME"
+    - name: Build Scala CLI
+      run: ./mill copyJvmLauncher build
+    - name: Build Benchmark
+      run: java -jar ./build/scala-cli package --standalone gcbenchmark/gcbenchmark.scala -o gc
+    - name: Run Benchmark
+      run: ./gc $(realpath ./build/scala-cli)
 
   vc-redist:
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,11 +244,7 @@ jobs:
 
   bloop-memory-footprint:
     timeout-minutes: 120
-    runs-on: ${{ matrix.OS }}
-    strategy:
-      fail-fast: false
-      matrix:
-        OS: ["ubuntu-latest"]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:

--- a/build.sc
+++ b/build.sc
@@ -65,7 +65,8 @@ object integration extends Module {
       }
       def forkEnv = super.forkEnv() ++ Seq(
         "SCALA_CLI_TMP"   -> tmpDirBase().path.toString,
-        "SCALA_CLI_IMAGE" -> "scala-cli"
+        "SCALA_CLI_IMAGE" -> "scala-cli",
+        "CI"              -> "1"
       )
     }
   }
@@ -79,7 +80,8 @@ object integration extends Module {
       }
       def forkEnv = super.forkEnv() ++ Seq(
         "SCALA_CLI_TMP"   -> tmpDirBase().path.toString,
-        "SCALA_CLI_IMAGE" -> "scala-cli-slim"
+        "SCALA_CLI_IMAGE" -> "scala-cli-slim",
+        "CI"              -> "1"
       )
     }
   }
@@ -414,7 +416,8 @@ trait CliIntegrationBase extends SbtModule with ScalaCliPublishModule with HasTe
     def forkEnv = super.forkEnv() ++ Seq(
       "SCALA_CLI"      -> testLauncher().path.toString,
       "SCALA_CLI_KIND" -> cliKind(),
-      "SCALA_CLI_TMP"  -> tmpDirBase().path.toString
+      "SCALA_CLI_TMP"  -> tmpDirBase().path.toString,
+      "CI"             -> "1"
     )
     def sources = T.sources {
       val name = mainArtifactName().stripPrefix(prefix)

--- a/modules/cli/src/main/java/scala/cli/internal/ScalaJSLinkerSubst.java
+++ b/modules/cli/src/main/java/scala/cli/internal/ScalaJSLinkerSubst.java
@@ -4,6 +4,7 @@ import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
+import org.scalajs.logging.Logger;
 import scala.build.internal.ScalaJsConfig;
 
 import java.nio.file.Path;
@@ -18,7 +19,8 @@ final class ScalaJsLinkerSubst {
         String mainClassOrNull,
         boolean addTestInitializer,
         ScalaJsConfig config,
-        Path dest
+        Path dest,
+        Logger logger
     ) {
         throw new RuntimeException("Scala.JS linking unsupported on Windows");
     }

--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -415,7 +415,7 @@ object Package extends ScalaCommand[PackageOptions] {
     logger: Logger
   ): Unit = {
     val linkerConfig = build.options.scalaJsOptions.linkerConfig(logger)
-    linkJs(build, destPath, Some(mainClass), addTestInitializer = false, linkerConfig)
+    linkJs(build, destPath, Some(mainClass), addTestInitializer = false, linkerConfig, logger)
   }
 
   private def buildNative(
@@ -544,7 +544,8 @@ object Package extends ScalaCommand[PackageOptions] {
     dest: os.Path,
     mainClassOpt: Option[String],
     addTestInitializer: Boolean,
-    config: StandardConfig
+    config: StandardConfig,
+    logger: Logger
   ): Unit =
     withLibraryJar(build, dest.last.toString.stripSuffix(".jar")) { mainJar =>
       val classPath = mainJar +: build.artifacts.classPath
@@ -553,7 +554,8 @@ object Package extends ScalaCommand[PackageOptions] {
         mainClassOpt.orNull,
         addTestInitializer,
         new ScalaJsConfig(config),
-        dest.toNIO
+        dest.toNIO,
+        logger.scalaJsLogger
       )
     }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -25,6 +25,7 @@ import scala.build.options.{PackageType, Platform}
 import scala.build.{Build, Inputs, Logger, Os}
 import scala.cli.CurrentParams
 import scala.cli.commands.OptionsHelper._
+import scala.cli.errors.ScalaJsLinkingError
 import scala.cli.internal.{ProcUtil, ScalaJsLinker}
 import scala.util.Properties
 
@@ -180,7 +181,7 @@ object Package extends ScalaCommand[PackageOptions] {
         assembly(build, destPath, value(mainClass), () => alreadyExistsCheck())
 
       case PackageType.Js =>
-        buildJs(build, destPath, value(mainClass), logger)
+        value(buildJs(build, destPath, value(mainClass), logger))
 
       case PackageType.Native =>
         buildNative(inputs, build, destPath, value(mainClass), logger)
@@ -413,7 +414,7 @@ object Package extends ScalaCommand[PackageOptions] {
     destPath: os.Path,
     mainClass: String,
     logger: Logger
-  ): Unit = {
+  ): Either[BuildException, Unit] = {
     val linkerConfig = build.options.scalaJsOptions.linkerConfig(logger)
     linkJs(build, destPath, Some(mainClass), addTestInitializer = false, linkerConfig, logger)
   }
@@ -546,17 +547,29 @@ object Package extends ScalaCommand[PackageOptions] {
     addTestInitializer: Boolean,
     config: StandardConfig,
     logger: Logger
-  ): Unit =
+  ): Either[BuildException, Unit] =
     withLibraryJar(build, dest.last.toString.stripSuffix(".jar")) { mainJar =>
-      val classPath = mainJar +: build.artifacts.classPath
+      val classPath  = mainJar +: build.artifacts.classPath
+      val linkingDir = os.temp.dir(prefix = "scala-cli-js-linking")
       (new ScalaJsLinker).link(
         classPath.toArray,
         mainClassOpt.orNull,
         addTestInitializer,
         new ScalaJsConfig(config),
-        dest.toNIO,
+        linkingDir.toNIO,
         logger.scalaJsLogger
       )
+      val relMainJs = os.rel / "main.js"
+      val mainJs    = linkingDir / relMainJs
+      if (os.exists(mainJs)) {
+        os.copy(mainJs, dest, replaceExisting = true)
+        os.remove.all(linkingDir)
+        Right(())
+      }
+      else {
+        val found = os.walk(linkingDir).map(_.relativeTo(linkingDir))
+        Left(new ScalaJsLinkingError(relMainJs, found))
+      }
     }
 
   def buildNative(

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -130,7 +130,7 @@ object Run extends ScalaCommand[RunOptions] {
     val (finalMainClass, finalArgs) =
       if (jvmRunner) (Constants.runnerMainClass, mainClass +: verbosity +: args)
       else (mainClass, args)
-    runOnce(
+    val res = runOnce(
       root,
       projectName,
       build,
@@ -140,6 +140,7 @@ object Run extends ScalaCommand[RunOptions] {
       allowExecve,
       exitOnError
     )
+    value(res)
   }
 
   private def runOnce(
@@ -151,20 +152,22 @@ object Run extends ScalaCommand[RunOptions] {
     logger: Logger,
     allowExecve: Boolean,
     exitOnError: Boolean
-  ): Boolean = {
+  ): Either[BuildException, Boolean] = either {
 
     val retCode = build.options.platform.value match {
       case Platform.JS =>
         val linkerConfig = build.options.scalaJsOptions.linkerConfig(logger)
-        withLinkedJs(build, Some(mainClass), addTestInitializer = false, linkerConfig, logger) {
-          js =>
-            Runner.runJs(
-              js.toIO,
-              args,
-              logger,
-              allowExecve = allowExecve
-            )
-        }
+        val res =
+          withLinkedJs(build, Some(mainClass), addTestInitializer = false, linkerConfig, logger) {
+            js =>
+              Runner.runJs(
+                js.toIO,
+                args,
+                logger,
+                allowExecve = allowExecve
+              )
+          }
+        value(res)
       case Platform.Native =>
         withNativeLauncher(
           build,
@@ -210,10 +213,9 @@ object Run extends ScalaCommand[RunOptions] {
     addTestInitializer: Boolean,
     config: StandardConfig,
     logger: Logger
-  )(f: os.Path => T): T = {
+  )(f: os.Path => T): Either[BuildException, T] = {
     val dest = os.temp(prefix = "main", suffix = ".js")
-    try {
-      Package.linkJs(build, dest, mainClassOpt, addTestInitializer, config, logger)
+    try Package.linkJs(build, dest, mainClassOpt, addTestInitializer, config, logger).map { _ =>
       f(dest)
     }
     finally if (os.exists(dest)) os.remove(dest)

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -156,13 +156,14 @@ object Run extends ScalaCommand[RunOptions] {
     val retCode = build.options.platform.value match {
       case Platform.JS =>
         val linkerConfig = build.options.scalaJsOptions.linkerConfig(logger)
-        withLinkedJs(build, Some(mainClass), addTestInitializer = false, linkerConfig) { js =>
-          Runner.runJs(
-            js.toIO,
-            args,
-            logger,
-            allowExecve = allowExecve
-          )
+        withLinkedJs(build, Some(mainClass), addTestInitializer = false, linkerConfig, logger) {
+          js =>
+            Runner.runJs(
+              js.toIO,
+              args,
+              logger,
+              allowExecve = allowExecve
+            )
         }
       case Platform.Native =>
         withNativeLauncher(
@@ -207,11 +208,12 @@ object Run extends ScalaCommand[RunOptions] {
     build: Build.Successful,
     mainClassOpt: Option[String],
     addTestInitializer: Boolean,
-    config: StandardConfig
+    config: StandardConfig,
+    logger: Logger
   )(f: os.Path => T): T = {
     val dest = os.temp(prefix = "main", suffix = ".js")
     try {
-      Package.linkJs(build, dest, mainClassOpt, addTestInitializer, config)
+      Package.linkJs(build, dest, mainClassOpt, addTestInitializer, config, logger)
       f(dest)
     }
     finally if (os.exists(dest)) os.remove(dest)

--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -149,7 +149,7 @@ object Test extends ScalaCommand[TestOptions] {
               testFrameworkOpt,
               logger
             )
-          }
+          }.flatMap(e => e)
         }
       case Platform.Native =>
         value {

--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -140,7 +140,7 @@ object Test extends ScalaCommand[TestOptions] {
       case Platform.JS =>
         val linkerConfig = build.options.scalaJsOptions.linkerConfig(logger)
         value {
-          Run.withLinkedJs(build, None, addTestInitializer = true, linkerConfig) { js =>
+          Run.withLinkedJs(build, None, addTestInitializer = true, linkerConfig, logger) { js =>
             Runner.testJs(
               build.fullClassPath,
               js.toIO,

--- a/modules/cli/src/main/scala/scala/cli/errors/ScalaJsLinkingError.scala
+++ b/modules/cli/src/main/scala/scala/cli/errors/ScalaJsLinkingError.scala
@@ -1,0 +1,11 @@
+package scala.cli.errors
+
+import scala.build.errors.BuildException
+
+final class ScalaJsLinkingError(
+  val expected: os.RelPath,
+  val foundFiles: Seq[os.RelPath]
+) extends BuildException(
+      s"Error: $expected not found after Scala.JS linking " +
+        (if (foundFiles.isEmpty) "(no files found)" else s"(found ${foundFiles.mkString(", ")})")
+    )

--- a/modules/cli/src/main/scala/scala/cli/internal/ScalaJsLinker.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/ScalaJsLinker.scala
@@ -2,7 +2,7 @@ package scala.cli.internal
 
 import org.scalajs.linker.interface.{LinkerOutput, ModuleInitializer}
 import org.scalajs.linker.{PathIRContainer, PathOutputFile, StandardImpl}
-import org.scalajs.logging.{Level, ScalaConsoleLogger}
+import org.scalajs.logging.Logger
 import org.scalajs.testing.adapter.{TestAdapterInitializer => TAI}
 
 import java.net.URI
@@ -17,7 +17,8 @@ final class ScalaJsLinker {
     mainClassOrNull: String,
     addTestInitializer: Boolean,
     config: ScalaJsConfig,
-    dest: Path
+    dest: Path,
+    logger: Logger
   ): Unit = {
 
     // adapted from https://github.com/scala-js/scala-js-cli/blob/729824848e25961a3d9a1cfe6ac0260745033148/src/main/scala/org/scalajs/cli/Scalajsld.scala#L158-L193
@@ -45,8 +46,6 @@ final class ScalaJsLinker {
         Nil
 
     val moduleInitializers = mainInitializers ++ testInitializers
-
-    val logger = new ScalaConsoleLogger(Level.Info)
 
     import scala.concurrent.Await
     import scala.concurrent.duration.Duration

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -269,7 +269,7 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
           )
         )
     }
-  if (TestUtil.canRunNative && actualScalaVersion.startsWith("2.12"))
+  if (actualScalaVersion.startsWith("2.12"))
     test("JVM options only for JVM platform") {
       val inputs = TestInputs(
         Seq(os.rel / "Main.scala" -> "//> using `java-opt` \"-Xss1g\"")

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
@@ -79,7 +79,7 @@ abstract class ExportMillTestDefinitions(val scalaVersionOpt: Option[String])
       simpleTest(ExportTestProjects.jsTest(actualScalaVersion))
     }
 
-  if (runExportTests && TestUtil.canRunNative && !actualScalaVersion.startsWith("3."))
+  if (runExportTests && !actualScalaVersion.startsWith("3."))
     test("Scala Native") {
       simpleTest(ExportTestProjects.nativeTest(actualScalaVersion))
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestDefinitions.scala
@@ -74,7 +74,7 @@ abstract class ExportSbtTestDefinitions(val scalaVersionOpt: Option[String])
       simpleTest(ExportTestProjects.jsTest(actualScalaVersion))
     }
 
-  if (runExportTests && TestUtil.canRunNative && !actualScalaVersion.startsWith("3."))
+  if (runExportTests && !actualScalaVersion.startsWith("3."))
     test("Scala Native") {
       simpleTest(ExportTestProjects.nativeTest(actualScalaVersion))
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -129,7 +129,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
 
-  if (TestUtil.canRunNative && canRunScWithNative())
+  if (canRunScWithNative())
     test("simple script native") {
       simpleNativeTests()
     }
@@ -260,7 +260,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
 
-  if (TestUtil.canRunNative && canRunScWithNative())
+  if (canRunScWithNative())
     test("Multiple scripts native") {
       multipleScriptsNative()
     }
@@ -401,7 +401,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   }
 
   // TODO: make nice messages that the scenario is unsupported with 2.12
-  if (TestUtil.canRunNative && actualScalaVersion.startsWith("2.13"))
+  if (actualScalaVersion.startsWith("2.13"))
     test("Directory native") {
       directoryNative()
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -198,7 +198,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
       expect(output.contains("Hello from tests"))
     }
 
-  if (TestUtil.canRunNative && actualScalaVersion.startsWith("2."))
+  if (actualScalaVersion.startsWith("2."))
     test("successful test native") {
       successfulNativeTest()
     }
@@ -233,7 +233,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
       expect(output.contains("Hello from tests"))
     }
 
-  if (TestUtil.canRunNative && actualScalaVersion.startsWith("2."))
+  if (actualScalaVersion.startsWith("2."))
     test("failing test native") {
       failingNativeTest()
     }
@@ -278,7 +278,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
       expect(output.contains("Hello from tests"))
     }
 
-  if (TestUtil.canRunNative && actualScalaVersion.startsWith("2."))
+  if (actualScalaVersion.startsWith("2."))
     test("utest native") {
       utestNative()
     }
@@ -316,7 +316,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
   val platforms = {
     val maybeJs = if (TestUtil.canRunJs) Seq("JS" -> Seq("--js")) else Nil
     val maybeNative =
-      if (TestUtil.canRunNative && actualScalaVersion.startsWith("2."))
+      if (actualScalaVersion.startsWith("2."))
         Seq("Native" -> Seq("--native"))
       else
         Nil
@@ -451,7 +451,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
   }
 
   test("Cross-tests") {
-    val supportsNative = TestUtil.canRunNative && actualScalaVersion.startsWith("2.")
+    val supportsNative = actualScalaVersion.startsWith("2.")
     val platforms = {
       var pf = Seq("\"jvm\"")
       if (TestUtil.canRunJs)

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -29,8 +29,7 @@ object TestUtil {
   )
   // format: on
 
-  lazy val canRunJs     = !isNativeCli || !Properties.isWin
-  lazy val canRunNative = true
+  lazy val canRunJs = !isNativeCli || !Properties.isWin
 
   def fromPath(app: String): Option[String] = {
 

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -727,7 +727,7 @@ trait ScalaCliCompile extends ScalaModule {
             values.toList.flatMap(v => Seq(opt, v.toString))
 
           val proc = os.proc(
-            Seq("scala-cli", "compile", "--classpath"),
+            Seq(fromPath("scala-cli"), "compile", "--classpath"),
             if (scalaVersion().startsWith("3")) Nil
             else Seq("-O", s"-P:semanticdb:sourceroot:${os.pwd}"),
             Seq("-S", scalaVersion()),

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -271,11 +271,6 @@ trait CliLaunchers extends SbtModule { self =>
         )
       )
     }
-    def nativeImageOptions = T {
-      super.nativeImageOptions() ++ Seq(
-        "-H:-CheckToolchain"
-      )
-    }
     def buildHelperImage = T {
       os.proc("docker", "build", "-t", Docker.customMuslBuilderImageName, ".")
         .call(cwd = os.pwd / "project" / "musl-image", stdout = os.Inherit)


### PR DESCRIPTION
This:
- ~enables Scala.JS linking on Windows (used to be disabled because of weird GraalVM errors)~ (still disabled because of possible memory issues on CI, moved to https://github.com/VirtusLab/scala-cli/pull/676)
- ~enables more Scala Native tests (many were disabled for Scala 3 and now pass)~ (seems munit and all [aren't published](https://github.com/scalameta/munit/pull/477) for Scala 3 + Native yet, this will have to wait)
- passes a logger taking into account verbosity to the Scala.JS linker
- tweaks other minor stuff.