### PR TITLE
Add config command

### DIFF
--- a/modules/build/src/main/scala/scala/build/Directories.scala
+++ b/modules/build/src/main/scala/scala/build/Directories.scala
@@ -13,6 +13,7 @@ trait Directories {
   def bspSocketDir: os.Path
   def bloopDaemonDir: os.Path
   def bloopWorkingDir: os.Path
+  def secretsDir: os.Path
 }
 
 object Directories {
@@ -38,6 +39,8 @@ object Directories {
         else projDirs.dataLocalDir
       os.Path(baseDir, Os.pwd) / "bloop"
     }
+    lazy val secretsDir: os.Path =
+      os.Path(projDirs.dataLocalDir, Os.pwd) / "secrets"
   }
 
   final case class SubDir(dir: os.Path) extends Directories {
@@ -55,6 +58,8 @@ object Directories {
       bloopWorkingDir / "daemon"
     lazy val bloopWorkingDir: os.Path =
       dir / "data-local" / "bloop"
+    lazy val secretsDir: os.Path =
+      dir / "data-local" / "secrets"
   }
 
   def default(): Directories = {

--- a/modules/cli-options/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
@@ -1,0 +1,35 @@
+package scala.cli.commands.config
+
+import caseapp._
+
+import scala.cli.commands.{CoursierOptions, LoggingOptions, SharedDirectoriesOptions}
+
+// format: off
+final case class ConfigOptions(
+  @Recurse
+    logging: LoggingOptions = LoggingOptions(),
+  @Recurse
+    directories: SharedDirectoriesOptions = SharedDirectoriesOptions(),
+  @Recurse
+    coursier: CoursierOptions = CoursierOptions(),
+
+  @Group("Config")
+  @HelpMessage("Dump config DB as JSON")
+  @Hidden
+    dump: Boolean = false,
+  @Group("Config")
+  @HelpMessage("Create PGP key in config")
+    createPgpKey: Boolean = false,
+  @Group("Config")
+  @HelpMessage("If the entry is a password, print the password value rather than how to get the password")
+    password: Boolean = false,
+  @Group("Config")
+  @HelpMessage("Remove an entry from config")
+    unset: Boolean = false
+)
+// format: on
+
+object ConfigOptions {
+  implicit lazy val parser: Parser[ConfigOptions] = Parser.derive
+  implicit lazy val help: Help[ConfigOptions]     = Help.derive
+}

--- a/modules/cli/src/main/scala/scala/cli/ScalaCliCommands.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCliCommands.scala
@@ -7,6 +7,7 @@ import java.nio.file.InvalidPathException
 
 import scala.cli.commands._
 import scala.cli.commands.bloop.BloopOutput
+import scala.cli.commands.config.Config
 import scala.cli.commands.default.DefaultFile
 import scala.cli.commands.github.{SecretCreate, SecretList}
 import scala.cli.commands.pgp.{PgpCommands, PgpCommandsSubst, PgpPull, PgpPush}
@@ -34,6 +35,7 @@ class ScalaCliCommands(
     Bsp,
     Clean,
     Compile,
+    Config,
     DefaultFile,
     Directories,
     Doc,

--- a/modules/cli/src/main/scala/scala/cli/commands/Directories.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Directories.scala
@@ -23,5 +23,6 @@ object Directories extends ScalaCommand[DirectoriesOptions] {
     println("Virtual projects: " + directories.virtualProjectsDir)
     println("BSP sockets: " + directories.bspSocketDir)
     println("Bloop daemon directory: " + directories.bloopDaemonDir)
+    println("Secrets directory: " + directories.secretsDir)
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
@@ -1,0 +1,101 @@
+package scala.cli.commands.config
+
+import caseapp.core.RemainingArgs
+
+import java.util.Base64
+
+import scala.cli.commands.ScalaCommand
+import scala.cli.commands.util.CommonOps._
+import scala.cli.config.{ConfigDb, Keys}
+import scala.cli.signing.shared.PasswordOption
+
+object Config extends ScalaCommand[ConfigOptions] {
+  override def hidden     = true
+  override def inSipScala = false
+
+  def run(options: ConfigOptions, args: RemainingArgs): Unit = {
+
+    val logger      = options.logging.logger
+    val directories = options.directories.directories
+
+    if (options.dump) {
+      val path    = ConfigDb.dbPath(directories)
+      val content = os.read.bytes(path)
+      System.out.write(content)
+    }
+    else {
+      val db = ConfigDb.open(directories)
+        .orExit(logger)
+
+      def unrecognizedKey(key: String): Nothing = {
+        System.err.println(s"Error: unrecognized key $key")
+        sys.exit(1)
+      }
+
+      args.all match {
+        case Seq() =>
+          if (options.createPgpKey) {
+            val coursierCache       = options.coursier.coursierCache(logger.coursierLogger(""))
+            val secKeyEntry         = Keys.pgpSecretKey
+            val secKeyPasswordEntry = Keys.pgpSecretKeyPassword
+            val pubKeyEntry         = Keys.pgpPublicKey
+
+            val mail = db.get(Keys.userEmail).orExit(logger)
+              .getOrElse {
+                System.err.println("Error: user.email not set (required to generate PGP key)")
+                sys.exit(1)
+              }
+
+            val password = ThrowawayPgpSecret.pgpPassPhrase()
+            val (pgpPublic, pgpSecret0) =
+              ThrowawayPgpSecret.pgpSecret(mail, password, logger, coursierCache)
+                .orExit(logger)
+            val pgpSecretBase64 = pgpSecret0.map(Base64.getEncoder.encodeToString)
+
+            db.set(secKeyEntry, PasswordOption.Value(pgpSecretBase64))
+            db.set(secKeyPasswordEntry, PasswordOption.Value(password))
+            db.set(pubKeyEntry, PasswordOption.Value(pgpPublic))
+            db.save(directories)
+          }
+          else {
+            System.err.println("No argument passed")
+            sys.exit(1)
+          }
+        case Seq(name, values @ _*) =>
+          Keys.map.get(name) match {
+            case None => unrecognizedKey(name)
+            case Some(entry) =>
+              if (values.isEmpty)
+                if (options.unset) {
+                  db.remove(entry)
+                  db.save(directories)
+                }
+                else {
+                  val valueOpt = db.getAsString(entry).orExit(logger)
+                  valueOpt match {
+                    case Some(value) =>
+                      for (v <- value)
+                        if (options.password && entry.isPasswordOption)
+                          PasswordOption.parse(v) match {
+                            case Left(err) =>
+                              System.err.println(err)
+                              sys.exit(1)
+                            case Right(passwordOption) =>
+                              val password = passwordOption.getBytes()
+                              System.out.write(password.value)
+                          }
+                        else
+                          println(v)
+                    case None =>
+                      logger.debug(s"No value found for $name")
+                  }
+                }
+              else {
+                db.setFromString(entry, values).orExit(logger)
+                db.save(directories)
+              }
+          }
+      }
+    }
+  }
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/config/ThrowawayPgpSecret.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/ThrowawayPgpSecret.scala
@@ -1,0 +1,70 @@
+package scala.cli.commands.config
+
+import coursier.cache.Cache
+import coursier.util.Task
+
+import java.security.SecureRandom
+
+import scala.build.EitherCps.{either, value}
+import scala.build.Logger
+import scala.build.errors.BuildException
+import scala.cli.commands.pgp.PgpProxyMaker
+import scala.cli.errors.PgpError
+import scala.cli.signing.shared.Secret
+
+object ThrowawayPgpSecret {
+
+  private val secretChars =
+    (('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9') ++ Seq('$', '/', '*', '&', '\'', '"', '!', '(',
+      ')', '-', '_', '\\', ';', '.', ':', '=', '+', '?', ',', '%')).toVector
+  private def secretChars(rng: SecureRandom): Iterator[Char] =
+    Iterator.continually {
+      val idx = rng.nextInt(secretChars.length)
+      secretChars(idx)
+    }
+
+  def pgpPassPhrase(): Secret[String] = {
+    val random = new SecureRandom
+    Secret(secretChars(random).take(32).mkString)
+  }
+  def pgpSecret(
+    mail: String,
+    password: Secret[String],
+    logger: Logger,
+    cache: Cache[Task]
+  ): Either[BuildException, (Secret[String], Secret[Array[Byte]])] = either {
+
+    val dir    = os.temp.dir(perms = "rwx------")
+    val pubKey = dir / "pub"
+    val secKey = dir / "sec"
+    val retCode = value {
+      (new PgpProxyMaker).get().createKey(
+        pubKey.toString,
+        secKey.toString,
+        mail,
+        logger.verbosity <= 0,
+        password.value,
+        cache,
+        logger
+      )
+    }
+
+    def cleanUp(): Unit =
+      os.remove.all(dir)
+
+    if (retCode == 0)
+      try (Secret(os.read(pubKey)), Secret(os.read.bytes(secKey)))
+      finally cleanUp()
+    else {
+      cleanUp()
+      value {
+        Left {
+          new PgpError(
+            s"Failed to create PGP key pair (see messages above, scala-cli-signing return code: $retCode)"
+          )
+        }
+      }
+    }
+  }
+
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpProxy.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpProxy.scala
@@ -5,11 +5,42 @@ import coursier.util.Task
 
 import scala.build.Logger
 import scala.build.errors.BuildException
-import scala.cli.commands.pgp.PgpKeyIdExternal
+import scala.cli.commands.pgp.{PgpCreateExternal, PgpKeyIdExternal}
 import scala.cli.errors.PgpError
 import scala.util.Properties
 
 class PgpProxy {
+  def createKey(
+    pubKey: String,
+    secKey: String,
+    mail: String,
+    quiet: Boolean,
+    password: String,
+    cache: Cache[Task],
+    logger: Logger
+  ): Either[BuildException, Int] = {
+    val quietOptions = Nil
+    (new PgpCreateExternal).tryRun(
+      cache,
+      None,
+      Seq(
+        "pgp",
+        "create",
+        "--pub-dest",
+        pubKey.toString,
+        "--secret-dest",
+        secKey.toString,
+        "--email",
+        mail,
+        "--password",
+        s"env:SCALA_CLI_RANDOM_KEY_PASSWORD"
+      ) ++ quietOptions,
+      Map("SCALA_CLI_RANDOM_KEY_PASSWORD" -> password),
+      logger,
+      allowExecve = false
+    )
+  }
+
   def keyId(
     key: String,
     keyPrintablePath: String,
@@ -39,4 +70,5 @@ class PgpProxy {
         Right(rawOutput)
     }
   }
+
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpProxyJvm.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpProxyJvm.scala
@@ -1,5 +1,6 @@
 package scala.cli.commands.pgp
 
+import caseapp.core.RemainingArgs
 import coursier.cache.Cache
 import coursier.util.Task
 
@@ -8,9 +9,33 @@ import java.nio.charset.StandardCharsets
 import scala.build.Logger
 import scala.build.errors.BuildException
 import scala.cli.errors.PgpError
-import scala.cli.signing.commands.PgpKeyId
+import scala.cli.signing.commands.{PgpCreate, PgpCreateOptions, PgpKeyId}
+import scala.cli.signing.shared.{PasswordOption, Secret}
 
 class PgpProxyJvm extends PgpProxy {
+  override def createKey(
+    pubKey: String,
+    secKey: String,
+    mail: String,
+    quiet: Boolean,
+    password: String,
+    cache: Cache[Task],
+    logger: Logger
+  ): Either[BuildException, Int] = {
+
+    PgpCreate.tryRun(
+      PgpCreateOptions(
+        email = mail,
+        password = PasswordOption.Value(Secret(password)),
+        pubDest = Some(pubKey),
+        secretDest = Some(secKey),
+        quiet = quiet
+      ),
+      RemainingArgs(Seq(), Nil)
+    )
+    Right(0)
+  }
+
   override def keyId(
     key: String,
     keyPrintablePath: String,

--- a/modules/cli/src/main/scala/scala/cli/config/ConfigDb.scala
+++ b/modules/cli/src/main/scala/scala/cli/config/ConfigDb.scala
@@ -1,0 +1,227 @@
+package scala.cli.config
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{Key => _, _}
+import com.github.plokhotnyuk.jsoniter_scala.macros._
+import coursier.parse.RawJson
+
+import java.nio.file.attribute.PosixFilePermission
+
+import scala.build.Directories
+import scala.build.errors.BuildException
+import scala.collection.immutable.ListMap
+import scala.util.Properties
+
+/** In-memory representation of a configuration DB content.
+  *
+  * Use [[ConfigDb.apply]] or [[ConfigDb.open]] to create an instance of it.
+  *
+  * [[set]], [[setFromString]], and [[remove]] only change values in memory.
+  *
+  * Use [[save]] to persist values on disk.
+  */
+final class ConfigDb private (
+  var rawEntries: Map[String, Array[Byte]]
+) {
+
+  /** Gets an entry.
+    *
+    * If the value cannot be decoded, an error is returned on the left side of the either.
+    *
+    * If the key isn't in DB, None is returned on the right side of the either.
+    *
+    * Else, the value is returned wrapped in Some on the right side of the either.
+    */
+  def get[T](key: Key[T]): Either[ConfigDb.ConfigDbFormatError, Option[T]] =
+    rawEntries.get(key.fullName) match {
+      case None => Right(None)
+      case Some(rawEntryContent) =>
+        key.parse(rawEntryContent)
+          .left.map { e =>
+            new ConfigDb.ConfigDbFormatError(s"Error parsing ${key.fullName} value", Some(e))
+          }
+          .map(Some(_))
+    }
+
+  /** Sets an entry in memory */
+  def set[T](key: Key[T], value: T): this.type = {
+    val b = key.write(value)
+    rawEntries += key.fullName -> b
+    this
+  }
+
+  /** Removes an entry from memory */
+  def remove(key: Key[_]): this.type = {
+    rawEntries -= key.fullName
+    this
+  }
+
+  /** Gets an entry in printable form.
+    *
+    * See [[get]] for when a left value, or a None on the right, can be returned.
+    */
+  def getAsString[T](key: Key[T]): Either[ConfigDb.ConfigDbFormatError, Option[Seq[String]]] =
+    get(key).map(_.map(key.asString))
+
+  /** Sets an entry in memory, from a printable / user-writable representation.
+    */
+  def setFromString[T](
+    key: Key[T],
+    values: Seq[String]
+  ): Either[Key.MalformedValue, this.type] =
+    key.fromString(values).map { typedValue =>
+      set(key, typedValue)
+    }
+
+  /** Dumps this DB content as JSON */
+  def dump: Array[Byte] = {
+
+    def serializeMap(m: Map[String, Array[Byte]]): Array[Byte] = {
+      val keyValues = m
+        .groupBy(_._1.split("\\.", 2).apply(0))
+        .toVector
+        .sortBy(_._1)
+        .map {
+          case (k, v) =>
+            val v0 = v.map {
+              case (k1, v1) =>
+                (k1.stripPrefix(k).stripPrefix("."), v1)
+            }
+            (k, serialize(v0))
+        }
+      val sortedMap: Map[String, RawJson] = ListMap.from(keyValues)
+      writeToArray(sortedMap)(ConfigDb.codec)
+    }
+
+    def serialize(m: Map[String, Array[Byte]]): RawJson =
+      m.get("") match {
+        case Some(value) =>
+          if (m.size == 1)
+            RawJson(value)
+          else
+            sys.error(s"Inconsistent keys: ${m.keySet.toVector.sorted}")
+        case None =>
+          RawJson(serializeMap(m))
+      }
+
+    serializeMap(rawEntries)
+  }
+
+  def saveUnsafe(path: os.Path): Either[ConfigDb.ConfigDbPermissionsError, Unit] = {
+    val dir = path / os.up
+
+    if (Properties.isWin) {
+      os.write.over(path, dump, createFolders = true)
+      Right(())
+    }
+    else {
+      if (!os.exists(dir))
+        os.makeDir.all(dir, perms = "rwx------")
+      val dirPerms = os.perms(dir)
+      val permsOk =
+        !dirPerms.contains(PosixFilePermission.GROUP_READ) &&
+        !dirPerms.contains(PosixFilePermission.GROUP_WRITE) &&
+        !dirPerms.contains(PosixFilePermission.GROUP_EXECUTE) &&
+        !dirPerms.contains(PosixFilePermission.OTHERS_READ) &&
+        !dirPerms.contains(PosixFilePermission.OTHERS_WRITE) &&
+        !dirPerms.contains(PosixFilePermission.OTHERS_EXECUTE)
+      if (permsOk) {
+        os.write.over(path, dump, perms = "rw-------", createFolders = false)
+        Right(())
+      }
+      else
+        Left(new ConfigDb.ConfigDbPermissionsError(path, dirPerms))
+    }
+  }
+
+  /** Saves this DB at the config directory of the passed Directories */
+  def save(directories: Directories): Either[BuildException, Unit] = {
+    // no file locks…
+    val path = ConfigDb.dbPath(directories)
+    saveUnsafe(path)
+  }
+}
+
+object ConfigDb {
+
+  def dbPath(directories: Directories): os.Path =
+    directories.secretsDir / defaultDbFileName
+
+  final class ConfigDbFormatError(
+    message: String,
+    causeOpt: Option[Throwable] = None
+  ) extends BuildException(message, cause = causeOpt.orNull)
+
+  final class ConfigDbPermissionsError(path: os.Path, perms: os.PermSet)
+      extends BuildException(s"$path has wrong permissions $perms (expected rwx------)")
+
+  private val codec: JsonValueCodec[Map[String, RawJson]] = JsonCodecMaker.make
+
+  /** Create a ConfigDb instance from binary content
+    *
+    * @param dbContent:
+    *   JSON, as a UTF-8 array of bytes
+    * @param printablePath:
+    *   DB location, for error messages
+    * @return
+    *   either an error on failure, or a ConfigDb instance on success
+    */
+  def apply(
+    dbContent: Array[Byte],
+    printablePath: Option[String] = None
+  ): Either[ConfigDbFormatError, ConfigDb] = {
+
+    def flatten(map: Map[String, RawJson]): Map[String, Array[Byte]] =
+      map.flatMap {
+        case (k, v) =>
+          try {
+            val subMap = flatten(readFromArray(v.value)(codec))
+            subMap.toSeq.map {
+              case (k0, v0) =>
+                (k + "." + k0, v0)
+            }
+          }
+          catch {
+            case _: JsonReaderException =>
+              Seq(k -> v.value)
+          }
+      }
+
+    val maybeRawEntries =
+      try Right(flatten(readFromArray(dbContent)(codec)))
+      catch {
+        case e: JsonReaderException =>
+          Left(new ConfigDbFormatError(
+            "Error parsing config DB" + printablePath.fold("")(" " + _),
+            Some(e)
+          ))
+      }
+
+    maybeRawEntries.map(rawEntries => new ConfigDb(rawEntries))
+  }
+
+  def defaultDbFileName: String =
+    "config.json"
+
+  /** Creates a ConfigDb from a file
+    *
+    * @param path:
+    *   path to a config UTF-8 JSON file
+    * @return
+    *   either an error on failure, or a ConfigDb instance on success
+    */
+  def open(path: os.Path): Either[BuildException, ConfigDb] =
+    if (os.exists(path))
+      apply(os.read.bytes(path), Some(path.toString))
+    else
+      Right(new ConfigDb(Map()))
+
+  /** Creates a ConfigDb from Scala CLI directories
+    *
+    * @param directories:
+    *   a Scala CLI Directories instance
+    * @return
+    *   either an error on failure, or a ConfigDb instance on success
+    */
+  def open(directories: Directories): Either[BuildException, ConfigDb] =
+    open(dbPath(directories))
+}

--- a/modules/cli/src/main/scala/scala/cli/config/Key.scala
+++ b/modules/cli/src/main/scala/scala/cli/config/Key.scala
@@ -1,0 +1,139 @@
+package scala.cli.config
+
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import com.github.plokhotnyuk.jsoniter_scala.macros._
+
+import scala.build.errors.BuildException
+import scala.cli.signing.shared.PasswordOption
+
+/** A configuration key
+  */
+sealed abstract class Key[T] {
+
+  /** Key prefix, such as "foo.a" in "foo.a.b" */
+  def prefix: Seq[String]
+
+  /** Key name, such as "b" in "foo.a.b" */
+  def name: String
+
+  /** Try to parse a value of this key */
+  def parse(json: Array[Byte]): Either[Key.EntryError, T]
+
+  /** Converts a value of this key to JSON
+    *
+    * @return
+    *   UTF-8 encoded JSON
+    */
+  def write(value: T): Array[Byte]
+
+  /** Converts a value of this key to a sequence of strings
+    *
+    * Such a sequence can be printed in the console, and converted back to a [[T]] with
+    * [[fromString]].
+    */
+  def asString(value: T): Seq[String]
+
+  /** Reads a value of this key from a sequence of string */
+  def fromString(values: Seq[String]): Either[Key.MalformedValue, T]
+
+  /** The fully qualified name of this key */
+  final def fullName = (prefix :+ name).mkString(".")
+
+  /** Whether this key corresponds to a password (see [[Key.PasswordEntry]]) */
+  def isPasswordOption: Boolean = false
+}
+
+object Key {
+
+  abstract class EntryError(
+    message: String,
+    causeOpt: Option[Throwable] = None
+  ) extends BuildException(message, cause = causeOpt.orNull)
+
+  final class JsonReaderError(cause: JsonReaderException)
+      extends EntryError("Error parsing config JSON", Some(cause))
+
+  final class MalformedValue(
+    entry: Key[_],
+    input: Seq[String],
+    messageOrExpectedShape: Either[String, String],
+    cause: Option[Throwable] = None
+  ) extends EntryError(
+        s"Malformed values ${input.mkString(", ")} for ${entry.fullName}, " +
+          messageOrExpectedShape.fold(shape => s"expected $shape", identity),
+        cause
+      )
+
+  private val stringCodec: JsonValueCodec[String] = JsonCodecMaker.make
+
+  final class StringEntry(
+    val prefix: Seq[String],
+    val name: String
+  ) extends Key[String] {
+    def parse(json: Array[Byte]): Either[EntryError, String] =
+      try Right(readFromArray(json)(stringCodec))
+      catch {
+        case e: JsonReaderException =>
+          Left(new JsonReaderError(e))
+      }
+    def write(value: String): Array[Byte] =
+      writeToArray(value)(stringCodec)
+    def asString(value: String): Seq[String] =
+      Seq(value)
+    def fromString(values: Seq[String]): Either[MalformedValue, String] =
+      values match {
+        case Seq(value) => Right(value)
+        case _          => Left(new MalformedValue(this, values, Left("value")))
+      }
+  }
+
+  final class PasswordEntry(
+    val prefix: Seq[String],
+    val name: String
+  ) extends Key[PasswordOption] {
+    def parse(json: Array[Byte]): Either[EntryError, PasswordOption] =
+      try {
+        val str = readFromArray(json)(stringCodec)
+        PasswordOption.parse(str).left.map { e =>
+          new MalformedValue(this, Seq(str), Right(e))
+        }
+      }
+      catch {
+        case e: JsonReaderException =>
+          Left(new JsonReaderError(e))
+      }
+    def write(value: PasswordOption): Array[Byte] =
+      writeToArray(value.asString.value)(stringCodec)
+    def asString(value: PasswordOption): Seq[String] = Seq(value.asString.value)
+    def fromString(values: Seq[String]): Either[MalformedValue, PasswordOption] =
+      values match {
+        case Seq(value) =>
+          PasswordOption.parse(value).left.map { err =>
+            new MalformedValue(this, values, Right(err))
+          }
+        case _ => Left(new MalformedValue(this, values, Left("value")))
+      }
+
+    override def isPasswordOption: Boolean = true
+  }
+
+  private val stringListCodec: JsonValueCodec[List[String]] = JsonCodecMaker.make
+
+  final class StringListEntry(
+    val prefix: Seq[String],
+    val name: String
+  ) extends Key[List[String]] {
+    def parse(json: Array[Byte]): Either[EntryError, List[String]] =
+      try Right(readFromArray(json)(stringListCodec))
+      catch {
+        case e: JsonReaderException =>
+          Left(new JsonReaderError(e))
+      }
+    def write(value: List[String]): Array[Byte] =
+      writeToArray(value)(stringListCodec)
+    def asString(value: List[String]): Seq[String] = value
+    def fromString(values: Seq[String]): Either[MalformedValue, List[String]] =
+      Right(values.toList)
+  }
+
+}

--- a/modules/cli/src/main/scala/scala/cli/config/Keys.scala
+++ b/modules/cli/src/main/scala/scala/cli/config/Keys.scala
@@ -1,0 +1,32 @@
+package scala.cli.config
+
+object Keys {
+
+  val userName  = new Key.StringEntry(Seq("user"), "name")
+  val userEmail = new Key.StringEntry(Seq("user"), "email")
+  val userUrl   = new Key.StringEntry(Seq("user"), "url")
+
+  val ghToken = new Key.PasswordEntry(Seq("github"), "token")
+
+  val pgpSecretKey         = new Key.PasswordEntry(Seq("pgp"), "secret-key")
+  val pgpSecretKeyPassword = new Key.PasswordEntry(Seq("pgp"), "secret-key-password")
+  val pgpPublicKey         = new Key.PasswordEntry(Seq("pgp"), "public-key")
+
+  val sonatypeUser     = new Key.PasswordEntry(Seq("sonatype"), "user")
+  val sonatypePassword = new Key.PasswordEntry(Seq("sonatype"), "password")
+
+  def all = Seq[Key[_]](
+    userName,
+    userEmail,
+    userUrl,
+    ghToken,
+    pgpSecretKey,
+    pgpSecretKeyPassword,
+    pgpPublicKey,
+    sonatypeUser,
+    sonatypePassword
+  )
+
+  lazy val map = all.map(e => e.fullName -> e).toMap
+
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
@@ -1,0 +1,51 @@
+package scala.cli.integration
+
+import com.eed3si9n.expecty.Expecty.expect
+
+class ConfigTests extends munit.FunSuite {
+
+  test("simple") {
+    val homeDir    = os.rel / "home"
+    val dirOptions = Seq[os.Shellable]("--home-directory", homeDir)
+    val name       = "Alex"
+    TestInputs(Nil).fromRoot { root =>
+      val before = os.proc(TestUtil.cli, "config", dirOptions, "user.name").call(cwd = root)
+      expect(before.out.text().trim.isEmpty)
+
+      os.proc(TestUtil.cli, "config", dirOptions, "user.name", name).call(cwd = root)
+      val res = os.proc(TestUtil.cli, "config", dirOptions, "user.name").call(cwd = root)
+      expect(res.out.text().trim == name)
+
+      os.proc(TestUtil.cli, "config", dirOptions, "user.name", "--unset").call(cwd = root)
+      val after = os.proc(TestUtil.cli, "config", dirOptions, "user.name").call(cwd = root)
+      expect(after.out.text().trim.isEmpty)
+    }
+  }
+
+  test("password") {
+    val homeDir    = os.rel / "home"
+    val dirOptions = Seq[os.Shellable]("--home-directory", homeDir)
+    val password   = "1234"
+    TestInputs(Nil).fromRoot { root =>
+      val before = os.proc(TestUtil.cli, "config", dirOptions, "sonatype.password")
+        .call(cwd = root)
+      expect(before.out.text().trim.isEmpty)
+
+      os.proc(TestUtil.cli, "config", dirOptions, "sonatype.password", s"value:$password")
+        .call(cwd = root)
+      val res = os.proc(TestUtil.cli, "config", dirOptions, "sonatype.password")
+        .call(cwd = root)
+      expect(res.out.text().trim == s"value:$password")
+      val res0 = os.proc(TestUtil.cli, "config", dirOptions, "sonatype.password", "--password")
+        .call(cwd = root)
+      expect(res0.out.text().trim == password)
+
+      os.proc(TestUtil.cli, "config", dirOptions, "sonatype.password", "--unset")
+        .call(cwd = root)
+      val after = os.proc(TestUtil.cli, "config", dirOptions, "sonatype.password")
+        .call(cwd = root)
+      expect(after.out.text().trim.isEmpty)
+    }
+  }
+
+}

--- a/website/docs/commands/misc/config.md
+++ b/website/docs/commands/misc/config.md
@@ -1,0 +1,82 @@
+---
+title: Config
+sidebar_position: 1
+---
+
+import {ChainedSnippets} from "../../../src/components/MarkdownComponents.js";
+
+The `config` sub-command allows to get and set various configuration values, used by
+other Scala CLI sub-commands.
+
+Examples of use:
+<ChainedSnippets>
+
+```bash
+scala-cli config user.name "Alex Me"
+scala-cli config user.name
+```
+
+```text
+Alex Me
+```
+
+</ChainedSnippets>
+
+The `--dump` option allows to print all config entries in JSON format:
+<ChainedSnippets>
+
+```bash
+scala-cli config --dump | jq .
+```
+```json
+{
+  "github": {
+    "token": "value:qWeRtYuIoP"
+  },
+  "pgp": {
+    "public-key": "value:-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: BCPG v1.68\n\n…\n-----END PGP PUBLIC KEY BLOCK-----\n",
+    "secret-key": "value:…",
+    "secret-key-password": "value:1234"
+  },
+  "user": {
+    "email": "alex@alex.me",
+    "name": "Alex Me",
+    "url": "https://alex.me"
+  }
+}
+```
+
+</ChainedSnippets>
+
+Use `--password` to get the value of a password entry:
+
+<ChainedSnippets>
+
+```bash
+export MY_GITHUB_TOKEN=1234
+scala-cli config github.token "env:MY_GITHUB_TOKEN"
+scala-cli config github.token
+```
+```text
+env:MY_GITHUB_TOKEN
+```
+```bash
+export MY_GITHUB_TOKEN=1234
+scala-cli config --password github.token
+```
+```text
+1234
+```
+
+</ChainedSnippets>
+
+Use `--create-key` to create a PGP key pair, protected by a randomly-generated password, to
+be used by the `publish setup` sub-command:
+```sh
+scala-cli config --create-key
+```
+
+Configuration values are stored in a directory under your home directory, with restricted permissions:
+- on macOS: `~/Library/Application Support/ScalaCli/secrets/config.json`
+- on Linux: `~/.config/scala-cli/secrets/config.json`
+- on Windows: `%LOCALAPPDATA%\ScalaCli\secrets\config.json` (typically `C:\Users\username\AppData\Local\ScalaCli\secrets\config.json`)

--- a/website/docs/commands/misc/default-file.md
+++ b/website/docs/commands/misc/default-file.md
@@ -1,6 +1,6 @@
 ---
 title: Default File
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 The `default-file` sub-command provides sensible default content for files

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -215,6 +215,30 @@ Available in commands:
 
 Cross-compile sources
 
+## Config options
+
+Available in commands:
+- [`config`](./commands.md#config)
+
+
+<!-- Automatically generated, DO NOT EDIT MANUALLY -->
+
+#### `--dump`
+
+Dump config DB as JSON
+
+#### `--create-pgp-key`
+
+Create PGP key in config
+
+#### `--password`
+
+If the entry is a password, print the password value rather than how to get the password
+
+#### `--unset`
+
+Remove an entry from config
+
 ## Coursier options
 
 Available in commands:
@@ -222,6 +246,7 @@ Available in commands:
 - [`bloop start`](./commands.md#bloop-start)
 - [`bsp`](./commands.md#bsp)
 - [`compile`](./commands.md#compile)
+- [`config`](./commands.md#config)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
 - [`fmt` / `format` / `scalafmt`](./commands.md#fmt)
@@ -336,6 +361,7 @@ Available in commands:
 - [`bsp`](./commands.md#bsp)
 - [`clean`](./commands.md#clean)
 - [`compile`](./commands.md#compile)
+- [`config`](./commands.md#config)
 - [`directories`](./commands.md#directories)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
@@ -455,6 +481,7 @@ Available in commands:
 - [`bsp`](./commands.md#bsp)
 - [`clean`](./commands.md#clean)
 - [`compile`](./commands.md#compile)
+- [`config`](./commands.md#config)
 - [`default-file`](./commands.md#default-file)
 - [`directories`](./commands.md#directories)
 - [`doc`](./commands.md#doc)
@@ -684,6 +711,7 @@ Available in commands:
 - [`bsp`](./commands.md#bsp)
 - [`clean`](./commands.md#clean)
 - [`compile`](./commands.md#compile)
+- [`config`](./commands.md#config)
 - [`default-file`](./commands.md#default-file)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
@@ -1598,6 +1626,7 @@ Available in commands:
 - [`bsp`](./commands.md#bsp)
 - [`clean`](./commands.md#clean)
 - [`compile`](./commands.md#compile)
+- [`config`](./commands.md#config)
 - [`default-file`](./commands.md#default-file)
 - [`directories`](./commands.md#directories)
 - [`doc`](./commands.md#doc)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -444,6 +444,15 @@ Accepts options:
 - [verbosity](./cli-options.md#verbosity-options)
 - [workspace](./cli-options.md#workspace-options)
 
+### `config`
+
+Accepts options:
+- [config](./cli-options.md#config-options)
+- [coursier](./cli-options.md#coursier-options)
+- [directories](./cli-options.md#directories-options)
+- [logging](./cli-options.md#logging-options)
+- [verbosity](./cli-options.md#verbosity-options)
+
 ### `default-file`
 
 Accepts options:


### PR DESCRIPTION
This adds a `config` sub-command, that users can use to set and get values of pre-defined config keys, like
```text
$ scala-cli config user.name "Alex"
$ scala-cli config user.email "alex@alex.me"
$ scala-cli config github.token "file:$HOME/.secrets/scala-cli-gh-token"
$ scala-cli config pgp.public-key
…
```

These values are meant to be used in the upcoming `publish setup` sub-command.