### PR TITLE
Add implementation for  `BSP` `workspace/reload`

### DIFF
--- a/modules/build/src/main/scala/scala/build/bsp/Bsp.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/Bsp.scala
@@ -14,7 +14,8 @@ trait Bsp {
 
 object Bsp {
   def create(
-    inputs: Inputs,
+    initialInputs: Inputs,
+    argsToInputs: Seq[String] => Either[String, Inputs],
     buildOptions: BuildOptions,
     logger: Logger,
     bloopRifleConfig: BloopRifleConfig,
@@ -26,7 +27,8 @@ object Bsp {
     new BspImpl(
       logger,
       bloopRifleConfig,
-      inputs,
+      initialInputs,
+      argsToInputs,
       buildOptions,
       verbosity,
       threads,

--- a/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
@@ -9,10 +9,10 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.{CompletableFuture, TimeUnit}
 import java.{util => ju}
 
-import scala.build.{Inputs, Logger}
 import scala.build.bloop.{ScalaDebugServer, ScalaDebugServerForwardStubs}
 import scala.build.internal.Constants
 import scala.build.options.Scope
+import scala.build.{Inputs, Logger}
 import scala.concurrent.{Future, Promise}
 import scala.jdk.CollectionConverters.*
 import scala.util.Random
@@ -29,8 +29,8 @@ class BspServer(
   setProjectName(inputs.workspace, mainProjectName, Scope.Main)
   setProjectName(inputs.workspace, testProjectName, Scope.Test)
 
-  private var client: Option[BuildClient] = None
-  private val isIntelliJ: AtomicBoolean   = new AtomicBoolean(false)
+  var client: Option[BuildClient]       = None
+  private val isIntelliJ: AtomicBoolean = new AtomicBoolean(false)
 
   def testProjectName: String = s"${inputs.projectName}-test"
   def mainProjectName: String = inputs.projectName

--- a/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
@@ -9,25 +9,32 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.{CompletableFuture, TimeUnit}
 import java.{util => ju}
 
-import scala.build.Logger
+import scala.build.{Inputs, Logger}
 import scala.build.bloop.{ScalaDebugServer, ScalaDebugServerForwardStubs}
 import scala.build.internal.Constants
 import scala.build.options.Scope
 import scala.concurrent.{Future, Promise}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Random
 
 class BspServer(
   bloopServer: b.BuildServer with b.ScalaBuildServer with b.JavaBuildServer with ScalaDebugServer,
   compile: (() => CompletableFuture[b.CompileResult]) => CompletableFuture[b.CompileResult],
-  logger: Logger
+  logger: Logger,
+  val inputs: Inputs
 ) extends b.BuildServer with b.ScalaBuildServer with b.JavaBuildServer with BuildServerForwardStubs
     with ScalaScriptBuildServer
     with ScalaDebugServerForwardStubs
     with ScalaBuildServerForwardStubs with JavaBuildServerForwardStubs with HasGeneratedSources {
+  setProjectName(inputs.workspace, mainProjectName, Scope.Main)
+  setProjectName(inputs.workspace, testProjectName, Scope.Test)
 
   private var client: Option[BuildClient] = None
   private val isIntelliJ: AtomicBoolean   = new AtomicBoolean(false)
+
+  def testProjectName: String = s"${inputs.projectName}-test"
+  def mainProjectName: String = inputs.projectName
+  def workspace: os.Path      = inputs.workspace
 
   override def onConnectWithClient(client: BuildClient): Unit = this.client = Some(client)
 

--- a/modules/build/src/main/scala/scala/build/bsp/BspServerProxy.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServerProxy.scala
@@ -1,5 +1,5 @@
 package scala.build.bsp
-import ch.epfl.scala.{bsp4j => b}
+import ch.epfl.scala.bsp4j as b
 import com.github.plokhotnyuk.jsoniter_scala.core
 
 import java.util.concurrent.CompletableFuture
@@ -7,8 +7,9 @@ import java.util.concurrent.CompletableFuture
 import scala.build.bloop.BloopServer
 import scala.build.blooprifle.BloopRifleConfig
 import scala.build.compiler.BloopCompiler
+import scala.build.errors.BuildException
 import scala.build.internal.Constants
-import scala.build.options.BuildOptions
+import scala.build.options.{BuildOptions, Scope}
 import scala.build.{BloopBuildClient, Build, Inputs, Logger}
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters.*
@@ -22,7 +23,8 @@ class BspServerProxy(
   compile: (() => CompletableFuture[b.CompileResult]) => CompletableFuture[b.CompileResult],
   logger: Logger,
   initialInputs: Inputs,
-  argsToInputs: Seq[String] => Either[String, Inputs]
+  argsToInputs: Seq[String] => Either[String, Inputs],
+  prepareBuild: () => Either[(BuildException, Scope), PreBuildProject]
 ) extends BspServerWrapper {
   var currentBloopCompiler: BloopCompiler = createBloopCompiler(initialInputs)
   localClient.onConnectWithServer(currentBloopCompiler.bloopServer.server)
@@ -30,7 +32,8 @@ class BspServerProxy(
 
   override def workspaceReload(): CompletableFuture[AnyRef] =
     super.workspaceReload().thenCompose { res =>
-      val ideInputsJsonPath = currentBspServer.workspace / Constants.workspaceDirName / "ide-inputs.json"
+      val ideInputsJsonPath =
+        currentBspServer.workspace / Constants.workspaceDirName / "ide-inputs.json"
       if (os.isFile(ideInputsJsonPath))
         (for {
           ideInputs <-
@@ -58,16 +61,18 @@ class BspServerProxy(
     currentBloopCompiler = createBloopCompiler(newInputs)
     currentBspServer = createBspServer(currentBloopCompiler, newInputs)
     val newTargetIds = currentBspServer.targetIds
-    if (previousInputs.projectName != newInputs.projectName) {
-      val events = newTargetIds.map(buildTargetIdToEvent(_, b.BuildTargetEventKind.CREATED)) ++
-        previousTargetIds.map(buildTargetIdToEvent(_, b.BuildTargetEventKind.DELETED))
-      val didChangeBuildTargetParams = new b.DidChangeBuildTarget(events.asJava)
-      currentBspServer.client.foreach(_.onBuildTargetDidChange(didChangeBuildTargetParams))
+    prepareBuild() match {
+      case Left((_, _)) =>
+        CompletableFuture.completedFuture(new Object()) // TODO add proper error handling
+      case Right(preBuildProject) =>
+        if (previousInputs.projectName != preBuildProject.mainScope.project.projectName) {
+          val events = newTargetIds.map(buildTargetIdToEvent(_, b.BuildTargetEventKind.CREATED)) ++
+            previousTargetIds.map(buildTargetIdToEvent(_, b.BuildTargetEventKind.DELETED))
+          val didChangeBuildTargetParams = new b.DidChangeBuildTarget(events.asJava)
+          currentBspServer.client.foreach(_.onBuildTargetDidChange(didChangeBuildTargetParams))
+        }
+        CompletableFuture.completedFuture(new Object())
     }
-    buildTargetCompile(new b.CompileParams(newTargetIds.asJava))
-      .thenApply[AnyRef] { _ => // TODO add proper error handling
-        new Object()
-      }
   }
 
   private def createBloopCompiler(inputs: Inputs): BloopCompiler = {

--- a/modules/build/src/main/scala/scala/build/bsp/BspServerProxy.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServerProxy.scala
@@ -1,30 +1,102 @@
 package scala.build.bsp
-import java.util.concurrent.CompletableFuture
-import scala.build.{Inputs, Logger}
-import scala.build.bloop.ScalaDebugServer
 import ch.epfl.scala.{bsp4j => b}
 import com.github.plokhotnyuk.jsoniter_scala.core
 
+import java.util.concurrent.CompletableFuture
+
+import scala.build.bloop.BloopServer
+import scala.build.blooprifle.BloopRifleConfig
+import scala.build.compiler.BloopCompiler
+import scala.build.internal.Constants
+import scala.build.options.BuildOptions
+import scala.build.{BloopBuildClient, Build, Inputs, Logger}
+import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters.*
 import scala.util.Try
 
 class BspServerProxy(
-  bloopServer: b.BuildServer & b.ScalaBuildServer & b.JavaBuildServer & ScalaDebugServer,
+  bloopRifleConfig: BloopRifleConfig,
+  threads: BspThreads,
+  localClient: b.BuildClient & BloopBuildClient,
+  buildOptions: BuildOptions,
   compile: (() => CompletableFuture[b.CompileResult]) => CompletableFuture[b.CompileResult],
   logger: Logger,
   initialInputs: Inputs,
   argsToInputs: Seq[String] => Either[String, Inputs]
 ) extends BspServerWrapper {
-  var currentBspServer = new BspServer(bloopServer, compile, logger, initialInputs)
+  var currentBloopCompiler: BloopCompiler = createBloopCompiler(initialInputs)
+  localClient.onConnectWithServer(currentBloopCompiler.bloopServer.server)
+  var currentBspServer: BspServer = createBspServer(currentBloopCompiler, initialInputs)
 
   override def workspaceReload(): CompletableFuture[AnyRef] =
-    super.workspaceReload().thenApply { res =>
-      val ideInputsJsonPath = currentBspServer.workspace / ".scala-build" / "ide-inputs.json"
-      if (os.isFile(ideInputsJsonPath)) for {
-        ideInputs <- Try(core.readFromString(os.read(ideInputsJsonPath))(IdeInputs.codec))
-        inputs = argsToInputs(ideInputs.args)
-      } yield {
-        inputs
-      }
-      res
+    super.workspaceReload().thenCompose { res =>
+      val ideInputsJsonPath = currentBspServer.workspace / Constants.workspaceDirName / "ide-inputs.json"
+      if (os.isFile(ideInputsJsonPath))
+        (for {
+          ideInputs <-
+            Try(core.readFromString(os.read(ideInputsJsonPath))(IdeInputs.codec)).toEither.fold(
+              t => Left(t.getMessage),
+              Right(_)
+            )
+          newInputs <- argsToInputs(ideInputs.args)
+          previousInputs = currentBspServer.inputs
+        } yield
+          if (newInputs != previousInputs) reloadBspServer(previousInputs, newInputs)
+          else CompletableFuture.completedFuture(res)) match {
+          case Left(_) =>
+            CompletableFuture.completedFuture(res) // TODO return a proper json-rpc error message
+          case Right(r) => r
+        }
+      else CompletableFuture.completedFuture(res)
     }
+
+  private def reloadBspServer(
+    previousInputs: Inputs,
+    newInputs: Inputs
+  ): CompletableFuture[AnyRef] = {
+    val previousTargetIds = currentBspServer.targetIds
+    currentBloopCompiler = createBloopCompiler(newInputs)
+    currentBspServer = createBspServer(currentBloopCompiler, newInputs)
+    val newTargetIds = currentBspServer.targetIds
+    if (previousInputs.projectName != newInputs.projectName) {
+      val events = newTargetIds.map(buildTargetIdToEvent(_, b.BuildTargetEventKind.CREATED)) ++
+        previousTargetIds.map(buildTargetIdToEvent(_, b.BuildTargetEventKind.DELETED))
+      val didChangeBuildTargetParams = new b.DidChangeBuildTarget(events.asJava)
+      currentBspServer.client.foreach(_.onBuildTargetDidChange(didChangeBuildTargetParams))
+    }
+    buildTargetCompile(new b.CompileParams(newTargetIds.asJava))
+      .thenApply[AnyRef] { _ => // TODO add proper error handling
+        new Object()
+      }
+  }
+
+  private def createBloopCompiler(inputs: Inputs): BloopCompiler = {
+    val bloopServer = BloopServer.buildServer(
+      bloopRifleConfig,
+      "scala-cli",
+      Constants.version,
+      (inputs.workspace / Constants.workspaceDirName).toNIO,
+      Build.classesRootDir(inputs.workspace, inputs.projectName).toNIO,
+      localClient,
+      threads.buildThreads.bloop,
+      logger.bloopRifleLogger
+    )
+    new BloopCompiler(
+      bloopServer,
+      20.seconds,
+      strictBloopJsonCheck = buildOptions.internal.strictBloopJsonCheckOrDefault
+    )
+  }
+
+  private def createBspServer(bloopCompiler: BloopCompiler, inputs: Inputs) =
+    new BspServer(bloopCompiler.bloopServer.server, compile, logger, inputs)
+
+  private def buildTargetIdToEvent(
+    targetId: b.BuildTargetIdentifier,
+    eventKind: b.BuildTargetEventKind
+  ): b.BuildTargetEvent = {
+    val event = new b.BuildTargetEvent(targetId)
+    event.setKind(eventKind)
+    event
+  }
 }

--- a/modules/build/src/main/scala/scala/build/bsp/BspServerProxy.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServerProxy.scala
@@ -1,0 +1,19 @@
+package scala.build.bsp
+import java.util.concurrent.CompletableFuture
+import scala.build.{Inputs, Logger}
+import scala.build.bloop.ScalaDebugServer
+import ch.epfl.scala.{bsp4j => b}
+
+class BspServerProxy(
+  bloopServer: b.BuildServer & b.ScalaBuildServer & b.JavaBuildServer & ScalaDebugServer,
+  compile: (() => CompletableFuture[b.CompileResult]) => CompletableFuture[b.CompileResult],
+  logger: Logger,
+  initialInputs: Inputs
+) extends BspServerWrapper {
+  var currentBspServer = new BspServer(bloopServer, compile, logger, initialInputs)
+
+  override def workspaceReload(): CompletableFuture[AnyRef] =
+    super.workspaceReload().thenApply { res =>
+      res
+    }
+}

--- a/modules/build/src/main/scala/scala/build/bsp/BspServerProxy.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServerProxy.scala
@@ -3,17 +3,28 @@ import java.util.concurrent.CompletableFuture
 import scala.build.{Inputs, Logger}
 import scala.build.bloop.ScalaDebugServer
 import ch.epfl.scala.{bsp4j => b}
+import com.github.plokhotnyuk.jsoniter_scala.core
+
+import scala.util.Try
 
 class BspServerProxy(
   bloopServer: b.BuildServer & b.ScalaBuildServer & b.JavaBuildServer & ScalaDebugServer,
   compile: (() => CompletableFuture[b.CompileResult]) => CompletableFuture[b.CompileResult],
   logger: Logger,
-  initialInputs: Inputs
+  initialInputs: Inputs,
+  argsToInputs: Seq[String] => Either[String, Inputs]
 ) extends BspServerWrapper {
   var currentBspServer = new BspServer(bloopServer, compile, logger, initialInputs)
 
   override def workspaceReload(): CompletableFuture[AnyRef] =
     super.workspaceReload().thenApply { res =>
+      val ideInputsJsonPath = currentBspServer.workspace / ".scala-build" / "ide-inputs.json"
+      if (os.isFile(ideInputsJsonPath)) for {
+        ideInputs <- Try(core.readFromString(os.read(ideInputsJsonPath))(IdeInputs.codec))
+        inputs = argsToInputs(ideInputs.args)
+      } yield {
+        inputs
+      }
       res
     }
 }

--- a/modules/build/src/main/scala/scala/build/bsp/BspServerProxy.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServerProxy.scala
@@ -1,6 +1,7 @@
 package scala.build.bsp
 import ch.epfl.scala.bsp4j as b
 import com.github.plokhotnyuk.jsoniter_scala.core
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError
 
 import java.util.concurrent.CompletableFuture
 
@@ -14,8 +15,6 @@ import scala.build.{BloopBuildClient, Build, Inputs, Logger}
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
-
-import org.eclipse.lsp4j.jsonrpc.messages.ResponseError
 
 class BspServerProxy(
   bloopRifleConfig: BloopRifleConfig,
@@ -55,7 +54,9 @@ class BspServerProxy(
           case Right(r) => r
         }
       else CompletableFuture.completedFuture(
-        responseError(s"Workspace reload failed, inputs file missing from workspace directory: ${ideInputsJsonPath.toString()}")
+        responseError(
+          s"Workspace reload failed, inputs file missing from workspace directory: ${ideInputsJsonPath.toString()}"
+        )
       )
     }
 
@@ -117,6 +118,9 @@ class BspServerProxy(
     event
   }
 
-  private def responseError(message: String, errorCode: Int = JsonRpcErrorCodes.InternalError): ResponseError =
+  private def responseError(
+    message: String,
+    errorCode: Int = JsonRpcErrorCodes.InternalError
+  ): ResponseError =
     new ResponseError(errorCode, message, new Object())
 }

--- a/modules/build/src/main/scala/scala/build/bsp/BspServerWrapper.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServerWrapper.scala
@@ -1,9 +1,10 @@
 package scala.build.bsp
 
-import scala.build.bloop.ScalaDebugServer
 import ch.epfl.scala.{bsp4j => b}
 
 import java.util.concurrent.CompletableFuture
+
+import scala.build.bloop.ScalaDebugServer
 import scala.build.options.Scope
 import scala.concurrent.Future
 

--- a/modules/build/src/main/scala/scala/build/bsp/BspServerWrapper.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServerWrapper.scala
@@ -1,0 +1,83 @@
+package scala.build.bsp
+
+import scala.build.bloop.ScalaDebugServer
+import ch.epfl.scala.{bsp4j => b}
+
+import java.util.concurrent.CompletableFuture
+import scala.build.options.Scope
+import scala.concurrent.Future
+
+trait BspServerWrapper extends b.BuildServer with b.ScalaBuildServer with b.JavaBuildServer
+    with ScalaDebugServer with ScalaScriptBuildServer {
+  wrapper: BspServerProxy =>
+  override def buildInitialize(params: b.InitializeBuildParams)
+    : CompletableFuture[b.InitializeBuildResult] = currentBspServer.buildInitialize(params)
+
+  override def onBuildInitialized(): Unit = currentBspServer.onBuildInitialized()
+
+  override def buildShutdown(): CompletableFuture[AnyRef] = currentBspServer.buildShutdown()
+
+  override def onBuildExit(): Unit = currentBspServer.onBuildExit()
+
+  override def workspaceBuildTargets(): CompletableFuture[b.WorkspaceBuildTargetsResult] =
+    currentBspServer.workspaceBuildTargets()
+
+  override def workspaceReload(): CompletableFuture[AnyRef] = currentBspServer.workspaceReload()
+
+  override def buildTargetSources(params: b.SourcesParams): CompletableFuture[b.SourcesResult] =
+    currentBspServer.buildTargetSources(params)
+
+  override def buildTargetInverseSources(params: b.InverseSourcesParams)
+    : CompletableFuture[b.InverseSourcesResult] = currentBspServer.buildTargetInverseSources(params)
+
+  override def buildTargetDependencySources(params: b.DependencySourcesParams)
+    : CompletableFuture[b.DependencySourcesResult] =
+    currentBspServer.buildTargetDependencySources(params)
+
+  override def buildTargetResources(params: b.ResourcesParams)
+    : CompletableFuture[b.ResourcesResult] = currentBspServer.buildTargetResources(params)
+
+  override def buildTargetCompile(params: b.CompileParams): CompletableFuture[b.CompileResult] =
+    currentBspServer.buildTargetCompile(params)
+
+  override def buildTargetTest(params: b.TestParams): CompletableFuture[b.TestResult] =
+    currentBspServer.buildTargetTest(params)
+
+  override def buildTargetRun(params: b.RunParams): CompletableFuture[b.RunResult] =
+    currentBspServer.buildTargetRun(params)
+
+  override def buildTargetCleanCache(params: b.CleanCacheParams)
+    : CompletableFuture[b.CleanCacheResult] = currentBspServer.buildTargetCleanCache(params)
+
+  override def buildTargetDependencyModules(params: b.DependencyModulesParams)
+    : CompletableFuture[b.DependencyModulesResult] =
+    currentBspServer.buildTargetDependencyModules(params)
+
+  override def buildTargetScalacOptions(params: b.ScalacOptionsParams)
+    : CompletableFuture[b.ScalacOptionsResult] = currentBspServer.buildTargetScalacOptions(params)
+
+  override def buildTargetScalaTestClasses(params: b.ScalaTestClassesParams)
+    : CompletableFuture[b.ScalaTestClassesResult] =
+    currentBspServer.buildTargetScalaTestClasses(params)
+
+  override def buildTargetScalaMainClasses(params: b.ScalaMainClassesParams)
+    : CompletableFuture[b.ScalaMainClassesResult] =
+    currentBspServer.buildTargetScalaMainClasses(params)
+
+  override def buildTargetJavacOptions(params: b.JavacOptionsParams)
+    : CompletableFuture[b.JavacOptionsResult] = currentBspServer.buildTargetJavacOptions(params)
+
+  override def buildTargetDebugSession(params: b.DebugSessionParams)
+    : CompletableFuture[b.DebugSessionAddress] = currentBspServer.buildTargetDebugSession(params)
+
+  override def buildTargetWrappedSources(params: WrappedSourcesParams)
+    : CompletableFuture[WrappedSourcesResult] = currentBspServer.buildTargetWrappedSources(params)
+
+  override def onConnectWithClient(server: b.BuildClient): Unit =
+    currentBspServer.onConnectWithClient(server)
+
+  def targetIds: List[b.BuildTargetIdentifier] = currentBspServer.targetIds
+  def targetScopeIdOpt(scope: Scope): Option[b.BuildTargetIdentifier] =
+    currentBspServer.targetScopeIdOpt(scope)
+  def initiateShutdown: Future[Unit] = currentBspServer.initiateShutdown
+}

--- a/modules/build/src/main/scala/scala/build/bsp/BspServerWrapper.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServerWrapper.scala
@@ -8,6 +8,9 @@ import scala.build.bloop.ScalaDebugServer
 import scala.build.options.Scope
 import scala.concurrent.Future
 
+/** Wrapper trait containing all the boilerplate logic forwarding all RPC traffic to the wrapped
+  * [[BspServer]] instance.
+  */
 trait BspServerWrapper extends b.BuildServer with b.ScalaBuildServer with b.JavaBuildServer
     with ScalaDebugServer with ScalaScriptBuildServer {
   wrapper: BspServerProxy =>

--- a/modules/build/src/main/scala/scala/build/bsp/IdeInputs.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/IdeInputs.scala
@@ -3,6 +3,10 @@ package scala.build.bsp
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
 import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 
+/** Model for the `.scala-build/ide-inputs.json` file.
+  * @param args
+  *   validated input (sources) arguments passed to the `setup-ide` command.
+  */
 case class IdeInputs(args: Seq[String])
 object IdeInputs {
   implicit lazy val codec: JsonValueCodec[IdeInputs] = JsonCodecMaker.make[IdeInputs]

--- a/modules/build/src/main/scala/scala/build/bsp/IdeInputs.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/IdeInputs.scala
@@ -1,0 +1,9 @@
+package scala.build.bsp
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+
+case class IdeInputs(args: Seq[String])
+object IdeInputs {
+  implicit lazy val codec: JsonValueCodec[IdeInputs] = JsonCodecMaker.make[IdeInputs]
+}

--- a/modules/build/src/main/scala/scala/build/bsp/JsonRpcErrorCodes.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/JsonRpcErrorCodes.scala
@@ -1,0 +1,13 @@
+package scala.build.bsp
+
+/**
+ * Response error codes as defined in JSON RPC.
+ * [[https://www.jsonrpc.org/specification#error_object]]
+ */
+object JsonRpcErrorCodes {
+  val ParseError: Int     = -32700 // Invalid JSON was received by the server.
+  val InvalidRequest: Int = -32600 // The JSON sent is not a valid Request object.
+  val MethodNotFound: Int = -32601 // The method does not exist / is not available.
+  val InvalidParams: Int  = -32602 // Invalid method parameter(s).
+  val InternalError: Int  = -32603 // Internal JSON-RPC error.
+}

--- a/modules/build/src/main/scala/scala/build/bsp/JsonRpcErrorCodes.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/JsonRpcErrorCodes.scala
@@ -1,9 +1,8 @@
 package scala.build.bsp
 
-/**
- * Response error codes as defined in JSON RPC.
- * [[https://www.jsonrpc.org/specification#error_object]]
- */
+/** Response error codes as defined in JSON RPC.
+  * [[https://www.jsonrpc.org/specification#error_object]]
+  */
 object JsonRpcErrorCodes {
   val ParseError: Int     = -32700 // Invalid JSON was received by the server.
   val InvalidRequest: Int = -32600 // The JSON sent is not a valid Request object.

--- a/modules/build/src/main/scala/scala/build/bsp/PreBuildProject.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/PreBuildProject.scala
@@ -1,0 +1,24 @@
+package scala.build.bsp
+
+import dependency.ScalaParameters
+
+import scala.build.errors.Diagnostic
+import scala.build.options.BuildOptions
+import scala.build.{Artifacts, GeneratedSource, Project, Sources}
+
+final case class PreBuildData(
+  sources: Sources,
+  buildOptions: BuildOptions,
+  classesDir: os.Path,
+  scalaParams: ScalaParameters,
+  artifacts: Artifacts,
+  project: Project,
+  generatedSources: Seq[GeneratedSource],
+  buildChanged: Boolean
+)
+
+final case class PreBuildProject(
+  mainScope: PreBuildData,
+  testScope: PreBuildData,
+  diagnostics: Seq[Diagnostic]
+)

--- a/modules/cli/src/main/scala/scala/cli/commands/Bsp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Bsp.scala
@@ -3,9 +3,9 @@ package scala.cli.commands
 import caseapp._
 import com.github.plokhotnyuk.jsoniter_scala.core._
 
-import scala.build.{Build, Inputs}
 import scala.build.bsp.BspThreads
 import scala.build.options.BuildOptions
+import scala.build.{Build, Inputs}
 import scala.cli.CurrentParams
 import scala.cli.commands.util.CommonOps._
 import scala.cli.commands.util.SharedOptionsUtil._
@@ -30,12 +30,13 @@ object Bsp extends ScalaCommand[BspOptions] {
     val logger            = sharedOptions.logging.logger
 
     val argsToInputs: Seq[String] => Either[String, Inputs] =
-      argsSeq => options.shared.inputs(argsSeq, () => Inputs.default())
-        .map{ i =>
-          if (options.shared.logging.verbosity >= 3)
-            pprint.err.log(i)
-          Build.updateInputs(i, buildOptionsToUse)
-        }
+      argsSeq =>
+        options.shared.inputs(argsSeq, () => Inputs.default())
+          .map { i =>
+            if (options.shared.logging.verbosity >= 3)
+              pprint.err.log(i)
+            Build.updateInputs(i, buildOptionsToUse)
+          }
     val inputs = options.shared.inputsOrExit(argsToInputs(args.all))
     CurrentParams.workspaceOpt = Some(inputs.workspace)
     BspThreads.withThreads { threads =>

--- a/modules/cli/src/main/scala/scala/cli/commands/Compile.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Compile.scala
@@ -26,7 +26,8 @@ object Compile extends ScalaCommand[CompileOptions] {
       options.shared,
       inputs,
       logger,
-      Some(name)
+      Some(name),
+      args.all
     )
     if (CommandUtils.shouldCheckUpdate)
       Update.checkUpdateSafe(logger)

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -98,7 +98,8 @@ object Run extends ScalaCommand[RunOptions] {
       options.shared,
       inputs,
       logger,
-      Some(name)
+      Some(name),
+      inputArgs
     )
     if (CommandUtils.shouldCheckUpdate)
       Update.checkUpdateSafe(logger)

--- a/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
@@ -68,7 +68,12 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
     previousCommandName: Option[String],
     args: Seq[String]
   ): Unit =
-    writeBspConfiguration(SetupIdeOptions(shared = options), inputs, previousCommandName, args) match {
+    writeBspConfiguration(
+      SetupIdeOptions(shared = options),
+      inputs,
+      previousCommandName,
+      args
+    ) match {
       case Left(ex) =>
         logger.debug(s"Ignoring error during setup-ide: ${ex.message}")
       case Right(_) =>

--- a/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
@@ -114,10 +114,12 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
 
     val inputArgs = inputs.elements.collect { case d: Inputs.OnDisk => d.path.toString }
 
-    val ideInputs = IdeInputs(args = args.map { arg =>
-      if (Paths.get(arg).isAbsolute) arg
-      else (os.pwd / arg).toString()
-    })
+    val ideInputs = IdeInputs(args =
+      options.shared.validateInputArgs(args)
+        .flatMap(_.toOption)
+        .flatten
+        .collect { case d: Inputs.OnDisk => d.path.toString }
+    )
 
     val debugOpt = options.shared.jvm.bspDebugPort.toSeq.map(port =>
       s"-J-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:$port,suspend=y"

--- a/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
@@ -6,6 +6,8 @@ import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.google.gson.GsonBuilder
 
 import java.nio.charset.Charset
+import java.nio.file.Paths
+
 import scala.build.EitherCps.{either, value}
 import scala.build.Inputs.WorkspaceOrigin
 import scala.build.bsp.IdeInputs
@@ -112,7 +114,10 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
 
     val inputArgs = inputs.elements.collect { case d: Inputs.OnDisk => d.path.toString }
 
-    val ideInputs = IdeInputs(args = args)
+    val ideInputs = IdeInputs(args = args.map { arg =>
+      if (Paths.get(arg).isAbsolute) arg
+      else (os.pwd / arg).toString()
+    })
 
     val debugOpt = options.shared.jvm.bspDebugPort.toSeq.map(port =>
       s"-J-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:$port,suspend=y"

--- a/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
@@ -6,7 +6,6 @@ import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.google.gson.GsonBuilder
 
 import java.nio.charset.Charset
-import java.nio.file.Paths
 
 import scala.build.EitherCps.{either, value}
 import scala.build.Inputs.WorkspaceOrigin

--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -49,7 +49,8 @@ object Test extends ScalaCommand[TestOptions] {
       options.shared,
       inputs,
       logger,
-      Some(name)
+      Some(name),
+      args.remaining
     )
     if (CommandUtils.shouldCheckUpdate)
       Update.checkUpdateSafe(logger)

--- a/modules/cli/src/main/scala/scala/cli/commands/util/SharedOptionsUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/SharedOptionsUtil.scala
@@ -219,12 +219,14 @@ object SharedOptionsUtil {
       inputsOrExit(args, () => Inputs.default())
 
     def inputsOrExit(args: Seq[String], defaultInputs: () => Option[Inputs]): Inputs =
-      inputs(args, defaultInputs) match {
-        case Left(message) =>
-          System.err.println(message)
-          sys.exit(1)
-        case Right(i) => i
-      }
+      inputsOrExit(inputs(args, defaultInputs))
+
+    def inputsOrExit(maybeInputs: Either[String, Inputs]): Inputs = maybeInputs match {
+      case Left(message) =>
+        System.err.println(message)
+        sys.exit(1)
+      case Right(i) => i
+    }
 
     def inputs(args: Seq[String], defaultInputs: () => Option[Inputs]): Either[String, Inputs] = {
       val download: String => Either[String, Array[Byte]] = { url =>
@@ -257,7 +259,7 @@ object SharedOptionsUtil {
         acceptFds = !Properties.isWin,
         forcedWorkspace = workspace.forcedWorkspaceOpt
       ) match {
-        case l@Left(_) => l
+        case l @ Left(_) => l
         case Right(inputs) =>
           val forbiddenDirs =
             (if (defaultForbiddenDirectories) myDefaultForbiddenDirectories else Nil) ++

--- a/modules/cli/src/main/scala/scala/cli/commands/util/SharedOptionsUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/SharedOptionsUtil.scala
@@ -274,7 +274,13 @@ object SharedOptionsUtil {
     }
 
     def validateInputArgs(args: Seq[String]): Seq[Either[String, Seq[Inputs.Element]]] =
-      Inputs.validateArgs(args, Os.pwd, downloadInputs, readStdin(logger = logger), !Properties.isWin)
+      Inputs.validateArgs(
+        args,
+        Os.pwd,
+        downloadInputs,
+        readStdin(logger = logger),
+        !Properties.isWin
+      )
 
     def strictBloopJsonCheckOrDefault =
       strictBloopJsonCheck.getOrElse(bo.InternalOptions.defaultStrictBloopJsonCheck)

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -176,7 +176,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
         os.proc(TestUtil.cli, command, ".", extraOptions).call(cwd = root, stdout = os.Inherit)
         val details                = readBspConfig(root)
         val expectedIdeOptionsFile = root / Constants.workspaceDirName / "ide-options-v2.json"
-        val expectedIdeInputsFile = root / Constants.workspaceDirName / "ide-inputs.json"
+        val expectedIdeInputsFile  = root / Constants.workspaceDirName / "ide-inputs.json"
         val expectedArgv = Seq(
           TestUtil.cliPath,
           "bsp",

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -176,6 +176,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
         os.proc(TestUtil.cli, command, ".", extraOptions).call(cwd = root, stdout = os.Inherit)
         val details                = readBspConfig(root)
         val expectedIdeOptionsFile = root / Constants.workspaceDirName / "ide-options-v2.json"
+        val expectedIdeInputsFile = root / Constants.workspaceDirName / "ide-inputs.json"
         val expectedArgv = Seq(
           TestUtil.cliPath,
           "bsp",
@@ -185,6 +186,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
         )
         expect(details.argv == expectedArgv)
         expect(os.isFile(expectedIdeOptionsFile))
+        expect(os.isFile(expectedIdeInputsFile))
       }
     }
 

--- a/website/docs/guides/ide.md
+++ b/website/docs/guides/ide.md
@@ -45,13 +45,17 @@ In an ideal world we would replace the rest of this guide with something along t
 ## Metals
 
 Once Metals picks up the project structure that’s created by Scala CLI, basic features like navigation, diagnostics, and code completion should work.
-However, picking up source files newly included in the project structure by Scala CLI may require restarting the build server manually. (Closing & reopening the project should also be sufficient)
+Reloading the workspace on project structure changes is currently experimental and should work for most scenarios, we are working on improving its stability.
+For some cases it may still be necessary to restart the build server manually. 
+(Closing & reopening the project should also be sufficient.)
 
 ## IntelliJ
 
 Here are a few notes related to IntelliJ support:
 - IntelliJ currently does not automatically pick up changes in the project structure, so any change in dependencies, compiler options, etc., need to be manually reloaded.
-- Similarly to Metals, picking up source files newly included in the project structure by Scala CLI may require restarting the build server manually. (Closing & reopening the project should also be sufficient)
+- Similarly to Metals, reloading the workspace on project structure changes is currently experimental and should work for most scenarios. 
+  We are working on improving its stability. For some cases it may still be necessary to restart the build server manually. 
+  (Closing & reopening the project should also be sufficient.)
 
 ## Directories vs single files when working with an IDE
 When working with Scala CLI in an IDE, it is generally suggested to use directories rather than single files.


### PR DESCRIPTION
![bsp_reload_2](https://user-images.githubusercontent.com/18601388/161759714-84f7b30e-8ab1-4d64-ab11-0a7f31b1ee08.gif)

The reload generally works now, but there are some limitations on IntelliJ:
- if there are sources directly in the primary workspace directory (first input arg passed to the `scala-cli setup-ide` command), they will not be included in the new build after the reload if the project hash has changed.
- The reason for this is the old problem with `intellij-scala` creating an empty `*-root` module. Even though we work around it on BSP initialization (as per changes in #780), it becomes harder when handling a `workspace/reload` request with changed sources. If the source directories change on reload, the build target ids also change (the bsp project has a new hash). As a result, some targets need to be deleted, while others are created and `intellij-scala` creates the `*-root` module in between, as it's their hack for there always being a module with the primary workspace source directory. 
 
<img width="446" alt="image" src="https://user-images.githubusercontent.com/18601388/161764154-1caa5586-8437-4594-a8a0-141dc96190a6.png">

- Now, this is tolerable if the sources are hidden in subdirectories (screenshot above), as then this only causes an empty, harmless module to be added to the IntelliJ project structure. It gets worse if the workspace root directory also contains sources, as then we have a duplicate, and IntelliJ immediately gets rid of it just as we reload. This is because IntelliJ never allows for 2 modules to have overlapping source directories (and in all likelihood, the pre-reload build & the post-reload build share the root workspace directory).  Thus, even though we reload correctly, we miss any sources in the root directory. (screenshot below)
<img width="446" alt="image" src="https://user-images.githubusercontent.com/18601388/161764537-5699f33e-624d-49f3-8a06-cff7785cf7a6.png">

- There may be some workaround for this, but I think it should be handled outside of the scope of this PR. Currently if a user runs into this, they have to either fix the project structure manually (by adding the correct sources directory to the BSP module and getting rid of the `*-root` module) or get rid of the `.idea` directory and reimport the project. Quite annoying 😞 
- This issue is absent from Metals, of course.