### PR TITLE
Convinient way to support nightly versions of compiler + more meaningfull error messages about missconfigured Scala versions

### DIFF
--- a/modules/build/src/main/scala/scala/build/Artifacts.scala
+++ b/modules/build/src/main/scala/scala/build/Artifacts.scala
@@ -21,6 +21,7 @@ import scala.build.internal.Constants
 import scala.build.internal.Constants._
 import scala.build.internal.CsLoggerUtil._
 import scala.build.internal.Util.ScalaDependencyOps
+import scala.build.options.BuildOptions.scala2NightlyRegex
 
 final case class Artifacts(
   compilerDependencies: Seq[AnyDependency],
@@ -134,12 +135,21 @@ object Artifacts {
         Nil
     }
 
+    val scala2NightlyRepo = Seq(coursier.Repositories.scalaIntegration.root)
+
     val scalaNativeCliDependency =
       scalaNativeCliVersion.map(version =>
         Seq(dep"org.scala-native:scala-native-cli_2.12:$version")
       )
 
-    val allExtraRepositories = maybeSnapshotRepo ++ extraRepositories
+    val isScala2NightlyRequested = scala2NightlyRegex.unapplySeq(params.scalaVersion).isDefined
+
+    val allExtraRepositories = {
+      val baseRepos =
+        maybeSnapshotRepo ++ extraRepositories
+      if (isScala2NightlyRequested) baseRepos ++ scala2NightlyRepo
+      else baseRepos
+    }
 
     val updatedDependencies =
       dependencies ++

--- a/modules/build/src/main/scala/scala/build/Artifacts.scala
+++ b/modules/build/src/main/scala/scala/build/Artifacts.scala
@@ -8,20 +8,14 @@ import coursier.{Dependency => CsDependency, Fetch, core => csCore, util => csUt
 import dependency._
 
 import java.nio.file.Path
-
 import scala.build.EitherCps.{either, value}
 import scala.build.Ops._
-import scala.build.errors.{
-  BuildException,
-  CompositeBuildException,
-  FetchingDependenciesError,
-  RepositoryFormatError
-}
+import scala.build.errors.{BuildException, CompositeBuildException, FetchingDependenciesError, RepositoryFormatError}
 import scala.build.internal.Constants
 import scala.build.internal.Constants._
 import scala.build.internal.CsLoggerUtil._
+import scala.build.internal.ScalaParse.scala2NightlyRegex
 import scala.build.internal.Util.ScalaDependencyOps
-import scala.build.options.BuildOptions.scala2NightlyRegex
 
 final case class Artifacts(
   compilerDependencies: Seq[AnyDependency],

--- a/modules/build/src/main/scala/scala/build/Artifacts.scala
+++ b/modules/build/src/main/scala/scala/build/Artifacts.scala
@@ -8,9 +8,15 @@ import coursier.{Dependency => CsDependency, Fetch, core => csCore, util => csUt
 import dependency._
 
 import java.nio.file.Path
+
 import scala.build.EitherCps.{either, value}
 import scala.build.Ops._
-import scala.build.errors.{BuildException, CompositeBuildException, FetchingDependenciesError, RepositoryFormatError}
+import scala.build.errors.{
+  BuildException,
+  CompositeBuildException,
+  FetchingDependenciesError,
+  RepositoryFormatError
+}
 import scala.build.internal.Constants
 import scala.build.internal.Constants._
 import scala.build.internal.CsLoggerUtil._

--- a/modules/build/src/main/scala/scala/build/errors/InvalidBinaryScalaVersionError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/InvalidBinaryScalaVersionError.scala
@@ -1,10 +1,9 @@
 package scala.build.errors
 
+import scala.build.errors.ScalaVersionError.getTheGeneralErrorInfo
+
 final class InvalidBinaryScalaVersionError(
   val invalidBinaryVersion: String,
   val latestSupportedStableVersions: Seq[String]
 ) extends ScalaVersionError(s"Cannot find matching Scala version for '$invalidBinaryVersion'\n" +
-      s"You can only choose one of the 3.x, 2.13.x, and 2.12.x. versions \n" +
-      s"The latest supported stable versions are ${latestSupportedStableVersions.mkString(", ")}. \n" +
-      s"In addition, you can request the latest Scala 2 and Scala 3 nightly versions by passing 2.nightly, and 3.nightly arguments respectively.\n" +
-      s"For requesting a specific Scala 2 or Scala 3 nightly version, please specify the full version of the nightly without the repository argument.")
+      getTheGeneralErrorInfo(latestSupportedStableVersions))

--- a/modules/build/src/main/scala/scala/build/errors/InvalidBinaryScalaVersionError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/InvalidBinaryScalaVersionError.scala
@@ -1,5 +1,10 @@
 package scala.build.errors
 
 final class InvalidBinaryScalaVersionError(
-  val binaryVersion: String
-) extends ScalaVersionError(s"Cannot find matching Scala version for '$binaryVersion'")
+  val invalidBinaryVersion: String,
+  val latestSupportedStableVersions: Seq[String]
+) extends ScalaVersionError(s"Cannot find matching Scala version for '$invalidBinaryVersion'\n" +
+      s"You can only choose one of the 3.x, 2.13.x, and 2.12.x. versions \n" +
+      s"The latest supported stable versions are ${latestSupportedStableVersions.mkString(", ")}. \n" +
+      s"In addition, you can request the latest Scala 2 and Scala 3 nightly versions by passing 2.nightly, and 3.nightly arguments respectively.\n" +
+      s"For requesting a specific Scala 2 or Scala 3 nightly version, please specify the full version of the nightly without the repository argument.")

--- a/modules/build/src/main/scala/scala/build/errors/NetworkUnaccessibleScalaVersionError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/NetworkUnaccessibleScalaVersionError.scala
@@ -1,0 +1,6 @@
+package scala.build.errors
+
+final class NetworkUnaccessibleScalaVersionError(
+  val maybeScalaVersion: Option[String]
+) extends ScalaVersionError(s"Most probably, right now the network is not accessible for processing the requested Scala version ${maybeScalaVersion.getOrElse("")}\n" +
+      "Please try again later. Thank you.")

--- a/modules/build/src/main/scala/scala/build/errors/NetworkUnaccessibleScalaVersionError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/NetworkUnaccessibleScalaVersionError.scala
@@ -1,6 +1,0 @@
-package scala.build.errors
-
-final class NetworkUnaccessibleScalaVersionError(
-  val maybeScalaVersion: Option[String]
-) extends ScalaVersionError(s"Most probably, right now the network is not accessible for processing the requested Scala version ${maybeScalaVersion.getOrElse("")}\n" +
-      "Please try again later. Thank you.")

--- a/modules/build/src/main/scala/scala/build/errors/NoValidScalaVersionFoundError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/NoValidScalaVersionFoundError.scala
@@ -1,12 +1,11 @@
 package scala.build.errors
 
+import scala.build.errors.ScalaVersionError.getTheGeneralErrorInfo
+
 final class NoValidScalaVersionFoundError(
   val foundVersions: Seq[String],
   val latestSupportedStableVersions: Seq[String]
 ) extends ScalaVersionError(
       s"Cannot find a valid matching Scala version among ${foundVersions.mkString(", ")}\n" +
-        s"You can only choose one of the 3.x, 2.13.x, and 2.12.x. versions \n" +
-        s"The latest supported stable versions are ${latestSupportedStableVersions.mkString(", ")}. \n" +
-        s"In addition, you can request the latest Scala 2 and Scala 3 nightly versions by passing 2.nightly, and 3.nightly arguments respectively.\n" +
-        s"For requesting a specific Scala 2 or Scala 3 nightly version, please specify the full version of the nightly without the repository argument."
+        getTheGeneralErrorInfo(latestSupportedStableVersions)
     )

--- a/modules/build/src/main/scala/scala/build/errors/NoValidScalaVersionFoundError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/NoValidScalaVersionFoundError.scala
@@ -1,7 +1,12 @@
 package scala.build.errors
 
 final class NoValidScalaVersionFoundError(
-  val foundVersions: Seq[String]
+  val foundVersions: Seq[String],
+  val latestSupportedStableVersions: Seq[String]
 ) extends ScalaVersionError(
-      s"Cannot find valid Scala version among ${foundVersions.mkString(", ")}"
+      s"Cannot find a valid matching Scala version among ${foundVersions.mkString(", ")}\n" +
+        s"You can only choose one of the 3.x, 2.13.x, and 2.12.x. versions \n" +
+        s"The latest supported stable versions are ${latestSupportedStableVersions.mkString(", ")}. \n" +
+        s"In addition, you can request the latest Scala 2 and Scala 3 nightly versions by passing 2.nightly, and 3.nightly arguments respectively.\n" +
+        s"For requesting a specific Scala 2 or Scala 3 nightly version, please specify the full version of the nightly without the repository argument."
     )

--- a/modules/build/src/main/scala/scala/build/errors/ScalaVersionError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/ScalaVersionError.scala
@@ -10,6 +10,6 @@ object ScalaVersionError {
     s"""You can only choose one of the 3.x, 2.13.x, and 2.12.x. versions.
        |The latest supported stable versions are ${latestSupportedStableVersions.mkString(", ")}.
        |In addition, you can request the latest Scala 2 and Scala 3 nightly versions by passing 2.nightly, and 3.nightly arguments respectively.
-       |For requesting a specific Scala 2 or Scala 3 nightly version, please specify the full version of the nightly without the repository argument.
+       |Specific Scala 2 or Scala 3 nightly versions are also accepted.
        |""".stripMargin
 }

--- a/modules/build/src/main/scala/scala/build/errors/ScalaVersionError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/ScalaVersionError.scala
@@ -4,3 +4,12 @@ import scala.build.Position
 
 class ScalaVersionError(message: String, positions: Seq[Position] = Nil)
     extends BuildException(message, positions = positions)
+
+object ScalaVersionError {
+  def getTheGeneralErrorInfo(latestSupportedStableVersions: Seq[String]): String =
+    s"""You can only choose one of the 3.x, 2.13.x, and 2.12.x. versions.
+       |The latest supported stable versions are ${latestSupportedStableVersions.mkString(", ")}.
+       |In addition, you can request the latest Scala 2 and Scala 3 nightly versions by passing 2.nightly, and 3.nightly arguments respectively.
+       |For requesting a specific Scala 2 or Scala 3 nightly version, please specify the full version of the nightly without the repository argument.
+       |""".stripMargin
+}

--- a/modules/build/src/main/scala/scala/build/errors/UnsupportedScalaVersionError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/UnsupportedScalaVersionError.scala
@@ -1,5 +1,10 @@
 package scala.build.errors
 
 final class UnsupportedScalaVersionError(
-  val binaryVersion: String
-) extends ScalaVersionError(s"Unsupported Scala version: $binaryVersion")
+  val binaryVersion: String,
+  val latestSupportedStableVersions: Seq[String]
+) extends ScalaVersionError(s"Unsupported Scala version: $binaryVersion" + "\n" +
+      s"You can only choose one of the 3.x, 2.13.x, and 2.12.x. versions \n" +
+      s"The latest supported stable versions are ${latestSupportedStableVersions.mkString(", ")}. \n" +
+      s"In addition, you can request the latest Scala 2 and Scala 3 nightly versions by passing 2.nightly, and 3.nightly arguments respectively.\n" +
+      s"For requesting a specific Scala 2 or Scala 3 nightly version, please specify the full version of the nightly without the repository argument.")

--- a/modules/build/src/main/scala/scala/build/errors/UnsupportedScalaVersionError.scala
+++ b/modules/build/src/main/scala/scala/build/errors/UnsupportedScalaVersionError.scala
@@ -1,10 +1,12 @@
 package scala.build.errors
 
+import scala.build.errors.ScalaVersionError.getTheGeneralErrorInfo
+
 final class UnsupportedScalaVersionError(
   val binaryVersion: String,
   val latestSupportedStableVersions: Seq[String]
-) extends ScalaVersionError(s"Unsupported Scala version: $binaryVersion" + "\n" +
-      s"You can only choose one of the 3.x, 2.13.x, and 2.12.x. versions \n" +
-      s"The latest supported stable versions are ${latestSupportedStableVersions.mkString(", ")}. \n" +
-      s"In addition, you can request the latest Scala 2 and Scala 3 nightly versions by passing 2.nightly, and 3.nightly arguments respectively.\n" +
-      s"For requesting a specific Scala 2 or Scala 3 nightly version, please specify the full version of the nightly without the repository argument.")
+) extends ScalaVersionError(
+      s"Unsupported Scala version: $binaryVersion" + "\n" + getTheGeneralErrorInfo(
+        latestSupportedStableVersions
+      )
+    )

--- a/modules/build/src/main/scala/scala/build/internal/ScalaParse.scala
+++ b/modules/build/src/main/scala/scala/build/internal/ScalaParse.scala
@@ -8,6 +8,9 @@ object ScalaParse {
 
   import Scala._
 
+  val scala2NightlyRegex = raw"""2\.(\d+)\.(\d+)-bin-[a-f0-9]*""".r
+
+
   // from https://github.com/com-lihaoyi/Ammonite/blob/0f0d597f04e62e86cbf76d3bd16deb6965331470/amm/compiler/src/main/scala/ammonite/compiler/Parsers.scala#L162-L176
   def formatFastparseError(fileName: String, rawCode: String, f: Parsed.Failure) = {
 

--- a/modules/build/src/main/scala/scala/build/internal/ScalaParse.scala
+++ b/modules/build/src/main/scala/scala/build/internal/ScalaParse.scala
@@ -10,7 +10,6 @@ object ScalaParse {
 
   val scala2NightlyRegex = raw"""2\.(\d+)\.(\d+)-bin-[a-f0-9]*""".r
 
-
   // from https://github.com/com-lihaoyi/Ammonite/blob/0f0d597f04e62e86cbf76d3bd16deb6965331470/amm/compiler/src/main/scala/ammonite/compiler/Parsers.scala#L162-L176
   def formatFastparseError(fileName: String, rawCode: String, f: Parsed.Failure) = {
 

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -13,16 +13,11 @@ import java.security.MessageDigest
 
 import scala.build.EitherCps.{either, value}
 import scala.build.blooprifle.VersionUtil.parseJavaVersion
-import scala.build.errors.{
-  BuildException,
-  Diagnostic,
-  InvalidBinaryScalaVersionError,
-  NoValidScalaVersionFoundError,
-  UnsupportedScalaVersionError
-}
+import scala.build.errors._
 import scala.build.internal.Constants._
 import scala.build.internal.CsLoggerUtil._
 import scala.build.internal.{OsLibc, StableScalaVersion, Util}
+import scala.build.options.BuildOptions.scala2NightlyRegex
 import scala.build.options.validation.BuildOptionsRule
 import scala.build.{Artifacts, Logger, Os, Position, Positioned}
 import scala.util.Properties
@@ -230,7 +225,7 @@ final case class BuildOptions(
   private def defaultStableScalaVersions =
     Seq(defaultScala212Version, defaultScala213Version, defaultScalaVersion)
 
-  private def latestSupportedScalaVersion(): Seq[Version] = {
+  private def latestSupportedStableScalaVersion(): Seq[Version] = {
 
     val cache = finalCache.withMessage("Getting list of Scala CLI-supported Scala versions")
     val supportedScalaVersionsUrl = scalaOptions.scalaVersionsUrl
@@ -298,19 +293,32 @@ final case class BuildOptions(
   def finalRepositories: Seq[String] =
     classPathOptions.extraRepositories ++ internal.localRepository.toSeq
 
-  private def computeScalaVersions(
-    scalaVersion: Option[String],
-    scalaBinaryVersion: Option[String]
+  private lazy val maxSupportedStableScalaVersions = latestSupportedStableScalaVersion()
+
+  private lazy val latestSupportedStableVersions = maxSupportedStableScalaVersions.map(_.repr)
+
+  /** @param scalaVersionArg
+    *   the command line, using directive, or default argument passed as scala version
+    * @param scalaBinaryVersionArg
+    *   the command line, using directive, or default argument passed as scala Binary version
+    * @return
+    *   Either a BuildException or the calculated (ScalaVersion, ScalaBinaryVersion) tuple
+    */
+  private def turnScalaVersionArgToScalaVersions(
+    scalaVersionArg: Option[String],
+    scalaBinaryVersionArg: Option[String]
   ): Either[BuildException, (String, String)] = either {
-    lazy val allVersions = {
+    def isSupportedVersion(version: String): Boolean =
+      version.startsWith("2.12.") || version.startsWith("2.13.") || version.startsWith("3.")
+    lazy val allStableVersions = {
       import coursier._
-      import scala.concurrent.ExecutionContext.{global => ec}
       val modules = {
         def scala2 = mod"org.scala-lang:scala-library"
         // No unstable, that *ought* not to be a problem down-the-line…?
         def scala3 = mod"org.scala-lang:scala3-library_3"
-        if (scalaVersion.contains("2") || scalaVersion.exists(_.startsWith("2."))) Seq(scala2)
-        else if (scalaVersion.contains("3") || scalaVersion.exists(_.startsWith("3."))) Seq(scala3)
+        if (scalaVersionArg.contains("2") || scalaVersionArg.exists(_.startsWith("2."))) Seq(scala2)
+        else if (scalaVersionArg.contains("3") || scalaVersionArg.exists(_.startsWith("3.")))
+          Seq(scala3)
         else Seq(scala2, scala3)
       }
       def isStable(v: String): Boolean =
@@ -330,53 +338,186 @@ final case class BuildOptions(
       }
       modules.flatMap(moduleVersions).distinct
     }
-    def matchNewestScalaVersion(sv: Option[String]) = {
-      lazy val maxSupportedScalaVersions = latestSupportedScalaVersion()
 
-      sv match {
-        case Some(sv0) =>
-          val prefix           = if (sv0.endsWith(".")) sv0 else sv0 + "."
-          val matchingVersions = allVersions.filter(_.startsWith(prefix)).map(Version(_))
+    def matchNewestStableScalaVersion(maybeScalaVersionStringArg: Option[String])
+      : Either[ScalaVersionError, String] =
+      maybeScalaVersionStringArg match {
+        case Some(scalaVersionStringArg) =>
+          val prefix =
+            if (Util.isFullScalaVersion(scalaVersionStringArg)) scalaVersionStringArg
+            else if (scalaVersionStringArg.endsWith(".")) scalaVersionStringArg
+            else scalaVersionStringArg + "."
+          val matchingVersions = allStableVersions.filter(_.startsWith(prefix)).map(Version(_))
           if (matchingVersions.isEmpty)
-            Left(new InvalidBinaryScalaVersionError(sv0))
+            Left(new InvalidBinaryScalaVersionError(
+              scalaVersionStringArg,
+              latestSupportedStableVersions
+            ))
           else {
-            val validMaxVersions = maxSupportedScalaVersions
+            val validMaxVersions = maxSupportedStableScalaVersions
               .filter(_.repr.startsWith(prefix))
             val validMatchingVersions = {
               val filtered = matchingVersions.filter(v => validMaxVersions.exists(v <= _))
               if (filtered.isEmpty) matchingVersions
               else filtered
-            }
+            }.filter(v => isSupportedVersion(v.repr))
             if (validMatchingVersions.isEmpty)
-              Left(new UnsupportedScalaVersionError(sv0))
+              Left(new UnsupportedScalaVersionError(
+                scalaVersionStringArg,
+                latestSupportedStableVersions
+              ))
             else
               Right(validMatchingVersions.max.repr)
           }
         case None =>
-          val validVersions = allVersions
+          val validVersions = allStableVersions
             .map(Version(_))
-            .filter(v => maxSupportedScalaVersions.exists(v <= _))
+            .filter(v => maxSupportedStableScalaVersions.exists(v <= _))
           if (validVersions.isEmpty)
-            Left(new NoValidScalaVersionFoundError(allVersions))
+            Left(new NoValidScalaVersionFoundError(
+              allStableVersions,
+              latestSupportedStableVersions
+            ))
           else
             Right(validVersions.max.repr)
       }
-    }
-    val maybeSv = scalaVersion match {
-      case None => matchNewestScalaVersion(None)
-      case Some(sv0) =>
-        if (Util.isFullScalaVersion(sv0)) Right(sv0)
-        else matchNewestScalaVersion(Some(sv0))
+
+    val scalaVersion       = value(matchNewestStableScalaVersion(scalaVersionArg))
+    val scalaBinaryVersion = scalaBinaryVersionArg.getOrElse(ScalaVersion.binary(scalaVersion))
+    (scalaVersion, scalaBinaryVersion)
+  }
+
+  /** @return
+    *   Either a BuildException or the calculated (ScalaVersion, ScalaBinaryVersion) tuple
+    */
+  private def computeLatestScalaThreeNightlyVersions(): Either[BuildException, (String, String)] =
+    either {
+      import coursier.Versions
+      import coursier.core.Latest
+      import coursier._
+
+      val moduleVersion: Either[ScalaVersionError, String] = {
+        def scala3 = mod"org.scala-lang:scala3-library_3"
+        val res = finalCache.logger.use {
+          Versions()
+            .withModule(scala3)
+            .result()
+            .unsafeRun()(finalCache.ec)
+        }
+        res.versions.latest(Latest.Release) match {
+          case Some(versionString) => Right(versionString)
+          case None                => Left(new NetworkUnaccessibleScalaVersionError(None))
+        }
+      }
+
+      val scalaVersion       = value(moduleVersion)
+      val scalaBinaryVersion = ScalaVersion.binary(scalaVersion)
+      (scalaVersion, scalaBinaryVersion)
     }
 
-    val sv  = value(maybeSv)
-    val sbv = scalaBinaryVersion.getOrElse(ScalaVersion.binary(sv))
-    (sv, sbv)
+  /** @return
+    *   Either a BuildException or the calculated (ScalaVersion, ScalaBinaryVersion) tuple
+    */
+  private def computeLatestScalaTwoNightlyVersions(): Either[BuildException, (String, String)] =
+    either {
+      import coursier.Versions
+      import coursier.core.Latest
+      import coursier._
+
+      val moduleVersion: Either[ScalaVersionError, String] = {
+        def scalaNightly2Module: Module = mod"org.scala-lang:scala-library"
+        val res = finalCache.logger.use {
+          Versions()
+            .withModule(scalaNightly2Module)
+            .withRepositories(Seq(coursier.Repositories.scalaIntegration))
+            .result()
+            .unsafeRun()(finalCache.ec)
+        }
+        res.versions.latest(Latest.Release) match {
+          case Some(versionString) => Right(versionString)
+          case None                => Left(new NetworkUnaccessibleScalaVersionError(None))
+        }
+      }
+
+      val scalaVersion       = value(moduleVersion)
+      val scalaBinaryVersion = ScalaVersion.binary(scalaVersion)
+      (scalaVersion, scalaBinaryVersion)
+    }
+
+  private def turnScala2NightlyVersionArgToVersions(versionString: String)
+    : Either[BuildException, (String, String)] = either {
+
+    val moduleVersion: Either[ScalaVersionError, String] = {
+      import coursier._
+      def scalaNightly2Module: Module = mod"org.scala-lang:scala-library"
+      val res = finalCache.logger.use {
+        Versions()
+          .withModule(scalaNightly2Module)
+          .withRepositories(Seq(coursier.Repositories.scalaIntegration))
+          .result()
+          .unsafeRun()(finalCache.ec)
+      }
+      res.versions.available.find(versionString == _) match {
+        case Some(vStr) => Right(vStr)
+        case None => Left(new NoValidScalaVersionFoundError(
+            res.versions.available,
+            latestSupportedStableVersions
+          ))
+      }
+    }
+
+    val scalaVersion       = value(moduleVersion)
+    val scalaBinaryVersion = ScalaVersion.binary(scalaVersion)
+    (scalaVersion, scalaBinaryVersion)
+  }
+
+  private def turnScala3NightlyVersionArgIntoVersion(versionString: String)
+    : Either[BuildException, (String, String)] = either {
+    println("inside turnScala3NightlyVersionArgIntoVersion: " + versionString)
+    val moduleVersion: Either[ScalaVersionError, String] = {
+      import coursier._
+      def scala3 = mod"org.scala-lang:scala3-library_3"
+      val res = finalCache.logger.use {
+        Versions()
+          .withModule(scala3)
+          .result()
+          .unsafeRun()(finalCache.ec)
+      }
+      res.versions.available.find(versionString == _) match {
+        case Some(vStr) => Right(vStr)
+        case None => Left(new NoValidScalaVersionFoundError(
+            res.versions.available,
+            latestSupportedStableVersions
+          ))
+      }
+    }
+    println("moduleVersion: " + moduleVersion)
+
+    val scalaVersion       = value(moduleVersion)
+    val scalaBinaryVersion = ScalaVersion.binary(scalaVersion)
+    (scalaVersion, scalaBinaryVersion)
   }
 
   lazy val scalaParams: Either[BuildException, ScalaParameters] = either {
+    def isScala2Nightly(version: String): Boolean =
+      scala2NightlyRegex.unapplySeq(version).isDefined
+    def isScala3Nightly(version: String): Boolean =
+      version.startsWith("3") && version.endsWith("-NIGHTLY")
+
     val (scalaVersion, scalaBinaryVersion) =
-      value(computeScalaVersions(scalaOptions.scalaVersion, scalaOptions.scalaBinaryVersion))
+      scalaOptions.scalaVersion match {
+        case Some("3.nightly") => value(computeLatestScalaThreeNightlyVersions())
+        case Some("2.nightly") => value(computeLatestScalaTwoNightlyVersions())
+        case Some(versionString) if isScala3Nightly(versionString) =>
+          value(turnScala3NightlyVersionArgIntoVersion(versionString))
+        case Some(versionString) if isScala2Nightly(versionString) =>
+          value(turnScala2NightlyVersionArgToVersions(versionString))
+        case _ => value(turnScalaVersionArgToScalaVersions(
+            scalaOptions.scalaVersion,
+            scalaOptions.scalaBinaryVersion
+          ))
+      }
+
     val maybePlatformSuffix = platform.value match {
       case Platform.JVM    => None
       case Platform.JS     => Some(scalaJsOptions.platformSuffix)
@@ -508,6 +649,8 @@ object BuildOptions {
     scalaVersion: String,
     platform: Platform
   )
+
+  val scala2NightlyRegex = raw"""2\.(\d+)\.(\d+)-bin-[a-f0-9]*""".r
 
   implicit val hasHashData: HasHashData[BuildOptions] = HasHashData.derive
   implicit val monoid: ConfigMonoid[BuildOptions]     = ConfigMonoid.derive

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -10,14 +10,13 @@ import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 import java.security.MessageDigest
-
 import scala.build.EitherCps.{either, value}
 import scala.build.blooprifle.VersionUtil.parseJavaVersion
 import scala.build.errors._
 import scala.build.internal.Constants._
 import scala.build.internal.CsLoggerUtil._
+import scala.build.internal.ScalaParse.scala2NightlyRegex
 import scala.build.internal.{OsLibc, StableScalaVersion, Util}
-import scala.build.options.BuildOptions.scala2NightlyRegex
 import scala.build.options.validation.BuildOptionsRule
 import scala.build.{Artifacts, Logger, Os, Position, Positioned}
 import scala.util.Properties
@@ -648,8 +647,6 @@ object BuildOptions {
     scalaVersion: String,
     platform: Platform
   )
-
-  val scala2NightlyRegex = raw"""2\.(\d+)\.(\d+)-bin-[a-f0-9]*""".r
 
   implicit val hasHashData: HasHashData[BuildOptions] = HasHashData.derive
   implicit val monoid: ConfigMonoid[BuildOptions]     = ConfigMonoid.derive

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -10,6 +10,7 @@ import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 import java.security.MessageDigest
+
 import scala.build.EitherCps.{either, value}
 import scala.build.blooprifle.VersionUtil.parseJavaVersion
 import scala.build.errors._
@@ -471,7 +472,6 @@ final case class BuildOptions(
 
   private def turnScala3NightlyVersionArgIntoVersion(versionString: String)
     : Either[BuildException, (String, String)] = either {
-    println("inside turnScala3NightlyVersionArgIntoVersion: " + versionString)
     val moduleVersion: Either[ScalaVersionError, String] = {
       import coursier._
       def scala3 = mod"org.scala-lang:scala3-library_3"
@@ -489,7 +489,6 @@ final case class BuildOptions(
           ))
       }
     }
-    println("moduleVersion: " + moduleVersion)
 
     val scalaVersion       = value(moduleVersion)
     val scalaBinaryVersion = ScalaVersion.binary(scalaVersion)

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -479,13 +479,11 @@ final case class BuildOptions(
           .result()
           .unsafeRun()(finalCache.ec)
       }
-      res.versions.available.find(versionString == _) match {
-        case Some(vStr) => Right(vStr)
-        case None => Left(new NoValidScalaVersionFoundError(
-            res.versions.available,
-            latestSupportedStableVersions
-          ))
-      }
+      if (res.versions.available.contains(versionString)) versionString
+      else
+        Left(
+          new NoValidScalaVersionFoundError(res.versions.available, latestSupportedStableVersions)
+        )
     }
 
     val scalaVersion       = value(moduleVersion)

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -456,13 +456,11 @@ final case class BuildOptions(
           .result()
           .unsafeRun()(finalCache.ec)
       }
-      res.versions.available.find(versionString == _) match {
-        case Some(vStr) => Right(vStr)
-        case None => Left(new NoValidScalaVersionFoundError(
-            res.versions.available,
-            latestSupportedStableVersions
-          ))
-      }
+      if (res.versions.available.contains(versionString)) versionString
+      else
+        Left(
+          new NoValidScalaVersionFoundError(res.versions.available, latestSupportedStableVersions)
+        )
     }
 
     val scalaVersion       = value(moduleVersion)

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -456,7 +456,7 @@ final case class BuildOptions(
           .result()
           .unsafeRun()(finalCache.ec)
       }
-      if (res.versions.available.contains(versionString)) versionString
+      if (res.versions.available.contains(versionString)) Right(versionString)
       else
         Left(
           new NoValidScalaVersionFoundError(res.versions.available, latestSupportedStableVersions)
@@ -479,7 +479,7 @@ final case class BuildOptions(
           .result()
           .unsafeRun()(finalCache.ec)
       }
-      if (res.versions.available.contains(versionString)) versionString
+      if (res.versions.available.contains(versionString)) Right(versionString)
       else
         Left(
           new NoValidScalaVersionFoundError(res.versions.available, latestSupportedStableVersions)

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -324,9 +324,8 @@ final case class BuildOptions(
       def isStable(v: String): Boolean =
         !v.endsWith("-NIGHTLY") && !v.contains("-RC")
       def moduleVersions(mod: Module): Seq[String] = {
-        val cache = finalCache.withMessage("Getting Scala version list")
-        val res = cache.logger.use {
-          try Versions(cache)
+        val res = finalCache.logger.use {
+          try Versions(finalCache)
             .withModule(mod)
             .result()
             .unsafeRun()(finalCache.ec)
@@ -399,7 +398,7 @@ final case class BuildOptions(
       val moduleVersion: Either[ScalaVersionError, String] = {
         def scala3 = mod"org.scala-lang:scala3-library_3"
         val res = finalCache.logger.use {
-          Versions()
+          Versions(finalCache)
             .withModule(scala3)
             .result()
             .unsafeRun()(finalCache.ec)
@@ -427,7 +426,7 @@ final case class BuildOptions(
       val moduleVersion: Either[ScalaVersionError, String] = {
         def scalaNightly2Module: Module = mod"org.scala-lang:scala-library"
         val res = finalCache.logger.use {
-          Versions()
+          Versions(finalCache)
             .withModule(scalaNightly2Module)
             .withRepositories(Seq(coursier.Repositories.scalaIntegration))
             .result()
@@ -451,7 +450,7 @@ final case class BuildOptions(
       import coursier._
       def scalaNightly2Module: Module = mod"org.scala-lang:scala-library"
       val res = finalCache.logger.use {
-        Versions()
+        Versions(finalCache)
           .withModule(scalaNightly2Module)
           .withRepositories(Seq(coursier.Repositories.scalaIntegration))
           .result()
@@ -478,7 +477,7 @@ final case class BuildOptions(
       import coursier._
       def scala3 = mod"org.scala-lang:scala3-library_3"
       val res = finalCache.logger.use {
-        Versions()
+        Versions(finalCache)
           .withModule(scala3)
           .result()
           .unsafeRun()(finalCache.ec)

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -498,17 +498,19 @@ final case class BuildOptions(
       version.startsWith("3") && version.endsWith("-NIGHTLY")
 
     val (scalaVersion, scalaBinaryVersion) =
-      scalaOptions.scalaVersion match {
-        case Some("3.nightly") => value(computeLatestScalaThreeNightlyVersions())
-        case Some("2.nightly") => value(computeLatestScalaTwoNightlyVersions())
-        case Some(versionString) if isScala3Nightly(versionString) =>
-          value(turnScala3NightlyVersionArgIntoVersion(versionString))
-        case Some(versionString) if isScala2Nightly(versionString) =>
-          value(turnScala2NightlyVersionArgToVersions(versionString))
-        case _ => value(turnScalaVersionArgToScalaVersions(
-            scalaOptions.scalaVersion,
-            scalaOptions.scalaBinaryVersion
-          ))
+      value {
+        scalaOptions.scalaVersion match {
+          case Some("3.nightly") => computeLatestScalaThreeNightlyVersions()
+          case Some("2.nightly") => computeLatestScalaTwoNightlyVersions()
+          case Some(versionString) if isScala3Nightly(versionString) =>
+            turnScala3NightlyVersionArgIntoVersion(versionString)
+          case Some(versionString) if isScala2Nightly(versionString) =>
+            turnScala2NightlyVersionArgToVersions(versionString)
+          case _ => turnScalaVersionArgToScalaVersions(
+              scalaOptions.scalaVersion,
+              scalaOptions.scalaBinaryVersion
+            )
+        }
       }
 
     val maybePlatformSuffix = platform.value match {

--- a/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/build/src/main/scala/scala/build/options/BuildOptions.scala
@@ -1,9 +1,9 @@
 package scala.build.options
-
 import coursier.cache.{ArchiveCache, FileCache}
 import coursier.core.Version
 import coursier.jvm.{JavaHome, JvmCache, JvmIndex}
 import coursier.util.{Artifact, Task}
+import coursier.{Module, Versions}
 import dependency._
 
 import java.math.BigInteger
@@ -329,7 +329,7 @@ final case class BuildOptions(
           try Versions(cache)
             .withModule(mod)
             .result()
-            .unsafeRun()(ec)
+            .unsafeRun()(finalCache.ec)
           catch {
             case NonFatal(e) => throw new Exception(e)
           }

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -4,13 +4,9 @@ import com.eed3si9n.expecty.Expecty.{assert => expect}
 import dependency.ScalaParameters
 
 import scala.build.Ops._
-import scala.build.errors.{
-  InvalidBinaryScalaVersionError,
-  NoValidScalaVersionFoundError,
-  UnsupportedScalaVersionError
-}
+import scala.build.errors.{InvalidBinaryScalaVersionError, NoValidScalaVersionFoundError, UnsupportedScalaVersionError}
 import scala.build.internal.Constants._
-import scala.build.options.BuildOptions.scala2NightlyRegex
+import scala.build.internal.ScalaParse.scala2NightlyRegex
 import scala.build.options.{BuildOptions, BuildRequirements, ScalaOptions}
 import scala.util.Random
 

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -30,10 +30,7 @@ class BuildOptionsTests extends munit.FunSuite {
       scalaOptions = ScalaOptions(
         scalaVersion = Some("3.nightly"),
         scalaBinaryVersion = None,
-        supportedScalaVersionsUrl =
-          Some(
-            Random.alphanumeric.take(10).mkString("")
-          ) // invalid url, it should use defaults from Deps.sc
+        supportedScalaVersionsUrl = None
       )
     )
     val scalaParams = options.scalaParams.orThrow
@@ -49,10 +46,7 @@ class BuildOptionsTests extends munit.FunSuite {
       scalaOptions = ScalaOptions(
         scalaVersion = Some("3.2"),
         scalaBinaryVersion = None,
-        supportedScalaVersionsUrl =
-          Some(
-            Random.alphanumeric.take(10).mkString("")
-          ) // invalid url, it should use defaults from Deps.sc
+        supportedScalaVersionsUrl = None
       )
     )
     println("3.2: " + options.projectParams)
@@ -70,10 +64,7 @@ class BuildOptionsTests extends munit.FunSuite {
       scalaOptions = ScalaOptions(
         scalaVersion = Some("2.11.2"),
         scalaBinaryVersion = None,
-        supportedScalaVersionsUrl =
-          Some(
-            Random.alphanumeric.take(10).mkString("")
-          ) // invalid url, it should use defaults from Deps.sc
+        supportedScalaVersionsUrl = None
       )
     )
     println("2.11.2: " + options.projectParams)
@@ -91,10 +82,7 @@ class BuildOptionsTests extends munit.FunSuite {
       scalaOptions = ScalaOptions(
         scalaVersion = Some("2.11"),
         scalaBinaryVersion = None,
-        supportedScalaVersionsUrl =
-          Some(
-            Random.alphanumeric.take(10).mkString("")
-          ) // invalid url, it should use defaults from Deps.sc
+        supportedScalaVersionsUrl = None
       )
     )
     println("2.11: " + options.projectParams)
@@ -112,10 +100,7 @@ class BuildOptionsTests extends munit.FunSuite {
       scalaOptions = ScalaOptions(
         scalaVersion = Some("3.3.3"),
         scalaBinaryVersion = None,
-        supportedScalaVersionsUrl =
-          Some(
-            Random.alphanumeric.take(10).mkString("")
-          ) // invalid url, it should use defaults from Deps.sc
+        supportedScalaVersionsUrl = None
       )
     )
     println("3.3.3: " + options.projectParams)
@@ -133,10 +118,7 @@ class BuildOptionsTests extends munit.FunSuite {
       scalaOptions = ScalaOptions(
         scalaVersion = Some("3.1.3-RC1-bin-20220213-fd97eee-NIGHTLY"),
         scalaBinaryVersion = None,
-        supportedScalaVersionsUrl =
-          Some(
-            Random.alphanumeric.take(10).mkString("")
-          ) // invalid url, it should use defaults from Deps.sc
+        supportedScalaVersionsUrl = None
       )
     )
     assert(
@@ -153,10 +135,7 @@ class BuildOptionsTests extends munit.FunSuite {
       scalaOptions = ScalaOptions(
         scalaVersion = Some("2.13.9-bin-1111111"),
         scalaBinaryVersion = None,
-        supportedScalaVersionsUrl =
-          Some(
-            Random.alphanumeric.take(10).mkString("")
-          ) // invalid url, it should use defaults from Deps.sc
+        supportedScalaVersionsUrl = None
       )
     )
     assert(
@@ -173,10 +152,7 @@ class BuildOptionsTests extends munit.FunSuite {
       scalaOptions = ScalaOptions(
         scalaVersion = Some("2.33"),
         scalaBinaryVersion = None,
-        supportedScalaVersionsUrl =
-          Some(
-            Random.alphanumeric.take(10).mkString("")
-          ) // invalid url, it should use defaults from Deps.sc
+        supportedScalaVersionsUrl = None
       )
     )
     assert(options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
@@ -189,10 +165,7 @@ class BuildOptionsTests extends munit.FunSuite {
       scalaOptions = ScalaOptions(
         scalaVersion = Some("2.nightly"),
         scalaBinaryVersion = None,
-        supportedScalaVersionsUrl =
-          Some(
-            Random.alphanumeric.take(10).mkString("")
-          ) // invalid url, it should use defaults from Deps.sc
+        supportedScalaVersionsUrl = None
       )
     )
     val scalaParams = options.scalaParams.orThrow
@@ -207,10 +180,7 @@ class BuildOptionsTests extends munit.FunSuite {
       scalaOptions = ScalaOptions(
         scalaVersion = Some("2.13.9-bin-4505094"),
         scalaBinaryVersion = None,
-        supportedScalaVersionsUrl =
-          Some(
-            Random.alphanumeric.take(10).mkString("")
-          ) // invalid url, it should use defaults from Deps.sc
+        supportedScalaVersionsUrl = None
       )
     )
     val scalaParams = options.scalaParams.orThrow

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -129,9 +129,7 @@ class BuildOptionsTests extends munit.FunSuite {
 
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
-        scalaVersion = Some("2.12.9-bin-1111111"),
-        scalaBinaryVersion = None,
-        supportedScalaVersionsUrl = None
+        scalaVersion = Some("2.12.9-bin-1111111")
       )
     )
     assert(

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -4,7 +4,13 @@ import com.eed3si9n.expecty.Expecty.{assert => expect}
 import dependency.ScalaParameters
 
 import scala.build.Ops._
+import scala.build.errors.{
+  InvalidBinaryScalaVersionError,
+  NoValidScalaVersionFoundError,
+  UnsupportedScalaVersionError
+}
 import scala.build.internal.Constants._
+import scala.build.options.BuildOptions.scala2NightlyRegex
 import scala.build.options.{BuildOptions, BuildRequirements, ScalaOptions}
 import scala.util.Random
 
@@ -16,6 +22,201 @@ class BuildOptionsTests extends munit.FunSuite {
     expect(
       empty == zero,
       "Unexpected Option / Seq / Set / Boolean with a non-empty / non-false default value"
+    )
+  }
+
+  test("-S 3.nightly option works") {
+    val options = BuildOptions(
+      scalaOptions = ScalaOptions(
+        scalaVersion = Some("3.nightly"),
+        scalaBinaryVersion = None,
+        supportedScalaVersionsUrl =
+          Some(
+            Random.alphanumeric.take(10).mkString("")
+          ) // invalid url, it should use defaults from Deps.sc
+      )
+    )
+    val scalaParams = options.scalaParams.orThrow
+    assert(
+      scalaParams.scalaVersion.startsWith("3") && scalaParams.scalaVersion.endsWith("-NIGHTLY"),
+      "-S 3.nightly argument does not lead to scala3 nightly build option"
+    )
+  }
+
+  test("Scala 3.2 shows Invalid Binary Scala Version Error") {
+
+    val options = BuildOptions(
+      scalaOptions = ScalaOptions(
+        scalaVersion = Some("3.2"),
+        scalaBinaryVersion = None,
+        supportedScalaVersionsUrl =
+          Some(
+            Random.alphanumeric.take(10).mkString("")
+          ) // invalid url, it should use defaults from Deps.sc
+      )
+    )
+    println("3.2: " + options.projectParams)
+    assert(
+      options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
+        InvalidBinaryScalaVersionError
+      ],
+      "specifying the 3.2 scala version does not lead to the Invalid Binary Scala Version Error"
+    )
+  }
+
+  test("Scala 2.11.2 shows Unupported Scala Version Error") {
+
+    val options = BuildOptions(
+      scalaOptions = ScalaOptions(
+        scalaVersion = Some("2.11.2"),
+        scalaBinaryVersion = None,
+        supportedScalaVersionsUrl =
+          Some(
+            Random.alphanumeric.take(10).mkString("")
+          ) // invalid url, it should use defaults from Deps.sc
+      )
+    )
+    println("2.11.2: " + options.projectParams)
+    assert(
+      options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
+        UnsupportedScalaVersionError
+      ],
+      "specifying the 2.11.2 scala version does not lead to the Unsupported Scala Version Error"
+    )
+  }
+
+  test("Scala 2.11 shows Unupported Scala Version Error") {
+
+    val options = BuildOptions(
+      scalaOptions = ScalaOptions(
+        scalaVersion = Some("2.11"),
+        scalaBinaryVersion = None,
+        supportedScalaVersionsUrl =
+          Some(
+            Random.alphanumeric.take(10).mkString("")
+          ) // invalid url, it should use defaults from Deps.sc
+      )
+    )
+    println("2.11: " + options.projectParams)
+    assert(
+      options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
+        UnsupportedScalaVersionError
+      ],
+      "specifying the 2.11 scala version does not lead to the Unsupported Scala Version Error"
+    )
+  }
+
+  test("Scala 3.3.3 shows Invalid Binary Scala Version Error") {
+
+    val options = BuildOptions(
+      scalaOptions = ScalaOptions(
+        scalaVersion = Some("3.3.3"),
+        scalaBinaryVersion = None,
+        supportedScalaVersionsUrl =
+          Some(
+            Random.alphanumeric.take(10).mkString("")
+          ) // invalid url, it should use defaults from Deps.sc
+      )
+    )
+    println("3.3.3: " + options.projectParams)
+    assert(
+      options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
+        InvalidBinaryScalaVersionError
+      ],
+      "specifying the 3.3.3 scala version does not lead to the Invalid Binary Scala Version Error"
+    )
+  }
+
+  test("Scala 3.1.3-RC1-bin-20220213-fd97eee-NIGHTLY shows No Valid Scala Version Error") {
+
+    val options = BuildOptions(
+      scalaOptions = ScalaOptions(
+        scalaVersion = Some("3.1.3-RC1-bin-20220213-fd97eee-NIGHTLY"),
+        scalaBinaryVersion = None,
+        supportedScalaVersionsUrl =
+          Some(
+            Random.alphanumeric.take(10).mkString("")
+          ) // invalid url, it should use defaults from Deps.sc
+      )
+    )
+    assert(
+      options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
+        NoValidScalaVersionFoundError
+      ],
+      "specifying the wrong full scala 3 nightly version does not lead to the No Valid Scala Version Found Error"
+    )
+  }
+
+  test("Scala 2.13.9-bin-1111111 shows No Valid Scala Version Error") {
+
+    val options = BuildOptions(
+      scalaOptions = ScalaOptions(
+        scalaVersion = Some("2.13.9-bin-1111111"),
+        scalaBinaryVersion = None,
+        supportedScalaVersionsUrl =
+          Some(
+            Random.alphanumeric.take(10).mkString("")
+          ) // invalid url, it should use defaults from Deps.sc
+      )
+    )
+    assert(
+      options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
+        NoValidScalaVersionFoundError
+      ],
+      "specifying the wrong full scala 2 nightly version does not lead to the No Valid Scala Version Found Error"
+    )
+  }
+
+  test("Scala 2.33 shows Invalid Binary Scala Version Error") {
+
+    val options = BuildOptions(
+      scalaOptions = ScalaOptions(
+        scalaVersion = Some("2.33"),
+        scalaBinaryVersion = None,
+        supportedScalaVersionsUrl =
+          Some(
+            Random.alphanumeric.take(10).mkString("")
+          ) // invalid url, it should use defaults from Deps.sc
+      )
+    )
+    assert(options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
+      InvalidBinaryScalaVersionError
+    ])
+  }
+
+  test("-S 2.nightly option works") {
+    val options = BuildOptions(
+      scalaOptions = ScalaOptions(
+        scalaVersion = Some("2.nightly"),
+        scalaBinaryVersion = None,
+        supportedScalaVersionsUrl =
+          Some(
+            Random.alphanumeric.take(10).mkString("")
+          ) // invalid url, it should use defaults from Deps.sc
+      )
+    )
+    val scalaParams = options.scalaParams.orThrow
+    assert(
+      scala2NightlyRegex.unapplySeq(scalaParams.scalaVersion).isDefined,
+      "-S 2.nightly argument does not lead to scala2 nightly build option"
+    )
+  }
+
+  test("-S 2.13.9-bin-4505094 option works without repo specification") {
+    val options = BuildOptions(
+      scalaOptions = ScalaOptions(
+        scalaVersion = Some("2.13.9-bin-4505094"),
+        scalaBinaryVersion = None,
+        supportedScalaVersionsUrl =
+          Some(
+            Random.alphanumeric.take(10).mkString("")
+          ) // invalid url, it should use defaults from Deps.sc
+      )
+    )
+    val scalaParams = options.scalaParams.orThrow
+    assert(
+      scalaParams.scalaVersion == "2.13.9-bin-4505094",
+      "-S 2.13.9-bin-4505094 argument does not lead to 2.13.9-bin-4505094 scala version in build option"
     )
   }
 

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -50,9 +50,9 @@ class BuildOptionsTests extends munit.FunSuite {
       )
     )
     assert(
-      options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
-        InvalidBinaryScalaVersionError
-      ],
+      options.projectParams.swap.exists {
+        case _: InvalidBinaryScalaVersionError => true; case _ => false
+      },
       s"specifying the 3.${Int.MaxValue} scala version does not lead to the Invalid Binary Scala Version Error"
     )
   }
@@ -67,7 +67,9 @@ class BuildOptionsTests extends munit.FunSuite {
       )
     )
     assert(
-      options.projectParams.swap.exists { case _: UnsupportedScalaVersionError => true; case _ => false },
+      options.projectParams.swap.exists {
+        case _: UnsupportedScalaVersionError => true; case _ => false
+      },
       "specifying the 2.11.2 scala version does not lead to the Unsupported Scala Version Error"
     )
   }
@@ -82,9 +84,9 @@ class BuildOptionsTests extends munit.FunSuite {
       )
     )
     assert(
-      options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
-        UnsupportedScalaVersionError
-      ],
+      options.projectParams.swap.exists {
+        case _: UnsupportedScalaVersionError => true; case _ => false
+      },
       "specifying the 2.11 scala version does not lead to the Unsupported Scala Version Error"
     )
   }
@@ -99,9 +101,9 @@ class BuildOptionsTests extends munit.FunSuite {
       )
     )
     assert(
-      options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
-        InvalidBinaryScalaVersionError
-      ],
+      options.projectParams.swap.exists {
+        case _: InvalidBinaryScalaVersionError => true; case _ => false
+      },
       "specifying the 3.2147483647.3 scala version does not lead to the Invalid Binary Scala Version Error"
     )
   }
@@ -116,9 +118,9 @@ class BuildOptionsTests extends munit.FunSuite {
       )
     )
     assert(
-      options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
-        NoValidScalaVersionFoundError
-      ],
+      options.projectParams.swap.exists {
+        case _: NoValidScalaVersionFoundError => true; case _ => false
+      },
       "specifying the wrong full scala 3 nightly version does not lead to the No Valid Scala Version Found Error"
     )
   }
@@ -131,9 +133,9 @@ class BuildOptionsTests extends munit.FunSuite {
       )
     )
     assert(
-      options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
-        NoValidScalaVersionFoundError
-      ],
+      options.projectParams.swap.exists {
+        case _: NoValidScalaVersionFoundError => true; case _ => false
+      },
       "specifying the wrong full scala 2 nightly version does not lead to the No Valid Scala Version Found Error"
     )
   }
@@ -147,9 +149,12 @@ class BuildOptionsTests extends munit.FunSuite {
         supportedScalaVersionsUrl = None
       )
     )
-    assert(options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
-      InvalidBinaryScalaVersionError
-    ])
+    assert(
+      options.projectParams.swap.exists {
+        case _: InvalidBinaryScalaVersionError => true; case _ => false
+      },
+      s"specifying 2.${Int.MaxValue} as Scala version does not lead to Invalid Binary Scala Version Error"
+    )
   }
 
   test("-S 2.nightly option works") {
@@ -210,10 +215,7 @@ class BuildOptionsTests extends munit.FunSuite {
         scalaOptions = ScalaOptions(
           scalaVersion = prefix,
           scalaBinaryVersion = None,
-          supportedScalaVersionsUrl =
-            Some(
-              Random.alphanumeric.take(10).mkString("")
-            ) // invalid url, it should use defaults from Deps.sc
+          supportedScalaVersionsUrl = None
         )
       )
       val scalaParams = options.scalaParams.orThrow

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -67,9 +67,7 @@ class BuildOptionsTests extends munit.FunSuite {
       )
     )
     assert(
-      options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
-        UnsupportedScalaVersionError
-      ],
+      options.projectParams.swap.exists { case _: UnsupportedScalaVersionError => true; case _ => false },
       "specifying the 2.11.2 scala version does not lead to the Unsupported Scala Version Error"
     )
   }

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -4,7 +4,11 @@ import com.eed3si9n.expecty.Expecty.{assert => expect}
 import dependency.ScalaParameters
 
 import scala.build.Ops._
-import scala.build.errors.{InvalidBinaryScalaVersionError, NoValidScalaVersionFoundError, UnsupportedScalaVersionError}
+import scala.build.errors.{
+  InvalidBinaryScalaVersionError,
+  NoValidScalaVersionFoundError,
+  UnsupportedScalaVersionError
+}
 import scala.build.internal.Constants._
 import scala.build.internal.ScalaParse.scala2NightlyRegex
 import scala.build.options.{BuildOptions, BuildRequirements, ScalaOptions}
@@ -45,7 +49,6 @@ class BuildOptionsTests extends munit.FunSuite {
         supportedScalaVersionsUrl = None
       )
     )
-    println("3.2: " + options.projectParams)
     assert(
       options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
         InvalidBinaryScalaVersionError
@@ -63,7 +66,6 @@ class BuildOptionsTests extends munit.FunSuite {
         supportedScalaVersionsUrl = None
       )
     )
-    println("2.11.2: " + options.projectParams)
     assert(
       options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
         UnsupportedScalaVersionError
@@ -81,7 +83,6 @@ class BuildOptionsTests extends munit.FunSuite {
         supportedScalaVersionsUrl = None
       )
     )
-    println("2.11: " + options.projectParams)
     assert(
       options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
         UnsupportedScalaVersionError
@@ -99,7 +100,6 @@ class BuildOptionsTests extends munit.FunSuite {
         supportedScalaVersionsUrl = None
       )
     )
-    println("3.3.3: " + options.projectParams)
     assert(
       options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
         InvalidBinaryScalaVersionError

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -40,11 +40,11 @@ class BuildOptionsTests extends munit.FunSuite {
     )
   }
 
-  test("Scala 3.2 shows Invalid Binary Scala Version Error") {
+  test(s"Scala 3.${Int.MaxValue} shows Invalid Binary Scala Version Error") {
 
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
-        scalaVersion = Some("3.2"),
+        scalaVersion = Some(s"3.${Int.MaxValue}"),
         scalaBinaryVersion = None,
         supportedScalaVersionsUrl = None
       )
@@ -53,7 +53,7 @@ class BuildOptionsTests extends munit.FunSuite {
       options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
         InvalidBinaryScalaVersionError
       ],
-      "specifying the 3.2 scala version does not lead to the Invalid Binary Scala Version Error"
+      s"specifying the 3.${Int.MaxValue} scala version does not lead to the Invalid Binary Scala Version Error"
     )
   }
 
@@ -91,11 +91,11 @@ class BuildOptionsTests extends munit.FunSuite {
     )
   }
 
-  test("Scala 3.3.3 shows Invalid Binary Scala Version Error") {
+  test(s"Scala 3.${Int.MaxValue}.3 shows Invalid Binary Scala Version Error") {
 
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
-        scalaVersion = Some("3.3.3"),
+        scalaVersion = Some(s"3.${Int.MaxValue}.3"),
         scalaBinaryVersion = None,
         supportedScalaVersionsUrl = None
       )
@@ -104,7 +104,7 @@ class BuildOptionsTests extends munit.FunSuite {
       options.projectParams.isLeft && options.projectParams.left.get.isInstanceOf[
         InvalidBinaryScalaVersionError
       ],
-      "specifying the 3.3.3 scala version does not lead to the Invalid Binary Scala Version Error"
+      "specifying the 3.2147483647.3 scala version does not lead to the Invalid Binary Scala Version Error"
     )
   }
 
@@ -125,11 +125,11 @@ class BuildOptionsTests extends munit.FunSuite {
     )
   }
 
-  test("Scala 2.13.9-bin-1111111 shows No Valid Scala Version Error") {
+  test("Scala 2.12.9-bin-1111111 shows No Valid Scala Version Error") {
 
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
-        scalaVersion = Some("2.13.9-bin-1111111"),
+        scalaVersion = Some("2.12.9-bin-1111111"),
         scalaBinaryVersion = None,
         supportedScalaVersionsUrl = None
       )
@@ -142,11 +142,11 @@ class BuildOptionsTests extends munit.FunSuite {
     )
   }
 
-  test("Scala 2.33 shows Invalid Binary Scala Version Error") {
+  test(s"Scala 2.${Int.MaxValue} shows Invalid Binary Scala Version Error") {
 
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
-        scalaVersion = Some("2.33"),
+        scalaVersion = Some(s"2.${Int.MaxValue}"),
         scalaBinaryVersion = None,
         supportedScalaVersionsUrl = None
       )

--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -811,20 +811,20 @@ class BuildTests extends munit.FunSuite {
     }
   }
 
-  test("Scala 3.3.3 makes the build fail with InvalidBinaryScalaVersionError") {
+  test(s"Scala 3.${Int.MaxValue}.3 makes the build fail with InvalidBinaryScalaVersionError") {
     val testInputs = TestInputs(
       os.rel / "Simple.scala" ->
-        """ // using scala "3.2"
-          |object Hello {
-          |  def main(args: Array[String]): Unit =
-          |    println("Hello")
-          |}
-          |
-          |""".stripMargin
+        s""" // using scala "3.${Int.MaxValue}.3"
+           |object Hello {
+           |  def main(args: Array[String]): Unit =
+           |    println("Hello")
+           |}
+           |
+           |""".stripMargin
     )
     val buildOptions = BuildOptions(
       scalaOptions = ScalaOptions(
-        scalaVersion = Some("3.3.3"),
+        scalaVersion = Some(s"3.${Int.MaxValue}.3"),
         scalaBinaryVersion = None,
         supportedScalaVersionsUrl = None
       )

--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -830,8 +830,10 @@ class BuildTests extends munit.FunSuite {
       )
     )
     testInputs.withBuild(buildOptions, buildThreads, bloopConfig) { (_, _, maybeBuild) =>
-      assert(maybeBuild.isLeft)
-      assert(maybeBuild.left.get.isInstanceOf[InvalidBinaryScalaVersionError])
+      assert(
+        maybeBuild.swap.exists { case _: InvalidBinaryScalaVersionError => true; case _ => false },
+        s"specifying Scala 3.${Int.MaxValue}.3 as version does not lead to InvalidBinaryScalaVersionError"
+      )
     }
   }
 

--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -811,7 +811,7 @@ class BuildTests extends munit.FunSuite {
     }
   }
 
-  test("Scala 3.2 makes the build fail with InvalidBinaryScalaVersionError") {
+  test("Scala 3.3.3 makes the build fail with InvalidBinaryScalaVersionError") {
     val testInputs = TestInputs(
       os.rel / "Simple.scala" ->
         """ // using scala "3.2"
@@ -826,10 +826,7 @@ class BuildTests extends munit.FunSuite {
       scalaOptions = ScalaOptions(
         scalaVersion = Some("3.3.3"),
         scalaBinaryVersion = None,
-        supportedScalaVersionsUrl =
-          Some(
-            Random.alphanumeric.take(10).mkString("")
-          ) // invalid url, it should use defaults from Deps.sc
+        supportedScalaVersionsUrl = None
       )
     )
     testInputs.withBuild(buildOptions, buildThreads, bloopConfig) { (_, _, maybeBuild) =>

--- a/website/docs/commands/compile.md
+++ b/website/docs/commands/compile.md
@@ -68,15 +68,15 @@ scala-cli compile --scala 3 Hello.scala
 
 The nightly builds of Scala compiler are unstable ones which are published on a nightly basis.
 
-For using the latest scala 2 and scala 3 nightly builds, you should pass `2.nightly` and `3.nightly`, respectively.
+For using the latest Scala 2 and Scala 3 nightly builds, you should pass `2.nightly` and `3.nightly`, respectively.
 
-Scala-cli takes care of fetching the nightly builds of Scala 2 and Scala 3 from different online repositories, without you having to pass their addresses as input after the `--repo` flag.
+Scala CLI takes care of fetching the nightly builds of Scala 2 and Scala 3 from different repositories, without you having to pass their addresses as input after the `--repo` flag.
 
 For compiling with the latest Scala 2 nightly build: 
 ```bash
 scala-cli Hello.scala -S 2.nightly
 ```
-For compiling with the latest Scala 3 nightly build, in the command line:
+For compiling with the latest Scala 3 nightly build:
 ```bash
 scala-cli Hello.scala -S 3.nightly
 ```

--- a/website/docs/commands/compile.md
+++ b/website/docs/commands/compile.md
@@ -85,7 +85,7 @@ For compiling with an specific nightly build, you have the full version for:
 scala-cli Hello.scala -S 2.13.9-bin-4505094 
 ```
 
-For adding this inside scala files through the using directives syntax, you write:
+For adding this inside scala files with [using directives](../guides/using-directives.md), use:
 
 ```scala
 //> using scala "2.nightly"

--- a/website/docs/commands/compile.md
+++ b/website/docs/commands/compile.md
@@ -91,7 +91,7 @@ For adding this inside scala files through the using directives syntax, you writ
 //> using scala "2.nightly"
 ```
 ```scala
-\\ using scala "3.nightly"
+//> using scala "3.nightly"
 ```
 ```scala
 \\ using scala "2.13.9-bin-4505094"

--- a/website/docs/commands/compile.md
+++ b/website/docs/commands/compile.md
@@ -88,7 +88,7 @@ scala-cli Hello.scala -S 2.13.9-bin-4505094
 For adding this inside scala files through the using directives syntax, you write:
 
 ```scala
-\\ using scala "2.nightly"
+//> using scala "2.nightly"
 ```
 ```scala
 \\ using scala "3.nightly"

--- a/website/docs/commands/compile.md
+++ b/website/docs/commands/compile.md
@@ -64,6 +64,39 @@ scala-cli compile --scala 2 Hello.scala
 scala-cli compile --scala 3 Hello.scala
 ```
 
+## Scala Nightlies
+
+The nightly builds of Scala compiler are unstable ones which are published on a nightly basis.
+
+For using the latest scala 2 and scala 3 nightly builds, you should pass `2.nightly` and `3.nightly`, respectively.
+
+Scala-cli takes care of fetching the nightly builds of Scala 2 and Scala 3 from different online repositories, without you having to pass their addresses as input after the `--repo` flag.
+
+For compiling with the latest Scala 2 nightly build: 
+```bash
+scala-cli Hello.scala -S 2.nightly
+```
+For compiling with the latest Scala 3 nightly build, in the command line:
+```bash
+scala-cli Hello.scala -S 3.nightly
+```
+For compiling with an specific nightly build, you have the full version for, in the command line:
+```bash
+scala-cli Hello.scala -S 2.13.9-bin-4505094 
+```
+
+For adding this inside scala files through the using directives syntax, you write:
+
+```scala
+\\ using scala "2.nightly"
+```
+```scala
+\\ using scala "3.nightly"
+```
+```scala
+\\ using scala "2.13.9-bin-4505094"
+```
+
 ## Dependencies
 
 You can add dependencies on the command-line with `--dependency`:

--- a/website/docs/commands/compile.md
+++ b/website/docs/commands/compile.md
@@ -94,7 +94,7 @@ For adding this inside scala files through the using directives syntax, you writ
 //> using scala "3.nightly"
 ```
 ```scala
-\\ using scala "2.13.9-bin-4505094"
+//> using scala "2.13.9-bin-4505094"
 ```
 
 ## Dependencies

--- a/website/docs/commands/compile.md
+++ b/website/docs/commands/compile.md
@@ -80,7 +80,7 @@ For compiling with the latest Scala 3 nightly build, in the command line:
 ```bash
 scala-cli Hello.scala -S 3.nightly
 ```
-For compiling with an specific nightly build, you have the full version for, in the command line:
+For compiling with an specific nightly build, you have the full version for:
 ```bash
 scala-cli Hello.scala -S 2.13.9-bin-4505094 
 ```


### PR DESCRIPTION
Rebased version of #655 with some latest touches applied.

All the hard work by @zmerr, I am only a merger tool ;)

