### PR TITLE
Allow users to override scalac options set internally

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -14,8 +14,8 @@ import scala.build.Ops._
 import scala.build.compiler.{ScalaCompiler, ScalaCompilerMaker}
 import scala.build.errors._
 import scala.build.internal.{Constants, CustomCodeWrapper, MainClass, Util}
+import scala.build.options._
 import scala.build.options.validation.ValidationException
-import scala.build.options.{BuildOptions, ClassPathOptions, Platform, SNNumeralVersion, Scope}
 import scala.build.postprocessing._
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration.DurationInt
@@ -656,7 +656,7 @@ object Build {
 
     val pluginScalacOptions = artifacts.compilerPlugins.distinct.map {
       case (_, _, path) =>
-        s"-Xplugin:$path"
+        ScalacOpt(s"-Xplugin:$path")
     }
 
     val generateSemanticDbs = options.scalaOptions.generateSemanticDbs.getOrElse(false)
@@ -669,11 +669,13 @@ object Build {
             "-P:semanticdb:failures:warning",
             "-P:semanticdb:synthetics:on",
             s"-P:semanticdb:sourceroot:${inputs.workspace}"
-          )
+          ).map(ScalacOpt(_))
         else
           Seq(
-            "-Xsemanticdb"
-          )
+            "-Xsemanticdb",
+            "-sourceroot",
+            inputs.workspace.toString
+          ).map(ScalacOpt(_))
       else Nil
 
     val semanticDbJavacOptions =
@@ -701,20 +703,22 @@ object Build {
 
     val sourceRootScalacOptions =
       if (params.scalaVersion.startsWith("2.")) Nil
-      else Seq("-sourceroot", inputs.workspace.toString)
+      else Seq("-sourceroot", inputs.workspace.toString).map(ScalacOpt(_))
 
     val scalaJsScalacOptions =
       if (options.platform.value == Platform.JS && !params.scalaVersion.startsWith("2."))
-        Seq("-scalajs")
+        Seq(ScalacOpt("-scalajs"))
       else Nil
 
     val releaseFlagVersion = releaseFlag(options, compilerJvmVersionOpt, logger).map(_.toString)
 
-    val scalacReleaseV = releaseFlagVersion.map(v => List("-release", v)).getOrElse(Nil)
-    val javacReleaseV  = releaseFlagVersion.map(v => List("--release", v)).getOrElse(Nil)
+    val scalacReleaseV = releaseFlagVersion
+      .map(v => List("-release", v).map(ScalacOpt(_)))
+      .getOrElse(Nil)
+    val javacReleaseV = releaseFlagVersion.map(v => List("--release", v)).getOrElse(Nil)
 
     val scalacOptions =
-      options.scalaOptions.scalacOptions.toSeq.map(_.value.value) ++
+      options.scalaOptions.scalacOptions.map(_.value) ++
         pluginScalacOptions ++
         semanticDbScalacOptions ++
         sourceRootScalacOptions ++
@@ -724,7 +728,7 @@ object Build {
     val scalaCompilerParams = ScalaCompilerParams(
       scalaVersion = params.scalaVersion,
       scalaBinaryVersion = params.scalaBinaryVersion,
-      scalacOptions = scalacOptions,
+      scalacOptions = scalacOptions.toSeq.map(_.value),
       compilerClassPath = artifacts.compilerClassPath
     )
 

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -11,7 +11,17 @@ import scala.build.errors.{
 }
 import scala.build.internal.Constants._
 import scala.build.internal.Regexes.scala2NightlyRegex
-import scala.build.options.{BuildOptions, BuildRequirements, ScalaOptions}
+import scala.build.options.{
+  BuildOptions,
+  BuildRequirements,
+  InternalOptions,
+  ScalaOptions,
+  ShadowingSeq
+}
+import scala.build.{Build, BuildThreads, LocalRepo}
+import scala.build.Directories
+import scala.build.options.ScalacOpt
+import scala.build.Positioned
 
 class BuildOptionsTests extends munit.FunSuite {
 
@@ -315,5 +325,57 @@ class BuildOptionsTests extends munit.FunSuite {
       }
 
     }
+
+  val extraRepoTmpDir = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
+  val directories     = Directories.under(extraRepoTmpDir)
+  val buildThreads    = BuildThreads.create()
+  override def afterAll(): Unit = {
+    buildThreads.shutdown()
+  }
+
+  test("User scalac options shadow internal ones") {
+    val defaultOptions = BuildOptions(
+      internal = InternalOptions(
+        localRepository = LocalRepo.localRepo(directories.localRepoDir)
+      )
+    )
+
+    val newSourceRoot = os.pwd / "out" / "foo"
+
+    val extraScalacOpt = Seq("-sourceroot", newSourceRoot.toString)
+    val options = defaultOptions.copy(
+      scalaOptions = defaultOptions.scalaOptions.copy(
+        scalaVersion = Some("3.1.1"),
+        scalacOptions = ShadowingSeq.from(
+          extraScalacOpt
+            .map(ScalacOpt(_))
+            .map(Positioned.none)
+        )
+      )
+    )
+
+    val dummyInputs = TestInputs(
+      os.rel / "Foo.scala" ->
+        """object Foo
+          |""".stripMargin
+    )
+
+    dummyInputs.withLoadedBuild(options, buildThreads, None) {
+      (_, _, build) =>
+
+        val build0 = build match {
+          case s: Build.Successful => s
+          case _                   => sys.error(s"Unexpected failed or cancelled build $build")
+        }
+
+        val rawOptions = build0.project.scalaCompiler.scalacOptions
+        val seq        = ShadowingSeq.from(rawOptions.map(ScalacOpt(_)))
+
+        expect(seq.toSeq.length == rawOptions.length) // no option needs to be shadowed
+
+        pprint.err.log(rawOptions)
+        expect(rawOptions.containsSlice(extraScalacOpt))
+    }
+  }
 
 }

--- a/modules/cli/src/main/resources/META-INF/native-image/org.virtuslab/scala-cli-core/resource-config.json
+++ b/modules/cli/src/main/resources/META-INF/native-image/org.virtuslab/scala-cli-core/resource-config.json
@@ -18,9 +18,6 @@
       },
       {
         "pattern": "\\Qcommons-logging.properties\\E"
-      },
-      {
-        "pattern": "\\Qcom/google/javascript/jscomp/js/polyfills.txt\\E"
       }
     ]
   },

--- a/modules/options/src/main/scala-2.13/scala/build/options/ShadowingSeq.scala
+++ b/modules/options/src/main/scala-2.13/scala/build/options/ShadowingSeq.scala
@@ -8,6 +8,8 @@ import scala.collection.mutable
 /** Seq ensuring some of its values are unique according to some key */
 final case class ShadowingSeq[T] private (values: Seq[Seq[T]]) {
   lazy val toSeq: Seq[T] = values.flatten
+  def map[U](f: T => U)(implicit key: ShadowingSeq.KeyOf[U]): ShadowingSeq[U] =
+    ShadowingSeq.empty[U] ++ toSeq.map(f)
   def ++(other: Seq[T])(implicit key: ShadowingSeq.KeyOf[T]): ShadowingSeq[T] =
     addGroups(ShadowingSeq.groups(other, key.groups(other)))
   private def addGroups(other: Seq[Seq[T]])(implicit key: ShadowingSeq.KeyOf[T]): ShadowingSeq[T] =

--- a/modules/options/src/main/scala-3.1/scala/build/options/ShadowingSeq.scala
+++ b/modules/options/src/main/scala-3.1/scala/build/options/ShadowingSeq.scala
@@ -7,6 +7,8 @@ import scala.collection.mutable
 /** Seq ensuring some of its values are unique according to some key */
 final case class ShadowingSeq[T] private (values: Seq[Seq[T]]) {
   lazy val toSeq: Seq[T] = values.flatten
+  def map[U](f: T => U)(implicit key: ShadowingSeq.KeyOf[U]): ShadowingSeq[U] =
+    ShadowingSeq.empty[U] ++ toSeq.map(f)
   def ++(other: Seq[T])(implicit key: ShadowingSeq.KeyOf[T]): ShadowingSeq[T] =
     addGroups(ShadowingSeq.groups(other, key.groups(other)))
   private def addGroups(other: Seq[Seq[T]])(implicit key: ShadowingSeq.KeyOf[T]): ShadowingSeq[T] =

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -772,8 +772,7 @@ trait ScalaCliCompile extends ScalaModule {
                   asOpt("--jar", compileClasspath().map(_.path)),
                   asOpt("-O", scalacPluginClasspath().map(p => s"-Xplugin:${p.path}")),
                   Seq("--jvm", "zulu:17"),
-                  // re-enable this when switching to Scala CLI > 0.1.2
-                  // "--strict-bloop-json-check=false", // don't check Bloop JSON files at each run
+                  "--strict-bloop-json-check=false", // don't check Bloop JSON files at each run
                   workspace,
                   sourceFiles
                 )

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -838,6 +838,8 @@ trait ScalaCliScalafixModule extends ScalafixModule with ScalaCliCompile {
       .getOrElse(millSourcePath)
     val semDbOptions =
       if (isScala2) Seq(s"-P:semanticdb:sourceroot:$sourceRoot")
+      // Once we switch to Scala CLI 0.1.4, change this to
+      // else Seq(s"-sourceroot", sourceRoot.toString)
       else Nil
     super.scalacOptions() ++ semDbOptions
   }


### PR DESCRIPTION
This allows users to override `-sourceroot` in particular, that we should override in the Scala CLI build, so that building Scala 3 modules doesn't write `*.semanticdb` files in source directories.