### PR TITLE
Fix Scala 3.1.nightly tests

### DIFF
--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -45,7 +45,7 @@ class BuildOptionsTests extends munit.FunSuite {
       )
     )
     val scalaParams = options.scalaParams.orThrow
-    assert(
+    expect(
       scalaParams.scalaVersion.startsWith("3.1.") && scalaParams.scalaVersion.endsWith("-NIGHTLY"),
       "-S 3.1.nightly argument does not lead to scala 3.1. nightly build option"
     )

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -490,7 +490,7 @@ final case class BuildOptions(
             .withModule(scala3)
             .result()
             .unsafeRun()(finalCache.ec)
-        }.versions.available
+        }.versions.available.filter(_.endsWith("-NIGHTLY"))
 
         val threeXNightlies = res.filter(_.startsWith(s"3.$threeSubBinaryNum.")).map(Version(_))
         if (threeXNightlies.nonEmpty) Right(threeXNightlies.max.repr)


### PR DESCRIPTION
Currently `3.1.3-RC2` is the latest released Scala 3 and this is not a nightly...