### PR TITLE
 docs: fix examples in scala-js.md and native-images.md

### DIFF
--- a/website/docs/cookbooks/native-images.md
+++ b/website/docs/cookbooks/native-images.md
@@ -17,7 +17,7 @@ object Echo {
 
 The following command packages this application as a native executable:
 ```bash
-scala-cli package Echo.scala -o echo
+scala-cli package --native-image Echo.scala -o echo
 ```
 
 <!-- Expected-regex:
@@ -31,15 +31,15 @@ Wrote .*echo
 # a b
 ```
 
-<!-- 
+<!--
 ```bash
 rm ./echo
-``` 
+```
 -->
 
 You can pass custom options to GraalVM native image by passing them after `--`, like
 ```bash
-scala-cli package Echo.scala -o echo -- --no-fallback
+scala-cli package --native-image Echo.scala -o echo -- --no-fallback
 ```
 
 <!-- Expected-regex:

--- a/website/docs/guides/scala-js.md
+++ b/website/docs/guides/scala-js.md
@@ -151,4 +151,3 @@ The table below lists the last supported version of Scala.js in ScalaCLI. If you
 | 0.1.1               |   1.8.0           |
 | 0.1.2               |   1.8.0           |
 | 0.1.3               |   1.9.0           |
-

--- a/website/docs/guides/scala-js.md
+++ b/website/docs/guides/scala-js.md
@@ -16,7 +16,7 @@ In order to run Scala.js sources, `node` is required.
 Enable Scala.js support by passing `--js` to `scala-cli`, such as:
 
 ```scala
-scala Test.scala --js
+scala-cli Test.scala --js
 ```
 
 ## Dependencies
@@ -151,3 +151,4 @@ The table below lists the last supported version of Scala.js in ScalaCLI. If you
 | 0.1.1               |   1.8.0           |
 | 0.1.2               |   1.8.0           |
 | 0.1.3               |   1.9.0           |
+


### PR DESCRIPTION
This change fixes the example command on https://scala-cli.virtuslab.org/docs/guides/scala-js/ to use `scala-cli` instead of `scala`.