### PR TITLE
Tweak build (cli2) and scala-cli.sh script

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -44,6 +44,7 @@ object cli extends Cli3 {
 
 // remove once we do not have blockers with Scala 3
 object cli2 extends Cli {
+  def myScalaVersion = Scala.scala213
   def sources = T.sources {
     super.sources() ++ cli.sources()
   }
@@ -619,7 +620,7 @@ trait Cli extends SbtModule with ProtoBuildModule with CliLaunchers
   }
   def generatedSources = super.generatedSources() ++ Seq(constantsFile())
 
-  def myScalaVersion = Scala.defaultInternal
+  def myScalaVersion: String
 
   def scalaVersion = T(myScalaVersion)
 
@@ -668,7 +669,7 @@ trait Cli extends SbtModule with ProtoBuildModule with CliLaunchers
 }
 
 trait Cli3 extends Cli {
-  override def myScalaVersion = Scala.scala3
+  def myScalaVersion = Scala.scala3
 
   override def nativeImageClassPath = T {
     val classpath = super.nativeImageClassPath().map(_.path).mkString(File.pathSeparator)

--- a/build.sc
+++ b/build.sc
@@ -188,7 +188,8 @@ class BuildMacros(val crossScalaVersion: String) extends ScalaCliCrossSbtModule
     with ScalaCliScalafixModule
     with HasTests {
   def scalacOptions = T {
-    super.scalacOptions() ++ Seq("-Ywarn-unused")
+    super.scalacOptions() ++
+      (if (scalaVersion().startsWith("2.")) Seq("-Ywarn-unused") else Nil)
   }
   def compileIvyDeps = T {
     if (scalaVersion().startsWith("3"))
@@ -275,7 +276,9 @@ trait ProtoBuildModule extends ScalaCliPublishModule with HasTests
 trait BuildLikeModule extends ScalaCliCrossSbtModule with ProtoBuildModule {
 
   def scalacOptions = T {
-    super.scalacOptions() ++ Seq("-Ywarn-unused", "-deprecation")
+    super.scalacOptions() ++
+      (if (scalaVersion().startsWith("2.")) Seq("-Ywarn-unused") else Nil) ++
+      Seq("-deprecation")
   }
 
   def repositories = super.repositories ++ customRepositories
@@ -621,7 +624,8 @@ trait Cli extends SbtModule with ProtoBuildModule with CliLaunchers
   def scalaVersion = T(myScalaVersion)
 
   def scalacOptions = T {
-    super.scalacOptions() ++ asyncScalacOptions(scalaVersion()) ++ Seq("-Ywarn-unused")
+    super.scalacOptions() ++ asyncScalacOptions(scalaVersion()) ++
+      (if (scalaVersion().startsWith("2.")) Seq("-Ywarn-unused") else Nil)
   }
   def javacOptions = T {
     super.javacOptions() ++ Seq("--release", "16")
@@ -907,7 +911,9 @@ class BloopRifle(val crossScalaVersion: String) extends ScalaCliCrossSbtModule
     with HasTests
     with ScalaCliScalafixModule {
   def scalacOptions = T {
-    super.scalacOptions() ++ Seq("-Ywarn-unused", "-deprecation")
+    super.scalacOptions() ++
+      (if (scalaVersion().startsWith("2.")) Seq("-Ywarn-unused") else Nil) ++
+      Seq("-deprecation")
   }
   def ivyDeps = super.ivyDeps() ++ Agg(
     Deps.bsp4j,

--- a/build.sc
+++ b/build.sc
@@ -34,7 +34,8 @@ import _root_.scala.util.Properties
 implicit def millModuleBasePath: define.BasePath =
   define.BasePath(super.millModuleBasePath.value / "modules")
 
-object cli extends Cli3 {
+object cli extends Cli3 with Bloop.Module {
+  def skipBloop = true
   object test extends Tests {
     def moduleDeps = super.moduleDeps ++ Seq(
       `build-module`(myScalaVersion).test

--- a/modules/cli/src/main/scala/scala/cli/commands/Doc.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Doc.scala
@@ -4,6 +4,7 @@ import caseapp._
 import dependency._
 
 import java.io.File
+
 import scala.build.EitherCps.{either, value}
 import scala.build._
 import scala.build.compiler.{ScalaCompilerMaker, SimpleScalaCompilerMaker}

--- a/modules/cli/src/main/scala/scala/cli/commands/Metabrowse.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Metabrowse.scala
@@ -3,7 +3,6 @@ package scala.cli.commands
 import caseapp._
 
 import java.io.File
-import java.nio.file.Path
 
 import scala.build.internal.{Constants, FetchExternalBinary, Runner}
 import scala.build.{Build, BuildThreads, Logger}

--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -2,7 +2,6 @@ package scala.cli.commands
 
 import caseapp._
 import coursier.launcher._
-import dependency._
 import packager.config._
 import packager.deb.DebianPackage
 import packager.docker.DockerPackage
@@ -11,7 +10,7 @@ import packager.mac.pkg.PkgPackage
 import packager.rpm.RedHatPackage
 import packager.windows.WindowsPackage
 
-import java.io.{ByteArrayOutputStream, File, OutputStream}
+import java.io.{ByteArrayOutputStream, OutputStream}
 import java.nio.charset.StandardCharsets
 import java.nio.file.attribute.FileTime
 import java.util.zip.{ZipEntry, ZipOutputStream}
@@ -161,7 +160,7 @@ object Package extends ScalaCommand[PackageOptions] {
             for (basePackageType <- basePackageTypeOpt)
               yield
                 if (validPackageScalaNative.contains(basePackageType)) Right(basePackageType)
-                else Left(MalformedCliInputError(
+                else Left(new MalformedCliInputError(
                   s"Unsuported package type: $basePackageType for Scala Native."
                 ))
           validatedPackageType.getOrElse(Right(PackageType.Native))

--- a/modules/cli/src/main/scala/scala/cli/commands/Update.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Update.scala
@@ -10,8 +10,8 @@ import scala.cli.CurrentParams
 import scala.cli.internal.ProcUtil
 import scala.cli.signing.shared.Secret
 import scala.io.StdIn.readLine
+import scala.util.Properties
 import scala.util.control.NonFatal
-import scala.util.{Failure, Properties, Success, Try}
 
 object Update extends ScalaCommand[UpdateOptions] {
 

--- a/modules/cli/src/main/scala/scala/cli/commands/github/LibSodiumJni.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/LibSodiumJni.scala
@@ -10,7 +10,7 @@ import java.nio.charset.StandardCharsets
 import scala.build.EitherCps.{either, value}
 import scala.build.Logger
 import scala.build.errors.BuildException
-import scala.build.internal.{Constants, FetchExternalBinary, OsLibc}
+import scala.build.internal.{Constants, FetchExternalBinary}
 import scala.cli.internal.{Constants => CliConstants}
 import scala.util.Properties
 import scala.util.control.NonFatal

--- a/modules/cli/src/main/scala/scala/cli/internal/ProcUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/ProcUtil.scala
@@ -1,6 +1,5 @@
 package scala.cli.internal
 
-import java.io.InputStream
 import java.net.{HttpURLConnection, URL, URLConnection}
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.{CancellationException, CompletableFuture, CompletionException}

--- a/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
@@ -13,7 +13,6 @@ import scala.build.{Artifacts, Os, Positioned}
 import scala.cli.commands.util.CommonOps._
 import scala.cli.commands.{CoursierOptions, LoggingOptions}
 import scala.concurrent.duration._
-import scala.util.Properties
 import scala.util.control.NonFatal
 
 object LauncherCli {

--- a/modules/cli/src/main/scala/scala/cli/packaging/Library.scala
+++ b/modules/cli/src/main/scala/scala/cli/packaging/Library.scala
@@ -2,7 +2,6 @@ package scala.cli.packaging
 
 import java.io.{ByteArrayOutputStream, OutputStream}
 import java.nio.file.attribute.FileTime
-import java.nio.file.{Files, Path}
 import java.util.jar.{Attributes => JarAttributes, JarOutputStream}
 import java.util.zip.{ZipEntry, ZipOutputStream}
 

--- a/modules/cli/src/test/scala/cli/tests/CachedBinaryTests.scala
+++ b/modules/cli/src/test/scala/cli/tests/CachedBinaryTests.scala
@@ -45,7 +45,7 @@ class CachedBinaryTests extends munit.FunSuite {
     test(s"should build native app at first time ($additionalMessage)") {
 
       inputs.withLoadedBuild(defaultOptions, buildThreads, Some(bloopConfig), fromDirectory) {
-        (root, _, maybeBuild) =>
+        (_, _, maybeBuild) =>
           val build = maybeBuild.successfulOpt.get
 
           val config        = build.options.scalaNativeOptions.configCliOptions()
@@ -62,7 +62,7 @@ class CachedBinaryTests extends munit.FunSuite {
 
     test(s"should not rebuild the second time ($additionalMessage)") {
       inputs.withLoadedBuild(defaultOptions, buildThreads, Some(bloopConfig), fromDirectory) {
-        (root, _, maybeBuild) =>
+        (_, _, maybeBuild) =>
           val build = maybeBuild.successfulOpt.get
 
           val config        = build.options.scalaNativeOptions.configCliOptions()
@@ -88,7 +88,7 @@ class CachedBinaryTests extends munit.FunSuite {
 
     test(s"should build native if output file was deleted ($additionalMessage)") {
       inputs.withLoadedBuild(defaultOptions, buildThreads, Some(bloopConfig), fromDirectory) {
-        (root, _, maybeBuild) =>
+        (_, _, maybeBuild) =>
           val build = maybeBuild.successfulOpt.get
 
           val config        = build.options.scalaNativeOptions.configCliOptions()
@@ -115,7 +115,7 @@ class CachedBinaryTests extends munit.FunSuite {
 
     test(s"should build native if output file was changed ($additionalMessage)") {
       inputs.withLoadedBuild(defaultOptions, buildThreads, Some(bloopConfig), fromDirectory) {
-        (root, _, maybeBuild) =>
+        (_, _, maybeBuild) =>
           val build = maybeBuild.successfulOpt.get
 
           val config        = build.options.scalaNativeOptions.configCliOptions()
@@ -168,7 +168,7 @@ class CachedBinaryTests extends munit.FunSuite {
 
     test(s"should build native if native config was changed ($additionalMessage)") {
       inputs.withLoadedBuild(defaultOptions, buildThreads, Some(bloopConfig), fromDirectory) {
-        (root, _, maybeBuild) =>
+        (_, _, maybeBuild) =>
           val build = maybeBuild.successfulOpt.get
 
           val config        = build.options.scalaNativeOptions.configCliOptions()

--- a/modules/cli/src/test/scala/cli/tests/LauncherCliTest.scala
+++ b/modules/cli/src/test/scala/cli/tests/LauncherCliTest.scala
@@ -7,7 +7,6 @@ import scala.build.tests.TestLogger
 import scala.cli.commands.CoursierOptions
 import scala.cli.commands.util.CommonOps._
 import scala.cli.launcher.LauncherCli
-import scala.util.Properties
 
 class LauncherCliTest extends munit.FunSuite {
 

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -662,8 +662,10 @@ trait HasMacroAnnotations extends ScalaModule {
   def scalacOptions = T {
     val sv = scalaVersion()
     val extra =
-      if (sv.startsWith("2.") && !sv.startsWith("2.13.")) Nil
-      else Seq("-Ymacro-annotations")
+      if (sv.startsWith("2."))
+        if (sv.startsWith("2.13.")) Seq("-Ymacro-annotations")
+        else Nil
+      else Nil
     super.scalacOptions() ++ extra
   }
   def scalacPluginIvyDeps = T {

--- a/scala-cli.sh
+++ b/scala-cli.sh
@@ -9,14 +9,23 @@ set -eu
 
 SCALA_CLI_VERSION="0.1.5"
 
+GH_ORG="VirtusLab"
+GH_NAME="scala-cli"
+
+if [ "$SCALA_CLI_VERSION" == "nightly" ]; then
+  TAG="nightly"
+else
+  TAG="v$SCALA_CLI_VERSION"
+fi
+
 if [ "$(expr substr $(uname -s) 1 5 2>/dev/null)" == "Linux" ]; then
-  SCALA_CLI_URL="https://github.com/VirtusLab/scala-cli/releases/download/v$SCALA_CLI_VERSION/scala-cli-x86_64-pc-linux.gz"
+  SCALA_CLI_URL="https://github.com/$GH_ORG/$GH_NAME/releases/download/$TAG/scala-cli-x86_64-pc-linux.gz"
   CACHE_BASE="$HOME/.cache/coursier/v1"
 elif [ "$(uname)" == "Darwin" ]; then
-  SCALA_CLI_URL="https://github.com/VirtusLab/scala-cli/releases/download/v$SCALA_CLI_VERSION/scala-cli-x86_64-apple-darwin.gz"
+  SCALA_CLI_URL="https://github.com/$GH_ORG/$GH_NAME/releases/download/$TAG/scala-cli-x86_64-apple-darwin.gz"
   CACHE_BASE="$HOME/Library/Caches/Coursier/v1"
 else
-   echo "This standalone scala-cli launcher is supported only in Linux and Darwin OS. If you are using Windows, please use the dedicated launcher scala-cli.bat"
+   echo "This standalone scala-cli launcher is supported only in Linux and macOS. If you are using Windows, please use the dedicated launcher scala-cli.bat"
    exit 1
 fi
 


### PR DESCRIPTION
First commit is kind of a follow-up of https://github.com/VirtusLab/scala-cli/pull/999.

Second commit restricts the Scala versions that we pass some options to.

The third commit makes `cli2` actually use Scala 2 (and fixes its compilation and scalafix checks).

The last commit disables `cli` in Bloop / Metals, as we already have `cli2` there (that provides unused stuff diagnostics, and for which the organize imports command in Metals works).