### PR TITLE
Launch older scala-cli version without --cli-scala-version

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
@@ -22,7 +22,7 @@ object LauncherCli {
 
     val logger          = LoggingOptions().logger
     val cache           = CoursierOptions().coursierCache(logger.coursierLogger(""))
-    val scalaVersion    = scalaCliVersion(version, options.cliScalaVersion)
+    val scalaVersion    = options.cliScalaVersion.getOrElse(scalaCliScalaVersion(version))
     val scalaParameters = ScalaParameters(scalaVersion)
     val snapshotsRepo   = Seq(Repositories.central.root, Repositories.sonatype("snapshots").root)
 
@@ -70,14 +70,10 @@ object LauncherCli {
     sys.exit(exitCode)
   }
 
-  def scalaCliVersion(cliVersion: String, cliScalaVersion: Option[String]): String =
-    cliScalaVersion match {
-      case Some(v) => v
-      case None => // it should be updated after migratation to Scala 3 => (Version(cliVersion) <= Version(x)) Constants.defaultScala213Version
-        if (cliVersion == "nightly") Properties.versionNumberString
-        else if (Version(cliVersion) <= Version("0.1.2")) Constants.defaultScala212Version
-        else Properties.versionNumberString
-    }
+  def scalaCliScalaVersion(cliVersion: String): String =
+    if (cliVersion == "nightly") Properties.versionNumberString
+    else if (Version(cliVersion) <= Version("0.1.2")) Constants.defaultScala212Version
+    else Properties.versionNumberString
 
   def resolveNightlyScalaCliVersion(
     cache: FileCache[Task],

--- a/modules/cli/src/test/scala/cli/tests/LauncherCliTest.scala
+++ b/modules/cli/src/test/scala/cli/tests/LauncherCliTest.scala
@@ -28,8 +28,8 @@ class LauncherCliTest extends munit.FunSuite {
   )
 
   for ((cliVersion, expectedScalaVersion) <- expectedScalaCliVersions)
-    test(s"use expected scala version for JVM Scala CLi launcher: $cliVersion") {
-      val scalaVersion = LauncherCli.scalaCliVersion(cliVersion, None)
+    test(s"use expected scala version for Scala CLI launcher: $cliVersion") {
+      val scalaVersion = LauncherCli.scalaCliScalaVersion(cliVersion)
 
       expect(scalaVersion == expectedScalaVersion)
     }

--- a/modules/cli/src/test/scala/cli/tests/LauncherCliTest.scala
+++ b/modules/cli/src/test/scala/cli/tests/LauncherCliTest.scala
@@ -2,6 +2,7 @@ package cli.tests
 import com.eed3si9n.expecty.Expecty.expect
 import dependency.ScalaParameters
 
+import scala.build.internal.Constants
 import scala.build.tests.TestLogger
 import scala.cli.commands.CoursierOptions
 import scala.cli.commands.util.CommonOps._
@@ -18,5 +19,19 @@ class LauncherCliTest extends munit.FunSuite {
     val nightlyCliVersion = LauncherCli.resolveNightlyScalaCliVersion(cache, scalaParameters)
     expect(nightlyCliVersion.endsWith("-SNAPSHOT"))
   }
+
+  val expectedScalaCliVersions = Seq(
+    "0.1.2"                       -> Constants.defaultScala212Version,
+    "0.1.1+43-g15666b67-SNAPSHOT" -> Constants.defaultScala212Version,
+    "0.1.3"                       -> Constants.defaultScala213Version,
+    "nightly"                     -> Properties.versionNumberString
+  )
+
+  for ((cliVersion, expectedScalaVersion) <- expectedScalaCliVersions)
+    test(s"use expected scala version for JVM Scala CLi launcher: $cliVersion") {
+      val scalaVersion = LauncherCli.scalaCliVersion(cliVersion, None)
+
+      expect(scalaVersion == expectedScalaVersion)
+    }
 
 }

--- a/website/docs/commands/basics.md
+++ b/website/docs/commands/basics.md
@@ -191,12 +191,12 @@ Running another Scala CLI version might be slower because it uses JVM-based Scal
 To run another Scala CLI version, specify it with `--cli-version` before any other argument:
 
 ```bash 
-scala-cli --cli-version 0.1.2+209-geb58be9d-SNAPSHOT about
-# Scala CLI version 0.1.2+209-geb58be9d-SNAPSHOT
+scala-cli --cli-version 0.1.3-51-g4d314eee-SNAPSHOT about
+# Scala CLI version 0.1.3-51-g4d314eee-SNAPSHOT
 ```
 
 <!-- Expected:
-Scala CLI version 0.1.2+209-geb58be9d-SNAPSHOT
+Scala CLI version 0.1.3-51-g4d314eee-SNAPSHOT
 -->
 
 To use the latest Scala CLI nightly build, pass `nightly` to `--cli-version` parameter:


### PR DESCRIPTION
After migration to Scala 3 one test should fail - `"0.1.3" -> Constants.defaultScala213Version,` and then we have to update logic `LauncherCli.scalaCliVersion` method to enforce using Scala `2.13` version for older `scala-cli` jvm launcher.
