### PR TITLE
Start repl with scalac options

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
@@ -211,7 +211,13 @@ object Repl extends ScalaCommand[ReplOptions] {
           " These will not be accessible from the REPL."
       )
 
-    val replArgs = options.notForBloopOptions.replOptions.ammoniteArgs ++ programArgs
+    val additionalArgs =
+      if (options.notForBloopOptions.replOptions.useAmmonite)
+        options.notForBloopOptions.replOptions.ammoniteArgs
+      else
+        options.scalaOptions.scalacOptions.toSeq.map(_.value.value)
+
+    val replArgs = additionalArgs ++ programArgs
 
     if (dryRun)
       logger.message("Dry run, not running REPL.")

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTests.scala
@@ -1,0 +1,22 @@
+package scala.cli.integration
+
+import com.eed3si9n.expecty.Expecty.expect
+
+class ReplTests extends munit.FunSuite {
+
+  test("calling repl with -Xshow-phases flag") {
+    val cmd = Seq[os.Shellable](
+      TestUtil.cli,
+      "repl",
+      "-Xshow-phases"
+    )
+
+    val builder   = new StringBuilder
+    val readLines = os.ProcessOutput.Readlines(s => builder.append(s))
+    val res       = os.proc(cmd).call(stdout = readLines, stderr = readLines)
+    expect(res.exitCode == 0)
+    val output = builder.mkString
+    expect(output.contains("parser") && output.contains("typer"))
+  }
+
+}


### PR DESCRIPTION
Add test to make sure that we pass options to repl correctly.

This fixes regression in #738