### PR TITLE
Tweak jsoniter-scala dependency

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -308,7 +308,6 @@ class Core(val crossScalaVersion: String) extends BuildLikeModule {
       .exclude(("com.google.collections", "google-collections"))
       // Coursier is not cross-compiled and pulls jsoniter-scala-macros in 2.13
       .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-macros")),
-    Deps.jsoniterMacros, // pulls jsoniter macros manually
     Deps.dependency,
     Deps.guava, // for coursierJvm / scalaJsEnvNodeJs, see above
     Deps.jgit,
@@ -318,6 +317,9 @@ class Core(val crossScalaVersion: String) extends BuildLikeModule {
     Deps.scalaJsEnvJsdomNodejs,
     Deps.scalaJsLogging,
     Deps.swoval
+  )
+  def compileIvyDeps = super.compileIvyDeps() ++ Seq(
+    Deps.jsoniterMacros
   )
 
   private def vcsState = T.persistent {
@@ -481,6 +483,9 @@ class Options(val crossScalaVersion: String) extends BuildLikeModule {
     Deps.bloopConfig,
     Deps.signingCliShared
   )
+  def compileIvyDeps = super.compileIvyDeps() ++ Seq(
+    Deps.jsoniterMacros
+  )
 
   object test extends Tests {
     // uncomment below to debug tests in attach mode on 5005 port
@@ -624,9 +629,11 @@ trait CliOptions extends SbtModule with ScalaCliPublishModule with ScalaCliCompi
   def ivyDeps = super.ivyDeps() ++ Agg(
     Deps.caseApp,
     Deps.jsoniterCore,
-    Deps.jsoniterMacros,
     Deps.osLib,
     Deps.signingCliOptions
+  )
+  def compileIvyDeps = super.compileIvyDeps() ++ Seq(
+    Deps.jsoniterMacros
   )
   def scalaVersion = Scala.scala213
   def repositories = super.repositories ++ customRepositories
@@ -755,14 +762,17 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
   trait Tests extends super.Tests with ScalaCliScalafixModule {
     def ivyDeps = super.ivyDeps() ++ Agg(
       Deps.bsp4j,
-      Deps.coursier,
+      Deps.coursier
+        .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-macros")),
       Deps.dockerClient,
       Deps.jsoniterCore,
-      Deps.jsoniterMacros,
       Deps.libsodiumjni,
       Deps.pprint,
       Deps.scalaAsync,
       Deps.slf4jNop
+    )
+    def compileIvyDeps = super.compileIvyDeps() ++ Seq(
+      Deps.jsoniterMacros
     )
     def forkEnv = super.forkEnv() ++ Seq(
       "SCALA_CLI_TMP" -> tmpDirBase().path.toString,

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -16,7 +16,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   protected val ciOpt = Option(System.getenv("CI")).map(v => Seq("-e", s"CI=$v")).getOrElse(Nil)
 
-  def simpleScriptTest(ignoreErrors: Boolean = false): Unit = {
+  def simpleScriptTest(ignoreErrors: Boolean = false, extraArgs: Seq[String] = Nil): Unit = {
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs = TestInputs(
@@ -28,7 +28,8 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
       )
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, fileName).call(cwd = root).out.text().trim
+      val output =
+        os.proc(TestUtil.cli, extraOptions, extraArgs, fileName).call(cwd = root).out.text().trim
       if (!ignoreErrors)
         expect(output == message)
     }
@@ -47,6 +48,10 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("simple script") {
     simpleScriptTest()
+  }
+
+  test("verbosity") {
+    simpleScriptTest(extraArgs = Seq("-v"))
   }
 
   def simpleJsTest(extraArgs: String*): Unit = {

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -86,7 +86,7 @@ object Deps {
   def jimfs    = ivy"com.google.jimfs:jimfs:1.2"
   def jniUtils = ivy"io.get-coursier.jniutils:windows-jni-utils:0.3.3"
   def jsoniterCore =
-    ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:${Versions.jsoniterScala}"
+    ivy"com.github.plokhotnyuk.jsoniter-scala:jsoniter-scala-core_2.13:${Versions.jsoniterScala}"
   def jsoniterMacros =
     ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:${Versions.jsoniterScala}"
   def libdaemonjvm  = ivy"io.github.alexarchambault.libdaemon::libdaemon:0.0.10"


### PR DESCRIPTION
- only depend on jsoniter-scala-core for Scala 2.13 (rather than both for Scala 2.13 and Scala 3)
- don't pull jsoniter-scala-macros at runtime (allows to use the 2.13 one in Scala 2.13 projects, and the Scala 3 in Scala 3 projects)

Fixes #1041