### PR TITLE
Fix release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-        ssh-key: ${{ secrets.SSH_PRIVATE_KEY_SCALA_CLI }}
     - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@267af2f1ed4911180b4bb25619ca4a586753cbd1
       with:
@@ -332,13 +331,17 @@ jobs:
         PGP_PASSWORD: ${{ secrets.PGP_PASSPHRASE }}
         SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
         SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+    - uses: webfactory/ssh-agent@fc49353b67b2b7c1e0e6a600572d01a69f2672dd
+      with:
+        ssh-private-key: |
+          ${{ secrets.SSH_PRIVATE_KEY_SCALA_CLI }}
     - name: Update stable branch
       if: env.SHOULD_PUBLISH == 'true' && startsWith(github.ref, 'refs/tags/v')
       run: |
         git config user.name gh-actions
         git config user.email actions@github.com
         git checkout stable
-        git merge main -m "Back port of documentation changes to stable"
+        git merge origin/main -m "Back port of documentation changes to stable"
         git push origin stable
 
   launchers:
@@ -414,3 +417,6 @@ jobs:
       - name: Publish to SDKMAN
         run: .github/scripts/publish-sdkman.sh
         shell: bash
+        env:
+          SDKMAN_KEY: ${{ secrets.SDKMAN_KEY }}
+          SDKMAN_TOKEN: ${{ secrets.SDKMAN_TOKEN }}

--- a/build.sc
+++ b/build.sc
@@ -953,7 +953,6 @@ private def commitChanges(name: String, branch: String, repoDir: os.Path): Unit 
   if (os.proc("git", "status").call(cwd = repoDir).out.text().trim.contains("nothing to commit"))
     println("Nothing Changes")
   else {
-    os.proc("git", "switch", "-c", branch).call(cwd = repoDir)
     os.proc("git", "add", "-A").call(cwd = repoDir)
     os.proc("git", "commit", "-am", name).call(cwd = repoDir)
     println(s"Trying to push on $branch branch")
@@ -1002,6 +1001,7 @@ object ci extends Module {
       )
     os.write.over(standaloneWindowsLauncherPath, updatedWindowsLauncherScript)
 
+    os.proc("git", "switch", "-c", targetBranch).call(cwd = scalaCliDir)
     commitChanges(s"Update scala-cli.sh launcher for $version", targetBranch, scalaCliDir)
     os.proc("gh", "auth", "login", "--with-token").call(cwd = scalaCliDir, stdin = ghToken())
     os.proc("gh", "pr", "create", "--fill", "--base", "main", "--head", targetBranch)


### PR DESCRIPTION
- `os.proc("git", "switch", "-c", branch).call(cwd = repoDir)` throws error, when exists `branch` in git repository. So I moved this one command to `updateStandaloneLauncher()` method, where we have to create new branch `s"update-standalone-launcher-$version"`
- I added env variables, which are mandatory to release scala-cli on SDKMAN
- `actions/checkout@v3` accepts `ssh-key` which is  used to fetch the repository, but post-job step removes the SSH key. Therefore in the next steps, `ssh-key` was unavailable, so it throw permissions error during pushing to the repository. 
  