### PR TITLE
Use closest previous version when looking for stable Scala versions

### DIFF
--- a/.github/release/release-procedure.md
+++ b/.github/release/release-procedure.md
@@ -8,7 +8,6 @@
   ```bash
   git shortlog -sn --no-merges {old-release-tag}...{new-release-tag}
   ```
-- [ ] Create a pull request with supported scala-versions for the new release to this repository: [Virtuslab/scala-cli-scala-versions ](https://github.com/Virtuslab/scala-cli-scala-versions)
 - [ ] ScalaCLI Setup
    - [ ] Merge pull request with updated ScalaCLI version in [scala-cli-setup](https://github.com/VirtusLab/scala-cli-setup) repository. Pull request should be opened automatically after release.
    - [ ] Make a release with the updated ScalaCLI version.

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -277,12 +277,24 @@ class BuildOptionsTests extends munit.FunSuite {
     Some("2.13.2") -> "2.13.2"
   )
 
-  val confFile = s"""[
-                    | {
-                    |  "scalaCliVersion": "$version",
-                    |  "supportedScalaVersions": ["3.0.1", "2.13.4", "2.12.13"]
-                    | }
-                    |]""".stripMargin
+  val testVersion     = "1.11.3"
+  val testPrevVersion = "1.11.1"
+  val testNextVersion = "1.11.5"
+  val confFile =
+    s"""[
+       | {
+       |  "scalaCliVersion": "$testPrevVersion",
+       |  "supportedScalaVersions": ["3.0.0", "2.13.3", "2.12.11"]
+       | },
+       | {
+       |  "scalaCliVersion": "$testVersion",
+       |  "supportedScalaVersions": ["3.0.1", "2.13.4", "2.12.13"]
+       | },
+       | {
+       |  "scalaCliVersion": "$testNextVersion",
+       |  "supportedScalaVersions": ["3.1.0", "2.13.8", "2.12.15]"]
+       | }
+       |]""".stripMargin
 
   for ((prefix, expectedScalaVersion) <- expectedScalaConfVersions)
     test(s"use expected scala version from conf file, prefix: ${prefix.getOrElse("empty")}") {
@@ -298,7 +310,7 @@ class BuildOptionsTests extends munit.FunSuite {
           )
         )
 
-        val scalaParams         = options.scalaParams.orThrow.getOrElse(???)
+        val scalaParams         = options.computeScalaParams(testVersion).orThrow.getOrElse(???)
         val expectedScalaParams = ScalaParameters(expectedScalaVersion)
 
         expect(scalaParams == expectedScalaParams)

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -38,9 +38,7 @@ class BuildOptionsTests extends munit.FunSuite {
   test("-S 3.nightly option works") {
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
-        scalaVersion = Some(MaybeScalaVersion("3.nightly")),
-        scalaBinaryVersion = None,
-        supportedScalaVersionsUrl = None
+        scalaVersion = Some(MaybeScalaVersion("3.nightly"))
       )
     )
     val scalaParams = options.scalaParams.orThrow.getOrElse(???)
@@ -66,9 +64,7 @@ class BuildOptionsTests extends munit.FunSuite {
 
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
-        scalaVersion = Some(MaybeScalaVersion(s"3.${Int.MaxValue}")),
-        scalaBinaryVersion = None,
-        supportedScalaVersionsUrl = None
+        scalaVersion = Some(MaybeScalaVersion(s"3.${Int.MaxValue}"))
       )
     )
     assert(
@@ -83,9 +79,7 @@ class BuildOptionsTests extends munit.FunSuite {
 
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
-        scalaVersion = Some(MaybeScalaVersion("2.11.2")),
-        scalaBinaryVersion = None,
-        supportedScalaVersionsUrl = None
+        scalaVersion = Some(MaybeScalaVersion("2.11.2"))
       )
     )
     assert(
@@ -100,9 +94,7 @@ class BuildOptionsTests extends munit.FunSuite {
 
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
-        scalaVersion = Some(MaybeScalaVersion("2.11")),
-        scalaBinaryVersion = None,
-        supportedScalaVersionsUrl = None
+        scalaVersion = Some(MaybeScalaVersion("2.11"))
       )
     )
     assert(
@@ -117,9 +109,7 @@ class BuildOptionsTests extends munit.FunSuite {
 
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
-        scalaVersion = Some(MaybeScalaVersion(s"3.${Int.MaxValue}.3")),
-        scalaBinaryVersion = None,
-        supportedScalaVersionsUrl = None
+        scalaVersion = Some(MaybeScalaVersion(s"3.${Int.MaxValue}.3"))
       )
     )
     assert(
@@ -134,9 +124,7 @@ class BuildOptionsTests extends munit.FunSuite {
 
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
-        scalaVersion = Some(MaybeScalaVersion("3.1.3-RC1-bin-20220213-fd97eee-NIGHTLY")),
-        scalaBinaryVersion = None,
-        supportedScalaVersionsUrl = None
+        scalaVersion = Some(MaybeScalaVersion("3.1.3-RC1-bin-20220213-fd97eee-NIGHTLY"))
       )
     )
     assert(
@@ -180,9 +168,7 @@ class BuildOptionsTests extends munit.FunSuite {
 
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
-        scalaVersion = Some(MaybeScalaVersion(s"2.${Int.MaxValue}")),
-        scalaBinaryVersion = None,
-        supportedScalaVersionsUrl = None
+        scalaVersion = Some(MaybeScalaVersion(s"2.${Int.MaxValue}"))
       )
     )
     assert(
@@ -196,9 +182,7 @@ class BuildOptionsTests extends munit.FunSuite {
   test("-S 2.nightly option works") {
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
-        scalaVersion = Some(MaybeScalaVersion("2.nightly")),
-        scalaBinaryVersion = None,
-        supportedScalaVersionsUrl = None
+        scalaVersion = Some(MaybeScalaVersion("2.nightly"))
       )
     )
     val scalaParams = options.scalaParams.orThrow.getOrElse(???)
@@ -237,9 +221,7 @@ class BuildOptionsTests extends munit.FunSuite {
   test("-S 2.13.9-bin-4505094 option works without repo specification") {
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
-        scalaVersion = Some(MaybeScalaVersion("2.13.9-bin-4505094")),
-        scalaBinaryVersion = None,
-        supportedScalaVersionsUrl = None
+        scalaVersion = Some(MaybeScalaVersion("2.13.9-bin-4505094"))
       )
     )
     val scalaParams = options.scalaParams.orThrow.getOrElse(???)
@@ -275,9 +257,7 @@ class BuildOptionsTests extends munit.FunSuite {
     ) {
       val options = BuildOptions(
         scalaOptions = ScalaOptions(
-          scalaVersion = prefix.map(MaybeScalaVersion(_)),
-          scalaBinaryVersion = None,
-          supportedScalaVersionsUrl = None
+          scalaVersion = prefix.map(MaybeScalaVersion(_))
         )
       )
       val scalaParams = options.scalaParams.orThrow.getOrElse(???)
@@ -314,8 +294,7 @@ class BuildOptionsTests extends munit.FunSuite {
         val options = BuildOptions(
           scalaOptions = ScalaOptions(
             scalaVersion = prefix.map(MaybeScalaVersion(_)),
-            scalaBinaryVersion = None,
-            supportedScalaVersionsUrl = Some(s"file://${confFilePath.toString()}")
+            supportedScalaVersionsUrl = Some(confFilePath.toNIO.toUri.toASCIIString)
           )
         )
 

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -277,9 +277,10 @@ class BuildOptionsTests extends munit.FunSuite {
     Some("2.13.2") -> "2.13.2"
   )
 
-  val testVersion     = "1.11.3"
-  val testPrevVersion = "1.11.1"
-  val testNextVersion = "1.11.5"
+  val testVersion           = "1.11.3"
+  val testRightAfterVersion = "1.11.4"
+  val testPrevVersion       = "1.11.1"
+  val testNextVersion       = "1.11.5"
   val confFile =
     s"""[
        | {
@@ -296,8 +297,14 @@ class BuildOptionsTests extends munit.FunSuite {
        | }
        |]""".stripMargin
 
-  for ((prefix, expectedScalaVersion) <- expectedScalaConfVersions)
-    test(s"use expected scala version from conf file, prefix: ${prefix.getOrElse("empty")}") {
+  for {
+    (testVer, testNameSuffix) <-
+      Seq((testVersion, "exact version"), (testRightAfterVersion, "next version"))
+    (prefix, expectedScalaVersion) <- expectedScalaConfVersions
+  }
+    test(
+      s"use expected scala version from conf file, prefix: ${prefix.getOrElse("empty")}, $testNameSuffix"
+    ) {
       TestInputs.withTmpDir("conf-scala-versions") { dirPath =>
 
         val confFilePath = dirPath / "conf-file.json"
@@ -310,7 +317,7 @@ class BuildOptionsTests extends munit.FunSuite {
           )
         )
 
-        val scalaParams         = options.computeScalaParams(testVersion).orThrow.getOrElse(???)
+        val scalaParams         = options.computeScalaParams(testVer).orThrow.getOrElse(???)
         val expectedScalaParams = ScalaParameters(expectedScalaVersion)
 
         expect(scalaParams == expectedScalaParams)

--- a/modules/core/src/main/scala/scala/build/internals/StableScalaVersion.scala
+++ b/modules/core/src/main/scala/scala/build/internals/StableScalaVersion.scala
@@ -2,8 +2,14 @@ package scala.build.internal
 
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.github.plokhotnyuk.jsoniter_scala.macros._
+import coursier.core.Version
 
-final case class StableScalaVersion(scalaCliVersion: String, supportedScalaVersions: Seq[String])
+final case class StableScalaVersion(
+  scalaCliVersion: String,
+  supportedScalaVersions: Seq[String]
+) {
+  lazy val scalaCliVersion0 = Version(scalaCliVersion)
+}
 
 object StableScalaVersion {
   val seqCodec: JsonValueCodec[Seq[StableScalaVersion]] = JsonCodecMaker.make

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -16,7 +16,7 @@ import scala.build.errors._
 import scala.build.internal.Constants._
 import scala.build.internal.CsLoggerUtil._
 import scala.build.internal.Regexes.scala3NightlyNicknameRegex
-import scala.build.internal.{OsLibc, StableScalaVersion}
+import scala.build.internal.{Constants, OsLibc, StableScalaVersion}
 import scala.build.options.validation.BuildOptionsRule
 import scala.build.{Artifacts, Logger, Os, Position, Positioned}
 import scala.util.control.NonFatal
@@ -230,7 +230,7 @@ final case class BuildOptions(
   private def defaultStableScalaVersions =
     Seq(defaultScala212Version, defaultScala213Version, defaultScalaVersion)
 
-  private def latestSupportedStableScalaVersion(): Seq[Version] = {
+  private def latestSupportedStableScalaVersion(scalaCliVersion: String): Seq[Version] = {
 
     val msg =
       if (internal.verbosityOrDefault > 0)
@@ -252,8 +252,7 @@ final case class BuildOptions(
       }
     }
 
-    val scalaCliVersion = version
-    val launchersTask   = cache.logger.using(task)
+    val launchersTask = cache.logger.using(task)
 
     //  If an error occurred while downloading stable versions,
     //  it uses stable scala versions from Deps.sc
@@ -324,9 +323,13 @@ final case class BuildOptions(
       internal.localRepository.toSeq
   }
 
-  lazy val scalaParams: Either[BuildException, Option[ScalaParameters]] = either {
+  lazy val scalaParams: Either[BuildException, Option[ScalaParameters]] =
+    computeScalaParams(Constants.version)
 
-    lazy val maxSupportedStableScalaVersions = latestSupportedStableScalaVersion()
+  private[build] def computeScalaParams(scalaCliVersion: String)
+    : Either[BuildException, Option[ScalaParameters]] = either {
+
+    lazy val maxSupportedStableScalaVersions = latestSupportedStableScalaVersion(scalaCliVersion)
     lazy val latestSupportedStableVersions   = maxSupportedStableScalaVersions.map(_.repr)
 
     val svOpt: Option[String] = scalaOptions.scalaVersion match {

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -266,8 +266,13 @@ final case class BuildOptions(
             // wrapped in an exception so that the current stack trace appears in the exception
             throw new Exception(e)
         case Right(versions) =>
-          versions
-            .find(_.scalaCliVersion == scalaCliVersion)
+          versions.find(_.scalaCliVersion == scalaCliVersion)
+            .orElse {
+              val scalaCliVersion0 = Version(scalaCliVersion)
+              versions
+                .filter(_.scalaCliVersion0.compareTo(scalaCliVersion0) <= 0)
+                .maxByOption(_.scalaCliVersion0)
+            }
             .map(_.supportedScalaVersions)
             .getOrElse {
               // FIXME Log that: logger.debug(s"Couldn't find Scala CLI version $scalaCliVersion in $versions")


### PR DESCRIPTION
This should allow not to have to update https://github.com/VirtusLab/scala-cli-scala-versions/blob/main/scala-versions-v1.json upon each release. This file only needs to be updated when new Scala versions are released (and known to be supported by Scala CLI).