### PR TITLE
Add alias to revolver mode

### DIFF
--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedWatchOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedWatchOptions.scala
@@ -8,11 +8,12 @@ final case class SharedWatchOptions(
   @HelpMessage("Watch source files for changes")
   @Name("w")
     watch: Boolean = false,
-  @HelpMessage("Run your application in background and automatically restart if sources have been changed") 
-    revolver: Boolean = false
+  @HelpMessage("Run your application in background and automatically restart if sources have been changed")
+  @Name("revolver") 
+    restart: Boolean = false
 ) { // format: on
 
-  lazy val watchMode = watch || revolver
+  lazy val watchMode = watch || restart
 }
 
 object SharedWatchOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -127,7 +127,7 @@ object Run extends ScalaCommand[RunOptions] {
               if (proc.isAlive) ProcUtil.forceKillProcess(proc, logger)
             val maybeProcess = maybeRun(s, allowTerminate = false)
               .orReport(logger)
-            if (options.watch.revolver)
+            if (options.watch.restart)
               processOpt = maybeProcess
             else
               for ((proc, onExit) <- maybeProcess)

--- a/website/docs/commands/run.md
+++ b/website/docs/commands/run.md
@@ -75,12 +75,12 @@ scala-cli run Hello.scala  --watch
 # Hello World
 # Watching sources, press Ctrl+C to exit.
 ```
-### Watch mode - revolver
+### Watch mode - restart
 
-`--revolver` mode runs your application in the background and automatically restart it upon any change:
+`--restart` mode runs your application in the background and automatically restart it upon any change:
 
 ```bash ignore
-scala-cli run Hello.scala --revolver
+scala-cli run Hello.scala --restart
 # Hello
 # Watching sources, press Ctrl+C to exit.
 # Compiling project (Scala 3.1.1, JVM)

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1392,7 +1392,9 @@ Aliases: `-w`
 
 Watch source files for changes
 
-#### `--revolver`
+#### `--restart`
+
+Aliases: `--revolver`
 
 Run your application in background and automatically restart if sources have been changed
 


### PR DESCRIPTION
Apply suggestion from [comment](https://github.com/VirtusLab/scala-cli/pull/747#issuecomment-1091592005) to make `revolver` more meaningful for user.