### PR TITLE
Add initial implementation for BSP workspace reload

### DIFF
--- a/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
@@ -261,8 +261,9 @@ class BspServer(
   override def onBuildExit(): Unit = ()
 
   override def workspaceReload(): CompletableFuture[Object] =
-    super.workspaceReload().thenApply { res =>
-      for {
+    super.workspaceReload().thenApply[Object] { res =>
+      for { // this is just a workaround hack to emulate workspace reloading until Bloop starts supporting it
+        // TODO: reload dependencies
         case (targetUri, targetName) <- buildTargetNamesByUri.toSeq
         scalaBuildDirPath = os.Path(new URI(targetUri).getRawPath)
         if os.isDir(scalaBuildDirPath)
@@ -282,7 +283,7 @@ class BspServer(
         val updatedBloopFileJson: Array[Byte] = core.writeToArray(updatedBloopFile)(BloopCodecs.codecFile)
         os.write.over(bloopFileJsonPath, updatedBloopFileJson, createFolders = true)
       }
-      res
+      res // TODO: return a valid message in case of an error
     }
 
   def initiateShutdown: Future[Unit] =

--- a/modules/build/src/main/scala/scala/build/bsp/IdeInputs.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/IdeInputs.scala
@@ -1,0 +1,9 @@
+package scala.build.bsp
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+
+case class IdeInputs(mainScopeSources: List[String], testScopeSources: List[String])
+object IdeInputs {
+  implicit lazy val codec: JsonValueCodec[IdeInputs] = JsonCodecMaker.make[IdeInputs]
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
@@ -109,9 +109,10 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
       val crossSources = value {
         CrossSources.forInputs(inputs, Sources.defaultPreprocessors(CustomCodeWrapper), logger)
       }
-      val scopedSources = value(crossSources.scopedSources(options.buildOptions))
-      val mainSources   = scopedSources.sources(Scope.Main, options.buildOptions)
-      val testSources   = scopedSources.sources(Scope.Test, options.buildOptions)
+      val bOpts         = buildOptions(options)
+      val scopedSources = value(crossSources.scopedSources(bOpts))
+      val mainSources   = scopedSources.sources(Scope.Main, bOpts)
+      val testSources   = scopedSources.sources(Scope.Test, bOpts)
       IdeInputs(
         mainScopeSources = mainSources.paths.toList.map(_._1.toString()),
         testScopeSources = testSources.paths.toList.map(_._1.toString())

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -176,7 +176,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
         os.proc(TestUtil.cli, command, ".", extraOptions).call(cwd = root, stdout = os.Inherit)
         val details                = readBspConfig(root)
         val expectedIdeOptionsFile = root / Constants.workspaceDirName / "ide-options-v2.json"
-        val expectedIdeInputsFile = root / Constants.workspaceDirName / "ide-inputs.json"
+        val expectedIdeInputsFile  = root / Constants.workspaceDirName / "ide-inputs.json"
         val expectedArgv = Seq(
           TestUtil.cliPath,
           "bsp",

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -176,6 +176,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
         os.proc(TestUtil.cli, command, ".", extraOptions).call(cwd = root, stdout = os.Inherit)
         val details                = readBspConfig(root)
         val expectedIdeOptionsFile = root / Constants.workspaceDirName / "ide-options-v2.json"
+        val expectedIdeInputsFile = root / Constants.workspaceDirName / "ide-inputs.json"
         val expectedArgv = Seq(
           TestUtil.cliPath,
           "bsp",
@@ -185,6 +186,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
         )
         expect(details.argv == expectedArgv)
         expect(os.isFile(expectedIdeOptionsFile))
+        expect(os.isFile(expectedIdeInputsFile))
       }
     }
 


### PR DESCRIPTION
Just to make sure things are clear, here's what this PR actually does:

- makes sure IDEs pick up any sources included in a Scala CLI build after subsequent runs of `scala-cli setup-ide` without the need for a BSP server restart

and here's what this PR does not yet do (but should, and I hope to make it happen in future PRs)

- make sure IDEs pick up any sources changes when running and building the project without the need for a BSP server restart
- make sure IDEs pick up any changes to library dependencies, java options or scala options without a BSP server restart
- return a valid json-rpc error code & message if any failures occur