### PR TITLE
Use Constants.defaultScalaVersion instead of properties scala version

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
@@ -71,9 +71,10 @@ object LauncherCli {
   }
 
   def scalaCliScalaVersion(cliVersion: String): String =
-    if (cliVersion == "nightly") Properties.versionNumberString
+    if (cliVersion == "nightly") Constants.defaultScalaVersion
     else if (Version(cliVersion) <= Version("0.1.2")) Constants.defaultScala212Version
-    else Properties.versionNumberString
+    else if (Version(cliVersion) <= Version("0.1.4")) Constants.defaultScala213Version
+    else Constants.defaultScalaVersion
 
   def resolveNightlyScalaCliVersion(
     cache: FileCache[Task],

--- a/modules/cli/src/test/scala/cli/tests/LauncherCliTest.scala
+++ b/modules/cli/src/test/scala/cli/tests/LauncherCliTest.scala
@@ -14,7 +14,7 @@ class LauncherCliTest extends munit.FunSuite {
   test("resolve nightly version") {
     val logger          = TestLogger()
     val cache           = CoursierOptions().coursierCache(logger.coursierLogger(""))
-    val scalaParameters = ScalaParameters(Properties.versionNumberString)
+    val scalaParameters = ScalaParameters(Constants.defaultScalaVersion)
 
     val nightlyCliVersion = LauncherCli.resolveNightlyScalaCliVersion(cache, scalaParameters)
     expect(nightlyCliVersion.endsWith("-SNAPSHOT"))
@@ -24,7 +24,7 @@ class LauncherCliTest extends munit.FunSuite {
     "0.1.2"                       -> Constants.defaultScala212Version,
     "0.1.1+43-g15666b67-SNAPSHOT" -> Constants.defaultScala212Version,
     "0.1.3"                       -> Constants.defaultScala213Version,
-    "nightly"                     -> Properties.versionNumberString
+    "nightly"                     -> Constants.defaultScalaVersion
   )
 
   for ((cliVersion, expectedScalaVersion) <- expectedScalaCliVersions)

--- a/modules/options/src/main/scala-3.1/scala/build/CoursierUtils.scala
+++ b/modules/options/src/main/scala-3.1/scala/build/CoursierUtils.scala
@@ -6,6 +6,7 @@ import coursier.core.{Module, Dependency => CDependency}
 import coursier.parse.{DependencyParser, ModuleParser}
 
 import dependency.{DependencyLike, NameAttributes}
+import scala.build.internal.Constants
 
 def noArgs(args: Expr[Seq[Any]])(using Quotes): Unit = {} // TODO
 
@@ -23,7 +24,7 @@ object CoursierUtils {
   def parseModule(cs: Expr[StringContext], args: Expr[Seq[Any]])(using Quotes): Expr[Module] =
     noArgs(args)
     val modString = extractString(cs)
-    ModuleParser.module(modString, scala.util.Properties.versionNumberString) match {
+    ModuleParser.module(modString, Constants.defaultScalaVersion) match {
       case Left(error) =>
         quotes.reflect.report.error(error)
         ???
@@ -31,7 +32,7 @@ object CoursierUtils {
         '{
           ModuleParser.module(
             ${ Expr(modString) },
-            scala.util.Properties.versionNumberString
+            Constants.defaultScalaVersion
           ).getOrElse(???)
         }
     }


### PR DESCRIPTION
`Properties.versionNumberString` returns `2.13.8` in Scala 3 - it is described very well in [stack-overflow](Properties.versionNumberString).

To avoid unexpected behavior, we shouldn't use `Properties.versionNumberString` in ScalaCLI repo after migration to Scala 3.