### PR TITLE
Allow forks to build their own launchers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
       run: ./mill -i nativeIntegrationTests
       env:
         COURSIER_JNI: force
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   native-mostly-static-tests:
     timeout-minutes: 120
@@ -116,6 +117,8 @@ jobs:
         retention-days: 2
     - name: Native integration tests
       run: ./mill -i integration.test.nativeMostlyStatic
+      env:
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Docker integration tests
       run: ./mill integration.docker-slim.test
     - name: Login to GitHub Container Registry
@@ -155,6 +158,8 @@ jobs:
         retention-days: 2
     - name: Native integration tests
       run: ./mill -i integration.test.nativeStatic
+      env:
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Docker integration tests
       run: ./mill integration.docker.test
     - name: Login to GitHub Container Registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
 
   publish:
     needs: [jvm-tests, format, checks, reference-doc]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository == 'VirtusLab/scala-cli'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -359,7 +359,7 @@ jobs:
     name: Update packages
     needs: launchers
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'VirtusLab/scala-cli'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/build.sc
+++ b/build.sc
@@ -787,6 +787,9 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
            |  def workspaceDirName = "$workspaceDirName"
            |  def libsodiumVersion = "${deps.libsodiumVersion}"
            |  def dockerArchLinuxImage = "${TestDeps.archLinuxImage}"
+           |
+           |  def ghOrg = "$ghOrg"
+           |  def ghName = "$ghName"
            |}
            |""".stripMargin
       if (!os.isFile(dest) || os.read(dest) != code)

--- a/build.sc
+++ b/build.sc
@@ -342,6 +342,8 @@ class Core(val crossScalaVersion: String) extends BuildLikeModule {
          |object Constants {
          |  def version = "${publishVersion()}"
          |  def detailedVersion: Option[String] = $detailedVersionValue
+         |  def ghOrg = "$ghOrg"
+         |  def ghName = "$ghName"
          |
          |  def scalaJsVersion = "${Scala.scalaJs}"
          |  def scalajsEnvJsdomNodejsVersion = "${Deps.scalaJsEnvJsdomNodejs.dep.version}"
@@ -1127,7 +1129,7 @@ object ci extends Module {
 
     val branch       = "main"
     val targetBranch = s"update-standalone-launcher-$version"
-    val repo         = s"https://oauth2:${ghToken()}@github.com/VirtusLab/scala-cli.git"
+    val repo         = s"https://oauth2:${ghToken()}@github.com/$ghOrg/$ghName.git"
 
     // Cloning
     gitClone(repo, branch, targetDir)

--- a/modules/cli-options/src/main/scala/scala/cli/commands/AboutOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/AboutOptions.scala
@@ -2,11 +2,16 @@ package scala.cli.commands
 
 import caseapp._
 
+import scala.cli.signing.shared.PasswordOption
+import scala.cli.signing.util.ArgParsers._
+
 // format: off
 @HelpMessage("Print details about this application")
 final case class AboutOptions(
   @Recurse
-    verbosity: VerbosityOptions = VerbosityOptions()
+    verbosity: VerbosityOptions = VerbosityOptions(),
+  @Hidden
+    ghToken: Option[PasswordOption] = None
 )
 // format: on
 

--- a/modules/cli-options/src/main/scala/scala/cli/commands/DoctorOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/DoctorOptions.scala
@@ -2,11 +2,16 @@ package scala.cli.commands
 
 import caseapp._
 
+import scala.cli.signing.shared.PasswordOption
+import scala.cli.signing.util.ArgParsers._
+
 // format: off
 @HelpMessage("Print details about this application")
 final case class DoctorOptions(
   @Recurse
-    verbosity: VerbosityOptions = VerbosityOptions()
+    verbosity: VerbosityOptions = VerbosityOptions(),
+  @Hidden
+    ghToken: Option[PasswordOption] = None
 )
 // format: on
 

--- a/modules/cli-options/src/main/scala/scala/cli/commands/UpdateOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/UpdateOptions.scala
@@ -2,6 +2,9 @@ package scala.cli.commands
 
 import caseapp._
 
+import scala.cli.signing.shared.PasswordOption
+import scala.cli.signing.util.ArgParsers._
+
 // format: off
 @HelpMessage("Update scala-cli - it works only for installation script")
 final case class UpdateOptions(
@@ -20,6 +23,8 @@ final case class UpdateOptions(
     force: Boolean = false,
   @Hidden
     isInternalRun: Boolean = false,
+  @Hidden
+    ghToken: Option[PasswordOption] = None
 )
 // format: on
 

--- a/modules/cli/src/main/scala/scala/cli/commands/About.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/About.scala
@@ -17,7 +17,7 @@ class About(isSipScala: Boolean) extends ScalaCommand[AboutOptions] {
       if (isSipScala) "Scala command"
       else "Scala CLI"
     println(s"$appName version $version" + detailedVersionOpt.fold("")(" (" + _ + ")"))
-    val newestScalaCliVersion = Update.newestScalaCliVersion
+    val newestScalaCliVersion = Update.newestScalaCliVersion(options.ghToken.map(_.get()))
     val isOutdated = CommandUtils.isOutOfDateVersion(
       newestScalaCliVersion,
       Constants.version

--- a/modules/cli/src/main/scala/scala/cli/commands/About.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/About.scala
@@ -6,7 +6,9 @@ import scala.build.internal.Constants
 import scala.cli.CurrentParams
 
 class About(isSipScala: Boolean) extends ScalaCommand[AboutOptions] {
+
   override def group = "Miscellaneous"
+
   def run(options: AboutOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.verbosity.verbosity
     val version            = Constants.version
@@ -15,6 +17,15 @@ class About(isSipScala: Boolean) extends ScalaCommand[AboutOptions] {
       if (isSipScala) "Scala command"
       else "Scala CLI"
     println(s"$appName version $version" + detailedVersionOpt.fold("")(" (" + _ + ")"))
-    if (Version.isOutdated(None)) println(Update.updateInstructions)
+    val newestScalaCliVersion = Update.newestScalaCliVersion
+    val isOutdated = CommandUtils.isOutOfDateVersion(
+      newestScalaCliVersion,
+      Constants.version
+    )
+    if (isOutdated)
+      println(
+        s"""Your Scala CLI version is outdated. The newest version is $newestScalaCliVersion
+           |It is recommended that you update Scala CLI through the same tool or method you used for its initial installation for avoiding the creation of outdated duplicates.""".stripMargin
+      )
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/Doctor.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Doctor.scala
@@ -3,6 +3,7 @@ package scala.cli.commands
 import caseapp.core.RemainingArgs
 
 import scala.build.internal.Constants
+import scala.cli.signing.shared.Secret
 
 // current version / latest version + potentially information that
 // scala-cli should be updated (and that should take SNAPSHOT version
@@ -27,7 +28,7 @@ object Doctor extends ScalaCommand[DoctorOptions] {
   override def group = "Doctor"
 
   def run(options: DoctorOptions, args: RemainingArgs): Unit = {
-    checkIsVersionOutdated()
+    checkIsVersionOutdated(options.ghToken.map(_.get()))
     checkBloopStatus()
     checkDuplicatesOnPath()
     checkNativeDependencies()
@@ -39,12 +40,13 @@ object Doctor extends ScalaCommand[DoctorOptions] {
     println("") // sometimes last line is cut off
   }
 
-  private def checkIsVersionOutdated(): Unit = {
-    val currentVersion = Constants.version
-    val isOutdated = CommandUtils.isOutOfDateVersion(Update.newestScalaCliVersion, currentVersion)
+  private def checkIsVersionOutdated(ghToken: Option[Secret[String]]): Unit = {
+    val currentVersion        = Constants.version
+    val newestScalaCliVersion = Update.newestScalaCliVersion(ghToken)
+    val isOutdated = CommandUtils.isOutOfDateVersion(newestScalaCliVersion, currentVersion)
     if (isOutdated)
       println(
-        s"Your scala-cli version is out of date. your version: $currentVersion. please update to: ${Update.newestScalaCliVersion}"
+        s"Your scala-cli version is out of date. your version: $currentVersion. please update to: $newestScalaCliVersion"
       )
     else
       println(s"Your scala-cli version ($currentVersion) is current.")

--- a/modules/cli/src/main/scala/scala/cli/commands/Update.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Update.scala
@@ -1,25 +1,53 @@
 package scala.cli.commands
 
 import caseapp._
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import com.github.plokhotnyuk.jsoniter_scala.macros._
 
 import scala.build.Logger
-import scala.build.internal.Constants.{ghName, ghOrg}
+import scala.build.internal.Constants.{ghName, ghOrg, version => scalaCliVersion}
 import scala.cli.CurrentParams
-import scala.cli.commands.Version.getCurrentVersion
 import scala.cli.internal.ProcUtil
 import scala.io.StdIn.readLine
+import scala.util.control.NonFatal
 import scala.util.{Failure, Properties, Success, Try}
 
 object Update extends ScalaCommand[UpdateOptions] {
 
-  lazy val newestScalaCliVersion = {
-    val resp = ProcUtil.downloadFile(s"https://github.com/$ghOrg/$ghName/releases/latest")
+  private final case class Release(
+    draft: Boolean,
+    prerelease: Boolean,
+    tag_name: String
+  ) {
+    lazy val version =
+      coursier.core.Version(tag_name.stripPrefix("v"))
+    def actualRelease: Boolean =
+      !draft && !prerelease
+  }
 
-    val scalaCliVersionRegex = "tag/v(.*?)\"".r
-    scalaCliVersionRegex.findFirstMatchIn(resp).map(_.group(1))
-  }.getOrElse(
-    sys.error("Can not resolve Scala CLI version to update")
-  )
+  private lazy val releaseListCodec: JsonValueCodec[List[Release]] = JsonCodecMaker.make
+
+  lazy val newestScalaCliVersion = {
+
+    // FIXME Do we need paging here?
+    val url  = s"https://api.github.com/repos/$ghOrg/$ghName/releases"
+    val resp = ProcUtil.download(url, "Accept" -> "application/vnd.github.v3+json")
+
+    val releases =
+      try readFromArray(resp)(releaseListCodec)
+      catch {
+        case e: JsonReaderException =>
+          throw new Exception(s"Error reading $url", e)
+      }
+
+    releases
+      .filter(_.actualRelease)
+      .maxByOption(_.version)
+      .map(_.version.repr)
+      .getOrElse {
+        sys.error(s"No Scala CLI versions found in $url")
+      }
+  }
 
   def installDirPath(options: UpdateOptions): os.Path =
     options.binDir.map(os.Path(_, os.pwd)).getOrElse(
@@ -66,13 +94,15 @@ object Update extends ScalaCommand[UpdateOptions] {
     }
   }
 
-  lazy val updateInstructions: String =
-    s"""Your Scala CLI version is outdated. The newest version is $newestScalaCliVersion
-       |It is recommended that you update Scala CLI through the same tool or method you used for its initial installation for avoiding the creation of outdated duplicates.""".stripMargin
+  private def getCurrentVersion(scalaCliBinPath: os.Path): String = {
+    val res = os.proc(scalaCliBinPath, "version").call(cwd = os.pwd, check = false)
+    if (res.exitCode == 0)
+      res.out.text().trim
+    else
+      "0.0.0"
+  }
 
-  def update(options: UpdateOptions, maybeScalaCliBinPath: Option[os.Path]): Unit = {
-
-    val currentVersion = getCurrentVersion(maybeScalaCliBinPath)
+  private def update(options: UpdateOptions, currentVersion: String): Unit = {
 
     val isOutdated = CommandUtils.isOutOfDateVersion(newestScalaCliVersion, currentVersion)
 
@@ -114,9 +144,9 @@ object Update extends ScalaCommand[UpdateOptions] {
         sys.exit(1)
       }
     }
-    else if (options.binaryName == "scala-cli") update(options, None)
+    else if (options.binaryName == "scala-cli") update(options, scalaCliVersion)
     else
-      update(options, Some(scalaCliBinPath))
+      update(options, getCurrentVersion(scalaCliBinPath))
   }
 
   def run(options: UpdateOptions, args: RemainingArgs): Unit = {
@@ -124,18 +154,17 @@ object Update extends ScalaCommand[UpdateOptions] {
     checkUpdate(options)
   }
 
-  def checkUpdateSafe(logger: Logger): Unit = {
-    Try {
+  def checkUpdateSafe(logger: Logger): Unit =
+    try {
       val classesDir =
-        this.getClass.getProtectionDomain.getCodeSource.getLocation.toURI.toString
+        getClass.getProtectionDomain.getCodeSource.getLocation.toURI.toString
       val binRepoDir = build.Directories.default().binRepoDir.toString()
       // log about update only if scala-cli was installed from installation script
       if (classesDir.contains(binRepoDir))
         checkUpdate(UpdateOptions(isInternalRun = true))
-    } match {
-      case Failure(ex) =>
-        logger.debug(s"Ignoring error during checking update: $ex")
-      case Success(_) => ()
     }
-  }
+    catch {
+      case NonFatal(ex) =>
+        logger.debug(s"Ignoring error during checking update: $ex")
+    }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/Update.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Update.scala
@@ -3,6 +3,7 @@ package scala.cli.commands
 import caseapp._
 
 import scala.build.Logger
+import scala.build.internal.Constants.{ghName, ghOrg}
 import scala.cli.CurrentParams
 import scala.cli.commands.Version.getCurrentVersion
 import scala.cli.internal.ProcUtil
@@ -12,7 +13,7 @@ import scala.util.{Failure, Properties, Success, Try}
 object Update extends ScalaCommand[UpdateOptions] {
 
   lazy val newestScalaCliVersion = {
-    val resp = ProcUtil.downloadFile("https://github.com/VirtusLab/scala-cli/releases/latest")
+    val resp = ProcUtil.downloadFile(s"https://github.com/$ghOrg/$ghName/releases/latest")
 
     val scalaCliVersionRegex = "tag/v(.*?)\"".r
     scalaCliVersionRegex.findFirstMatchIn(resp).map(_.group(1))

--- a/modules/cli/src/main/scala/scala/cli/commands/Version.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Version.scala
@@ -2,41 +2,13 @@ package scala.cli.commands
 
 import caseapp._
 
-import scala.build.internal.Constants.{ghName, ghOrg, version => scalaCliVersion}
+import scala.build.internal.Constants
 import scala.cli.CurrentParams
-import scala.cli.internal.ProcUtil
 
 object Version extends ScalaCommand[VersionOptions] {
   override def group = "Miscellaneous"
   def run(options: VersionOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.verbosity.verbosity
-    println(scalaCliVersion)
+    println(Constants.version)
   }
-
-  lazy val newestScalaCliVersion = {
-    val scalaCliVersionRegex = "tag/v(.*?)\"".r
-
-    val resp = ProcUtil.downloadFile(s"https://github.com/$ghOrg/$ghName/releases/latest")
-
-    scalaCliVersionRegex.findFirstMatchIn(resp).map(_.group(1))
-  }.getOrElse(
-    sys.error("Can not resolve Scala CLI version to update")
-  )
-
-  def isOutdated(maybeScalaCliBinPath: Option[os.Path]): Boolean =
-    CommandUtils.isOutOfDateVersion(newestScalaCliVersion, getCurrentVersion(maybeScalaCliBinPath))
-
-  def getCurrentVersion(maybeScalaCliBinPath: Option[os.Path]): String = {
-    val maybeCurrentVersion = maybeScalaCliBinPath.map {
-      scalaCliBinPath =>
-        val res = os.proc(scalaCliBinPath, "version").call(cwd = os.pwd, check = false)
-        if (res.exitCode == 0)
-          res.out.text().trim
-        else
-          "0.0.0"
-    }
-    maybeCurrentVersion.getOrElse(scalaCliVersion)
-
-  }
-
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/Version.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Version.scala
@@ -2,7 +2,7 @@ package scala.cli.commands
 
 import caseapp._
 
-import scala.build.internal.Constants
+import scala.build.internal.Constants.{ghName, ghOrg, version => scalaCliVersion}
 import scala.cli.CurrentParams
 import scala.cli.internal.ProcUtil
 
@@ -10,13 +10,13 @@ object Version extends ScalaCommand[VersionOptions] {
   override def group = "Miscellaneous"
   def run(options: VersionOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.verbosity.verbosity
-    println(Constants.version)
+    println(scalaCliVersion)
   }
 
   lazy val newestScalaCliVersion = {
     val scalaCliVersionRegex = "tag/v(.*?)\"".r
 
-    val resp = ProcUtil.downloadFile("https://github.com/VirtusLab/scala-cli/releases/latest")
+    val resp = ProcUtil.downloadFile(s"https://github.com/$ghOrg/$ghName/releases/latest")
 
     scalaCliVersionRegex.findFirstMatchIn(resp).map(_.group(1))
   }.getOrElse(
@@ -35,7 +35,7 @@ object Version extends ScalaCommand[VersionOptions] {
         else
           "0.0.0"
     }
-    maybeCurrentVersion.getOrElse(Constants.version)
+    maybeCurrentVersion.getOrElse(scalaCliVersion)
 
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/UpdateTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/UpdateTests.scala
@@ -100,7 +100,7 @@ class UpdateTests extends munit.FunSuite {
     }
   }
 
-  if (!Properties.isWin)
+  if (!Properties.isWin && Constants.ghOrg == "VirtusLab" && Constants.ghName == "scala-cli")
     test("updating dummy scala-cli using update command") {
       runUpdate()
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/UpdateTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/UpdateTests.scala
@@ -75,6 +75,9 @@ class UpdateTests extends munit.FunSuite {
       ).out.text().trim
       expect(v1Install == firstVersion)
 
+      val tokenOptions =
+        if (System.getenv("UPDATE_GH_TOKEN") == null) Nil
+        else Seq("--gh-token", "env:UPDATE_GH_TOKEN")
       // update to newest version
       // format: off
       val cmdUpdate = Seq[os.Shellable](
@@ -82,7 +85,8 @@ class UpdateTests extends munit.FunSuite {
         "update",
         "--binary-name", dummyScalaCliBinName,
         "--bin-dir", binDirPath,
-        "--force"
+        "--force",
+        tokenOptions
       )
       // format: on
       os.proc(cmdUpdate).call(

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -5,6 +5,16 @@ sidebar_position: 1
 
 This is a summary of options that are available for each subcommand of the `scala-cli` command.
 
+## About options
+
+Available in commands:
+- [`about`](./commands.md#about)
+
+
+<!-- Automatically generated, DO NOT EDIT MANUALLY -->
+
+#### `--gh-token`
+
 ## Add path options
 
 Available in commands:
@@ -345,6 +355,16 @@ Overwrite the destination directory, if it exists
 Aliases: `--default-scaladoc-opts`
 
 Use default scaladoc options
+
+## Doctor options
+
+Available in commands:
+- [`doctor`](./commands.md#doctor)
+
+
+<!-- Automatically generated, DO NOT EDIT MANUALLY -->
+
+#### `--gh-token`
 
 ## Export options
 
@@ -1427,6 +1447,8 @@ Aliases: `-f`
 Force update scala-cli if is outdated
 
 #### `--is-internal-run`
+
+#### `--gh-token`
 
 ## Verbosity options
 

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -8,6 +8,7 @@ sidebar_position: 3
 Print details about this application
 
 Accepts options:
+- [about](./cli-options.md#about-options)
 - [verbosity](./cli-options.md#verbosity-options)
 
 ## `clean`
@@ -68,6 +69,7 @@ Accepts options:
 Print details about this application
 
 Accepts options:
+- [doctor](./cli-options.md#doctor-options)
 - [verbosity](./cli-options.md#verbosity-options)
 
 ## `export`


### PR DESCRIPTION
This allows forks (like [mine](https://github.com/alexarchambault/scala-cli)) to build launchers and push them to a GitHub release named `nightly` of their own (like [here](https://github.com/alexarchambault/scala-cli/releases/tag/nightly)). This works automatically by having the fork just enable GitHub actions for the `main` branch, if they create a release with a tag named `nightly` (the actual commit of this release is unused and doesn't matter).

I'm planning to use this to automatically build launchers of https://github.com/VirtusLab/scala-cli/pull/926 until it's merged, but also for ongoing / upcoming developments on top of this. Having these launchers there allows to use them straightaway on other projects' CI, to test newer `publish` command features before they're merged here.