### PR TITLE
Define valid package type for Scala.js and Scala Native

### DIFF
--- a/modules/core/src/main/scala/scala/build/errors/MalformedCliInputError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/MalformedCliInputError.scala
@@ -1,0 +1,4 @@
+package scala.build.errors
+
+final class MalformedCliInputError(message: String)
+    extends BuildException(message)


### PR DESCRIPTION
Accept valid package type for Scala.js and Scala.Native, in other case throws error. 

For example following command should generate `test.jar` file:
```
scala-cli package --js --library test.scala
```

Closed  #915 