### PR TITLE
Fix quotes in shebang help

### DIFF
--- a/modules/cli-options/src/main/scala/scala/cli/commands/ShebangOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/ShebangOptions.scala
@@ -3,7 +3,7 @@ package scala.cli.commands
 import caseapp._
 
 @HelpMessage(
-  """|Like 'run', but more handy from shebang scripts
+  """|Like `run`, but more handy from shebang scripts
      |
      |This command is equivalent to `run`, but it changes the way
      |`scala-cli` parses its command-line arguments in order to be compatible

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -236,7 +236,7 @@ Accepts options:
 
 ## `shebang`
 
-Like 'run', but more handy from shebang scripts
+Like `run`, but more handy from shebang scripts
 
 This command is equivalent to `run`, but it changes the way
 `scala-cli` parses its command-line arguments in order to be compatible


### PR DESCRIPTION
Replaces single quotes with backticks in the help for shebang, consistent with other help.
The single quotes cause issues with zsh completion, as they are placed in single quoted strings.

Closes #695.
