### PR TITLE
Update case-app to 2.1.0-M14

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -69,7 +69,7 @@ object Deps {
   // Force using of 2.13 - is there a better way?
   def bloopConfig      = ivy"io.github.alexarchambault.bleep:bloop-config_2.13:1.5.0-sc-1"
   def bsp4j            = ivy"ch.epfl.scala:bsp4j:2.0.0"
-  def caseApp          = ivy"com.github.alexarchambault:case-app_2.13:2.1.0-M13"
+  def caseApp          = ivy"com.github.alexarchambault:case-app_2.13:2.1.0-M14"
   def collectionCompat = ivy"org.scala-lang.modules::scala-collection-compat:2.7.0"
   // Force using of 2.13 - is there a better way?
   def coursier           = ivy"io.get-coursier:coursier_2.13:${Versions.coursier}"


### PR DESCRIPTION
This fixes issues with zsh completions, that were printing unescaped '|' in some option descriptions.