### PR TITLE
Update scala-cli-setup after release

### DIFF
--- a/.github/release/release-procedure.md
+++ b/.github/release/release-procedure.md
@@ -12,6 +12,10 @@
 - [ ] Update the supported scala versions for the new release in the docs:
   - [ ] Scala: [scala-cli-scala-versions.md](https://github.com/VirtusLab/scala-cli/blob/main/website/docs/reference/scala-versions.md)
   - [ ] Scala.js: [scala-js.md](https://github.com/VirtusLab/scala-cli/blob/main/website/docs/guides/scala-js.md#supported-scalajs-versions)
+- [ ] ScalaCLI Setup
+   - [ ] Merge pull request with updated ScalaCLI version in [scala-cli-setup](https://github.com/VirtusLab/scala-cli-setup) repository. Pull request should be opened automatically after release.
+   - [ ] Make a release with the updated ScalaCLI version.
+   - [ ] Update v0.1 tag to the newest tag.
 - [ ] Mark the release draft as `pre-release` and then `Publish Release`
 - [ ] Wait for a green release CI build with all the updated versions.
 - [ ] Unmark release as `pre-release`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,3 +411,4 @@ jobs:
         env:
           SDKMAN_KEY: ${{ secrets.SDKMAN_KEY }}
           SDKMAN_TOKEN: ${{ secrets.SDKMAN_TOKEN }}
+      - run: ./mill -i ci.updateScalaCliSetup


### PR DESCRIPTION
- it runs mill task which updates ScalaCLI version and pushes changes to `scala-cli-update` branch in `scala-cli-setup` repository 
-  in react of push commit to `scala-cli-setup` branch it automatically triggers CI which create pull request to `main` branch - https://github.com/VirtusLab/scala-cli-setup/pull/18