### PR TITLE
Use snailgun fork, allowing to slightly rework nailgun input stream handling

### DIFF
--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifle.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifle.scala
@@ -1,6 +1,6 @@
 package scala.build.blooprifle
 
-import java.io.{ByteArrayOutputStream, InputStream, OutputStream}
+import java.io.{ByteArrayOutputStream, OutputStream}
 import java.nio.file.Path
 import java.util.concurrent.ScheduledExecutorService
 
@@ -99,11 +99,7 @@ object BloopRifle {
       BspConnectionAddress.Tcp("127.0.0.1", Util.randomPort())
     }
 
-    val in = config.bspStdin.getOrElse {
-      new InputStream {
-        def read(): Int = -1
-      }
-    }
+    val inOpt = config.bspStdin
 
     val out = config.bspStdout.getOrElse(OutputStream.nullOutputStream())
     val err = config.bspStderr.getOrElse(OutputStream.nullOutputStream())
@@ -112,7 +108,7 @@ object BloopRifle {
       config.address,
       bspSocketOrPort,
       workingDir,
-      in,
+      inOpt,
       out,
       err,
       logger
@@ -136,19 +132,12 @@ object BloopRifle {
     logger: BloopRifleLogger
   ): Int = {
 
-    val in = config.bspStdin.getOrElse {
-      new InputStream {
-        def read(): Int = -1
-      }
-    }
-
     val out = config.bspStdout.getOrElse(OutputStream.nullOutputStream())
     val err = config.bspStderr.getOrElse(OutputStream.nullOutputStream())
 
     Operations.exit(
       config.address,
       workingDir,
-      in,
       out,
       err,
       logger
@@ -168,7 +157,6 @@ object BloopRifle {
       Operations.about(
         config.address,
         workdir,
-        InputStream.nullInputStream(),
         bufferedOStream,
         OutputStream.nullOutputStream(),
         logger,

--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Operations.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Operations.scala
@@ -218,7 +218,7 @@ object Operations {
     *
     * @param host
     * @param port
-    * @param in
+    * @param inOpt
     * @param out
     * @param err
     * @param logger
@@ -229,7 +229,7 @@ object Operations {
     address: BloopRifleConfig.Address,
     bspSocketOrPort: BspConnectionAddress,
     workingDir: Path,
-    in: InputStream,
+    inOpt: Option[InputStream],
     out: OutputStream,
     err: OutputStream,
     logger: BloopRifleLogger
@@ -237,7 +237,7 @@ object Operations {
 
     val stop0          = new AtomicBoolean
     val nailgunClient0 = nailgunClient(address)
-    val streams        = Streams(in, out, err)
+    val streams        = Streams(inOpt, out, err)
 
     val promise    = Promise[Int]()
     val threadName = "bloop-rifle-nailgun-out"
@@ -318,7 +318,6 @@ object Operations {
   def exit(
     address: BloopRifleConfig.Address,
     workingDir: Path,
-    in: InputStream,
     out: OutputStream,
     err: OutputStream,
     logger: BloopRifleLogger
@@ -326,7 +325,7 @@ object Operations {
 
     val stop0          = new AtomicBoolean
     val nailgunClient0 = nailgunClient(address)
-    val streams        = Streams(in, out, err)
+    val streams        = Streams(None, out, err)
 
     nailgunClient0.run(
       "ng-stop",
@@ -343,7 +342,6 @@ object Operations {
   def about(
     address: BloopRifleConfig.Address,
     workingDir: Path,
-    in: InputStream,
     out: OutputStream,
     err: OutputStream,
     logger: BloopRifleLogger,
@@ -352,7 +350,7 @@ object Operations {
 
     val stop0          = new AtomicBoolean
     val nailgunClient0 = nailgunClient(address)
-    val streams        = Streams(in, out, err)
+    val streams        = Streams(None, out, err)
 
     timeout(30.seconds, scheduler, logger) {
       nailgunClient0.run(

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -122,8 +122,8 @@ object Deps {
   def slf4jNop   = ivy"org.slf4j:slf4j-nop:1.8.0-beta4"
   // Force using of 2.13 - is there a better way?
   def snailgun(force213: Boolean = false) =
-    if (force213) ivy"me.vican.jorge:snailgun-core_2.13:0.4.0"
-    else ivy"me.vican.jorge::snailgun-core:0.4.0"
+    if (force213) ivy"io.github.alexarchambault.scala-cli.snailgun:snailgun-core_2.13:0.4.1-sc1"
+    else ivy"io.github.alexarchambault.scala-cli.snailgun::snailgun-core:0.4.1-sc1"
   def svm             = ivy"org.graalvm.nativeimage:svm:22.0.0.2"
   def swoval          = ivy"com.swoval:file-tree-views:2.1.9"
   def testInterface   = ivy"org.scala-sbt:test-interface:1.0"

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -83,9 +83,11 @@ object Deps {
     ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:${Versions.jsoniterScala}"
   def jsoniterMacros =
     ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:${Versions.jsoniterScala}"
-  def libdaemonjvm               = ivy"io.github.alexarchambault.libdaemon::libdaemon:0.0.10"
-  def macroParadise              = ivy"org.scalamacros:::paradise:2.1.1"
-  def metaconfigTypesafe         = ivy"com.geirsson::metaconfig-typesafe-config:0.10.0"
+  def libdaemonjvm  = ivy"io.github.alexarchambault.libdaemon::libdaemon:0.0.10"
+  def macroParadise = ivy"org.scalamacros:::paradise:2.1.1"
+  def metaconfigTypesafe =
+    ivy"com.geirsson::metaconfig-typesafe-config:0.10.0"
+      .exclude(("org.scala-lang", "scala-compiler"))
   def munit                      = ivy"org.scalameta::munit:0.7.29"
   def nativeTestRunner           = ivy"org.scala-native::test-runner:${Versions.scalaNative}"
   def nativeTools                = ivy"org.scala-native::tools:${Versions.scalaNative}"


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/932 (hopefully), by short-circuiting the former input stream handling stuff of snailgun

(snailgun was spawning a thread, to read from null input streams passed to it, and IIUC, that null input stream can make nailgun assume the connection is close, and make it disconnect from clients - now it doesn't try to read from anything, and doesn't spawn a thread for it)