### PR TITLE
Update coursier windows-jni-utils to 0.3.3

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -70,7 +70,7 @@ object Deps {
   def expecty                    = ivy"com.eed3si9n.expecty::expecty:0.15.4"
   def guava                      = ivy"com.google.guava:guava:31.0.1-jre"
   def jimfs                      = ivy"com.google.jimfs:jimfs:1.2"
-  def jniUtils                   = ivy"io.get-coursier.jniutils:windows-jni-utils:0.3.2"
+  def jniUtils                   = ivy"io.get-coursier.jniutils:windows-jni-utils:0.3.3"
   def libdaemonjvm               = ivy"io.github.alexarchambault.libdaemon::libdaemon:0.0.9"
   def macroParadise              = ivy"org.scalamacros:::paradise:2.1.1"
   def munit                      = ivy"org.scalameta::munit:0.7.29"


### PR DESCRIPTION
Ought to fix https://github.com/VirtusLab/scala-cli/issues/661.