### PR TITLE
Fix sorting SNAPSHOT version

### DIFF
--- a/project/publish.sc
+++ b/project/publish.sc
@@ -43,7 +43,7 @@ private def computePublishVersion(state: VcsState, simple: Boolean): String =
         .replace("latest", "0.0.0")
         .replace("nightly", "0.0.0")
       val idx = rawVersion.indexOf("-")
-      if (idx >= 0) rawVersion.take(idx) + "+" + rawVersion.drop(idx + 1) + "-SNAPSHOT"
+      if (idx >= 0) rawVersion.take(idx) + "-" + rawVersion.drop(idx + 1) + "-SNAPSHOT"
       else rawVersion
     }
   else


### PR DESCRIPTION
To resolve latest snapshot version for Scala CLI, we have to change the version naming

Anything after the `+` in versions is ignored when sorting versions in Coursier (it’s the semantic versioning spec), so it is impossible to find latest version.  To fix, I changed `+` to `-`, it unblock proper sorting versions using `cs`.