### PR TITLE
Update reflect-config.json

### DIFF
--- a/modules/cli/src/main/resources/META-INF/native-image/org.virtuslab/scala-cli-core/reflect-config.json
+++ b/modules/cli/src/main/resources/META-INF/native-image/org.virtuslab/scala-cli-core/reflect-config.json
@@ -8,6 +8,7 @@
   },
   {
     "name": "ch.epfl.scala.bsp4j.BuildClient",
+    "queryAllDeclaredMethods": true,
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,
     "allDeclaredMethods": true,
@@ -22,6 +23,7 @@
   },
   {
     "name": "ch.epfl.scala.bsp4j.BuildServer",
+    "queryAllDeclaredMethods": true,
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,
     "allDeclaredMethods": true,
@@ -133,6 +135,10 @@
     "allDeclaredFields": true
   },
   {
+    "name": "ch.epfl.scala.bsp4j.DebugProvider",
+    "allDeclaredFields": true
+  },
+  {
     "name": "ch.epfl.scala.bsp4j.DebugSessionAddress",
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,
@@ -239,6 +245,7 @@
   },
   {
     "name": "ch.epfl.scala.bsp4j.JavaBuildServer",
+    "queryAllDeclaredMethods": true,
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,
     "allDeclaredMethods": true,
@@ -414,6 +421,7 @@
   },
   {
     "name": "ch.epfl.scala.bsp4j.ScalaBuildServer",
+    "queryAllDeclaredMethods": true,
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,
     "allDeclaredMethods": true,
@@ -886,6 +894,10 @@
     "allPublicConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true
+  },
+  {
+    "name": "scala.build.ConsoleBloopBuildClient",
+    "queryAllDeclaredMethods": true
   },
   {
     "name": "scala.build.bloop.BuildServer",


### PR DESCRIPTION
Not sure why, I recently tried to compile a [somehow large project](https://github.com/alexarchambault/scalacheck-shapeless/pull/258) with Scala CLI, enabling cross-compilation, and got errors such as [these](https://gist.github.com/alexarchambault/3264771f108981b5be707a5871e30862).

It turned out it was specific to the native launcher, and updating the some native image conf files (from what runs with `./mill -i cli.runWithAssistedConfig …` wrote) fixed it.

I didn't take the time to minimize that (and we already have one IT using `--cross`…), but we might want to have that in the upcoming release anyway.