### PR TITLE
Add command to search for dependencies

### DIFF
--- a/modules/cli-options/src/main/scala/scala/cli/commands/SearchOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SearchOptions.scala
@@ -1,0 +1,38 @@
+package scala.cli.commands
+
+import caseapp._
+
+// format: off
+@HelpMessage("Search artifacts")
+final case class SearchOptions(
+  @Recurse
+    verbosity: VerbosityOptions = VerbosityOptions(),
+
+  @Group("Searching")
+  @HelpMessage("Query to search for")
+  @ExtraName("q")
+    query: Option[String] = None,
+
+  @Group("Searching")
+  @HelpMessage("Target platform")
+  @ValueDescription("JVM|JS|NATIVE|SBT")
+  @ExtraName("t")
+    target: Option[String] = None,
+
+  @Group("Searching")
+  @HelpMessage("Scala binary version")
+  @ExtraName("sv")
+    scalaBinary: Option[String] = None,
+
+  @Group("Searching")
+  @HelpMessage("Restrict to artifacts within the query")
+  @ValueDescription("true|false")
+    strict: Option[Boolean] = Some(true),
+)
+// format: on
+
+
+object SearchOptions {
+  implicit lazy val parser: Parser[SearchOptions] = Parser.derive
+  implicit lazy val help: Help[SearchOptions]   = Help.derive
+}

--- a/modules/cli/src/main/scala/scala/cli/ScalaCliCommands.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCliCommands.scala
@@ -37,6 +37,7 @@ class ScalaCliCommands(
     Package,
     Publish,
     Run,
+    Search,
     SetupIde,
     Shebang,
     Test,

--- a/modules/cli/src/main/scala/scala/cli/commands/Search.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Search.scala
@@ -1,0 +1,159 @@
+package scala.cli.commands
+
+import caseapp._
+
+import scala.cli.CurrentParams
+
+import scala.io.StdIn.readLine
+import com.github.plokhotnyuk.jsoniter_scala.macros._
+import com.github.plokhotnyuk.jsoniter_scala.core._
+
+object Search extends ScalaCommand[SearchOptions] {
+  override def group = "Main"
+
+  implicit val searchResultCodec: JsonValueCodec[SearchResult] = JsonCodecMaker.make
+  implicit val searchResultsCodec: JsonValueCodec[List[SearchResult]] = JsonCodecMaker.make
+  implicit val projectCodec: JsonValueCodec[Project] = JsonCodecMaker.make
+
+  case class SearchResult(
+    organization: String,
+    repository: String,
+    artifacts: List[String],
+  )
+
+  implicit class SearchResultOps(r: SearchResult) {
+    def enumerate(index: Int, count: Int): String = {
+      val artifactsLines = limitLine(r.artifacts, "  ").mkString("\n")
+      val idx = index.toString.padLeftTo(count.toString.size, ' ')
+
+      s"""$idx: ${r.organization}/${r.repository}
+         |$artifactsLines""".stripMargin
+    }
+
+    // Scaladex returns related searches, sometimes they don't contain `q`
+    def getStrict(q: String): Option[SearchResult] =
+      if (r.organization.contains(q) || r.repository.contains(q))
+        Some(r)
+      else {
+        val strictA = r.artifacts.filter(_.contains(q))
+        strictA match {
+          case Nil => None
+          case sa => Some(r.copy(artifacts = sa))
+        }
+      }
+  }
+
+  case class Project(
+    groupId: String,
+    artifactId: String,
+    version: String,
+  )
+
+  implicit class ProjectOps(project: Project) {
+    def getImportString = {
+      import project._
+      s"import $$ivy.`$groupId:$artifactId:$version`"
+    }
+  }
+
+  def limitLine(strs: List[String], lineStart: String = "", size: Int = 80) = {
+    def loop(strs: List[String], lastLine: String, allLines: List[String]): List[String] =
+      strs match {
+        case Nil => (lastLine :: allLines).reverse
+        case str :: rest =>
+          val newSize = lastLine.size + 2 + str.size + 1
+          if (newSize > size)
+            loop(rest, lineStart + str, (lastLine + ",") :: allLines)
+          else {
+            val newLine =
+              if (lastLine == lineStart)
+                lastLine + str
+              else
+                lastLine + ", " + str
+            loop(rest, newLine, allLines)
+          }
+      }
+
+    loop(strs, lineStart, Nil)
+  }
+
+  implicit class StringOps(s: String) {
+    def padLeftTo(len: Int, elem: Char): String =
+      s.reverse.padTo(len, elem).reverse
+
+    def enumerate(index: Int, count: Int): String = {
+      val idx = index.toString.padLeftTo(count.toString.size, ' ')
+
+      s"""$idx: $s"""
+    }
+  }
+
+  def fetch[A: JsonValueCodec](url: String): A = {
+    println(s"Fetching from $url...")
+    val text = scala.cli.internal.ProcUtil.downloadFile(url)
+
+    readFromArray[A](text.getBytes("UTF-8"))
+  }
+
+  def search(q: String, target: String, scalaBinary: String): List[SearchResult] = {
+    val url = s"https://index.scala-lang.org/api/search?q=$q&target=$target&scalaVersion=$scalaBinary"
+    fetch[List[SearchResult]](url)
+  }
+
+  def getProject(organization: String, repository: String, artifact: String, target: String, scalaBinary: String): Project = {
+    val url = s"https://index.scala-lang.org/api/project?organization=$organization&repository=$repository&artifact=$artifact&target=$target&scalaVersion=$scalaBinary"
+    fetch[Project](url)
+  }
+
+  def run(options: SearchOptions, args: RemainingArgs): Unit = {
+    CurrentParams.verbosity = options.verbosity.verbosity
+
+    val query = options.query.getOrElse("")
+    val target = options.target.getOrElse("")
+    val scalaBinary = options.scalaBinary.getOrElse("")
+    val strict = options.strict.getOrElse(true)
+
+    val searchResults: List[SearchResult] = {
+      val searchResults = search(query, target, scalaBinary)
+      if (strict) searchResults.flatMap(_.getStrict(query))
+      else searchResults
+    }
+
+    println("Found these artifacts:")
+    searchResults.zipWithIndex.map {
+      case (r, i) => r.enumerate(i + 1, searchResults.size)
+    }.foreach(println)
+
+    println()
+    print("Choose the repository: ")
+    val repositoryIndex = {
+      val idx = readLine()
+      idx.toInt - 1
+    }
+
+    val organization = searchResults(repositoryIndex).organization
+    val repository = searchResults(repositoryIndex).repository
+
+    println()
+    println(s"Artifacts in $organization/$repository:")
+    val artifacts = searchResults(repositoryIndex).artifacts
+    artifacts.zipWithIndex.map {
+      case (a, i) => a.enumerate(i + 1, artifacts.size)
+    }.foreach(println)
+
+    println()
+    print("Choose the artifact: ")
+    val artifactIndex = {
+      val idx = readLine()
+      idx.toInt - 1
+    }
+
+    val artifact = artifacts(artifactIndex)
+    val projectJson = getProject(organization, repository, artifact, target, scalaBinary)
+
+    println()
+    println("Use this import:")
+    println(projectJson.getImportString)
+    println()
+  }
+}


### PR DESCRIPTION
### Motivation
Scala CLI is all about being simple and intuitive while being powerful.
I am not a full time developer and many times I struggle to find the library I want to depend on.
For example, if I want to work with json, I know [Li Haoyi](https://github.com/lihaoyi) created a great (of many) library: ujson. But how can I depend on it? If I search the GitHub repositories of Li Haoyi, I need to know that ujson is inside [upickle](https://github.com/com-lihaoyi/upickle/). That is not very intuitive.
Well, we could also use [Scaladex](https://index.scala-lang.org/) and delve into the website, clicking our way through search and combo boxes until we find the library and the version. Then I can copy the dependency and paste into my file. That could be simpler.

### Solution
The solution I propose is to have a new command in `scala-cli` to `search` for the library:

```
> scala-cli search --query ujson --target JVM --scala-binary 3
Fetching from https://index.scala-lang.org/api/search?q=ujson&target=JVM&scalaVersion=3...
Found these artifacts:
1: com-lihaoyi/upickle
  ujson, ujson-argonaut, ujson-circe, ujson-js-2.11.11, ujson-js-2.12.4,
  ujson-json4s, ujson-jvm-2.11.11, ujson-jvm-2.12.4, ujson-play

Choose the repository:
```

Then you choose the repository:
```
Choose the repository: 1

Artifacts in com-lihaoyi/upickle:
1: ujson
2: ujson-argonaut
3: ujson-circe
4: ujson-js-2.11.11
5: ujson-js-2.12.4
6: ujson-json4s
7: ujson-jvm-2.11.11
8: ujson-jvm-2.12.4
9: ujson-play

Choose the artifact:
```

And finally the artifact:
```
Choose the artifact: 1
Fetching from https://index.scala-lang.org/api/project?organization=com-lihaoyi&repository=upickle&artifact=ujson&target=JVM&scalaVersion=3...

Use this import:
import $ivy.`com.lihaoyi:ujson_3:1.5.0`
```
Then you copy the dependency directly to you file.

I made a rough implementation and I would like to know if this is something that could make into Scala CLI. Of course, I am open to suggestions and to any kind of improvement of my code.