### PR TITLE
Name target dir with a unique name

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1126,7 +1126,7 @@ object ci extends Module {
   def updateScalaCliSetup() = T.command {
     val version = cli.publishVersion()
 
-    val targetDir       = os.pwd / "target"
+    val targetDir       = os.pwd / "target-scala-cli-setup"
     val mainDir         = targetDir / "scala-cli-setup"
     val setupScriptPath = mainDir / "src" / "main.ts"
 


### PR DESCRIPTION
CI release fails with the following error: - https://github.com/VirtusLab/scala-cli/runs/6559510925?check_suite_focus=true
``` 
Run ./mill -i ci.updateScalaCliSetup
[9](https://github.com/VirtusLab/scala-cli/runs/6559510925?check_suite_focus=true#step:15:10)
[1/5] de.tobiasroeser.mill.vcs.version.VcsVersion.vcsState.overridden.de.tobiasroeser.mill.vcs.version.VcsVersion.vcsState 
[10](https://github.com/VirtusLab/scala-cli/runs/6559510925?check_suite_focus=true#step:15:11)
[5/5] ci.updateScalaCliSetup 
[11](https://github.com/VirtusLab/scala-cli/runs/6559510925?check_suite_focus=true#step:15:12)
1 targets failed
[12](https://github.com/VirtusLab/scala-cli/runs/6559510925?check_suite_focus=true#step:15:13)
ci.updateScalaCliSetup java.nio.file.AccessDeniedException: /home/runner/work/scala-cli/scala-cli/target/scala-cli-packages/CentOS/Packages/repodata/f4e38e1c1e0402f1eaafe88ad3638165942d5bca883e6a7e7c7668b69cc2acb7-other.xml.gz
[13](https://github.com/VirtusLab/scala-cli/runs/6559510925?check_suite_focus=true#step:15:14)
    java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:90)
```
To avoid some permission issue with removing `targetDir` I named it with unique name.