### PR TITLE
In Doctor, account for absolute and relative paths

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/Doctor.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Doctor.scala
@@ -79,7 +79,10 @@ object Doctor extends ScalaCommand[DoctorOptions] {
       .split(pathSeparator)
       .map(d => if (d == ".") pwd else d) // on unix a bare "." counts as the current dir
       .map(_ + "/scala-cli")
-      .filter(f => os.isFile(os.Path(f)))
+      .filter { f =>
+        val p: os.Path = if f.startsWith("/") then os.Path(f) else os.RelPath(f).resolveFrom(os.pwd)
+        os.isFile(p)
+      }
       .toSet
 
     if (scalaCliPaths.size > 1)

--- a/modules/cli/src/main/scala/scala/cli/commands/Doctor.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Doctor.scala
@@ -79,10 +79,7 @@ object Doctor extends ScalaCommand[DoctorOptions] {
       .split(pathSeparator)
       .map(d => if (d == ".") pwd else d) // on unix a bare "." counts as the current dir
       .map(_ + "/scala-cli")
-      .filter { f =>
-        val p: os.Path = if f.startsWith("/") then os.Path(f) else os.RelPath(f).resolveFrom(os.pwd)
-        os.isFile(p)
-      }
+      .filter(f => os.isFile(os.Path(f, os.pwd)))
       .toSet
 
     if (scalaCliPaths.size > 1)


### PR DESCRIPTION
When checking PATH, some of the entries there are relative.
According to os-lib documentation, Path will throw
exception if you try to use it to construct a relative
path. RelPath needs to be used in this case. This happens,
e.g. when the path starts with `~` which is not handled
by the previous filter in the code.

Co-authored with @mtk during 15th Issue Spree of 3rd May 2022.