### PR TITLE
Use logger in console build bloop client

### DIFF
--- a/modules/build/src/main/scala/scala/build/BloopBuildClient.scala
+++ b/modules/build/src/main/scala/scala/build/BloopBuildClient.scala
@@ -2,8 +2,6 @@ package scala.build
 
 import ch.epfl.scala.bsp4j
 
-import java.io.PrintStream
-
 import scala.build.options.Scope
 
 trait BloopBuildClient extends bsp4j.BuildClient {
@@ -15,26 +13,11 @@ trait BloopBuildClient extends bsp4j.BuildClient {
 
 object BloopBuildClient {
   def create(
-    logger: Logger
-  ): BloopBuildClient =
-    create(logger, out = System.err, keepDiagnostics = false)
-  def create(
     logger: Logger,
-    keepDiagnostics: Boolean
-  ): BloopBuildClient =
-    create(
-      logger,
-      out = logger.compilerOutputStream,
-      keepDiagnostics = keepDiagnostics
-    )
-  def create(
-    logger: Logger,
-    out: PrintStream,
     keepDiagnostics: Boolean
   ): BloopBuildClient =
     new ConsoleBloopBuildClient(
       logger,
-      out,
       keepDiagnostics
     )
 }

--- a/modules/cli/src/main/scala/scala/cli/internal/CliLogger.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/CliLogger.scala
@@ -84,7 +84,7 @@ class CliLogger(
             diag.setCode(lines(f.startPos._1))
         }
         ConsoleBloopBuildClient.printFileDiagnostic(
-          out,
+          this,
           f.path,
           diag
         )
@@ -92,7 +92,7 @@ class CliLogger(
 
       if (otherPositions.nonEmpty)
         ConsoleBloopBuildClient.printOtherDiagnostic(
-          out,
+          this,
           message,
           severity,
           otherPositions


### PR DESCRIPTION
If someone pass `-q` flag, should cli should not print any log. But `out.println` every time print the following message: 
```
Compiling project (Scala 3.1.1, JVM)
Compiled project (Scala 3.1.1, JVM)
```
To fix it, we use `logger.message` which prints log only if, verbosity if higher then 0. 
If `-q` if pass, the verbosity is set to -1.