### PR TITLE
Only compile integration tests once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         ./mill -i unitTests
         ./mill -i bloop-rifle._.test
     - name: JVM integration tests
-      run: ./mill -i integration.jvm.test
+      run: ./mill -i integration.test.jvm
 
   native-tests:
     timeout-minutes: 120
@@ -115,7 +115,7 @@ jobs:
         if-no-files-found: error
         retention-days: 2
     - name: Native integration tests
-      run: ./mill -i integration.native-mostly-static.test
+      run: ./mill -i integration.test.nativeMostlyStatic
     - name: Docker integration tests
       run: ./mill integration.docker-slim.test
     - name: Login to GitHub Container Registry
@@ -154,7 +154,7 @@ jobs:
         if-no-files-found: error
         retention-days: 2
     - name: Native integration tests
-      run: ./mill -i integration.native-static.test
+      run: ./mill -i integration.test.nativeStatic
     - name: Docker integration tests
       run: ./mill integration.docker.test
     - name: Login to GitHub Container Registry

--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -38,12 +38,12 @@ Run unit tests with
 
 Run integration tests with a JVM-based `scala-cli` with
 ```bash
-./mill integration.jvm.test
+./mill integration.test.jvm
 ```
 
 Run integration tests with a native-image-based `scala-cli` with
 ```bash
-./mill integration.native.test
+./mill integration.test.native
 ```
 
 ## General workflow in most `scala-cli` commands

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ The Scala CLI sources ship with Mill launchers, so that Mill itself doesn't need
 #### Run integration tests with the JVM launcher
 
 ```bash
-./mill integration.jvm.test
+./mill integration.test.jvm
 ```
 
 Filter test suites with
 ```bash
-./mill integration.jvm.test 'scala.cli.integration.RunTestsDefault.*'
-./mill integration.jvm.test 'scala.cli.integration.RunTestsDefault.Multiple scripts'
+./mill integration.test.jvm 'scala.cli.integration.RunTestsDefault.*'
+./mill integration.test.jvm 'scala.cli.integration.RunTestsDefault.Multiple scripts'
 ```
 
 #### Run integration tests with the native launcher
@@ -50,7 +50,7 @@ Filter test suites with
 (generating the launcher can take several minutes)
 
 ```bash
-./mill integration.native.test
+./mill integration.test.native
 ```
 
 #### Generate native packages

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ User-facing documentation can be found on our website: [scala-cli.virtuslab.org]
 
 ### Requirements
 
-Building Scala CLI requires a JVM 17 to work properly. 
+Building Scala CLI requires a JVM 17 to work properly.
 
-In theory, our build is able to download and install for its own needs JVM 17 on some OSes however it may not work in Intellij / Metals out of the box. 
+In theory, our build is able to download and install for its own needs JVM 17 on some OSes however it may not work in Intellij / Metals out of the box.
 
 The Scala CLI sources ship with Mill launchers, so that Mill itself doesn't need to be installed on your system.
 
@@ -127,9 +127,9 @@ that embeds JARs of the scala-cli modules, and downloads their dependencies
 from Maven Central upon first launch (using the coursier cache, just like
 a coursier bootstrap).
 
-### Website 
+### Website
 
-The Scala CLI website is built with [Docusaurus](https://v1.docusaurus.io/en/) and uses [Infima](https://infima.dev/docs/layout/spacing) for styling. 
+The Scala CLI website is built with [Docusaurus](https://v1.docusaurus.io/en/) and uses [Infima](https://infima.dev/docs/layout/spacing) for styling.
 
 #### Generate the website once
 
@@ -152,7 +152,7 @@ We have a built-in tool to validate `.md` files called [Sclicheck](/sclicheck/Re
 
 ```.github/scripts/check_docs.sh```
 
-You can also check single documents or directories using 
+You can also check single documents or directories using
 
 
 ```
@@ -181,4 +181,4 @@ Instructions on how to release - [Release Procedure](https://github.com/VirtusLa
 
 ## Debugging BSP server
 
-The easiest way to debug BSP sever is using `scala-cli-src` script with `--bsp-debug-port 5050` flag (the port should be unique to the workspace where BSP will be debugged). In such case BSP will be launched using local source and will run on JVM. It will also expects a debugger running in the listen mode using provided port (so the initialization of the connection can be debugged). In such case we recommend to have option to auto rerun debugging session off (so there is always a debugger instance ready to be used). 
+The easiest way to debug BSP sever is using `scala-cli-src` script with `--bsp-debug-port 5050` flag (the port should be unique to the workspace where BSP will be debugged). In such case BSP will be launched using local source and will run on JVM. It will also expects a debugger running in the listen mode using provided port (so the initialization of the connection can be debugged). In such case we recommend to have option to auto rerun debugging session off (so there is always a debugger instance ready to be used).

--- a/build.sc
+++ b/build.sc
@@ -676,7 +676,7 @@ trait Cli3 extends Cli {
   }
 }
 
-trait CliIntegrationBase extends SbtModule with ScalaCliPublishModule with HasTests
+trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
     with ScalaCliScalafixModule {
   def scalaVersion = sv
   def testLauncher: T[PathRef]
@@ -684,7 +684,7 @@ trait CliIntegrationBase extends SbtModule with ScalaCliPublishModule with HasTe
 
   def sv = Scala.scala213
 
-  def prefix: String
+  private def prefix = "integration-"
 
   def tmpDirBase = T.persistent {
     PathRef(T.dest / "working-dir")
@@ -807,10 +807,6 @@ trait CliIntegrationDocker extends SbtModule with ScalaCliPublishModule with Has
   def ivyDeps = super.ivyDeps() ++ Agg(
     Deps.osLib
   )
-}
-
-trait CliIntegration extends CliIntegrationBase {
-  def prefix = "integration-"
 }
 
 trait NativeIntegration extends CliIntegration {

--- a/build.sc
+++ b/build.sc
@@ -94,11 +94,12 @@ object `scala-cli-bsp` extends JavaModule with ScalaCliPublishModule {
     super.javacOptions() ++ Seq("-target", "8", "-source", "8")
   }
 }
-object integration extends Module {
+object integration extends CliIntegration {
+  object test extends Tests
   object docker extends CliIntegrationDocker {
     object test extends Tests {
       def sources = T.sources {
-        super.sources() ++ integration.jvm.sources()
+        super.sources() ++ integration.sources()
       }
       def tmpDirBase = T.persistent {
         PathRef(T.dest / "working-dir")
@@ -125,27 +126,6 @@ object integration extends Module {
         "CI"              -> "1",
         "ACTUAL_CI"       -> (if (System.getenv("CI") == null) "" else "1")
       )
-    }
-  }
-  object jvm extends JvmIntegration {
-    object test extends Tests
-  }
-  object native extends NativeIntegration with Bloop.Module {
-    def skipBloop = true
-    object test extends Tests with Bloop.Module {
-      def skipBloop = true
-    }
-  }
-  object `native-static` extends NativeIntegrationStatic with Bloop.Module {
-    def skipBloop = true
-    object test extends Tests with Bloop.Module {
-      def skipBloop = true
-    }
-  }
-  object `native-mostly-static` extends NativeIntegrationMostlyStatic with Bloop.Module {
-    def skipBloop = true
-    object test extends Tests with Bloop.Module {
-      def skipBloop = true
     }
   }
 }
@@ -679,8 +659,6 @@ trait Cli3 extends Cli {
 trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
     with ScalaCliScalafixModule {
   def scalaVersion = sv
-  def testLauncher: T[PathRef]
-  def cliKind: T[String]
 
   def sv = Scala.scala213
 
@@ -726,11 +704,9 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
       Deps.slf4jNop
     )
     def forkEnv = super.forkEnv() ++ Seq(
-      "SCALA_CLI"      -> testLauncher().path.toString,
-      "SCALA_CLI_KIND" -> cliKind(),
-      "SCALA_CLI_TMP"  -> tmpDirBase().path.toString,
-      "CI"             -> "1",
-      "ACTUAL_CI"      -> (if (System.getenv("CI") == null) "" else "1")
+      "SCALA_CLI_TMP" -> tmpDirBase().path.toString,
+      "CI"            -> "1",
+      "ACTUAL_CI"     -> (if (System.getenv("CI") == null) "" else "1")
     )
     private def updateRef(name: String, ref: PathRef): PathRef = {
       val rawPath = ref.path.toString.replace(
@@ -790,15 +766,57 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
     }
     def generatedSources = super.generatedSources() ++ Seq(constantsFile())
 
-    def test(args: String*) = T.command {
-      val res            = super.test(args: _*)()
-      val dotScalaInRoot = os.pwd / workspaceDirName
-      assert(
-        !os.isDir(dotScalaInRoot),
-        s"Expected $workspaceDirName ($dotScalaInRoot) not to have been created"
-      )
-      res
+    private final class TestHelper(
+      launcherTask: T[PathRef],
+      cliKind: String
+    ) {
+      def doTest(args: String*) =
+        T.command {
+          val argsTask = T.task {
+            val launcher = launcherTask().path
+            val extraArgs = Seq(
+              s"-Dtest.scala-cli.path=$launcher",
+              s"-Dtest.scala-cli.kind=$cliKind"
+            )
+            args ++ extraArgs
+          }
+          testTask(argsTask, T.task(Seq.empty[String]))
+        }
+      def test(args: String*) =
+        T.command {
+          val res            = doTest(args: _*)()
+          val dotScalaInRoot = os.pwd / workspaceDirName
+          assert(
+            !os.isDir(dotScalaInRoot),
+            s"Expected $workspaceDirName ($dotScalaInRoot) not to have been created"
+          )
+          res
+        }
     }
+
+    def test(args: String*) =
+      jvm(args: _*)
+
+    def jvm(args: String*) =
+      new TestHelper(
+        cli.standaloneLauncher,
+        "jvm"
+      ).test(args: _*)
+    def native(args: String*) =
+      new TestHelper(
+        cli.nativeImage,
+        "native"
+      ).test(args: _*)
+    def nativeStatic(args: String*) =
+      new TestHelper(
+        cli.nativeImageStatic,
+        "native-static"
+      ).test(args: _*)
+    def nativeMostlyStatic(args: String*) =
+      new TestHelper(
+        cli.nativeImageMostlyStatic,
+        "native-mostly-static"
+      ).test(args: _*)
   }
 }
 
@@ -807,26 +825,6 @@ trait CliIntegrationDocker extends SbtModule with ScalaCliPublishModule with Has
   def ivyDeps = super.ivyDeps() ++ Agg(
     Deps.osLib
   )
-}
-
-trait NativeIntegration extends CliIntegration {
-  def testLauncher = cli.nativeImage()
-  def cliKind      = "native"
-}
-
-trait NativeIntegrationStatic extends CliIntegration {
-  def testLauncher = cli.nativeImageStatic()
-  def cliKind      = "native-static"
-}
-
-trait NativeIntegrationMostlyStatic extends CliIntegration {
-  def testLauncher = cli.nativeImageMostlyStatic()
-  def cliKind      = "native-mostly-static"
-}
-
-trait JvmIntegration extends CliIntegration {
-  def testLauncher = cli.standaloneLauncher()
-  def cliKind      = "jvm"
 }
 
 class Runner(val crossScalaVersion: String) extends ScalaCliCrossSbtModule
@@ -1029,7 +1027,7 @@ def defaultNativeImage() =
 
 def nativeIntegrationTests() =
   T.command {
-    integration.native.test.test()()
+    integration.test.native()()
   }
 
 def copyDefaultLauncher(directory: String = "artifacts") =

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -10,13 +10,13 @@ import scala.util.Properties
 
 object TestUtil {
 
-  val cliKind     = System.getenv("SCALA_CLI_KIND")
+  val cliKind     = sys.props("test.scala-cli.kind")
   val isNativeCli = cliKind.startsWith("native")
   val isCI = Option(System.getenv("ACTUAL_CI")) match {
     case None        => System.getenv("CI") != null
     case Some(value) => value.nonEmpty
   }
-  val cliPath = System.getenv("SCALA_CLI")
+  val cliPath = sys.props("test.scala-cli.path")
   val cli     = cliCommand(cliPath)
 
   def cliCommand(cliPath: String): Seq[String] =


### PR DESCRIPTION
And use a different command than 'test' to run the native flavors of the
ITs, like
```text
$ ./mill -i integration.test.native
$ ./mill -i integration.test.nativeStatic
$ ./mill -i integration.test.nativeMostlyStatic
```

The JVM ITs can be run in a few equivalent ways:
```text
$ ./mill -i integration.test
$ ./mill -i integration.test.test
$ ./mill -i integration.test.jvm
```

Note that `./mill __.test` will only run JVM ITs, not native ones.