### PR TITLE
Update installation instructions for Nix

### DIFF
--- a/website/docs/_advanced_install.mdx
+++ b/website/docs/_advanced_install.mdx
@@ -139,7 +139,7 @@ This method is provided and supported by the community, not the core team of Sca
 Scala CLI can be installed with [Nix](https://nixos.org) with
 
 ```bash
-nix-env -if https://github.com/NixOS/nixpkgs/archive/refs/heads/master.tar.gz -A scala-cli
+nix-env -iA scala-cli
 ```
 
 </TabItem>
@@ -272,7 +272,7 @@ This method is provided and supported by the community, not the core team of Sca
 Scala CLI can be installed with [Nix](https://nixos.org) with
 
 ```bash
-nix-env -if https://github.com/NixOS/nixpkgs/archive/refs/heads/master.tar.gz -A scala-cli
+nix-env -iA scala-cli
 ```
 
 </TabItem>


### PR DESCRIPTION
It's already in the unstable / 22.05 channels so it shouldn't be necessary to specify a path to Nixpkgs master.