### PR TITLE
Reload options on a BSP workspace/reload

### DIFF
--- a/modules/build/src/main/scala/scala/build/bsp/Bsp.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/Bsp.scala
@@ -15,7 +15,7 @@ trait Bsp {
 object Bsp {
   def create(
     argsToInputs: Seq[String] => Either[String, Inputs],
-    buildOptions: BuildOptions,
+    getBuildOptions: () => BuildOptions,
     logger: Logger,
     bloopRifleConfig: BloopRifleConfig,
     verbosity: Int,
@@ -27,7 +27,7 @@ object Bsp {
       logger,
       bloopRifleConfig,
       argsToInputs,
-      buildOptions,
+      getBuildOptions,
       verbosity,
       threads,
       in,

--- a/modules/build/src/main/scala/scala/build/bsp/Bsp.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/Bsp.scala
@@ -2,9 +2,7 @@ package scala.build.bsp
 
 import java.io.{InputStream, OutputStream}
 
-import scala.build.blooprifle.BloopRifleConfig
-import scala.build.options.BuildOptions
-import scala.build.{Inputs, Logger}
+import scala.build.Inputs
 import scala.concurrent.Future
 
 trait Bsp {
@@ -15,20 +13,14 @@ trait Bsp {
 object Bsp {
   def create(
     argsToInputs: Seq[String] => Either[String, Inputs],
-    getBuildOptions: () => BuildOptions,
-    logger: Logger,
-    bloopRifleConfig: BloopRifleConfig,
-    verbosity: Int,
+    bspReloadableOptionsReference: BspReloadableOptions.Reference,
     threads: BspThreads,
     in: InputStream,
     out: OutputStream
   ): Bsp =
     new BspImpl(
-      logger,
-      bloopRifleConfig,
       argsToInputs,
-      getBuildOptions,
-      verbosity,
+      bspReloadableOptionsReference,
       threads,
       in,
       out

--- a/modules/build/src/main/scala/scala/build/bsp/BspClient.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspClient.scala
@@ -15,7 +15,7 @@ import scala.jdk.CollectionConverters._
 
 class BspClient(
   readFilesEs: ExecutorService,
-  logger: Logger,
+  @volatile var logger: Logger,
   var forwardToOpt: Option[b.BuildClient] = None
 ) extends b.BuildClient with BuildClientForwardStubs with BloopBuildClient
     with HasGeneratedSourcesImpl {

--- a/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
@@ -27,7 +27,7 @@ final class BspImpl(
   logger: Logger,
   bloopRifleConfig: BloopRifleConfig,
   argsToInputs: Seq[String] => Either[String, Inputs],
-  buildOptions: BuildOptions,
+  getBuildOptions: () => BuildOptions,
   verbosity: Int,
   threads: BspThreads,
   in: InputStream,
@@ -56,6 +56,8 @@ final class BspImpl(
     val persistentLogger = new PersistentDiagnosticLogger(logger)
     val bspServer        = currentBloopSession.bspServer
     val inputs           = currentBloopSession.inputs
+
+    val buildOptions = getBuildOptions()
 
     val crossSources = value {
       CrossSources.forInputs(
@@ -289,7 +291,7 @@ final class BspImpl(
     val remoteServer = new BloopCompiler(
       bloopServer,
       20.seconds,
-      strictBloopJsonCheck = buildOptions.internal.strictBloopJsonCheckOrDefault
+      strictBloopJsonCheck = getBuildOptions().internal.strictBloopJsonCheckOrDefault
     )
     lazy val bspServer = new BspServer(
       remoteServer.bloopServer.server,

--- a/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
@@ -29,10 +29,6 @@ final class BspImpl(
   in: InputStream,
   out: OutputStream
 ) extends Bsp {
-  private def reloadableOptions: BspReloadableOptions = bspReloadableOptionsReference.get
-  private def logger: Logger                          = reloadableOptions.logger
-  private def buildOptions: BuildOptions              = reloadableOptions.buildOptions
-  private def verbosity: Int                          = reloadableOptions.verbosity
 
   import BspImpl.{PreBuildData, PreBuildProject, buildTargetIdToEvent, responseError}
 
@@ -49,8 +45,12 @@ final class BspImpl(
   }
 
   private def prepareBuild(
-    currentBloopSession: BloopSession
+    currentBloopSession: BloopSession,
+    reloadableOptions: BspReloadableOptions
   ): Either[(BuildException, Scope), PreBuildProject] = either[(BuildException, Scope)] {
+    val logger       = reloadableOptions.logger
+    val buildOptions = reloadableOptions.buildOptions
+    val verbosity    = reloadableOptions.verbosity
     logger.log("Preparing build")
 
     val persistentLogger = new PersistentDiagnosticLogger(logger)
@@ -149,7 +149,8 @@ final class BspImpl(
 
   private def buildE(
     currentBloopSession: BloopSession,
-    notifyChanges: Boolean
+    notifyChanges: Boolean,
+    reloadableOptions: BspReloadableOptions
   ): Either[(BuildException, Scope), Unit] = {
     def doBuildOnce(data: PreBuildData, scope: Scope): Either[(BuildException, Scope), Build] =
       Build.buildOnce(
@@ -158,14 +159,14 @@ final class BspImpl(
         data.generatedSources,
         data.buildOptions,
         scope,
-        logger,
+        reloadableOptions.logger,
         actualLocalClient,
         currentBloopSession.remoteServer,
         partialOpt = None
       ).left.map(_ -> scope)
 
     either[(BuildException, Scope)] {
-      val preBuild = value(prepareBuild(currentBloopSession))
+      val preBuild = value(prepareBuild(currentBloopSession, reloadableOptions))
       if (notifyChanges && (preBuild.mainScope.buildChanged || preBuild.testScope.buildChanged))
         notifyBuildChange(currentBloopSession)
       value(doBuildOnce(preBuild.mainScope, Scope.Main))
@@ -178,15 +179,15 @@ final class BspImpl(
     currentBloopSession: BloopSession,
     client: BspClient,
     notifyChanges: Boolean,
-    logger: Logger
+    reloadableOptions: BspReloadableOptions
   ): Unit =
-    buildE(currentBloopSession, notifyChanges) match {
+    buildE(currentBloopSession, notifyChanges, reloadableOptions) match {
       case Left((ex, scope)) =>
         client.reportBuildException(
           currentBloopSession.bspServer.targetScopeIdOpt(scope),
           ex
         )
-        logger.debug(s"Caught $ex during BSP build, ignoring it")
+        reloadableOptions.logger.debug(s"Caught $ex during BSP build, ignoring it")
       case Right(()) =>
         for (targetId <- currentBloopSession.bspServer.targetIds)
           client.resetBuildExceptionDiagnostics(targetId)
@@ -207,11 +208,12 @@ final class BspImpl(
   private def compile(
     currentBloopSession: BloopSession,
     executor: Executor,
+    reloadableOptions: BspReloadableOptions,
     doCompile: () => CompletableFuture[b.CompileResult]
   ): CompletableFuture[b.CompileResult] = {
     val preBuild = CompletableFuture.supplyAsync(
       () =>
-        prepareBuild(currentBloopSession) match {
+        prepareBuild(currentBloopSession, reloadableOptions) match {
           case Right(preBuild) =>
             if (preBuild.mainScope.buildChanged || preBuild.testScope.buildChanged)
               notifyBuildChange(currentBloopSession)
@@ -244,7 +246,7 @@ final class BspImpl(
               data.generatedSources,
               currentBloopSession.inputs.generatedSrcRoot(scope),
               data.classesDir,
-              logger,
+              reloadableOptions.logger,
               currentBloopSession.inputs.workspace,
               updateSemanticDbs = true,
               scalaVersion = data.project.scalaCompiler.scalaVersion
@@ -265,17 +267,22 @@ final class BspImpl(
     }
   }
 
-  private val actualLocalClient = new BspClient(
-    threads.buildThreads.bloop.jsonrpc, // meh
-    logger
-  )
-  private val localClient: b.BuildClient with BloopBuildClient =
+  private var actualLocalClient: BspClient                     = _
+  private var localClient: b.BuildClient with BloopBuildClient = _
+
+  private def getLocalClient(verbosity: Int): b.BuildClient with BloopBuildClient =
     if (verbosity >= 3)
       new BspImpl.LoggingBspClient(actualLocalClient)
     else
       actualLocalClient
 
-  private def newBloopSession(inputs: Inputs, presetIntelliJ: Boolean = false): BloopSession = {
+  private def newBloopSession(
+    inputs: Inputs,
+    reloadableOptions: BspReloadableOptions,
+    presetIntelliJ: Boolean = false
+  ): BloopSession = {
+    val logger       = reloadableOptions.logger
+    val buildOptions = reloadableOptions.buildOptions
     val bloopServer = BloopServer.buildServer(
       reloadableOptions.bloopRifleConfig,
       "scala-cli",
@@ -293,7 +300,8 @@ final class BspImpl(
     )
     lazy val bspServer = new BspServer(
       remoteServer.bloopServer.server,
-      doCompile => compile(bloopSession0, threads.prepareBuildExecutor, doCompile),
+      doCompile =>
+        compile(bloopSession0, threads.prepareBuildExecutor, reloadableOptions, doCompile),
       logger,
       presetIntelliJ
     )
@@ -301,7 +309,7 @@ final class BspImpl(
     lazy val watcher = new Build.Watcher(
       ListBuffer(),
       threads.buildThreads.fileWatcher,
-      build(bloopSession0, actualLocalClient, notifyChanges = true, logger),
+      build(bloopSession0, actualLocalClient, notifyChanges = true, reloadableOptions),
       ()
     )
     lazy val bloopSession0: BloopSession = new BloopSession(
@@ -320,8 +328,17 @@ final class BspImpl(
   private val bloopSession = new BloopSession.Reference
 
   def run(initialInputs: Inputs): Future[Unit] = {
+    val reloadableOptions = bspReloadableOptionsReference.get
+    val logger            = reloadableOptions.logger
+    val verbosity         = reloadableOptions.verbosity
 
-    val currentBloopSession = newBloopSession(initialInputs)
+    actualLocalClient = new BspClient(
+      threads.buildThreads.bloop.jsonrpc, // meh
+      logger
+    )
+    localClient = getLocalClient(verbosity)
+
+    val currentBloopSession = newBloopSession(initialInputs, reloadableOptions)
     bloopSession.update(null, currentBloopSession, "BSP server already initialized")
 
     val actualLocalServer: b.BuildServer with b.ScalaBuildServer with b.JavaBuildServer
@@ -353,7 +370,7 @@ final class BspImpl(
     actualLocalClient.newInputs(initialInputs)
     currentBloopSession.resetDiagnostics(actualLocalClient)
 
-    prepareBuild(currentBloopSession) match {
+    prepareBuild(currentBloopSession, reloadableOptions) match {
       case Left((ex, scope)) =>
         actualLocalClient.reportBuildException(actualLocalServer.targetScopeIdOpt(scope), ex)
         logger.log(ex)
@@ -370,7 +387,7 @@ final class BspImpl(
     val f = launcher.startListening()
 
     val initiateFirstBuild: Runnable = { () =>
-      try build(currentBloopSession, actualLocalClient, notifyChanges = false, logger)
+      try build(currentBloopSession, actualLocalClient, notifyChanges = false, reloadableOptions)
       catch {
         case t: Throwable =>
           logger.debug(s"Caught $t during initial BSP build, ignoring it")
@@ -393,18 +410,19 @@ final class BspImpl(
   private def reloadBsp(
     currentBloopSession: BloopSession,
     previousInputs: Inputs,
-    newInputs: Inputs
+    newInputs: Inputs,
+    reloadableOptions: BspReloadableOptions
   ): CompletableFuture[AnyRef] = {
     val previousTargetIds = currentBloopSession.bspServer.targetIds
     val wasIntelliJ       = currentBloopSession.bspServer.isIntelliJ
-    val newBloopSession0  = newBloopSession(newInputs, wasIntelliJ)
+    val newBloopSession0  = newBloopSession(newInputs, reloadableOptions, wasIntelliJ)
     bloopSession.update(currentBloopSession, newBloopSession0, "Concurrent reload of workspace")
     currentBloopSession.dispose()
     actualLocalClient.newInputs(newInputs)
     localClient.onConnectWithServer(newBloopSession0.remoteServer.bloopServer.server)
 
     newBloopSession0.resetDiagnostics(actualLocalClient)
-    prepareBuild(newBloopSession0) match {
+    prepareBuild(newBloopSession0, reloadableOptions) match {
       case Left((buildException, scope)) =>
         CompletableFuture.completedFuture(
           responseError(
@@ -428,6 +446,11 @@ final class BspImpl(
   private def onReload(): CompletableFuture[AnyRef] = {
     val currentBloopSession = bloopSession.get()
     bspReloadableOptionsReference.reload()
+    val reloadableOptions = bspReloadableOptionsReference.get
+    val logger            = reloadableOptions.logger
+    val verbosity         = reloadableOptions.verbosity
+    actualLocalClient.logger = logger
+    localClient = getLocalClient(verbosity)
     val ideInputsJsonPath =
       currentBloopSession.inputs.workspace / Constants.workspaceDirName / "ide-inputs.json"
     if (os.isFile(ideInputsJsonPath)) {
@@ -443,7 +466,7 @@ final class BspImpl(
         val newInputs      = value(argsToInputs(ideInputs.args))
         val previousInputs = currentBloopSession.inputs
         if (newInputs == previousInputs) CompletableFuture.completedFuture(new Object)
-        else reloadBsp(currentBloopSession, previousInputs, newInputs)
+        else reloadBsp(currentBloopSession, previousInputs, newInputs, reloadableOptions)
       }
       maybeResponse match {
         case Left(errorMessage) =>

--- a/modules/build/src/main/scala/scala/build/bsp/BspReloadableOptions.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspReloadableOptions.scala
@@ -1,7 +1,5 @@
 package scala.build.bsp
 
-import java.util.concurrent.atomic.AtomicReference
-
 import scala.build.Logger
 import scala.build.blooprifle.BloopRifleConfig
 import scala.build.options.BuildOptions
@@ -14,13 +12,12 @@ case class BspReloadableOptions(
 )
 
 object BspReloadableOptions {
-  case class Reference(getReloaded: () => BspReloadableOptions) {
-    private val ref: AtomicReference[BspReloadableOptions] = new AtomicReference(getReloaded())
-
-    def get: BspReloadableOptions = ref.get()
-    def reload(): Unit = {
-      val reloaded = getReloaded()
-      if (ref.get() != reloaded) ref.set(reloaded)
-    }
+  class Reference(getReloaded: () => BspReloadableOptions) {
+    @volatile private var ref: BspReloadableOptions = getReloaded()
+    def get: BspReloadableOptions                   = ref
+    def reload(): Unit                              = ref = getReloaded()
+  }
+  object Reference {
+    def apply(getReloaded: () => BspReloadableOptions): Reference = new Reference(getReloaded)
   }
 }

--- a/modules/build/src/main/scala/scala/build/bsp/BspReloadableOptions.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspReloadableOptions.scala
@@ -1,0 +1,26 @@
+package scala.build.bsp
+
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.build.Logger
+import scala.build.blooprifle.BloopRifleConfig
+import scala.build.options.BuildOptions
+
+case class BspReloadableOptions(
+  buildOptions: BuildOptions,
+  bloopRifleConfig: BloopRifleConfig,
+  logger: Logger,
+  verbosity: Int
+)
+
+object BspReloadableOptions {
+  case class Reference(getReloaded: () => BspReloadableOptions) {
+    private val ref: AtomicReference[BspReloadableOptions] = new AtomicReference(getReloaded())
+
+    def get: BspReloadableOptions = ref.get()
+    def reload(): Unit = {
+      val reloaded = getReloaded()
+      if (ref.get() != reloaded) ref.set(reloaded)
+    }
+  }
+}

--- a/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
@@ -5,7 +5,6 @@ import ch.epfl.scala.bsp4j as b
 
 import java.io.{File, PrintWriter, StringWriter}
 import java.net.URI
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.{CompletableFuture, TimeUnit}
 import java.util as ju
 
@@ -30,8 +29,8 @@ class BspServer(
 
   private var client: Option[BuildClient] = None
 
-  private val atomicIntelliJ: AtomicBoolean = new AtomicBoolean(presetIntelliJ)
-  def isIntelliJ: Boolean                   = atomicIntelliJ.get()
+  @volatile private var intelliJ: Boolean = presetIntelliJ
+  def isIntelliJ: Boolean                 = intelliJ
 
   def clientOpt: Option[BuildClient] = client
 
@@ -156,7 +155,7 @@ class BspServer(
       capabilities
     )
     val buildComesFromIntelliJ = params.getDisplayName.toLowerCase.contains("intellij")
-    atomicIntelliJ.set(buildComesFromIntelliJ)
+    intelliJ = buildComesFromIntelliJ
     logger.debug(s"IntelliJ build: $buildComesFromIntelliJ")
     CompletableFuture.completedFuture(res)
   }


### PR DESCRIPTION
This allows for BSP workspace/reload to pick up options passed to the CLI, i.e. `--dependency` args.