### PR TITLE
Allow for dependencies to fallback to a JAR url provided in a `url` user param

### DIFF
--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/UsingDependencyDirectiveHandler.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/UsingDependencyDirectiveHandler.scala
@@ -17,7 +17,8 @@ case object UsingDependencyDirectiveHandler extends UsingDirectiveHandler {
   override def usageMd = "`//> using lib \"`_org_`:`name`:`ver\""
   override def examples = Seq(
     "//> using lib \"org.scalatest::scalatest:3.2.10\"",
-    "//> using lib \"org.scalameta::munit:0.7.29\""
+    "//> using lib \"org.scalameta::munit:0.7.29\"",
+    "//> using lib \"tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar\""
   )
 
   private def parseDependency(depStr: String): Either[BuildException, AnyDependency] =

--- a/modules/options/src/main/scala/scala/build/TemporaryInMemoryRepository.scala
+++ b/modules/options/src/main/scala/scala/build/TemporaryInMemoryRepository.scala
@@ -1,0 +1,212 @@
+package scala.build
+
+import coursier.cache.{ConnectionBuilder, FileCache}
+import coursier.core.*
+import coursier.util.{Artifact, EitherT, Monad}
+
+import java.io.{File, FileNotFoundException, IOException}
+import java.net.{HttpURLConnection, URL, URLConnection}
+
+import scala.util.Try
+
+/** Copied over from [[https://github.com/coursier/sbt-coursier]]. Should probably be removed in the
+  * future, when (and if) the source lands in coursier itself.
+  *
+  * [[https://github.com/coursier/sbt-coursier/blob/master/modules/lm-coursier/src/main/scala/lmcoursier/internal/TemporaryInMemoryRepository.scala]]
+  */
+object TemporaryInMemoryRepository {
+
+  def closeConn(conn: URLConnection): Unit = {
+    Try(conn.getInputStream).toOption.filter(_ != null).foreach(_.close())
+    conn match {
+      case conn0: HttpURLConnection =>
+        Try(conn0.getErrorStream).toOption.filter(_ != null).foreach(_.close())
+        conn0.disconnect()
+      case _ =>
+    }
+  }
+
+  def exists(
+    url: URL,
+    localArtifactsShouldBeCached: Boolean
+  ): Boolean =
+    exists(url, localArtifactsShouldBeCached, None)
+
+  def exists(
+    url: URL,
+    localArtifactsShouldBeCached: Boolean,
+    cacheOpt: Option[FileCache[Nothing]]
+  ): Boolean = {
+
+    // Sometimes HEAD attempts fail even though standard GETs are fine.
+    // E.g. https://github.com/NetLogo/NetLogo/releases/download/5.3.1/NetLogo.jar
+    // returning 403s. Hence the second attempt below.
+
+    val protocolSpecificAttemptOpt = {
+
+      def ifFile: Option[Boolean] =
+        if (localArtifactsShouldBeCached && !new File(url.toURI).exists()) {
+          val cachePath = coursier.cache.CacheDefaults.location
+          // 'file' here stands for the protocol (e.g. it's https instead for https:// URLs)
+          Some(new File(cachePath, s"file/${url.getPath}").exists())
+        }
+        else
+          Some(new File(url.toURI).exists()) // FIXME Escaping / de-escaping needed here?
+
+      def ifHttp: Option[Boolean] = {
+        // HEAD request attempt, adapted from http://stackoverflow.com/questions/22541629/android-how-can-i-make-an-http-head-request/22545275#22545275
+
+        var conn: URLConnection = null
+        try {
+          conn = ConnectionBuilder(url.toURI.toASCIIString)
+            .withFollowHttpToHttpsRedirections(
+              cacheOpt.fold(false)(_.followHttpToHttpsRedirections)
+            )
+            .withFollowHttpsToHttpRedirections(
+              cacheOpt.fold(false)(_.followHttpsToHttpRedirections)
+            )
+            .withSslSocketFactoryOpt(cacheOpt.flatMap(_.sslSocketFactoryOpt))
+            .withHostnameVerifierOpt(cacheOpt.flatMap(_.hostnameVerifierOpt))
+            .withMethod("HEAD")
+            .withMaxRedirectionsOpt(cacheOpt.flatMap(_.maxRedirections))
+            .connection()
+          // Even though the finally clause handles this too, this has to be run here, so that we return Some(true)
+          // iff this doesn't throw.
+          conn.getInputStream.close()
+          Some(true)
+        }
+        catch {
+          case _: FileNotFoundException => Some(false)
+          case _: IOException           => None // error other than not found
+        }
+        finally
+          if (conn != null)
+            closeConn(conn)
+      }
+
+      url.getProtocol match {
+        case "file"           => ifFile
+        case "http" | "https" => ifHttp
+        case _                => None
+      }
+    }
+
+    def genericAttempt: Boolean = {
+      var conn: URLConnection = null
+      try {
+        conn = url.openConnection()
+        // NOT setting request type to HEAD here.
+        conn.getInputStream.close()
+        true
+      }
+      catch {
+        case _: IOException => false
+      }
+      finally
+        if (conn != null)
+          closeConn(conn)
+    }
+
+    protocolSpecificAttemptOpt
+      .getOrElse(genericAttempt)
+  }
+
+  def apply(fallbacks: Map[(Module, String), (URL, Boolean)]): TemporaryInMemoryRepository =
+    new TemporaryInMemoryRepository(fallbacks, localArtifactsShouldBeCached = false, None)
+
+  def apply(
+    fallbacks: Map[(Module, String), (URL, Boolean)],
+    localArtifactsShouldBeCached: Boolean
+  ): TemporaryInMemoryRepository =
+    new TemporaryInMemoryRepository(fallbacks, localArtifactsShouldBeCached, None)
+
+  def apply[F[_]](
+    fallbacks: Map[(Module, String), (URL, Boolean)],
+    cache: FileCache[F]
+  ): TemporaryInMemoryRepository =
+    new TemporaryInMemoryRepository(
+      fallbacks,
+      localArtifactsShouldBeCached = cache.localArtifactsShouldBeCached,
+      Some(cache.asInstanceOf[FileCache[Nothing]])
+    )
+
+}
+
+final class TemporaryInMemoryRepository private (
+  val fallbacks: Map[(Module, String), (URL, Boolean)],
+  val localArtifactsShouldBeCached: Boolean,
+  val cacheOpt: Option[FileCache[Nothing]]
+) extends Repository {
+
+  def find[F[_]](
+    module: Module,
+    version: String,
+    fetch: Repository.Fetch[F]
+  )(implicit
+    F: Monad[F]
+  ): EitherT[F, String, (ArtifactSource, Project)] = {
+
+    def res = fallbacks
+      .get((module, version))
+      .fold[Either[String, (ArtifactSource, Project)]](Left("No fallback URL found")) {
+        case (url, _) =>
+          val urlStr = url.toExternalForm
+          val idx    = urlStr.lastIndexOf('/')
+
+          if (idx < 0 || urlStr.endsWith("/"))
+            Left(s"$url doesn't point to a file")
+          else {
+            val (dirUrlStr, fileName) = urlStr.splitAt(idx + 1)
+
+            if (TemporaryInMemoryRepository.exists(url, localArtifactsShouldBeCached, cacheOpt)) {
+              val proj = Project(
+                module,
+                version,
+                Nil,
+                Map.empty,
+                None,
+                Nil,
+                Nil,
+                Nil,
+                None,
+                None,
+                None,
+                relocated = false,
+                None,
+                Nil,
+                Info.empty
+              )
+
+              Right((this, proj))
+            }
+            else
+              Left(s"$fileName not found under $dirUrlStr")
+          }
+      }
+
+    // EitherT(F.bind(F.point(()))(_ => F.point(res)))
+    EitherT(F.map(F.point(()))(_ => res))
+  }
+
+  def artifacts(
+    dependency: Dependency,
+    project: Project,
+    overrideClassifiers: Option[Seq[Classifier]]
+  ): Seq[(Publication, Artifact)] =
+    fallbacks
+      .get(dependency.moduleVersion)
+      .toSeq
+      .map {
+        case (url, changing) =>
+          val url0 = url.toString
+          val ext  = url0.substring(url0.lastIndexOf('.') + 1)
+          val pub = Publication(
+            dependency.module.name.value, // ???
+            Type(ext),
+            Extension(ext),
+            Classifier.empty
+          )
+          (pub, Artifact(url0, Map.empty, Map.empty, changing, optional = false, None))
+      }
+
+}

--- a/website/docs/guides/dependencies.md
+++ b/website/docs/guides/dependencies.md
@@ -11,6 +11,12 @@ scala-cli compile Hello.scala \
   --dependency org.scala-lang.modules::scala-parallel-collections:1.0.4
 ```
 
+You can also add a URL fallback for a JAR dependency, if it can't be fetched otherwise:
+```bash
+scala-cli compile Hello.scala \
+  -- dependency "org::name::version,url=https://url-to-the-jar"
+```
+
 Note that `--dependency` is only meant as a convenience.
 You should favor adding dependencies in the sources themselves via [using directives](./guides/configuration.md#special-imports).
 <!-- TODO #344 

--- a/website/docs/guides/using-directives.md
+++ b/website/docs/guides/using-directives.md
@@ -109,7 +109,8 @@ The only exceptions are `using target` directives, which only apply to the given
 Below is a list of the most important `using` directives that Scala CLI supports. The full list can be found in the [Reference section of this documentation](./reference/directives.md).
 
 - `//> using scala "<scala-version>"` - defines version of Scala used
-- `//> using lib "org::name:version"` - defines dependency to given library [more in dedicated guide](./guides/dependencies.md)
+- `//> using lib "org::name:version"` - defines dependency to a given library [more in dedicated guide](./guides/dependencies.md)
+- `//> using lib "org::name:version,url=url"` - defines dependency to a given library with a fallback to its jar url
 - `//> using resourceDir "<dir>"` - marks directory as source of resources. Resources accessible at runtime and packaged together with compiled code.
 - ``//> using `java-opt` "<opt>"`` - use given java options when running application or tests
 - `//> using target ["test"|"main"]` used to marked or unmarked given source as test

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -49,6 +49,8 @@ Add dependencies
 
 `//> using lib "org.scalameta::munit:0.7.29"`
 
+`//> using lib "tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar"`
+
 ### Java home
 
 Sets Java home used to run your application or tests


### PR DESCRIPTION
Fixes #857 

This allows for passing a dependency url through Scala CLI like this:
```bash
scala-cli run --dependency "tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar" UsingRemoteJar.scala
```
or even with a `using directive`:
```scala
//> using lib "tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar"
import tabby.Grid

object UsingRemoteJar extends App {
  println(Grid("a", "b", "c")(1, 2, 3))
}
```
