### PR TITLE
Add dependency update command

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -12,6 +12,7 @@ import java.util.concurrent.{ScheduledExecutorService, ScheduledFuture}
 import scala.annotation.tailrec
 import scala.build.EitherCps.{either, value}
 import scala.build.Ops.*
+import scala.build.actionable.ActionablePreprocessor
 import scala.build.compiler.{ScalaCompiler, ScalaCompilerMaker}
 import scala.build.errors.*
 import scala.build.internal.{Constants, CustomCodeWrapper, MainClass, Util}
@@ -900,6 +901,8 @@ object Build {
           }
         }
       }
+
+      if (scope == Scope.Main) ActionablePreprocessor.process(options, logger)
 
       (classesDir0, params, artifacts, project, projectChanged)
     }

--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -12,7 +12,6 @@ import java.util.concurrent.{ScheduledExecutorService, ScheduledFuture}
 import scala.annotation.tailrec
 import scala.build.EitherCps.{either, value}
 import scala.build.Ops.*
-import scala.build.actionable.ActionablePreprocessor
 import scala.build.compiler.{ScalaCompiler, ScalaCompilerMaker}
 import scala.build.errors.*
 import scala.build.internal.{Constants, CustomCodeWrapper, MainClass, Util}
@@ -901,8 +900,6 @@ object Build {
           }
         }
       }
-
-      if (scope == Scope.Main) ActionablePreprocessor.process(options, logger)
 
       (classesDir0, params, artifacts, project, projectChanged)
     }

--- a/modules/build/src/main/scala/scala/build/PersistentDiagnosticLogger.scala
+++ b/modules/build/src/main/scala/scala/build/PersistentDiagnosticLogger.scala
@@ -26,6 +26,7 @@ class PersistentDiagnosticLogger(parent: Logger) extends Logger {
   }
 
   def log(ex: BuildException): Unit     = parent.log(ex)
+  def debug(ex: BuildException): Unit   = parent.debug(ex)
   def exit(ex: BuildException): Nothing = parent.exit(ex)
 
   def coursierLogger(printBefore: String): coursier.cache.CacheLogger =

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -247,8 +247,8 @@ case object ScalaPreprocessor extends Preprocessor {
       val toFilePos = Position.Raw.filePos(path, content)
       val deps = value {
         dependencyTrees
-          .map { t => // add 6 to start position to skip ivy syntax ($ivy.`) and dep ($dep.`)
-            val pos      = toFilePos(Position.Raw(t.start + 6, t.end))
+          .map { t => /// skip ivy ($ivy.`) or dep syntax ($dep.`)
+            val pos      = toFilePos(Position.Raw(t.start + "$ivy.`".length, t.end))
             val strDep   = t.prefix.drop(1).mkString(".")
             val maybeDep = parseDependency(strDep, pos)
             maybeDep.map(dep => Positioned(Seq(pos), dep))

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -247,8 +247,8 @@ case object ScalaPreprocessor extends Preprocessor {
       val toFilePos = Position.Raw.filePos(path, content)
       val deps = value {
         dependencyTrees
-          .map { t =>
-            val pos      = toFilePos(Position.Raw(t.start, t.end))
+          .map { t => // add 6 to start position to skip ivy syntax ($ivy.`) and dep ($dep.`)
+            val pos      = toFilePos(Position.Raw(t.start + 6, t.end))
             val strDep   = t.prefix.drop(1).mkString(".")
             val maybeDep = parseDependency(strDep, pos)
             maybeDep.map(dep => Positioned(Seq(pos), dep))

--- a/modules/build/src/test/scala/scala/build/tests/ActionableDiagnosticTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ActionableDiagnosticTests.scala
@@ -34,7 +34,7 @@ class ActionableDiagnosticTests extends munit.FunSuite {
       (_, _, maybeBuild) =>
         val build = maybeBuild.orThrow
         val updateDiagnostics =
-          ActionablePreprocessor.generateActionableDiagnostics(build.options, TestLogger())
+          ActionablePreprocessor.generateActionableDiagnostics(build.options).orThrow
 
         val osLibDiagnosticOpt = updateDiagnostics.collectFirst {
           case diagnostic: ActionableDependencyUpdateDiagnostic => diagnostic
@@ -62,7 +62,7 @@ class ActionableDiagnosticTests extends munit.FunSuite {
       (_, _, maybeBuild) =>
         val build = maybeBuild.orThrow
         val updateDiagnostics =
-          ActionablePreprocessor.generateActionableDiagnostics(build.options, TestLogger())
+          ActionablePreprocessor.generateActionableDiagnostics(build.options).orThrow
 
         val osLibDiagnosticOpt = updateDiagnostics.collectFirst {
           case diagnostic: ActionableDependencyUpdateDiagnostic => diagnostic
@@ -91,7 +91,7 @@ class ActionableDiagnosticTests extends munit.FunSuite {
       (_, _, maybeBuild) =>
         val build = maybeBuild.orThrow
         val updateDiagnostics =
-          ActionablePreprocessor.generateActionableDiagnostics(build.options, TestLogger())
+          ActionablePreprocessor.generateActionableDiagnostics(build.options).orThrow
 
         val osLibDiagnosticOpt = updateDiagnostics.collectFirst {
           case diagnostic: ActionableDependencyUpdateDiagnostic => diagnostic

--- a/modules/build/src/test/scala/scala/build/tests/ActionableDiagnosticTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ActionableDiagnosticTests.scala
@@ -1,0 +1,108 @@
+package scala.build.tests
+
+import com.eed3si9n.expecty.Expecty.expect
+import scala.build.options.{BuildOptions, InternalOptions}
+import scala.build.Ops._
+import scala.build.{BuildThreads, Directories, LocalRepo}
+import scala.build.actionable.ActionablePreprocessor
+import scala.build.actionable.ActionableDiagnostic._
+import coursier.core.Version
+
+class ActionableDiagnosticTests extends munit.FunSuite {
+
+  val extraRepoTmpDir = os.temp.dir(prefix = "scala-cli-tests-actionable-diagnostic-")
+  val directories     = Directories.under(extraRepoTmpDir)
+  val baseOptions = BuildOptions(
+    internal = InternalOptions(
+      localRepository = LocalRepo.localRepo(directories.localRepoDir)
+    )
+  )
+  val buildThreads = BuildThreads.create()
+
+  test("update os-lib") {
+    val dependencyOsLib = "com.lihaoyi::os-lib:0.7.8"
+    val testInputs = TestInputs(
+      os.rel / "Foo.scala" ->
+        s"""//> using lib "$dependencyOsLib"
+           |
+           |object Hello extends App {
+           |  println("Hello")
+           |}
+           |""".stripMargin
+    )
+    testInputs.withBuild(baseOptions, buildThreads, None) {
+      (_, _, maybeBuild) =>
+        val build = maybeBuild.orThrow
+        val updateDiagnostics =
+          ActionablePreprocessor.generateActionableDiagnostics(build.options, TestLogger())
+
+        val osLibDiagnosticOpt = updateDiagnostics.collectFirst {
+          case diagnostic: ActionableDependencyUpdateDiagnostic => diagnostic
+        }
+
+        expect(osLibDiagnosticOpt.nonEmpty)
+        val osLibDiagnostic = osLibDiagnosticOpt.get
+
+        expect(Version(osLibDiagnostic.newVersion) > Version(osLibDiagnostic.oldDependency.version))
+    }
+  }
+
+  test("update ivy dependence upickle") {
+    val dependencyOsLib = "com.lihaoyi::upickle:1.4.0"
+    val testInputs = TestInputs(
+      os.rel / "Foo.scala" ->
+        s"""import $$ivy.`$dependencyOsLib`
+           |
+           |object Hello extends App {
+           |  println("Hello")
+           |}
+           |""".stripMargin
+    )
+    testInputs.withBuild(baseOptions, buildThreads, None) {
+      (_, _, maybeBuild) =>
+        val build = maybeBuild.orThrow
+        val updateDiagnostics =
+          ActionablePreprocessor.generateActionableDiagnostics(build.options, TestLogger())
+
+        val osLibDiagnosticOpt = updateDiagnostics.collectFirst {
+          case diagnostic: ActionableDependencyUpdateDiagnostic => diagnostic
+        }
+
+        expect(osLibDiagnosticOpt.nonEmpty)
+        val osLibDiagnostic = osLibDiagnosticOpt.get
+
+        expect(osLibDiagnostic.oldDependency.render == dependencyOsLib)
+        expect(Version(osLibDiagnostic.newVersion) > Version(osLibDiagnostic.oldDependency.version))
+    }
+  }
+
+  test("update dep dependence upickle") {
+    val dependencyOsLib = "com.lihaoyi::upickle:1.4.0"
+    val testInputs = TestInputs(
+      os.rel / "Foo.scala" ->
+        s"""import $$dep.`$dependencyOsLib`
+           |
+           |object Hello extends App {
+           |  println("Hello")
+           |}
+           |""".stripMargin
+    )
+    testInputs.withBuild(baseOptions, buildThreads, None) {
+      (_, _, maybeBuild) =>
+        val build = maybeBuild.orThrow
+        val updateDiagnostics =
+          ActionablePreprocessor.generateActionableDiagnostics(build.options, TestLogger())
+
+        val osLibDiagnosticOpt = updateDiagnostics.collectFirst {
+          case diagnostic: ActionableDependencyUpdateDiagnostic => diagnostic
+        }
+
+        expect(osLibDiagnosticOpt.nonEmpty)
+        val osLibDiagnostic = osLibDiagnosticOpt.get
+
+        expect(osLibDiagnostic.oldDependency.render == dependencyOsLib)
+        expect(Version(osLibDiagnostic.newVersion) > Version(osLibDiagnostic.oldDependency.version))
+    }
+  }
+
+}

--- a/modules/build/src/test/scala/scala/build/tests/BuildProjectTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildProjectTests.scala
@@ -40,7 +40,8 @@ class BuildProjectTests extends munit.FunSuite {
       this.diagnostics = this.diagnostics ++ diagnostics
     }
 
-    override def log(ex: BuildException): Unit = {}
+    override def log(ex: BuildException): Unit   = {}
+    override def debug(ex: BuildException): Unit = {}
 
     override def exit(ex: BuildException): Nothing = ???
 

--- a/modules/build/src/test/scala/scala/build/tests/TestLogger.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestLogger.scala
@@ -37,6 +37,8 @@ case class TestLogger(info: Boolean = true, debug: Boolean = false) extends Logg
 
   def log(ex: BuildException): Unit =
     System.err.println(ex.getMessage)
+  def debug(ex: BuildException): Unit =
+    debug(ex.getMessage)
   def exit(ex: BuildException): Nothing =
     throw new Exception(ex)
 

--- a/modules/cli-options/src/main/scala/scala/cli/commands/DependencyUpdateOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/DependencyUpdateOptions.scala
@@ -1,0 +1,20 @@
+package scala.cli.commands
+
+import caseapp._
+import caseapp.core.help.Help
+
+// format: off
+@HelpMessage("Update dependencies in project")
+final case class DependencyUpdateOptions(
+  @Recurse
+    shared: SharedOptions = SharedOptions(),
+  @Group("DependencyUpdate")
+  @HelpMessage("Update all dependency")
+    all: Boolean = false,
+)
+  // format: on
+
+object DependencyUpdateOptions {
+  implicit lazy val parser: Parser[DependencyUpdateOptions] = Parser.derive
+  implicit lazy val help: Help[DependencyUpdateOptions]     = Help.derive
+}

--- a/modules/cli/src/main/scala/scala/cli/ScalaCliCommands.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCliCommands.scala
@@ -37,6 +37,7 @@ class ScalaCliCommands(
     Compile,
     Config,
     DefaultFile,
+    DependencyUpdate,
     Directories,
     Doc,
     Doctor,

--- a/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
@@ -58,6 +58,14 @@ object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
 
     if (options.all)
       updateDependencies(actionableUpdateDiagnostics, logger)
+    else {
+      println("Updates")
+      actionableUpdateDiagnostics.foreach(update =>
+        println(s"   * ${update.oldDependency.render} -> ${update.newVersion}")
+      )
+      println("""|To update all dependencies run: 
+                 |    scala-cli dependency-update --all""".stripMargin)
+    }
   }
 
   private def updateDependencies(

--- a/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
@@ -1,0 +1,69 @@
+package scala.cli.commands
+
+import caseapp._
+
+import scala.build.actionable.{ActionableDependencyHandler, ActionableDiagnostic}
+import scala.build.internal.CustomCodeWrapper
+import scala.build.options.Scope
+import scala.build.{CrossSources, Logger, Position, Sources}
+import scala.cli.CurrentParams
+import scala.cli.commands.util.SharedOptionsUtil._
+
+object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
+  override def group                                           = "Main"
+  override def sharedOptions(options: DependencyUpdateOptions) = Some(options.shared)
+
+  def run(options: DependencyUpdateOptions, args: RemainingArgs): Unit = {
+    val verbosity = options.shared.logging.verbosity
+    CurrentParams.verbosity = verbosity
+
+    val inputs       = options.shared.inputsOrExit(args)
+    val logger       = options.shared.logger
+    val buildOptions = options.shared.buildOptions()
+
+    val crossSources =
+      CrossSources.forInputs(
+        inputs,
+        Sources.defaultPreprocessors(
+          buildOptions.scriptOptions.codeWrapper.getOrElse(CustomCodeWrapper)
+        ),
+        logger
+      ).orExit(logger)
+
+    val scopedSources = crossSources.scopedSources(buildOptions).orExit(logger)
+    val sources       = scopedSources.sources(Scope.Main, crossSources.sharedOptions(buildOptions))
+
+    if (verbosity >= 3)
+      pprint.err.log(sources)
+
+    val options0 = buildOptions.orElse(sources.buildOptions)
+
+    val dependencies = ActionableDependencyHandler.extractPositionedOptions(options0)
+    val (errors, actionableUpdateDiagnostics) = dependencies.map(
+      ActionableDependencyHandler.createActionableDiagnostic(_, options0)
+    ).partitionMap(identity)
+
+    errors.foreach(logger.debug(_))
+
+    if (options.all)
+      updateDependencies(actionableUpdateDiagnostics.flatten, logger)
+  }
+
+  private def updateDependencies(
+    actionableUpdateDiagnostic: Seq[ActionableDiagnostic],
+    logger: Logger
+  ): Unit = {
+    actionableUpdateDiagnostic.map { diagnostic =>
+      diagnostic.positions.collect {
+        case Position.File(Right(path), _, _) => path
+      }.map { file =>
+        logger.message(s"Updating dependency    ${diagnostic.from}")
+        val content           = os.read(file)
+        val appliedDiagnostic = content.replace(diagnostic.from, diagnostic.to)
+        os.write.over(file, appliedDiagnostic)
+        logger.message(s"Updated dependency to: ${diagnostic.to}")
+      }
+    }
+  }
+
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
@@ -103,16 +103,8 @@ object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
     diagnostics.foldLeft(fileContent) {
       case (fileContent, (file, diagnostic)) =>
         val (line, column) = (file.startPos._1, file.startPos._2)
-        val startIndex = {
-          val index = startIndicies(line) + column
-          val skipIvySyntax =
-            fileContent.slice(index, index + 6) match {
-              case "$ivy.`" | "$dep.`" => 6
-              case _                   => 0
-            }
-          index + skipIvySyntax
-        }
-        val endIndex = startIndex + diagnostic.oldDependency.render.length()
+        val startIndex     = startIndicies(line) + column
+        val endIndex       = startIndex + diagnostic.oldDependency.render.length()
 
         val newDependency = diagnostic.to
         s"${fileContent.slice(0, startIndex)}$newDependency${fileContent.drop(endIndex)}"

--- a/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
@@ -23,7 +23,7 @@ object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
     val logger       = options.shared.logger
     val buildOptions = options.shared.buildOptions()
 
-    val crossSources =
+    val (crossSources, _) =
       CrossSources.forInputs(
         inputs,
         Sources.defaultPreprocessors(

--- a/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
@@ -43,12 +43,7 @@ object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
         pprint.err.log(sources)
 
       val options = buildOptions.orElse(sources.buildOptions)
-      val actionableDiagnostics =
-        ActionablePreprocessor.generateActionableDiagnostics(options).orExit(logger)
-
-      actionableDiagnostics.collect {
-        case ad: ActionableDependencyUpdateDiagnostic => ad
-      }
+      ActionableDependencyHandler.createActionableDiagnostics(options).orExit(logger)
     }
 
     val actionableMainUpdateDiagnostics = generateActionableUpdateDiagnostic(Scope.Main)

--- a/modules/cli/src/main/scala/scala/cli/internal/CliLogger.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/CliLogger.scala
@@ -119,6 +119,9 @@ class CliLogger(
     if (verbosity >= 0)
       printEx(ex, new mutable.HashMap)
 
+  def debug(ex: BuildException): Unit =
+    if (verbosity >= 2)
+      printEx(ex, new mutable.HashMap)
   def exit(ex: BuildException): Nothing =
     if (verbosity < 0)
       sys.exit(1)

--- a/modules/core/src/main/scala/scala/build/Logger.scala
+++ b/modules/core/src/main/scala/scala/build/Logger.scala
@@ -25,6 +25,7 @@ trait Logger {
   ): Unit = log(Seq(Diagnostic(message, severity, positions)))
 
   def log(ex: BuildException): Unit
+  def debug(ex: BuildException): Unit
   def exit(ex: BuildException): Nothing
 
   def coursierLogger(printBefore: String): coursier.cache.CacheLogger
@@ -48,6 +49,7 @@ object Logger {
 
     def log(diagnostics: Seq[Diagnostic]): Unit = ()
     def log(ex: BuildException): Unit           = ()
+    def debug(ex: BuildException): Unit         = ()
     def exit(ex: BuildException): Nothing =
       throw new Exception(ex)
 

--- a/modules/core/src/main/scala/scala/build/Position.scala
+++ b/modules/core/src/main/scala/scala/build/Position.scala
@@ -44,7 +44,7 @@ object Position {
 
     // from https://github.com/com-lihaoyi/Ammonite/blob/76673f7f3eb9d9ae054482635f57a31527d248de/amm/interp/src/main/scala/ammonite/interp/script/PositionOffsetConversion.scala#L7-L69
 
-    private def lineStartIndices(content: String): Array[Int] = {
+    def lineStartIndices(content: String): Array[Int] = {
 
       val content0 = content.toCharArray
 

--- a/modules/integration/src/test/scala/scala/cli/integration/DependencyUpdateTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DependencyUpdateTests.scala
@@ -1,0 +1,42 @@
+package scala.cli.integration
+
+import com.eed3si9n.expecty.Expecty.expect
+
+class DependencyUpdateTests extends munit.FunSuite {
+
+  test("dependency update test") {
+    val fileName = "Hello.scala"
+    val message  = "Hello World"
+    val fileContent =
+      s"""|//> using lib "com.lihaoyi::os-lib:0.7.8"
+          |//> using lib "com.lihaoyi::utest:0.7.10"
+          |import $$ivy.`com.lihaoyi::geny:0.6.5`
+          |import $$dep.`com.lihaoyi::pprint:0.6.6`
+          |
+          |object Hello extends App {
+          |  println("$message")
+          |}""".stripMargin
+    val inputs = TestInputs(
+      Seq(
+        os.rel / fileName -> fileContent
+      )
+    )
+    inputs.fromRoot { root =>
+      // update dependencies
+      val p = os.proc(TestUtil.cli, "dependency-update", "--all", fileName)
+        .call(
+          cwd = root,
+          stdin = os.Inherit,
+          mergeErrIntoOut = true
+        )
+      expect(p.out.text().trim.contains("Updated dependency to"))
+      expect(  // check if dependency update command modify file
+        os.read(root / fileName) != fileContent
+      )
+
+      // after updating dependencies app should run
+      val out = os.proc(TestUtil.cli, fileName).call(cwd = root).out.text().trim
+      expect(out == message)
+    }
+  }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/DependencyUpdateTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DependencyUpdateTests.scala
@@ -30,9 +30,8 @@ class DependencyUpdateTests extends munit.FunSuite {
           mergeErrIntoOut = true
         )
       expect(p.out.text().trim.contains("Updated dependency to"))
-      expect(  // check if dependency update command modify file
-        os.read(root / fileName) != fileContent
-      )
+      expect( // check if dependency update command modify file
+        os.read(root / fileName) != fileContent)
 
       // after updating dependencies app should run
       val out = os.proc(TestUtil.cli, fileName).call(cwd = root).out.text().trim

--- a/modules/options/src/main/scala/scala/build/actionable/ActionableDependencyHandler.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionableDependencyHandler.scala
@@ -50,11 +50,11 @@ case object ActionableDependencyHandler extends ActionableHandler {
         .unsafeRun()(cache.ec)
     }
 
-    val latestVersion = value(res.versions.latest(coursier.core.Latest.Release).toRight(
-      new ActionableHandlerError(s"Not found dependency versions for ${dependency.render}")
-    ))
-
-    latestVersion
+    value {
+      res.versions.latest(coursier.core.Latest.Release).toRight {
+        new ActionableHandlerError(s"No latest version found for ${dependency.render}")
+      }
+    }
   }
 
 }

--- a/modules/options/src/main/scala/scala/build/actionable/ActionableDependencyHandler.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionableDependencyHandler.scala
@@ -1,13 +1,14 @@
 package scala.build.actionable
 
 import coursier.Versions
-import coursier.core.{Module, ModuleName, Organization}
 import dependency._
 
 import scala.build.EitherCps.{either, value}
 import scala.build.Positioned
+import scala.build.actionable.ActionableDiagnostic._
 import scala.build.actionable.errors.ActionableHandlerError
 import scala.build.errors.BuildException
+import scala.build.internal.Util._
 import scala.build.options.BuildOptions
 import scala.concurrent.duration.DurationInt
 
@@ -19,17 +20,27 @@ case object ActionableDependencyHandler extends ActionableHandler[AnyDependency]
   override def createActionableDiagnostic(
     option: Positioned[AnyDependency],
     buildOptions: BuildOptions
-  ): Either[BuildException, Option[ActionableDiagnostic]] = either {
+  ): Either[BuildException, Option[ActionableDependencyUpdateDiagnostic]] = either {
 
-    val baseDependency = option.value
-    val currentVersion = baseDependency.version
-    val scalaParams    = value(buildOptions.scalaParams)
-    val dependency     = scalaParams.map(baseDependency.applyParams(_)).getOrElse(baseDependency)
+    val dependency     = option.value
+    val currentVersion = dependency.version
+    val latestVersion  = value(findLatestVersion(buildOptions, dependency))
 
-    val organization = Organization(dependency.organization)
-    val moduleName   = ModuleName(s"${dependency.name}")
-    val csModule     = Module(organization, moduleName, Map.empty)
-    val cache        = buildOptions.finalCache
+    if (latestVersion != currentVersion) {
+      val msg = s"${dependency.render} is outdated, update to $latestVersion"
+      Some(ActionableDependencyUpdateDiagnostic(msg, option.positions, dependency, latestVersion))
+    }
+    else
+      None
+  }
+
+  private def findLatestVersion(
+    buildOptions: BuildOptions,
+    dependency: AnyDependency
+  ): Either[BuildException, String] = either {
+    val scalaParams = value(buildOptions.scalaParams)
+    val cache       = buildOptions.finalCache
+    val csModule    = value(dependency.toCs(scalaParams)).module
 
     val res = cache.withTtl(0.seconds).logger.use {
       Versions(cache)
@@ -38,17 +49,11 @@ case object ActionableDependencyHandler extends ActionableHandler[AnyDependency]
         .unsafeRun()(cache.ec)
     }
 
-    val dependencyLatestVersion = value(res.versions.latest(coursier.core.Latest.Release).toRight(
-      new ActionableHandlerError(s"Not found dependency versions for ${baseDependency.render}")
+    val latestVersion = value(res.versions.latest(coursier.core.Latest.Release).toRight(
+      new ActionableHandlerError(s"Not found dependency versions for ${dependency.render}")
     ))
 
-    if (dependencyLatestVersion != currentVersion) {
-      val msg  = s"${baseDependency.render} is outdated, update to $dependencyLatestVersion"
-      val from = baseDependency.render
-      val to   = s"${baseDependency.module.render}:$dependencyLatestVersion"
-      Some(ActionableDiagnostic(msg, from, to, option.positions))
-    }
-    else
-      None
+    latestVersion
   }
+
 }

--- a/modules/options/src/main/scala/scala/build/actionable/ActionableDependencyHandler.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionableDependencyHandler.scala
@@ -14,15 +14,15 @@ import scala.concurrent.duration.DurationInt
 
 case object ActionableDependencyHandler extends ActionableHandler {
   type V = Positioned[AnyDependency]
+  type A = ActionableDependencyUpdateDiagnostic
 
   override def extractOptions(options: BuildOptions): Seq[Positioned[AnyDependency]] =
     options.classPathOptions.extraDependencies.toSeq
 
-  override def createActionableDiagnostic(
+  override def actionableDiagnostic(
     option: Positioned[AnyDependency],
     buildOptions: BuildOptions
   ): Either[BuildException, Option[ActionableDependencyUpdateDiagnostic]] = either {
-
     val dependency     = option.value
     val currentVersion = dependency.version
     val latestVersion  = value(findLatestVersion(buildOptions, dependency))

--- a/modules/options/src/main/scala/scala/build/actionable/ActionableDependencyHandler.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionableDependencyHandler.scala
@@ -12,24 +12,24 @@ import scala.build.internal.Util._
 import scala.build.options.BuildOptions
 import scala.concurrent.duration.DurationInt
 
-case object ActionableDependencyHandler extends ActionableHandler {
-  type V = Positioned[AnyDependency]
-  type A = ActionableDependencyUpdateDiagnostic
+case object ActionableDependencyHandler
+    extends ActionableHandler[ActionableDependencyUpdateDiagnostic] {
+  type Setting = Positioned[AnyDependency]
 
-  override def extractOptions(options: BuildOptions): Seq[Positioned[AnyDependency]] =
+  override def extractSettings(options: BuildOptions): Seq[Positioned[AnyDependency]] =
     options.classPathOptions.extraDependencies.toSeq
 
   override def actionableDiagnostic(
-    option: Positioned[AnyDependency],
+    setting: Positioned[AnyDependency],
     buildOptions: BuildOptions
   ): Either[BuildException, Option[ActionableDependencyUpdateDiagnostic]] = either {
-    val dependency     = option.value
+    val dependency     = setting.value
     val currentVersion = dependency.version
     val latestVersion  = value(findLatestVersion(buildOptions, dependency))
 
     if (latestVersion != currentVersion) {
       val msg = s"${dependency.render} is outdated, update to $latestVersion"
-      Some(ActionableDependencyUpdateDiagnostic(msg, option.positions, dependency, latestVersion))
+      Some(ActionableDependencyUpdateDiagnostic(msg, setting.positions, dependency, latestVersion))
     }
     else
       None

--- a/modules/options/src/main/scala/scala/build/actionable/ActionableDependencyHandler.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionableDependencyHandler.scala
@@ -1,0 +1,50 @@
+package scala.build.actionable
+
+import coursier.Versions
+import coursier.cache.FileCache
+import coursier.core.{Module, ModuleName, Organization}
+import dependency._
+
+import scala.build.Positioned
+import scala.build.options.BuildOptions
+import scala.concurrent.duration.DurationInt
+
+case object ActionableDependencyHandler extends ActionableHandler[AnyDependency] {
+
+  val cache = FileCache()
+
+  override def extractValues(options: BuildOptions): Seq[Positioned[AnyDependency]] =
+    options.classPathOptions.extraDependencies.toSeq
+
+  override def createActionableDiagnostic(
+    value: Positioned[AnyDependency],
+    options: BuildOptions
+  ): ActionableDiagnostic = {
+
+    val dependency         = value.value
+    val scalaParams        = options.scalaParams.getOrElse(sys.error("sys.err")).get
+    val scalaBinaryVersion = scalaParams.scalaBinaryVersion
+
+    val organization = Organization(dependency.organization)
+    val moduleName   = ModuleName(s"${dependency.name}_$scalaBinaryVersion")
+    val csModule     = Module(organization, moduleName, Map.empty)
+
+    val res = cache.withTtl(0.seconds).logger.use {
+      Versions(cache)
+        .withModule(csModule)
+        .result()
+        .unsafeRun()(cache.ec)
+    }
+
+    val dependencyLatestVersion = res.versions.latest(coursier.core.Latest.Release).get
+    val msg  = s"${dependency.render} is outdated, please update to $dependencyLatestVersion"
+    val from = dependency.render
+    val to   = s"${dependency.module.render}:$dependencyLatestVersion"
+    ActionableDiagnostic(
+      msg,
+      from,
+      to,
+      positions = value.positions
+    )
+  }
+}

--- a/modules/options/src/main/scala/scala/build/actionable/ActionableDependencyHandler.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionableDependencyHandler.scala
@@ -12,9 +12,10 @@ import scala.build.internal.Util._
 import scala.build.options.BuildOptions
 import scala.concurrent.duration.DurationInt
 
-case object ActionableDependencyHandler extends ActionableHandler[AnyDependency] {
+case object ActionableDependencyHandler extends ActionableHandler {
+  type V = Positioned[AnyDependency]
 
-  override def extractPositionedOptions(options: BuildOptions): Seq[Positioned[AnyDependency]] =
+  override def extractOptions(options: BuildOptions): Seq[Positioned[AnyDependency]] =
     options.classPathOptions.extraDependencies.toSeq
 
   override def createActionableDiagnostic(

--- a/modules/options/src/main/scala/scala/build/actionable/ActionableDiagnostic.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionableDiagnostic.scala
@@ -1,0 +1,45 @@
+package scala.build.actionable
+
+import scala.build.Position
+import scala.build.errors.{Diagnostic, Severity}
+
+trait ActionableDiagnostic {
+
+  /** Provide the message of actionable diagnostic
+    */
+  def message: String
+
+  /** Provide the old content which will be replaced by actionable diagnostic
+    */
+  def from: String
+
+  /** Provide the new content which will be replaced by actionable diagnostic
+    */
+  def to: String
+  def positions: Seq[Position]
+
+  final def toDiagnostic: Diagnostic = Diagnostic(
+    message = s"""|$message
+                  |     From: $from
+                  |       To: $to""".stripMargin,
+    severity = Severity.Warning,
+    positions = positions
+  )
+}
+
+object ActionableDiagnostic {
+
+  private case class AActionableDiagnostic(
+    message: String,
+    from: String,
+    to: String,
+    positions: Seq[Position]
+  ) extends ActionableDiagnostic
+
+  def apply(
+    message: String,
+    from: String,
+    to: String,
+    positions: Seq[Position] = Nil
+  ): ActionableDiagnostic = AActionableDiagnostic(message, from, to, positions)
+}

--- a/modules/options/src/main/scala/scala/build/actionable/ActionableDiagnostic.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionableDiagnostic.scala
@@ -5,7 +5,7 @@ import dependency._
 import scala.build.Position
 import scala.build.errors.{Diagnostic, Severity}
 
-sealed abstract class ActionableDiagnostic {
+abstract class ActionableDiagnostic {
 
   /** Provide the message of actionable diagnostic
     */

--- a/modules/options/src/main/scala/scala/build/actionable/ActionableDiagnostic.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionableDiagnostic.scala
@@ -1,17 +1,15 @@
 package scala.build.actionable
 
+import dependency._
+
 import scala.build.Position
 import scala.build.errors.{Diagnostic, Severity}
 
-trait ActionableDiagnostic {
+sealed abstract class ActionableDiagnostic {
 
   /** Provide the message of actionable diagnostic
     */
   def message: String
-
-  /** Provide the old content which will be replaced by actionable diagnostic
-    */
-  def from: String
 
   /** Provide the new content which will be replaced by actionable diagnostic
     */
@@ -20,7 +18,6 @@ trait ActionableDiagnostic {
 
   final def toDiagnostic: Diagnostic = Diagnostic(
     message = s"""|$message
-                  |     From: $from
                   |       To: $to""".stripMargin,
     severity = Severity.Warning,
     positions = positions
@@ -29,17 +26,13 @@ trait ActionableDiagnostic {
 
 object ActionableDiagnostic {
 
-  private case class AActionableDiagnostic(
+  case class ActionableDependencyUpdateDiagnostic(
     message: String,
-    from: String,
-    to: String,
-    positions: Seq[Position]
-  ) extends ActionableDiagnostic
+    positions: Seq[Position],
+    oldDependency: AnyDependency,
+    newVersion: String
+  ) extends ActionableDiagnostic {
+    override def to: String = oldDependency.copy(version = newVersion).render
+  }
 
-  def apply(
-    message: String,
-    from: String,
-    to: String,
-    positions: Seq[Position] = Nil
-  ): ActionableDiagnostic = AActionableDiagnostic(message, from, to, positions)
 }

--- a/modules/options/src/main/scala/scala/build/actionable/ActionableHandler.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionableHandler.scala
@@ -1,18 +1,19 @@
 package scala.build.actionable
-import scala.build.Positioned
+
 import scala.build.errors.BuildException
 import scala.build.options.BuildOptions
 
-trait ActionableHandler[V] {
+trait ActionableHandler {
+  type V
 
   /** Extract options on the basis of which actionable diagnostics will be generated
     *
     * @param options
-    *   the Build Options to extract positioned options
+    *   the Build Options to extract options
     * @return
-    *   the list of positioned options
+    *   the list of options on the basis of which actionable diagnostics will be generated
     */
-  def extractPositionedOptions(options: BuildOptions): Seq[Positioned[V]]
+  def extractOptions(options: BuildOptions): Seq[V]
 
   /** The option on the basis of which the Actionable Diagnostic is generated
     *
@@ -23,7 +24,7 @@ trait ActionableHandler[V] {
     *   Cache" See [[ActionableDependencyHandler]]
     */
   def createActionableDiagnostic(
-    option: Positioned[V],
+    option: V,
     buildOptions: BuildOptions
   ): Either[BuildException, Option[ActionableDiagnostic]]
 }

--- a/modules/options/src/main/scala/scala/build/actionable/ActionableHandler.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionableHandler.scala
@@ -1,9 +1,29 @@
 package scala.build.actionable
 import scala.build.Positioned
+import scala.build.errors.BuildException
 import scala.build.options.BuildOptions
 
 trait ActionableHandler[V] {
 
-  def extractValues(options: BuildOptions): Seq[Positioned[V]]
-  def createActionableDiagnostic(value: Positioned[V], options: BuildOptions): ActionableDiagnostic
+  /** Extract options on the basis of which actionable diagnostics will be generated
+    *
+    * @param options
+    *   the Build Options to extract positioned options
+    * @return
+    *   the list of positioned options
+    */
+  def extractPositionedOptions(options: BuildOptions): Seq[Positioned[V]]
+
+  /** The option on the basis of which the Actionable Diagnostic is generated
+    *
+    * @param option
+    *   this option is used to generate an actionable diagnostic
+    * @param buildOptions
+    *   used to extract additional parameter from buildOptions, such as "ScalaParams" or "Coursier
+    *   Cache" See [[ActionableDependencyHandler]]
+    */
+  def createActionableDiagnostic(
+    option: Positioned[V],
+    buildOptions: BuildOptions
+  ): Either[BuildException, Option[ActionableDiagnostic]]
 }

--- a/modules/options/src/main/scala/scala/build/actionable/ActionableHandler.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionableHandler.scala
@@ -12,7 +12,7 @@ trait ActionableHandler {
 
   /** Returned type of actionable diagnostics
     */
-  type A
+  type A <: ActionableDiagnostic
 
   /** Extract options on the basis of which actionable diagnostics will be generated
     *

--- a/modules/options/src/main/scala/scala/build/actionable/ActionableHandler.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionableHandler.scala
@@ -1,0 +1,9 @@
+package scala.build.actionable
+import scala.build.Positioned
+import scala.build.options.BuildOptions
+
+trait ActionableHandler[V] {
+
+  def extractValues(options: BuildOptions): Seq[Positioned[V]]
+  def createActionableDiagnostic(value: Positioned[V], options: BuildOptions): ActionableDiagnostic
+}

--- a/modules/options/src/main/scala/scala/build/actionable/ActionableHandler.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionableHandler.scala
@@ -4,26 +4,22 @@ import scala.build.Ops._
 import scala.build.errors.{BuildException, CompositeBuildException}
 import scala.build.options.BuildOptions
 
-trait ActionableHandler {
+trait ActionableHandler[A <: ActionableDiagnostic] {
 
-  /** Type of option used to generate actionable diagnostic
+  /** Type of setting used to generate actionable diagnostic
     */
-  type V
+  type Setting
 
-  /** Returned type of actionable diagnostics
-    */
-  type A <: ActionableDiagnostic
-
-  /** Extract options on the basis of which actionable diagnostics will be generated
+  /** Extract settings on the basis of which actionable diagnostics will be generated
     *
     * @param options
-    *   the Build Options to extract options
+    *   the Build Options to extract settings
     * @return
-    *   the list of options on the basis of which actionable diagnostics will be generated
+    *   the list of settings on the basis of which actionable diagnostics will be generated
     */
-  def extractOptions(options: BuildOptions): Seq[V]
+  def extractSettings(options: BuildOptions): Seq[Setting]
 
-  /** The option on the basis of which the Actionable Diagnostic is generated
+  /** The setting on the basis of which the Actionable Diagnostic is generated
     *
     * @param option
     *   this option is used to generate an actionable diagnostic
@@ -32,14 +28,14 @@ trait ActionableHandler {
     *   Cache" See [[ActionableDependencyHandler]]
     */
   def actionableDiagnostic(
-    option: V,
+    setting: Setting,
     buildOptions: BuildOptions
   ): Either[BuildException, Option[A]]
 
   final def createActionableDiagnostics(
     buildOptions: BuildOptions
   ): Either[BuildException, Seq[A]] =
-    extractOptions(buildOptions)
+    extractSettings(buildOptions)
       .map(v => actionableDiagnostic(v, buildOptions))
       .sequence
       .left.map(CompositeBuildException(_))

--- a/modules/options/src/main/scala/scala/build/actionable/ActionableHandler.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionableHandler.scala
@@ -5,12 +5,12 @@ import scala.build.errors.{BuildException, CompositeBuildException}
 import scala.build.options.BuildOptions
 
 trait ActionableHandler {
-  /** 
-    * Type of option used to generate actionable diagnostic
+
+  /** Type of option used to generate actionable diagnostic
     */
   type V
-  /** 
-    * Returned type of actionable diagnostics
+
+  /** Returned type of actionable diagnostics
     */
   type A
 

--- a/modules/options/src/main/scala/scala/build/actionable/ActionablePreprocessor.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionablePreprocessor.scala
@@ -1,0 +1,23 @@
+package scala.build.actionable
+
+import scala.build.Logger
+import scala.build.options.BuildOptions
+
+case object ActionablePreprocessor {
+
+  val actionableHandlers = Seq(
+    ActionableDependencyHandler
+  )
+
+  def generateActionableDiagnostics(options: BuildOptions): Seq[ActionableDiagnostic] =
+    actionableHandlers.flatMap { handler =>
+      val values = handler.extractValues(options)
+      values.map(v => handler.createActionableDiagnostic(v, options))
+    }
+
+  def process(options: BuildOptions, logger: Logger): Unit = {
+
+    val actionableDiagnostics = generateActionableDiagnostics(options)
+    actionableDiagnostics.foreach(ad => logger.log(Seq(ad.toDiagnostic)))
+  }
+}

--- a/modules/options/src/main/scala/scala/build/actionable/ActionablePreprocessor.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionablePreprocessor.scala
@@ -5,7 +5,7 @@ import scala.build.errors.{BuildException, CompositeBuildException}
 import scala.build.options.BuildOptions
 
 object ActionablePreprocessor {
-  val actionableHandlers = Seq[ActionableHandler[_ <: ActionableDiagnostic]](
+  val actionableHandlers = Seq[ActionableHandler[_]](
     ActionableDependencyHandler
   )
 

--- a/modules/options/src/main/scala/scala/build/actionable/ActionablePreprocessor.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionablePreprocessor.scala
@@ -1,4 +1,5 @@
 package scala.build.actionable
+
 import scala.build.Ops._
 import scala.build.errors.{BuildException, CompositeBuildException}
 import scala.build.options.BuildOptions
@@ -12,14 +13,7 @@ case object ActionablePreprocessor {
     options: BuildOptions
   ): Either[BuildException, Seq[ActionableDiagnostic]] =
     actionableHandlers
-      .map { handler =>
-        handler
-          .extractOptions(options)
-          .map(v => handler.createActionableDiagnostic(v, options))
-          .sequence
-          .left.map(CompositeBuildException(_))
-          .map(_.flatten)
-      }
+      .map(handler => handler.createActionableDiagnostics(options))
       .sequence
       .left.map(CompositeBuildException(_))
       .map(_.flatten)

--- a/modules/options/src/main/scala/scala/build/actionable/ActionablePreprocessor.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionablePreprocessor.scala
@@ -4,8 +4,8 @@ import scala.build.Ops._
 import scala.build.errors.{BuildException, CompositeBuildException}
 import scala.build.options.BuildOptions
 
-case object ActionablePreprocessor {
-  val actionableHandlers = Seq(
+object ActionablePreprocessor {
+  val actionableHandlers = Seq[ActionableHandler](
     ActionableDependencyHandler
   )
 

--- a/modules/options/src/main/scala/scala/build/actionable/ActionablePreprocessor.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionablePreprocessor.scala
@@ -4,20 +4,24 @@ import scala.build.Logger
 import scala.build.options.BuildOptions
 
 case object ActionablePreprocessor {
-
   val actionableHandlers = Seq(
     ActionableDependencyHandler
   )
 
-  def generateActionableDiagnostics(options: BuildOptions): Seq[ActionableDiagnostic] =
+  def generateActionableDiagnostics(
+    options: BuildOptions,
+    logger: Logger
+  ): Seq[ActionableDiagnostic] =
     actionableHandlers.flatMap { handler =>
-      val values = handler.extractValues(options)
-      values.map(v => handler.createActionableDiagnostic(v, options))
+      val values = handler.extractPositionedOptions(options)
+      val (errors, actionableDiagnostic) =
+        values.map(v => handler.createActionableDiagnostic(v, options)).partitionMap(identity)
+      errors.map(logger.debug(_))
+      actionableDiagnostic.flatten
     }
 
   def process(options: BuildOptions, logger: Logger): Unit = {
-
-    val actionableDiagnostics = generateActionableDiagnostics(options)
+    val actionableDiagnostics = generateActionableDiagnostics(options, logger)
     actionableDiagnostics.foreach(ad => logger.log(Seq(ad.toDiagnostic)))
   }
 }

--- a/modules/options/src/main/scala/scala/build/actionable/ActionablePreprocessor.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/ActionablePreprocessor.scala
@@ -5,7 +5,7 @@ import scala.build.errors.{BuildException, CompositeBuildException}
 import scala.build.options.BuildOptions
 
 object ActionablePreprocessor {
-  val actionableHandlers = Seq[ActionableHandler](
+  val actionableHandlers = Seq[ActionableHandler[_ <: ActionableDiagnostic]](
     ActionableDependencyHandler
   )
 

--- a/modules/options/src/main/scala/scala/build/actionable/errors/ActionableHandlerError.scala
+++ b/modules/options/src/main/scala/scala/build/actionable/errors/ActionableHandlerError.scala
@@ -1,0 +1,6 @@
+package scala.build.actionable.errors
+
+import scala.build.errors.BuildException
+
+final class ActionableHandlerError(message: String)
+    extends BuildException(message)

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -99,6 +99,7 @@ Available in commands:
 - [`bloop start`](./commands.md#bloop-start)
 - [`bsp`](./commands.md#bsp)
 - [`compile`](./commands.md#compile)
+- [`dependency-update`](./commands.md#dependency-update)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
 - [`fmt` / `format` / `scalafmt`](./commands.md#fmt)
@@ -252,6 +253,7 @@ Available in commands:
 - [`bsp`](./commands.md#bsp)
 - [`compile`](./commands.md#compile)
 - [`config`](./commands.md#config)
+- [`dependency-update`](./commands.md#dependency-update)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
 - [`fmt` / `format` / `scalafmt`](./commands.md#fmt)
@@ -324,6 +326,7 @@ Force overwriting destination files
 Available in commands:
 - [`bsp`](./commands.md#bsp)
 - [`compile`](./commands.md#compile)
+- [`dependency-update`](./commands.md#dependency-update)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
 - [`fmt` / `format` / `scalafmt`](./commands.md#fmt)
@@ -358,6 +361,18 @@ Aliases: `-P`, `--plugin`
 
 Add compiler plugin dependencies
 
+## Dependency update options
+
+Available in commands:
+- [`dependency-update`](./commands.md#dependency-update)
+
+
+<!-- Automatically generated, DO NOT EDIT MANUALLY -->
+
+#### `--all`
+
+Update all dependency
+
 ## Directories options
 
 Available in commands:
@@ -368,6 +383,7 @@ Available in commands:
 - [`clean`](./commands.md#clean)
 - [`compile`](./commands.md#compile)
 - [`config`](./commands.md#config)
+- [`dependency-update`](./commands.md#dependency-update)
 - [`directories`](./commands.md#directories)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
@@ -500,6 +516,7 @@ Available in commands:
 - [`compile`](./commands.md#compile)
 - [`config`](./commands.md#config)
 - [`default-file`](./commands.md#default-file)
+- [`dependency-update`](./commands.md#dependency-update)
 - [`directories`](./commands.md#directories)
 - [`doc`](./commands.md#doc)
 - [`doctor`](./commands.md#doctor)
@@ -554,6 +571,7 @@ Print help message, including hidden options, and exit
 Available in commands:
 - [`bsp`](./commands.md#bsp)
 - [`compile`](./commands.md#compile)
+- [`dependency-update`](./commands.md#dependency-update)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
 - [`fmt` / `format` / `scalafmt`](./commands.md#fmt)
@@ -670,6 +688,7 @@ Available in commands:
 - [`bloop start`](./commands.md#bloop-start)
 - [`bsp`](./commands.md#bsp)
 - [`compile`](./commands.md#compile)
+- [`dependency-update`](./commands.md#dependency-update)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
 - [`fmt` / `format` / `scalafmt`](./commands.md#fmt)
@@ -733,6 +752,7 @@ Available in commands:
 - [`compile`](./commands.md#compile)
 - [`config`](./commands.md#config)
 - [`default-file`](./commands.md#default-file)
+- [`dependency-update`](./commands.md#dependency-update)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
 - [`fmt` / `format` / `scalafmt`](./commands.md#fmt)
@@ -1338,6 +1358,7 @@ Temporary / working directory where to write generated launchers
 Available in commands:
 - [`bsp`](./commands.md#bsp)
 - [`compile`](./commands.md#compile)
+- [`dependency-update`](./commands.md#dependency-update)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
 - [`fmt` / `format` / `scalafmt`](./commands.md#fmt)
@@ -1433,6 +1454,7 @@ Whether to run the Scala.js CLI on the JVM or using a native executable
 Available in commands:
 - [`bsp`](./commands.md#bsp)
 - [`compile`](./commands.md#compile)
+- [`dependency-update`](./commands.md#dependency-update)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
 - [`fmt` / `format` / `scalafmt`](./commands.md#fmt)
@@ -1494,6 +1516,7 @@ Use default compile options
 Available in commands:
 - [`bsp`](./commands.md#bsp)
 - [`compile`](./commands.md#compile)
+- [`dependency-update`](./commands.md#dependency-update)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
 - [`fmt` / `format` / `scalafmt`](./commands.md#fmt)
@@ -1564,6 +1587,7 @@ Available in commands:
 Available in commands:
 - [`bsp`](./commands.md#bsp)
 - [`compile`](./commands.md#compile)
+- [`dependency-update`](./commands.md#dependency-update)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
 - [`fmt` / `format` / `scalafmt`](./commands.md#fmt)
@@ -1779,6 +1803,7 @@ Available in commands:
 - [`compile`](./commands.md#compile)
 - [`config`](./commands.md#config)
 - [`default-file`](./commands.md#default-file)
+- [`dependency-update`](./commands.md#dependency-update)
 - [`directories`](./commands.md#directories)
 - [`doc`](./commands.md#doc)
 - [`doctor`](./commands.md#doctor)
@@ -1852,6 +1877,7 @@ Available in commands:
 - [`bsp`](./commands.md#bsp)
 - [`clean`](./commands.md#clean)
 - [`compile`](./commands.md#compile)
+- [`dependency-update`](./commands.md#dependency-update)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
 - [`fmt` / `format` / `scalafmt`](./commands.md#fmt)

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1667,6 +1667,7 @@ Generate SemanticDBs
 Available in commands:
 - [`bsp`](./commands.md#bsp)
 - [`compile`](./commands.md#compile)
+- [`dependency-update`](./commands.md#dependency-update)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
 - [`fmt` / `format` / `scalafmt`](./commands.md#fmt)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -45,6 +45,26 @@ Accepts options:
 - [watch](./cli-options.md#watch-options)
 - [workspace](./cli-options.md#workspace-options)
 
+## `dependency-update`
+
+Update dependencies in project
+
+Accepts options:
+- [compilation server](./cli-options.md#compilation-server-options)
+- [coursier](./cli-options.md#coursier-options)
+- [dependency](./cli-options.md#dependency-options)
+- [dependency update](./cli-options.md#dependency-update-options)
+- [directories](./cli-options.md#directories-options)
+- [help group](./cli-options.md#help-group-options)
+- [jvm](./cli-options.md#jvm-options)
+- [logging](./cli-options.md#logging-options)
+- [Scala.js](./cli-options.md#scalajs-options)
+- [Scala Native](./cli-options.md#scala-native-options)
+- [scalac](./cli-options.md#scalac-options)
+- [shared](./cli-options.md#shared-options)
+- [verbosity](./cli-options.md#verbosity-options)
+- [workspace](./cli-options.md#workspace-options)
+
 ## `doc`
 
 Generate Scaladoc documentation

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -62,6 +62,7 @@ Accepts options:
 - [Scala Native](./cli-options.md#scala-native-options)
 - [scalac](./cli-options.md#scalac-options)
 - [shared](./cli-options.md#shared-options)
+- [snippet](./cli-options.md#snippet-options)
 - [verbosity](./cli-options.md#verbosity-options)
 - [workspace](./cli-options.md#workspace-options)
 


### PR DESCRIPTION
The actionable diagnostics logging is disable, because not there is no exists way to disable hints in ScalaCLI. 
After #1056 will be merged, then I will add entry to disable hints in ScalaCLI
```
hints.dependency-updates
```
so now, it os only possible to update all dependency in project running
```
scala-cli dependency-update --all Hello.scala
```