### PR TITLE
Make Bloop server ignore SIGINT

### DIFF
--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifleConfig.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifleConfig.scala
@@ -74,7 +74,8 @@ object BloopRifleConfig {
       "-XX:MaxInlineLevel=20", // Specific option for faster C2, ignored by GraalVM
       "-XX:+UseZGC", // ZGC returns unused memory back to the OS, so Bloop does not occupy so much memory if unused
       "-XX:ZUncommitDelay=30",
-      "-XX:ZCollectionInterval=5"
+      "-XX:ZCollectionInterval=5",
+      "-Dbloop.ignore-sig-int=true"
     )
 
   lazy val defaultJavaOpts: Seq[String] = {


### PR DESCRIPTION
Thanks to this, when the mill or scala-cli invocation that starts the Bloop server gets interrupted by Ctrl-C (to stop a watch mode for example), the Bloop server running in the background ignores the interruption and keeps running (allowed by https://github.com/scala-cli/bloop-core/pull/53).