### PR TITLE
Adjust BSP project base directory to scala-cli content root to fix IntelliJ import

### DIFF
--- a/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
@@ -5,9 +5,10 @@ import ch.epfl.scala.{bsp4j => b}
 
 import java.io.{File, PrintWriter, StringWriter}
 import java.net.URI
-import java.util.concurrent.{CompletableFuture, TimeUnit}
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{CompletableFuture, TimeUnit}
 import java.{util => ju}
+
 import scala.build.Logger
 import scala.build.bloop.{ScalaDebugServer, ScalaDebugServerForwardStubs}
 import scala.build.internal.Constants
@@ -147,10 +148,9 @@ class BspServer(
       scala.build.blooprifle.internal.Constants.bspVersion,
       capabilities
     )
-    val intellijBSPName        = "IntelliJ-BSP"
-    val buildComesFromIntelliJ = params.getDisplayName == "IntelliJ-BSP"
+    val buildComesFromIntelliJ = params.getDisplayName.toLowerCase.contains("intellij")
     isIntelliJ.set(buildComesFromIntelliJ)
-    logger.debug(s"$intellijBSPName build: $buildComesFromIntelliJ")
+    logger.debug(s"IntelliJ build: $buildComesFromIntelliJ")
     CompletableFuture.completedFuture(res)
   }
 
@@ -213,7 +213,9 @@ class BspServer(
         val capabilities = target.getCapabilities
         capabilities.setCanDebug(true)
         val baseDirectory = new File(new URI(target.getBaseDirectory))
-        if(isIntelliJ.get() && baseDirectory.getName == ".scala-build" && baseDirectory.getParentFile != null) {
+        if (
+          isIntelliJ.get() && baseDirectory.getName == ".scala-build" && baseDirectory.getParentFile != null
+        ) {
           val newBaseDirectory = baseDirectory.getParentFile.toPath.toUri.toASCIIString
           target.setBaseDirectory(newBaseDirectory)
         }

--- a/website/docs/guides/ide.md
+++ b/website/docs/guides/ide.md
@@ -53,6 +53,5 @@ Once Metals picks up the project structure that’s created by Scala CLI, basic 
 
 Here are a few notes related to IntelliJ support:
 
-- The most significant problem with IntelliJ is that it requires sources to be placed within a directory. Therefore, if you use IntelliJ, we strongly suggest that you place your sources in a directory (like `src`).
 - IntelliJ currently does not automatically pick up changes in the project structure, so any change in dependencies, compiler options, etc., need to be manually reloaded.
 - We currently don’t advise using IntelliJ as a source of truth, and we recommend falling back to command line in such cases.

--- a/website/docs/guides/ide.md
+++ b/website/docs/guides/ide.md
@@ -53,5 +53,9 @@ Once Metals picks up the project structure that’s created by Scala CLI, basic 
 
 Here are a few notes related to IntelliJ support:
 
+- IntelliJ operates strictly on directories (and not just individual source files, as allowed by `scala-cli`).
+  - This means that even if you pass a single file to Scala CLI (for example by running `scala-cli setup-ide some-dir/A.scala`), all the other files within the same directory (`some-dir`) would be imported to IntelliJ. 
+    This might change the behaviour of your builds in IntelliJ (or even break them), even though they run just fine in `scala-cli`.
+  - As a result, it is recommended to isolate Scala CLI builds' source files in separate directories before importing to IntelliJ.
 - IntelliJ currently does not automatically pick up changes in the project structure, so any change in dependencies, compiler options, etc., need to be manually reloaded.
 - We currently don’t advise using IntelliJ as a source of truth, and we recommend falling back to command line in such cases.


### PR DESCRIPTION
This fixes the BSP project import for scenarios where there are Scala sources directly within the `scala-cli` content root directory (no subdirectories in-between).
The root cause of the issue comes indirectly from this IntelliJ limitation: [IDEABKL-6745](https://youtrack.jetbrains.com/issue/IDEABKL-6745) (and all of its spin-off bugs created since).

Long story short, when running `scala-cli setup-ide .`, we create a `BSP` project to be imported.
The base directory for the `BSP` project is `./.scala-build`.
When that is imported into IntelliJ, a synthetic `folder-name-root` module is created by the `IntelliJ Scala Plugin`, because there is no importable project with the actual content root (as in, `.`) set as its base directory [(relevant code in `intellij-scala`)](https://github.com/JetBrains/intellij-scala/blob/f4e6caf1143f4a6ba3fa629d45ade773510f50b0/bsp/src/org/jetbrains/bsp/project/importing/BspResolverLogic.scala#L536)

<img width="1026" alt="image" src="https://user-images.githubusercontent.com/18601388/158353934-560c4675-1882-4640-a0ce-e05e64a5fec9.png">


As a result, we have 2 modules: a synthetic `folder-name-root` coming from `Intellij Scala Plugin` and our `BSP` module, both of which at least partially sharing their sources root (if any sources are directly in the root folder)
Now, because IntelliJ doesn't support multiple modules to have the same root (as described in the JetBrains ticket linked above), one of them is being filtered out, effectively breaking it.

<img width="399" alt="image" src="https://user-images.githubusercontent.com/18601388/158353791-75bdc4db-0df8-4705-8cfb-3de466724111.png">


What seems to be sufficient to fix it, is to just translate the `BSP` project's base directory to its parent when communicating with IntelliJ.