### PR TITLE
Publish tweaks + documentation

### DIFF
--- a/.github/scripts/check_docs.sh
+++ b/.github/scripts/check_docs.sh
@@ -25,7 +25,7 @@ fi
 
 statusFile="$(pwd)/out/sclicheck/.status"
 scala-cli sclicheck/sclicheck.scala -- --status-file "$statusFile" "${toCheck[@]}" || (
-  echo "Checking documentation failed. To run tests locally run `.github/scripts/check_docs.sh <failing_file>`"
+  echo "Checking documentation failed. To run tests locally run '.github/scripts/check_docs.sh <failing_file>'"
   echo "You can find more about automatic documentaiton testing in sclicheck/Readme.md file."
   exit 1
 )

--- a/build.sc
+++ b/build.sc
@@ -290,7 +290,9 @@ trait BuildLikeModule extends ScalaCliCrossSbtModule with ProtoBuildModule {
 
 class Core(val crossScalaVersion: String) extends BuildLikeModule {
   def moduleDeps = Seq(
-    `bloop-rifle`(),
+    `bloop-rifle`()
+  )
+  def compileModuleDeps = Seq(
     `build-macros`()
   )
   def scalacOptions = T {
@@ -414,7 +416,8 @@ class Core(val crossScalaVersion: String) extends BuildLikeModule {
 class Directives(val crossScalaVersion: String) extends BuildLikeModule {
   def moduleDeps = Seq(
     options(),
-    core()
+    core(),
+    `build-macros`()
   )
   def scalacOptions = T {
     super.scalacOptions() ++ asyncScalacOptions(scalaVersion())
@@ -469,7 +472,9 @@ class Directives(val crossScalaVersion: String) extends BuildLikeModule {
 
 class Options(val crossScalaVersion: String) extends BuildLikeModule {
   def moduleDeps = Seq(
-    core(),
+    core()
+  )
+  def compileModuleDeps = Seq(
     `build-macros`()
   )
   def scalacOptions = T {
@@ -604,7 +609,11 @@ trait CliOptions extends SbtModule with ScalaCliPublishModule with ScalaCliCompi
   def compileIvyDeps = super.compileIvyDeps() ++ Seq(
     Deps.jsoniterMacros
   )
-  def scalaVersion = Scala.scala213
+  private def scalaVer = Scala.scala213
+  def compileModuleDeps = Seq(
+    options(scalaVer)
+  )
+  def scalaVersion = scalaVer
   def repositories = super.repositories ++ customRepositories
 }
 
@@ -957,7 +966,7 @@ class BloopRifle(val crossScalaVersion: String) extends ScalaCliCrossSbtModule
     Deps.bsp4j,
     Deps.collectionCompat,
     Deps.libdaemonjvm,
-    Deps.snailgun(force213 = scalaVersion().startsWith("3."))
+    Deps.snailgun(force213 = !scalaVersion().startsWith("2.12."))
   )
   def compileIvyDeps = super.compileIvyDeps() ++ Agg(
     Deps.svm

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -57,6 +57,7 @@ case object ScalaPreprocessor extends Preprocessor {
     UsingResourcesDirectiveHandler,
     UsingCompilerPluginDirectiveHandler,
     UsingMainClassDirectiveHandler,
+    UsingPublishContextualDirectiveHandler,
     UsingPublishDirectiveHandler
   )
 

--- a/modules/cli-options/src/main/scala/scala/cli/commands/publish/PublishParamsOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/publish/PublishParamsOptions.scala
@@ -51,10 +51,18 @@ final case class PublishParamsOptions(
   @HelpMessage("Password of secret key to use to sign artifacts with Bouncy Castle")
   @ValueDescription("value:…")
   @ExtraName("secretKeyPass")
-    secretKeyPassword: Option[MaybeConfigPasswordOption] = None
+    secretKeyPassword: Option[MaybeConfigPasswordOption] = None,
 
-)
-// format: on
+  @Group("Publishing")
+  @HelpMessage("Use or setup publish parameters meant to be used on continuous integration")
+    ci: Option[Boolean] = None
+
+) {
+  // format: on
+
+  def isCi: Boolean =
+    ci.getOrElse(System.getenv("CI") != null)
+}
 
 object PublishParamsOptions {
   lazy val parser: Parser[PublishParamsOptions]                           = Parser.derive

--- a/modules/cli-options/src/main/scala/scala/cli/commands/publish/PublishParamsOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/publish/PublishParamsOptions.scala
@@ -2,8 +2,10 @@ package scala.cli.commands.publish
 
 import caseapp._
 
+import scala.build.options.publish.MaybeConfigPasswordOption
 import scala.cli.signing.shared.PasswordOption
 import scala.cli.signing.util.ArgParsers._
+import scala.cli.util.ArgParsers._
 
 // format: off
 final case class PublishParamsOptions(
@@ -43,13 +45,13 @@ final case class PublishParamsOptions(
 
   @Group("Publishing")
   @HelpMessage("Secret key to use to sign artifacts with Bouncy Castle")
-    secretKey: Option[PasswordOption] = None,
+    secretKey: Option[MaybeConfigPasswordOption] = None,
 
   @Group("Publishing")
   @HelpMessage("Password of secret key to use to sign artifacts with Bouncy Castle")
   @ValueDescription("value:…")
   @ExtraName("secretKeyPass")
-    secretKeyPassword: Option[PasswordOption] = None
+    secretKeyPassword: Option[MaybeConfigPasswordOption] = None
 
 )
 // format: on

--- a/modules/cli-options/src/main/scala/scala/cli/commands/publish/SharedPublishOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/publish/SharedPublishOptions.scala
@@ -39,7 +39,7 @@ final case class SharedPublishOptions(
 
   @Group("Publishing")
   @HelpMessage("Method to use to sign artifacts")
-  @ValueDescription("gpg|bc")
+  @ValueDescription("gpg|bc|none")
     signer: Option[String] = None,
 
   @Group("Publishing")

--- a/modules/cli-options/src/main/scala/scala/cli/util/ArgParsers.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/util/ArgParsers.scala
@@ -1,0 +1,40 @@
+package scala.cli.util
+
+import caseapp.core.argparser.ArgParser
+import caseapp.core.argparser.SimpleArgParser
+
+import scala.build.options.publish.MaybeConfigPasswordOption
+import scala.cli.signing.shared.PasswordOption
+
+abstract class LowPriorityArgParsers {
+
+  /** case-app [[ArgParser]] for [[MaybeConfigPasswordOption]]
+    *
+    * Given a lower priority than the one for `Option[MaybeConfigPasswordOption]`, as the latter
+    * falls back to `None` when given an empty string (like in `--password ""`), while letting it be
+    * automatically derived from this one (with the former parser and the generic [[ArgParser]] for
+    * `Option[T]` from case-app) would fail on such empty input.
+    */
+  implicit lazy val maybeConfigPasswordOptionArgParser: ArgParser[MaybeConfigPasswordOption] =
+    SimpleArgParser.from("password") { str =>
+      MaybeConfigPasswordOption.parse(str)
+        .left.map(caseapp.core.Error.Other(_))
+    }
+
+}
+
+object ArgParsers extends LowPriorityArgParsers {
+
+  /** case-app [[ArgParser]] for `Option[MaybeConfigPasswordOption]`
+    *
+    * Unlike a parser automatically derived through case-app [[ArgParser]] for `Option[T]`, the
+    * parser here accepts empty input (like in `--password ""`), and returns a `None` value in that
+    * case.
+    */
+  implicit lazy val optionMaybeConfigPasswordOptionArgParser
+    : ArgParser[Option[MaybeConfigPasswordOption]] =
+    SimpleArgParser.from("password") { str =>
+      if (str.trim.isEmpty) Right(None)
+      else maybeConfigPasswordOptionArgParser(None, -1, -1, str).map(Some(_))
+    }
+}

--- a/modules/cli/src/main/java/scala/cli/internal/LibsodiumjniFeature.java
+++ b/modules/cli/src/main/java/scala/cli/internal/LibsodiumjniFeature.java
@@ -8,17 +8,24 @@ import com.oracle.svm.hosted.c.NativeLibraries;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
+import java.util.Locale;
 
 @AutomaticFeature
-@Platforms({Platform.WINDOWS.class})
+@Platforms({Platform.LINUX.class, Platform.WINDOWS.class})
 public class LibsodiumjniFeature implements Feature {
 
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {
+        boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("windows");
+        boolean isStaticLauncher = Boolean.getBoolean("scala-cli.static-launcher");
+        if (!isWindows && !isStaticLauncher) {
+            System.err.println("Actually disabling LibsodiumjniFeature (not Windows nor static launcher)");
+            return;
+        }
         NativeLibrarySupport.singleton().preregisterUninitializedBuiltinLibrary("sodiumjni");
         PlatformNativeLibrarySupport.singleton().addBuiltinPkgNativePrefix("libsodiumjni_");
         NativeLibraries nativeLibraries = ((FeatureImpl.BeforeAnalysisAccessImpl) access).getNativeLibraries();
+        nativeLibraries.addStaticNonJniLibrary("sodium");
         nativeLibraries.addStaticJniLibrary("sodiumjni");
-        nativeLibraries.addDynamicNonJniLibrary("sodium");
     }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/GitRepo.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/GitRepo.scala
@@ -1,0 +1,23 @@
+package scala.cli.commands.publish
+
+import scala.util.Properties
+
+object GitRepo {
+
+  private lazy val user = os.owner(os.home)
+  private def trusted(path: os.Path): Boolean =
+    if (Properties.isWin)
+      path.toIO.canWrite()
+    else
+      os.owner(path) == user
+
+  def gitRepoOpt(workspace: os.Path): Option[os.Path] =
+    if (trusted(workspace))
+      if (os.isDir(workspace / ".git")) Some(workspace)
+      else if (workspace.segmentCount > 0)
+        gitRepoOpt(workspace / os.up)
+      else
+        None
+    else
+      None
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/GitRepoError.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/GitRepoError.scala
@@ -1,0 +1,5 @@
+package scala.cli.commands.publish
+
+import scala.build.errors.BuildException
+
+final class GitRepoError(message: String) extends BuildException(message)

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -148,10 +148,18 @@ object Publish extends ScalaCommand[PublishOptions] {
       sys.exit(0)
     }
 
+  def maybePrintChecksumsAndExit(options: SharedPublishOptions): Unit =
+    if (options.checksum.contains("list")) {
+      for (t <- ChecksumType.all)
+        println(t.name)
+      sys.exit(0)
+    }
+
   def run(options: PublishOptions, args: RemainingArgs): Unit = {
     maybePrintGroupHelp(options)
 
     maybePrintLicensesAndExit(options.publishParams)
+    maybePrintChecksumsAndExit(options.sharedPublish)
 
     CurrentParams.verbosity = options.shared.logging.verbosity
     val inputs = options.shared.inputsOrExit(args)

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -53,6 +53,7 @@ import scala.cli.errors.{
 }
 import scala.cli.packaging.Library
 import scala.cli.publish.BouncycastleSignerMaker
+import scala.cli.util.MaybeConfigPasswordOptionHelpers._
 
 object Publish extends ScalaCommand[PublishOptions] {
 
@@ -754,7 +755,7 @@ object Publish extends ScalaCommand[PublishOptions] {
         }
       case Some(PSigner.BouncyCastle) =>
         publishOptions.secretKey match {
-          case Some(secretKey) =>
+          case Some(secretKey0) =>
             val getLauncher: Supplier[NioPath] = { () =>
               val archiveCache = builds.headOption
                 .map(_.options.archiveCache)
@@ -764,16 +765,17 @@ object Publish extends ScalaCommand[PublishOptions] {
                 case Right(value) => value.wrapped
               }
             }
+            val secretKey = secretKey0.get(configDb()).orExit(logger)
             if (forceSigningBinary)
               (new scala.cli.internal.BouncycastleSignerMakerSubst).get(
-                publishOptions.secretKeyPassword.orNull,
+                publishOptions.secretKeyPassword.orNull.get(configDb()).orExit(logger),
                 secretKey,
                 getLauncher,
                 logger
               )
             else
               (new BouncycastleSignerMaker).get(
-                publishOptions.secretKeyPassword.orNull,
+                publishOptions.secretKeyPassword.orNull.get(configDb()).orExit(logger),
                 secretKey,
                 getLauncher,
                 logger

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -141,8 +141,17 @@ object Publish extends ScalaCommand[PublishOptions] {
     )
   }
 
+  def maybePrintLicensesAndExit(params: PublishParamsOptions): Unit =
+    if (params.license.contains("list")) {
+      for (l <- scala.build.internal.Licenses.list)
+        println(s"${l.id}: ${l.name} (${l.url})")
+      sys.exit(0)
+    }
+
   def run(options: PublishOptions, args: RemainingArgs): Unit = {
     maybePrintGroupHelp(options)
+
+    maybePrintLicensesAndExit(options.publishParams)
 
     CurrentParams.verbosity = options.shared.logging.verbosity
     val inputs = options.shared.inputsOrExit(args)

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
@@ -70,7 +70,7 @@ object PublishLocal extends ScalaCommand[PublishLocalOptions] {
       ivy2HomeOpt,
       publishLocal = true,
       forceSigningBinary = options.sharedPublish.forceSigningBinary,
-      parallelUpload = true,
+      parallelUpload = Some(true),
       options.watch.watch,
       () => ConfigDb.empty // shouldn't be used, no need of repo credentials here
     )

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
@@ -23,6 +23,7 @@ object PublishLocal extends ScalaCommand[PublishLocalOptions] {
     maybePrintGroupHelp(options)
 
     Publish.maybePrintLicensesAndExit(options.publishParams)
+    Publish.maybePrintChecksumsAndExit(options.sharedPublish)
 
     CurrentParams.verbosity = options.shared.logging.verbosity
     val inputs = options.shared.inputsOrExit(args)

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
@@ -72,6 +72,7 @@ object PublishLocal extends ScalaCommand[PublishLocalOptions] {
       forceSigningBinary = options.sharedPublish.forceSigningBinary,
       parallelUpload = Some(true),
       options.watch.watch,
+      isCi = options.publishParams.isCi,
       () => ConfigDb.empty // shouldn't be used, no need of repo credentials here
     )
   }

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
@@ -22,6 +22,8 @@ object PublishLocal extends ScalaCommand[PublishLocalOptions] {
   def run(options: PublishLocalOptions, args: RemainingArgs): Unit = {
     maybePrintGroupHelp(options)
 
+    Publish.maybePrintLicensesAndExit(options.publishParams)
+
     CurrentParams.verbosity = options.shared.logging.verbosity
     val inputs = options.shared.inputsOrExit(args)
     CurrentParams.workspaceOpt = Some(inputs.workspace)

--- a/modules/cli/src/main/scala/scala/cli/errors/FailedToSignFileError.scala
+++ b/modules/cli/src/main/scala/scala/cli/errors/FailedToSignFileError.scala
@@ -3,4 +3,4 @@ package scala.cli.errors
 import scala.build.errors.BuildException
 
 final class FailedToSignFileError(val path: Either[String, os.Path], val error: String)
-    extends BuildException(s"Failed to sign $path: $error")
+    extends BuildException(s"Failed to sign ${path.fold(identity, _.toString)}: $error")

--- a/modules/cli/src/main/scala/scala/cli/errors/MissingConfigEntryError.scala
+++ b/modules/cli/src/main/scala/scala/cli/errors/MissingConfigEntryError.scala
@@ -1,0 +1,6 @@
+package scala.cli.errors
+
+import scala.build.errors.BuildException
+
+final class MissingConfigEntryError(key: String)
+    extends BuildException(s"Missing config entry $key")

--- a/modules/cli/src/main/scala/scala/cli/util/MaybeConfigPasswordOptionHelpers.scala
+++ b/modules/cli/src/main/scala/scala/cli/util/MaybeConfigPasswordOptionHelpers.scala
@@ -1,0 +1,26 @@
+package scala.cli.util
+
+import scala.build.errors.BuildException
+import scala.build.options.publish.MaybeConfigPasswordOption
+import scala.cli.config.{ConfigDb, Key}
+import scala.cli.errors.MissingConfigEntryError
+import scala.cli.signing.shared.PasswordOption
+
+object MaybeConfigPasswordOptionHelpers {
+
+  implicit class MaybeConfigPasswordOptionOps(private val opt: MaybeConfigPasswordOption)
+      extends AnyVal {
+    def get(configDb: => ConfigDb): Either[BuildException, PasswordOption] =
+      opt match {
+        case a: MaybeConfigPasswordOption.ActualOption =>
+          Right(a.option)
+        case c: MaybeConfigPasswordOption.ConfigOption =>
+          val key = new Key.PasswordEntry(c.prefix, c.name)
+          configDb.get(key).flatMap {
+            case None        => Left(new MissingConfigEntryError(c.fullName))
+            case Some(value) => Right(value)
+          }
+      }
+  }
+
+}

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/UsingPublishContextualDirectiveHandler.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/UsingPublishContextualDirectiveHandler.scala
@@ -1,0 +1,130 @@
+package scala.build.preprocessing.directives
+
+import scala.build.EitherCps.{either, value}
+import scala.build.Logger
+import scala.build.errors.{BuildException, MalformedInputError, UnexpectedDirectiveError}
+import scala.build.options.publish.{ComputeVersion, MaybeConfigPasswordOption}
+import scala.build.options.{
+  BuildOptions,
+  PostBuildOptions,
+  PublishContextualOptions,
+  PublishOptions
+}
+import scala.cli.signing.shared.PasswordOption
+
+case object UsingPublishContextualDirectiveHandler extends UsingDirectiveHandler {
+
+  private def prefix = "publish."
+
+  def name        = "Publish (contextual)"
+  def description = "Set contextual parameters for publishing"
+  def usage       = s"//> using $prefix[ci.](computeVersion|repository|secretKey|…) [value]"
+
+  override def usageMd =
+    s"""`//> using ${prefix}computeVersion `"value"
+       |`//> using ${prefix}ci.repository `"value"
+       |`//> using ${prefix}secretKey `"value"
+       |""".stripMargin
+
+  private def q = "\""
+  override def examples = Seq(
+    s"//> using ${prefix}computeVersion ${q}git:tag$q",
+    s"//> using ${prefix}ci.repository ${q}central-s01$q",
+    s"//> using ${prefix}secretKey ${q}env:PUBLISH_SECRET_KEY$q"
+  )
+  def keys = Seq(
+    "computeVersion",
+    "compute-version",
+    "repository",
+    "gpgKey",
+    "gpg-key",
+    "gpgOption",
+    "gpg-option",
+    "gpgOptions",
+    "gpg-options",
+    "secretKey",
+    "secretKeyPassword",
+    "user",
+    "password",
+    "realm"
+  ).map(prefix + _)
+
+  override def getValueNumberBounds(key: String) = key match {
+    case "gpgOptions" | "gpg-options" | "gpgOption" | "gpg-option" =>
+      UsingDirectiveValueNumberBounds(1, Int.MaxValue)
+    case _ => UsingDirectiveValueNumberBounds(1, 1)
+  }
+
+  def handleValues(
+    scopedDirective: ScopedDirective,
+    logger: Logger
+  ): Either[BuildException, ProcessedUsingDirective] = either {
+
+    val groupedScopedValuesContainer = value(checkIfValuesAreExpected(scopedDirective))
+
+    val severalValues = groupedScopedValuesContainer.scopedStringValues.map(_.positioned)
+    val singleValue   = severalValues.head
+
+    val strippedKey =
+      if (scopedDirective.directive.key.startsWith(prefix))
+        scopedDirective.directive.key.stripPrefix(prefix)
+      else
+        value(Left(new UnexpectedDirectiveError(scopedDirective.directive.key)))
+
+    val publishContextualOptions = strippedKey match {
+      case "computeVersion" | "compute-version" =>
+        value {
+          ComputeVersion.parse(singleValue).map {
+            computeVersion =>
+              PublishContextualOptions(
+                computeVersion = Some(
+                  computeVersion
+                )
+              )
+          }
+        }
+      case "repository" =>
+        PublishContextualOptions(repository = Some(singleValue.value))
+      case "gpgKey" | "gpg-key" =>
+        PublishContextualOptions(gpgSignatureId = Some(singleValue.value))
+      case "gpgOptions" | "gpg-options" | "gpgOption" | "gpg-option" =>
+        PublishContextualOptions(gpgOptions = severalValues.map(_.value).toList)
+      case "secretKey" =>
+        PublishContextualOptions(secretKey =
+          Some(
+            MaybeConfigPasswordOption.ActualOption(value(parsePasswordOption(singleValue.value)))
+          )
+        )
+      case "secretKeyPassword" =>
+        PublishContextualOptions(
+          secretKeyPassword = Some(
+            MaybeConfigPasswordOption.ActualOption(value(parsePasswordOption(singleValue.value)))
+          )
+        )
+      case "user" =>
+        PublishContextualOptions(repoUser = Some(value(parsePasswordOption(singleValue.value))))
+      case "password" =>
+        PublishContextualOptions(repoPassword = Some(value(parsePasswordOption(singleValue.value))))
+      case "realm" =>
+        PublishContextualOptions(repoRealm = Some(singleValue.value))
+      case _ =>
+        value(Left(new UnexpectedDirectiveError(scopedDirective.directive.key)))
+    }
+
+    val publishOptions = PublishOptions(contextual = publishContextualOptions)
+
+    val options = BuildOptions(
+      notForBloopOptions = PostBuildOptions(
+        publishOptions = publishOptions
+      )
+    )
+
+    ProcessedDirective(Some(options), Seq.empty)
+  }
+
+  private def parsePasswordOption(input: String): Either[BuildException, PasswordOption] =
+    PasswordOption.parse(input)
+      .left.map(_ =>
+        new MalformedInputError("secret", input, "file:_path_|value:_value_|env:_env_var_name_")
+      )
+}

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/UsingPublishDirectiveHandler.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/UsingPublishDirectiveHandler.scala
@@ -9,7 +9,13 @@ import scala.build.errors.{
   MalformedInputError,
   UnexpectedDirectiveError
 }
-import scala.build.options.publish.{ComputeVersion, Developer, License, Vcs}
+import scala.build.options.publish.{
+  ComputeVersion,
+  Developer,
+  License,
+  MaybeConfigPasswordOption,
+  Vcs
+}
 import scala.build.options.{BuildOptions, PostBuildOptions, PublishOptions}
 import scala.cli.signing.shared.PasswordOption
 
@@ -142,9 +148,17 @@ case object UsingPublishDirectiveHandler extends UsingDirectiveHandler {
       case "gpgOptions" | "gpg-options" | "gpgOption" | "gpg-option" =>
         PublishOptions(gpgOptions = severalValues.map(_.value).toList)
       case "secretKey" =>
-        PublishOptions(secretKey = Some(value(parsePasswordOption(singleValue.value))))
+        PublishOptions(secretKey =
+          Some(
+            MaybeConfigPasswordOption.ActualOption(value(parsePasswordOption(singleValue.value)))
+          )
+        )
       case "secretKeyPassword" =>
-        PublishOptions(secretKeyPassword = Some(value(parsePasswordOption(singleValue.value))))
+        PublishOptions(secretKeyPassword =
+          Some(
+            MaybeConfigPasswordOption.ActualOption(value(parsePasswordOption(singleValue.value)))
+          )
+        )
       case "user" =>
         PublishOptions(repoUser = Some(value(parsePasswordOption(singleValue.value))))
       case "password" =>

--- a/modules/options/src/main/scala/scala/build/options/PublishContextualOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/PublishContextualOptions.scala
@@ -1,0 +1,26 @@
+package scala.build.options
+
+import scala.build.options.publish.{ComputeVersion, MaybeConfigPasswordOption, Signer}
+import scala.cli.signing.shared.PasswordOption
+
+/** Publishing-related options, that can have different values locally and on CIs */
+final case class PublishContextualOptions(
+  repository: Option[String] = None,
+  repositoryIsIvy2LocalLike: Option[Boolean] = None,
+  sourceJar: Option[Boolean] = None,
+  docJar: Option[Boolean] = None,
+  gpgSignatureId: Option[String] = None,
+  gpgOptions: List[String] = Nil,
+  signer: Option[Signer] = None,
+  secretKey: Option[MaybeConfigPasswordOption] = None,
+  secretKeyPassword: Option[MaybeConfigPasswordOption] = None,
+  repoUser: Option[PasswordOption] = None,
+  repoPassword: Option[PasswordOption] = None,
+  repoRealm: Option[String] = None,
+  computeVersion: Option[ComputeVersion] = None,
+  checksums: Option[Seq[String]] = None
+)
+
+object PublishContextualOptions {
+  implicit val monoid: ConfigMonoid[PublishContextualOptions] = ConfigMonoid.derive
+}

--- a/modules/options/src/main/scala/scala/build/options/PublishOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/PublishOptions.scala
@@ -1,7 +1,14 @@
 package scala.build.options
 
 import scala.build.Positioned
-import scala.build.options.publish.{ComputeVersion, Developer, License, Signer, Vcs}
+import scala.build.options.publish.{
+  ComputeVersion,
+  Developer,
+  License,
+  MaybeConfigPasswordOption,
+  Signer,
+  Vcs
+}
 import scala.cli.signing.shared.PasswordOption
 
 final case class PublishOptions(
@@ -23,8 +30,8 @@ final case class PublishOptions(
   gpgSignatureId: Option[String] = None,
   gpgOptions: List[String] = Nil,
   signer: Option[Signer] = None,
-  secretKey: Option[PasswordOption] = None,
-  secretKeyPassword: Option[PasswordOption] = None,
+  secretKey: Option[MaybeConfigPasswordOption] = None,
+  secretKeyPassword: Option[MaybeConfigPasswordOption] = None,
   repoUser: Option[PasswordOption] = None,
   repoPassword: Option[PasswordOption] = None,
   repoRealm: Option[String] = None,

--- a/modules/options/src/main/scala/scala/build/options/PublishOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/PublishOptions.scala
@@ -1,15 +1,7 @@
 package scala.build.options
 
 import scala.build.Positioned
-import scala.build.options.publish.{
-  ComputeVersion,
-  Developer,
-  License,
-  MaybeConfigPasswordOption,
-  Signer,
-  Vcs
-}
-import scala.cli.signing.shared.PasswordOption
+import scala.build.options.publish.{Developer, License, Vcs}
 
 final case class PublishOptions(
   organization: Option[Positioned[String]] = None,
@@ -23,20 +15,7 @@ final case class PublishOptions(
   developers: Seq[Developer] = Nil,
   scalaVersionSuffix: Option[String] = None,
   scalaPlatformSuffix: Option[String] = None,
-  repository: Option[String] = None,
-  repositoryIsIvy2LocalLike: Option[Boolean] = None,
-  sourceJar: Option[Boolean] = None,
-  docJar: Option[Boolean] = None,
-  gpgSignatureId: Option[String] = None,
-  gpgOptions: List[String] = Nil,
-  signer: Option[Signer] = None,
-  secretKey: Option[MaybeConfigPasswordOption] = None,
-  secretKeyPassword: Option[MaybeConfigPasswordOption] = None,
-  repoUser: Option[PasswordOption] = None,
-  repoPassword: Option[PasswordOption] = None,
-  repoRealm: Option[String] = None,
-  computeVersion: Option[ComputeVersion] = None,
-  checksums: Option[Seq[String]] = None
+  contextual: PublishContextualOptions = PublishContextualOptions()
 )
 
 object PublishOptions {

--- a/modules/options/src/main/scala/scala/build/options/PublishOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/PublishOptions.scala
@@ -15,8 +15,13 @@ final case class PublishOptions(
   developers: Seq[Developer] = Nil,
   scalaVersionSuffix: Option[String] = None,
   scalaPlatformSuffix: Option[String] = None,
-  contextual: PublishContextualOptions = PublishContextualOptions()
-)
+  local: PublishContextualOptions = PublishContextualOptions(),
+  ci: PublishContextualOptions = PublishContextualOptions()
+) {
+  def contextual(isCi: Boolean): PublishContextualOptions =
+    if (isCi) PublishContextualOptions.monoid.orElse(ci, local)
+    else local
+}
 
 object PublishOptions {
   implicit val monoid: ConfigMonoid[PublishOptions] = ConfigMonoid.derive

--- a/modules/options/src/main/scala/scala/build/options/publish/MaybeConfigPasswordOption.scala
+++ b/modules/options/src/main/scala/scala/build/options/publish/MaybeConfigPasswordOption.scala
@@ -1,0 +1,21 @@
+package scala.build.options.publish
+
+import scala.cli.signing.shared.PasswordOption
+
+/** Can be either a [[PasswordOption]], or something like "config:…" pointing at a config entry */
+sealed abstract class MaybeConfigPasswordOption extends Product with Serializable
+
+object MaybeConfigPasswordOption {
+  final case class ActualOption(option: PasswordOption) extends MaybeConfigPasswordOption
+  final case class ConfigOption(fullName: String) extends MaybeConfigPasswordOption {
+    private lazy val split  = fullName.split('.')
+    def prefix: Seq[String] = split.dropRight(1).toSeq
+    def name: String        = split.last
+  }
+
+  def parse(input: String): Either[String, MaybeConfigPasswordOption] =
+    if (input.startsWith("config:"))
+      Right(ConfigOption(input.stripPrefix("config:")))
+    else
+      PasswordOption.parse(input).map(ActualOption(_))
+}

--- a/modules/options/src/main/scala/scala/build/options/publish/Signer.scala
+++ b/modules/options/src/main/scala/scala/build/options/publish/Signer.scala
@@ -14,7 +14,7 @@ object Signer {
     input.value match {
       case "gpg"                 => Right(Signer.Gpg)
       case "bc" | "bouncycastle" => Right(Signer.BouncyCastle)
-      case "nop"                 => Right(Signer.Nop)
+      case "nop" | "none"        => Right(Signer.Nop)
       case _ => Left(new MalformedInputError("signer", input.value, "gpg|bc", input.positions))
     }
 }

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -135,7 +135,7 @@ object Deps {
   def snailgun(force213: Boolean = false) =
     if (force213) ivy"io.github.alexarchambault.scala-cli.snailgun:snailgun-core_2.13:0.4.1-sc1"
     else ivy"io.github.alexarchambault.scala-cli.snailgun::snailgun-core:0.4.1-sc1"
-  def sttp            = ivy"com.softwaremill.sttp.client3::core:3.6.2"
+  def sttp            = ivy"com.softwaremill.sttp.client3:core_2.13:3.6.2"
   def svm             = ivy"org.graalvm.nativeimage:svm:22.0.0.2"
   def swoval          = ivy"com.swoval:file-tree-views:2.1.9"
   def testInterface   = ivy"org.scala-sbt:test-interface:1.0"

--- a/website/docs/commands/misc/pgp.md
+++ b/website/docs/commands/misc/pgp.md
@@ -14,7 +14,9 @@ These commands allow to
 - sign files with `pgp sign`
 - verify signatures with `pgp verify`
 
-Note that these capabilities rely on the [Bouncy Castle library](https://www.bouncycastle.org).
+These capabilities rely on the [Bouncy Castle library](https://www.bouncycastle.org).
+Note that sub-commands relying on signing, such as `publish`, also allow signing
+to be handled using `gpg`.
 
 ## Create key pairs
 

--- a/website/docs/commands/publishing/_category_.json
+++ b/website/docs/commands/publishing/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Publishing",
+  "position": 26
+}

--- a/website/docs/commands/publishing/publish-local.md
+++ b/website/docs/commands/publishing/publish-local.md
@@ -1,0 +1,37 @@
+---
+title: Publish Local
+sidebar_position: 21
+---
+
+import {ChainedSnippets} from "../../../src/components/MarkdownComponents.js";
+
+The `publish local` sub-command publishes a Scala CLI project in the local Ivy2
+repository, just like how `sbt publishLocal` or `mill __.publishLocal` do. This
+repository usually lives under `~/.ivy2/local`, and is taken into account most of
+the time by most Scala tools when fetching artifacts.
+
+## Usage
+
+To publish locally a Scala CLI project, run
+
+<ChainedSnippets>
+
+```sh
+scala-cli publish local .
+```
+
+```text
+Publishing io.github.scala-cli:hello-scala-cli_3:0.1.0-SNAPSHOT
+ ✔ Computed 10 checksums
+ 🚚 Wrote 15 files
+
+ 👀 Check results at
+  ~/.ivy2/local/io.github.scala-cli/hello-scala-cli_3/0.1.0-SNAPSHOT/
+```
+
+</ChainedSnippets>
+
+## Required settings
+
+The `publish local` command needs the [same required settings as the `publish` command](publish.md#required-settings). Like for `publish`, Scala CLI might already be able to compute sensible defaults
+for those.

--- a/website/docs/commands/publishing/publish.md
+++ b/website/docs/commands/publishing/publish.md
@@ -1,0 +1,243 @@
+---
+title: Publish
+sidebar_position: 20
+---
+
+import {ChainedSnippets} from "../../../src/components/MarkdownComponents.js";
+
+The `publish` sub-command allows to publish Scala CLI projects to Maven repositories.
+
+## Required settings
+
+`scala-cli publish` and `scala-cli publish local` might complain about missing settings.
+An organization, a name (or a module name), and (a way to compute) a version are needed, but Scala CLI may
+be able to compute sensible defaults for them.
+
+We recommend setting the settings below via using directives rather than on the command-line,
+so that commands such as `scala publish .` or `scala publish local .` work fine for your
+project. Command-line options for those settings take over the using directive values, and are
+provided as a convenience.
+
+This table lists settings allowing to specify those. See the sub-sections right after for more details.
+
+|          | `using` directive | Command-line option | Example values | Notes |
+|----------|-------------------|---------------------|----------------|-------|
+| Organization | `publish.organization` | `--organization` | `org.virtuslab.scala-cli` | |
+| Name | `publish.name` | `--name` | `scala-cli` | |
+| Module Name | `publish.moduleName` | `--module-name` | `scala-cli_3` | Module Name includes the Scala prefix, such as `_2.13` or `_3`. Specifying Name should be favored over Module Name |
+| Compute Version | `publish.computeVersion` | `--compute-version` | `git:tag` | |
+| Version | `publish.version` | `--version` | `0.1.0`, `0.1.1-SNAPSHOT` | As much as possible, Compute Version (describing how to compute the version) should be favored over Version |
+
+### Organization
+
+If your Scala CLI project lives in a git repository having a GitHub remote, Scala CLI
+will infer an organization from it: if your project lives in GitHub organization `foo`
+(that is, lives somewhere under `https://github.com/foo/`), Scala CLI will use
+`io.github.foo` as default Maven organization.
+
+To override this default value, set the `publish.organization` directive, like
+```scala
+//> using publish.organization "io.github.foo"
+```
+
+### Name
+
+Scala CLI will use the project directory name as default Maven name. That is, if your
+Scala CLI project lives in a directory named `something`, it will be published as
+`something` (pure Java project) or `something_3` (Scala 3 project) for example.
+
+To override this default value, set the `publish.name` directive, like
+```scala
+//> using publish.name "something"
+```
+
+### Version
+
+If your Scala CLI project lives in a git repository, Scala CLI will infer a way to compute
+versions from it: if the current commit has a tag `v1.2.3`, version `1.2.3` is assumed.
+Else, if it has such a tag earlier in the git history, version `1.2.4-SNAPSHOT` is assumed.
+
+To override this default value, set the `publish.computeVersion` directive, like
+```scala
+//> using publish.computeVersion "git:tag"
+```
+
+## Repository settings
+
+A repository is required for the `publish` command, and might need other settings to work fine
+(to pass credentials for example).
+
+When publishing from you CI, we recommend letting `scala-cli publish setup`
+setting those settings via using directives. When publishing from your local machine to Maven Central,
+we recommend setting the repository via a `publish.repository` directive, and keeping your
+Sonatype credentials in the Scala CLI settings, via commands such as
+```bash
+SONATYPE_USER=… scala-cli config sonatype.user env:SONATYPE_USER --password-value
+SONATYPE_PASSWORD=… scala-cli config sonatype.password env:SONATYPE_PASSWORD
+```
+
+<!-- TODO Automatically generate that? -->
+|          | `using` directive | Command-line option | Example values | Notes |
+|----------|-------------------|---------------------|----------------|-------|
+| Repository | `publish.repository` | `--publish-repository` | `central`, `central-s01`, `github`, `https://artifacts.company.com/maven` | |
+| Repository User | `publish.user` | `--user` | `env:SONATYPE_USER` | Password value format |
+| Repository Password | `publish.password` | `--password` | `env:SONATYPE_PASSWORD` |
+| Repository Realm | `publish.realm` | `--realm` | | |
+
+## Other settings
+
+A number of metadata can be set either by `using` directives, or from the command-line. These
+metadata are optional in the `publish local` command, but might be mandatory for some repositories
+in the `publish` command, like Maven Central for non-snapshot versions.
+
+We recommend setting the settings below via using directives rather than on the command-line,
+so that these don't have to be recalled for each `scala-cli publish` or `scala-cli publish local`
+invocation. Command-line options for those settings take over the using directive values, and are
+provided as a convenience.
+
+<!-- TODO Automatically generate that? -->
+|          | `using` directive | Command-line option | Example values | Notes |
+|----------|-------------------|---------------------|----------------|-------|
+| License | `publish.license` | `--license` | `Apache-2.0`, `MIT`, `Foo:https://foo.com/license.txt`, … | Run `scala-cli publish --license list` to list pre-defined licenses |
+| URL | `publish.url` | `--url` | | |
+| VCS | `publish.vcs` | `--vcs` | `github:VirtusLab/scala-cli`, `https://github.com/VirtusLab/scala-cli.git` |scm:git:github.com/VirtusLab/scala-cli.git|scm:git:git@github.com:VirtusLab/scala-cli.git` | |
+| Developers | `publish.developer` | `--developer` | <code>alexme&vert;Alex Me&vert;https://alex.me</code> | Can be specified multiple times, using directives and CLI values add up |
+
+### Signing
+
+Scala CLI can sign the artifacts it publishes with PGP signatures. Signing in Scala CLI can be
+handled by either
+- the [Bouncy Castle library](https://www.bouncycastle.org) (default, recommended)
+- the local `gpg` binary on your machine
+
+#### Bouncy Castle
+
+A benefit of using Bouncy Castle to sign artifacts is that it has no external dependencies.
+Scala CLI is able to sign things with Bouncy Castle without further setup on your side.
+
+To enable signing with Bouncy Castle (recommended), pass a secret key with
+`--secret-key file:/path/to/secret-key`. If the key is protected by a password,
+pass it like `--secret-key-password env:MY_KEY_PASSWORD`.
+
+Scala CLI can generate and keep a secret key for you. For that, create the key with
+```sh
+scala-cli config --create-key
+```
+
+You can then ask publish to use the key kept in the Scala CLI config with
+```sh
+scala-cli publish \
+  --secret-key config:pgp.secret-key \
+  --secret-key-password config:pgp.secret-key-password \
+  …
+```
+
+#### GPG
+
+Using GPG to sign artifacts requires the `gpg` binary to be installed on your system.
+A benefit of using `gpg` to sign artifacts over Bouncy Castle is: you can use keys from
+your GPG key ring, or from external devices that GPG may support.
+
+To enable signing with GPG, pass `--gpg-key *key_id*` on the command line. If needed,
+you can specify arguments meant to be passed to `gpg`, with `--gpg-option`, like
+```text
+--gpg-key 1234567890ABCDEF --gpg-option --foo --gpg-option --bar
+```
+
+### Checksums
+
+Scala CLI can generate checksums of the artifacts it publishes.
+
+By default, Scala CLI generates SHA-1 and MD5 checksums. To disable checksums,
+pass `--checksum none`. To generate checksum formats to generate, pass them via
+`--checksum`, separating the checksum values with `,` or using `--checksum` multiple
+times:
+```text
+--checksum sha1,md5
+--checksum sha1 --checksum md5
+```
+
+To list supported checksum types, pass `--checksum list`.
+
+### CI overrides
+
+Scala CLI allows some publishing-related settings to have different values on your local machine and
+on CIs. In particular, this can be convenient to handle credentials and signing parameters, as these can
+be read from different locations on developers' machines and on CIs.
+
+On CIs (when `CI` is set in the environment, whatever its value), the CI override is
+used if it's there. Else the main directive is used.
+
+<!-- TODO Automatically generate that? -->
+| Settings | Directive | CI override directive |
+|----------|-------------------|-----------------------|
+| Compute Version | `publish.computeVersion` | `publish.ci.computeVersion` |
+| Repository | `publish.repository` | `publish.ci.repository` |
+| Repository User | `publish.user` | `publish.ci.user` |
+| Repository Password | `publish.password` | `publish.ci.password` |
+| Repository Realm | `publish.realm` | `publish.ci.realm` |
+| Secret Key | `publish.secretKey` | `publish.ci.secretKey` |
+| Secret Key Password | `publish.secretKeyPassword` | `publish.ci.secretKeyPassword` |
+| GPG key | `publish.gpgKey` | `publish.ci.gpgKey` |
+| GPG options | `publish.gpgOptions` | `publish.ci.gpgOptions` |
+
+## Repositories
+
+### Maven Central
+
+Use `central` as repository to push artifacts to Maven Central via `oss.sonatype.org`.
+To push to it via `s01.oss.sonatype.org` (the default for newly created repositories),
+use `central-s01`.
+
+### GitHub Packages
+
+Use `github` (GitHub organization and name computed from the git remotes)
+or `github:org/name` (replace `org` and `name` by the GitHub organization and name
+of your repository, like `github:VirtusLab/scala-cli`)
+to push artifacts to GitHub Packages.
+
+Note that, as of writing this, this disables parallel uploading of artifacts,
+checksums, and signing (all not supported by GitHub Packages as of writing this).
+
+### Ivy2 Local
+
+Use `ivy2Local` to put artifacts in the local Ivy2 repository, just like how
+[`publish local`](./publish-local.md) does.
+
+### Other pre-defined repositories
+
+All pre-defined repositories accepted by coursier, such as `jitpack` or `sonatype:snapshots`, are accepted as repositories for publishing.
+
+### Generic Maven repositories
+
+Pass a URL (beginning with `http://` or `https://`) to push to custom
+HTTP servers. Pushing to such repositories relies on HTTP PUT requests
+(just like for the pre-defined repositories above).
+
+### Authentication
+
+Specify publish repository authentication either on the command-line or via
+using directives. See user / password / realm in the [settings table](#settings)
+and the [CI overrides](#ci-overrides).
+
+## Publishing
+
+Once all the necessary settings are set, publish a Scala CLI with a command
+such as this one (`.` is for the Scala CLI project in the current directory):
+
+<ChainedSnippets>
+
+```sh
+scala-cli publish .
+```
+
+```text
+Publishing io.github.scala-cli:hello-scala-cli_3:0.1.0-SNAPSHOT
+ ✔ Computed 8 checksums
+ 🚚 Wrote 12 files
+
+ 👀 Check results at
+  https://s01.oss.sonatype.org/content/repositories/snapshots/io/github/scala-cli/hello-scala-cli_3/0.1.0-SNAPSHOT
+```
+
+</ChainedSnippets>

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1224,6 +1224,10 @@ Aliases: `--secret-key-pass`
 
 Password of secret key to use to sign artifacts with Bouncy Castle
 
+#### `--ci`
+
+Use or setup publish parameters meant to be used on continuous integration
+
 ## Publish repository options
 
 Available in commands:

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -121,6 +121,22 @@ Set parameters for publishing
 
 `//> using publish.version "0.1.1"`
 
+### Publish (contextual)
+
+Set contextual parameters for publishing
+
+`//> using publish.computeVersion `"value"
+`//> using publish.ci.repository `"value"
+`//> using publish.secretKey `"value"
+
+
+#### Examples
+`//> using publish.computeVersion "git:tag"`
+
+`//> using publish.ci.repository "central-s01"`
+
+`//> using publish.secretKey "env:PUBLISH_SECRET_KEY"`
+
 ### Repository
 
 Add a repository for dependency resolution


### PR DESCRIPTION
This tweaks things in the `publish` sub-command (allowing to list licenses or checksum types, better defaults, accept `github` as repository, …), and adds documentation for it.