### PR TITLE
Send the Bloop server output to a file when possible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,23 +13,6 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  migration-tests:
-    timeout-minutes: 120
-    runs-on: "ubuntu-latest"
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        submodules: true
-    - uses: coursier/cache-action@v6.3
-    - uses: VirtusLab/scala-cli-setup@267af2f1ed4911180b4bb25619ca4a586753cbd1
-      with:
-        jvm: "temurin:17"
-    - name: Unit 3.x tests
-      run: |
-        ./mill -i cli3.compile
-        ./mill -i cli3.test
-        ./mill -i _[3.1.1].test
   jvm-tests:
     timeout-minutes: 120
     runs-on: ${{ matrix.OS }}
@@ -202,6 +185,24 @@ jobs:
       run: ./mill copyTo cli.launcher ./scala-cli
     - name: Check examples
       run: bash ./scala-cli --jvm temurin:17  .github/scripts/check_examples.sc
+
+  migration-tests:
+    timeout-minutes: 120
+    runs-on: "ubuntu-latest"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@267af2f1ed4911180b4bb25619ca4a586753cbd1
+      with:
+        jvm: "temurin:17"
+    - name: Unit 3.x tests
+      run: |
+        ./mill -i cli3.compile
+        ./mill -i cli3.test
+        ./mill -i _[3.1.1].test
 
   checks:
     timeout-minutes: 15

--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifleConfig.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifleConfig.scala
@@ -11,7 +11,7 @@ final case class BloopRifleConfig(
   address: BloopRifleConfig.Address,
   javaPath: String,
   javaOpts: Seq[String],
-  classPath: String => Either[Throwable, Seq[File]],
+  classPath: String => Either[Throwable, (Seq[File], Boolean)],
   workingDir: File,
   bspSocketOrPort: Option[() => BspConnectionAddress],
   bspStdin: Option[InputStream],
@@ -38,6 +38,8 @@ object BloopRifleConfig {
     }
     final case class DomainSocket(path: Path) extends Address {
       def render = path.toString
+      def outputPath: Path =
+        path.resolve("output")
     }
   }
 
@@ -87,8 +89,9 @@ object BloopRifleConfig {
       .getOrElse(hardCodedDefaultJavaOpts)
   }
 
+  def scalaCliBloopOrg = "io.github.alexarchambault.bleep"
   def hardCodedDefaultModule: String =
-    "io.github.alexarchambault.bleep:bloop-frontend_2.12"
+    s"$scalaCliBloopOrg:bloop-frontend_2.12"
   def hardCodedDefaultVersion: String =
     Constants.bloopVersion
   def hardCodedDefaultScalaVersion: String =
@@ -118,7 +121,7 @@ object BloopRifleConfig {
 
   def default(
     address: Address,
-    bloopClassPath: String => Either[Throwable, Seq[File]],
+    bloopClassPath: String => Either[Throwable, (Seq[File], Boolean)],
     workingDir: File
   ): BloopRifleConfig =
     BloopRifleConfig(

--- a/modules/build/src/test/scala/scala/build/tests/util/BloopServer.scala
+++ b/modules/build/src/test/scala/scala/build/tests/util/BloopServer.scala
@@ -4,7 +4,6 @@ import coursier.cache.FileCache
 
 import scala.build.{Bloop, Logger}
 import scala.build.blooprifle.BloopRifleConfig
-import scala.util.Properties
 
 object BloopServer {
 
@@ -14,10 +13,7 @@ object BloopServer {
   // Not sure how to properly shut it down or have it exit after a period
   // of inactivity, so we keep using our default global Bloop for now.
   private def bloopAddress =
-    if (Properties.isWin)
-      BloopRifleConfig.Address.Tcp(BloopRifleConfig.defaultHost, BloopRifleConfig.defaultPort)
-    else
-      BloopRifleConfig.Address.DomainSocket(directories.bloopDaemonDir.toNIO)
+    BloopRifleConfig.Address.DomainSocket(directories.bloopDaemonDir.toNIO)
 
   val bloopConfig = BloopRifleConfig.default(
     bloopAddress,

--- a/modules/cli-options/src/main/scala/scala/cli/commands/bloop/BloopOutputOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/bloop/BloopOutputOptions.scala
@@ -1,0 +1,21 @@
+package scala.cli.commands.bloop
+
+import caseapp._
+
+import scala.cli.commands.{LoggingOptions, SharedCompilationServerOptions, SharedDirectoriesOptions}
+
+// format: off
+final case class BloopOutputOptions(
+  @Recurse
+    logging: LoggingOptions = LoggingOptions(),
+  @Recurse
+    compilationServer: SharedCompilationServerOptions = SharedCompilationServerOptions(),
+  @Recurse
+    directories: SharedDirectoriesOptions = SharedDirectoriesOptions()
+)
+// format: on
+
+object BloopOutputOptions {
+  implicit lazy val parser: Parser[BloopOutputOptions] = Parser.derive
+  implicit lazy val help: Help[BloopOutputOptions]   = Help.derive
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOutput.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOutput.scala
@@ -1,0 +1,49 @@
+package scala.cli.commands.bloop
+
+import caseapp.core.RemainingArgs
+
+import scala.build.blooprifle.BloopRifleConfig
+import scala.cli.CurrentParams
+import scala.cli.commands.util.CommonOps._
+import scala.cli.commands.util.SharedCompilationServerOptionsUtil._
+import scala.cli.commands.{CoursierOptions, ScalaCommand}
+
+object BloopOutput extends ScalaCommand[BloopOutputOptions] {
+  override def hidden     = true
+  override def inSipScala = false
+  override def names: List[List[String]] = List(
+    List("bloop", "output")
+  )
+
+  def run(options: BloopOutputOptions, args: RemainingArgs): Unit = {
+    CurrentParams.verbosity = options.logging.verbosity
+    val logger = options.logging.logger
+    val bloopRifleConfig = options.compilationServer.bloopRifleConfig(
+      logger,
+      CoursierOptions().coursierCache(logger.coursierLogger("Downloading Bloop")), // unused here
+      options.logging.verbosity,
+      "unused-java", // unused here
+      options.directories.directories
+    )
+    val outputFile = bloopRifleConfig.address match {
+      case s: BloopRifleConfig.Address.DomainSocket =>
+        logger.debug(s"Bloop server directory: ${s.path}")
+        logger.debug(s"Bloop server output path: ${s.outputPath}")
+        os.Path(s.outputPath, os.pwd)
+      case tcp: BloopRifleConfig.Address.Tcp =>
+        if (options.logging.verbosity >= 0)
+          System.err.println(
+            s"Error: Bloop server is listening on TCP at ${tcp.render}, output not available."
+          )
+        sys.exit(1)
+    }
+    if (!os.isFile(outputFile)) {
+      if (options.logging.verbosity >= 0)
+        System.err.println(s"Error: $outputFile not found")
+      sys.exit(1)
+    }
+    val content = os.read.bytes(outputFile)
+    logger.debug(s"Read ${content.length} bytes from $outputFile")
+    System.out.write(content)
+  }
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpCreateExternal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpCreateExternal.scala
@@ -3,6 +3,7 @@ package scala.cli.commands.pgp
 import scala.cli.signing.commands.PgpCreateOptions
 
 class PgpCreateExternal extends PgpExternalCommand {
+  override def hidden = true
   def actualHelp      = PgpCreateOptions.help
   def externalCommand = Seq("pgp", "create")
 

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpSignExternal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpSignExternal.scala
@@ -3,6 +3,7 @@ package scala.cli.commands.pgp
 import scala.cli.signing.commands.PgpSignOptions
 
 class PgpSignExternal extends PgpExternalCommand {
+  override def hidden = true
   def actualHelp      = PgpSignOptions.help
   def externalCommand = Seq("pgp", "sign")
 

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpVerifyExternal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpVerifyExternal.scala
@@ -3,6 +3,7 @@ package scala.cli.commands.pgp
 import scala.cli.signing.commands.PgpVerifyOptions
 
 class PgpVerifyExternal extends PgpExternalCommand {
+  override def hidden = true
   def actualHelp      = PgpVerifyOptions.help
   def externalCommand = Seq("pgp", "verify")
 


### PR DESCRIPTION
Needs https://github.com/scala-cli/bloop-core/pull/55, included in the upcoming (Scala CLI's) bloop-core `1.4.20`.

This sends the output of the Bloop server to a file under the user home directory (alongside the socket file, `~/Library/Caches/ScalaCli/bloop/daemon/output` on macOS for example), and adds a `scala-cli bloop output` command printing that file in the console, so that users can easily have a look at that file.

In order for that output file not to grow too big, we pass an option to the Bloop server so that it truncates that file periodically (as soon as it reaches 1 MB, https://github.com/scala-cli/bloop-core/pull/55).