### PR TITLE
No strict bloop check in build

### DIFF
--- a/modules/build/src/main/scala/scala/build/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/Inputs.scala
@@ -128,7 +128,8 @@ final case class Inputs(
     String.format(s"%040x", calculatedSum)
   }
 
-  private def singleFilesFromDirectory(d: Inputs.Directory): Seq[Inputs.SingleFile] =
+  private def singleFilesFromDirectory(d: Inputs.Directory): Seq[Inputs.SingleFile] = {
+    import Ordering.Implicits.seqOrdering
     os.walk.stream(d.path, skip = _.last.startsWith("."))
       .filter(os.isFile(_))
       .collect {
@@ -140,6 +141,8 @@ final case class Inputs(
           Inputs.Script(d.path, p.subRelativeTo(d.path))
       }
       .toVector
+      .sortBy(_.subPath.segments)
+  }
 }
 
 object Inputs {
@@ -175,8 +178,10 @@ object Inputs {
       ScopePath(Left(source), subPath)
   }
 
-  sealed trait SingleFile   extends OnDisk with SingleElement
-  sealed trait SourceFile   extends SingleFile
+  sealed trait SingleFile extends OnDisk with SingleElement
+  sealed trait SourceFile extends SingleFile {
+    def subPath: os.SubPath
+  }
   sealed trait Compiled     extends Element
   sealed trait AnyScalaFile extends Compiled
 

--- a/modules/build/src/main/scala/scala/build/Project.scala
+++ b/modules/build/src/main/scala/scala/build/Project.scala
@@ -5,6 +5,8 @@ import _root_.coursier.{Dependency => CsDependency, core => csCore, util => csUt
 import com.github.plokhotnyuk.jsoniter_scala.core.{writeToArray => writeAsJsonToArray}
 import coursier.core.Classifier
 
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 import java.util.Arrays
 
@@ -68,17 +70,46 @@ final case class Project(
   def bloopFile: BloopConfig.File =
     BloopConfig.File(BloopConfig.File.LatestVersion, bloopProject)
 
+  private def maybeUpdateInputs(logger: Logger): Boolean = {
+    val dest = directory / ".bloop" / s"$projectName.inputs.txt"
+    val onDiskOpt =
+      if (os.exists(dest)) Some(os.read.bytes(dest))
+      else None
+    val newContent = {
+      val linesIt =
+        if (sources.forall(_.startsWith(workspace)))
+          sources.iterator.map(_.relativeTo(workspace).toString)
+        else
+          sources.iterator.map(_.toString)
+      val it = linesIt.map(_ + System.lineSeparator()).map(_.getBytes(StandardCharsets.UTF_8))
+      val b  = new ByteArrayOutputStream
+      for (elem <- it)
+        b.write(elem)
+      b.toByteArray()
+    }
+    val doWrite = onDiskOpt.forall(onDisk => !Arrays.equals(onDisk, newContent))
+    if (doWrite) {
+      logger.debug(s"Writing source file list in $dest")
+      os.write.over(dest, newContent, createFolders = true)
+    }
+    else
+      logger.debug(s"Source file list in $dest doesn't need updating")
+    doWrite
+  }
+
   def writeBloopFile(strictCheck: Boolean, logger: Logger): Boolean = {
     lazy val bloopFileContent =
       writeAsJsonToArray(bloopFile)(BloopCodecs.codecFile)
     val dest = directory / ".bloop" / s"$projectName.json"
-    val doWrite = !os.isFile(dest) || {
-      strictCheck && {
-        logger.debug(s"Checking Bloop project in $dest")
-        val currentContent = os.read.bytes(dest)
-        !Arrays.equals(currentContent, bloopFileContent)
-      }
-    }
+    val doWrite =
+      if (strictCheck)
+        !os.isFile(dest) || {
+          logger.debug(s"Checking Bloop project in $dest")
+          val currentContent = os.read.bytes(dest)
+          !Arrays.equals(currentContent, bloopFileContent)
+        }
+      else
+        maybeUpdateInputs(logger) || !os.isFile(dest)
     if (doWrite) {
       logger.debug(s"Writing bloop project in $dest")
       os.write.over(dest, bloopFileContent, createFolders = true)

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -783,7 +783,8 @@ trait ScalaCliCompile extends ScalaModule {
                   asOpt("--jar", compileClasspath().map(_.path)),
                   asOpt("-O", scalacPluginClasspath().map(p => s"-Xplugin:${p.path}")),
                   Seq("--jvm", "zulu:17"),
-                  "--strict-bloop-json-check=false", // don't check Bloop JSON files at each run
+                  // re-enable this when switching to Scala CLI > 0.1.2
+                  // "--strict-bloop-json-check=false", // don't check Bloop JSON files at each run
                   workspace,
                   sourceFiles
                 )


### PR DESCRIPTION
This tweaks things related to the `--strict-bloop-json-check=false` option. This option basically short-circuits the (sometimes costly) checks for changes in Bloop config files written by Scala CLI. It was enabled in the Scala CLI build itself, but it seems it doesn't take into account new source files (it doesn't update Bloop config files when a new source file is added).

This PR fixes that, and also disables `--strict-bloop-json-check=false` in the build for now, until we can benefit from the fix in the build.