### PR TITLE
Suggest zip issue workaround when apparently running into it

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -107,6 +107,16 @@ object ScalaCli {
                  |  $progName bloop output
                  |might give more details.""".stripMargin
             )
+          case ex: java.util.zip.ZipException
+              if !Properties.isWin && ex.getMessage.contains("invalid entry CRC") =>
+            // Suggest workaround of https://github.com/VirtusLab/scala-cli/pull/865
+            // for https://github.com/VirtusLab/scala-cli/issues/828
+            System.err.println(
+              """Running
+                |  export SCALA_CLI_VENDORED_ZIS=true
+                |before running Scala CLI might fix the issue.
+                |""".stripMargin
+            )
           case _ =>
         }
 


### PR DESCRIPTION
Follow-up of https://github.com/VirtusLab/scala-cli/pull/865. This suggests users to set the right environment variable to disable checking zip CRC32 checksums.