### PR TITLE
Tweak Bloop launch-related messages

### DIFF
--- a/modules/bloop-rifle/src/main/scala/scala/build/bloop/BloopServer.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/bloop/BloopServer.scala
@@ -69,7 +69,8 @@ object BloopServer {
   ): BloopServerRuntimeInfo = {
     val workdir = new File(".").getCanonicalFile.toPath
     def startBloop(bloopVersion: String, bloopJava: String) = {
-      logger.info(s"Starting Bloop $bloopVersion at ${config.address.render} using JVM $bloopJava")
+      logger.info("Starting compilation server")
+      logger.debug(s"Starting Bloop $bloopVersion at ${config.address.render} using JVM $bloopJava")
       val fut = BloopRifle.startServer(
         config,
         startServerChecksPool,
@@ -104,7 +105,7 @@ object BloopServer {
     val isOk             = bloopVersionIsOk && bloopJvmIsOk
 
     if (!isOk) {
-      logger.info(s"Bloop daemon status: ${bloopInfo.fold(_.message, _.message)}")
+      logger.debug(s"Bloop daemon status: ${bloopInfo.fold(_.message, _.message)}")
       if (isRunning) exitBloop()
       startBloop(expectedBloopVersion.raw, javaPath)
     }


### PR DESCRIPTION
Instead of things like
```text
Bloop daemon status: not running
Starting Bloop 1.4.19 at /Users/foo/Library/Caches/ScalaCli/bloop/daemon using JVM /Users/foo/Library/Caches/Coursier/arc/https/github.com/adoptium/temurin17-binaries/releases/download/jdk-17%252B35/OpenJDK17-jdk_x64_mac_hotspot_17_35.tar.gz/jdk-17+35/Contents/Home/bin/java
```
this prints
```text
Starting compilation server
```