### PR TITLE
Extract java home from env variable

### DIFF
--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -183,8 +183,12 @@ final case class BuildOptions(
     javaOptions.javaHomeOpt
       .orElse {
         if (javaOptions.jvmIdOpt.isEmpty)
-          sys.props.get("java.home").map(p =>
-            Positioned(Position.Custom("java.home prop"), os.Path(p, Os.pwd))
+          Option(System.getenv("JAVA_HOME")).map(p =>
+            Positioned(Position.Custom("JAVA_HOME env"), os.Path(p, Os.pwd))
+          ).orElse(
+            sys.props.get("java.home").map(p =>
+              Positioned(Position.Custom("java.home prop"), os.Path(p, Os.pwd))
+            )
           )
         else None
       }


### PR DESCRIPTION
` sys.props.get("java.home")` return `None` for native launcher, so we extract `JAVA_HOME ` from env variable.