### PR TITLE
Add workaround for ArchLinux + native-image CRC32 miscalculation issue

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -544,7 +544,8 @@ class Build(val crossScalaVersion: String) extends BuildLikeModule {
     Deps.scalaJsEnvNodeJs,
     Deps.scalaJsTestAdapter,
     Deps.scalametaTrees,
-    Deps.swoval
+    Deps.swoval,
+    Deps.zipInputStream
   ) ++ (if (scalaVersion().startsWith("3")) Agg() else Agg(Deps.shapeless))
 
   object test extends Tests {
@@ -783,6 +784,7 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
            |  def cs = "${settings.cs().replace("\\", "\\\\")}"
            |  def workspaceDirName = "$workspaceDirName"
            |  def libsodiumVersion = "${deps.libsodiumVersion}"
+           |  def dockerArchLinuxImage = "${TestDeps.archLinuxImage}"
            |}
            |""".stripMargin
       if (!os.isFile(dest) || os.read(dest) != code)

--- a/modules/build/src/main/scala/scala/build/internal/zip/WrappedZipInputStream.scala
+++ b/modules/build/src/main/scala/scala/build/internal/zip/WrappedZipInputStream.scala
@@ -1,0 +1,47 @@
+package scala.build.internal.zip
+
+import java.io.{Closeable, InputStream}
+import java.util.zip.ZipEntry
+
+/*
+ * juz.ZipInputStream is buggy on Arch Linux from native images (CRC32 calculation issues,
+ * see oracle/graalvm#4479), so we use a custom ZipInputStream with disabled CRC32 calculation.
+ */
+final case class WrappedZipInputStream(
+  wrapped: Either[io.github.scala_cli.zip.ZipInputStream, java.util.zip.ZipInputStream]
+) extends Closeable {
+  def entries(): Iterator[ZipEntry] = {
+    val getNextEntry = wrapped match {
+      case Left(zis)  => () => zis.getNextEntry()
+      case Right(zis) => () => zis.getNextEntry()
+    }
+    Iterator.continually(getNextEntry()).takeWhile(_ != null)
+  }
+  def closeEntry(): Unit =
+    wrapped match {
+      case Left(zis)  => zis.closeEntry()
+      case Right(zis) => zis.closeEntry()
+    }
+  def readAllBytes(): Array[Byte] =
+    wrapped.merge.readAllBytes()
+  def close(): Unit =
+    wrapped.merge.close()
+}
+
+object WrappedZipInputStream {
+  lazy val shouldUseVendoredImplem = {
+    def toBoolean(input: String): Boolean =
+      input match {
+        case "true" | "1" => true
+        case _            => false
+      }
+    Option(System.getenv("SCALA_CLI_VENDORED_ZIS")).map(toBoolean)
+      .orElse(sys.props.get("scala-cli.zis.vendored").map(toBoolean))
+      .getOrElse(false)
+  }
+  def create(is: InputStream): WrappedZipInputStream =
+    WrappedZipInputStream {
+      if (shouldUseVendoredImplem) Left(new io.github.scala_cli.zip.ZipInputStream(is))
+      else Right(new java.util.zip.ZipInputStream(is))
+    }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -12,9 +12,9 @@ import scala.util.Properties
 abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     extends munit.FunSuite with TestScalaVersionArgs {
 
-  private lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
+  protected lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
 
-  private val ciOpt = Option(System.getenv("CI")).map(v => Seq("-e", s"CI=$v")).getOrElse(Nil)
+  protected val ciOpt = Option(System.getenv("CI")).map(v => Seq("-e", s"CI=$v")).getOrElse(Nil)
 
   def simpleScriptTest(ignoreErrors: Boolean = false): Unit = {
     val fileName = "simple.sc"

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
@@ -1,3 +1,52 @@
 package scala.cli.integration
 
-class RunTestsDefault extends RunTestDefinitions(scalaVersionOpt = None)
+import com.eed3si9n.expecty.Expecty.expect
+
+import scala.util.Properties
+
+class RunTestsDefault extends RunTestDefinitions(scalaVersionOpt = None) {
+
+  def archLinuxTest(): Unit = {
+    val message = "Hello from Scala CLI on Arch Linux"
+    val inputs = TestInputs(
+      Seq(
+        os.rel / "hello.sc" ->
+          s"""println("$message")
+             |""".stripMargin
+      )
+    )
+    val extraOptsStr = extraOptions.mkString(" ") /* meh escaping */
+    inputs.fromRoot { root =>
+      os.copy(os.Path(TestUtil.cli.head, os.pwd), root / "scala")
+      val script =
+        s"""#!/usr/bin/env sh
+           |set -e
+           |./scala --server=false $extraOptsStr . | tee -a output
+           |""".stripMargin
+      os.write(root / "script.sh", script)
+      os.perms.set(root / "script.sh", "rwxr-xr-x")
+      val termOpt = if (System.console() == null) Nil else Seq("-t")
+      // format: off
+      val cmd = Seq[os.Shellable](
+        "docker", "run", "--rm", termOpt,
+        "-e", "SCALA_CLI_VENDORED_ZIS=true",
+        "-v", s"${root}:/data",
+        "-w", "/data",
+        ciOpt,
+        Constants.dockerArchLinuxImage,
+        "/data/script.sh"
+      )
+      // format: on
+      val res = os.proc(cmd).call(cwd = root)
+      System.err.println(res.out.text())
+      val output = os.read(root / "output").trim
+      expect(output == message)
+    }
+  }
+
+  if (Properties.isLinux && TestUtil.isNativeCli)
+    test("arch linux") {
+      archLinuxTest()
+    }
+
+}

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -35,10 +35,14 @@ object Scala {
   def defaultUser = scala3
 }
 
+// Dependencies used in integration test fixtures
 object TestDeps {
   def pprint           = Deps.pprint
   def munit            = Deps.munit
   def scalaSnapshot213 = "2.13.8-bin-e814d78"
+
+  def archLinuxImage =
+    "archlinux@sha256:b15db21228c7cd5fd3ab364a97193ba38abfad0e8b9593c15b71850b74738153"
 }
 
 object InternalDeps {
@@ -134,6 +138,11 @@ object Deps {
   def swoval          = ivy"com.swoval:file-tree-views:2.1.9"
   def testInterface   = ivy"org.scala-sbt:test-interface:1.0"
   def usingDirectives = ivy"org.virtuslab:using_directives:0.0.8"
+  // Lives at https://github.com/scala-cli/no-crc32-zip-input-stream, see #865
+  // This provides a ZipInputStream that doesn't verify CRC32 checksums, that users
+  // can enable by setting SCALA_CLI_VENDORED_ZIS=true in the environment, to workaround
+  // some bad GraalVM / zlib issues (see #828 and linked issues for more details).
+  def zipInputStream = ivy"io.github.alexarchambault.scala-cli.tmp:zip-input-stream:0.1.0"
 }
 
 def graalVmVersion     = "22.1.0"


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/828.

~This vendors some GPL code, so I don't know if we're fine license-wise, here…~

Users need to set `SCALA_CLI_VENDORED_ZIS=true` in the environment to disable CRC32 calculations.