### PR TITLE
Export and import coursier caches

### DIFF
--- a/modules/cli-options/src/main/scala/scala/cli/commands/CacheExportOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/CacheExportOptions.scala
@@ -1,0 +1,20 @@
+package scala.cli.commands
+
+import caseapp._
+import caseapp.core.help.Help
+
+// format: off
+@HelpMessage("Export Coursier Cache")
+final case class CacheExportOptions(
+  @Recurse
+    runOptions: RunOptions = RunOptions(),
+  @HelpMessage("Set the destination path")
+  @Name("o")
+    output: Option[String] = None,
+)
+  // format: on
+
+object CacheExportOptions {
+  implicit lazy val parser: Parser[CacheExportOptions] = Parser.derive
+  implicit lazy val help: Help[CacheExportOptions]     = Help.derive
+}

--- a/modules/cli-options/src/main/scala/scala/cli/commands/CacheImportOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/CacheImportOptions.scala
@@ -1,0 +1,20 @@
+package scala.cli.commands
+
+import caseapp._
+import caseapp.core.help.Help
+
+// format: off
+@HelpMessage("Import Coursier Cache")
+final case class CacheImportOptions(
+  @Recurse
+    logging: LoggingOptions = LoggingOptions(),
+  @Name("c")
+  @Name("cache")
+    cachePath: Option[String] = None,
+)
+  // format: on
+
+object CacheImportOptions {
+  implicit lazy val parser: Parser[CacheImportOptions] = Parser.derive
+  implicit lazy val help: Help[CacheImportOptions]     = Help.derive
+}

--- a/modules/cli/src/main/java/scala/cli/internal/BloopCache.java
+++ b/modules/cli/src/main/java/scala/cli/internal/BloopCache.java
@@ -1,0 +1,35 @@
+package scala.cli.internal;
+
+import coursier.cache.shaded.dirs.GetWinDirs;
+import coursier.cache.shaded.dirs.ProjectDirectories;
+import coursier.jniutils.WindowsKnownFolders;
+import coursier.paths.Util;
+
+import java.util.ArrayList;
+
+// Copied from (https://github.com/scala-cli/bloop-core/blob/cbbe37ca36088fe314844bae5e8bf8ebbaf89060/shared/src/main/java/bloop/io/internal/ProjDirHelper.java)
+// To resolve bloop cache directories used in Cache Export and Import 
+public class BloopCache {
+  public static String cacheDir() {
+    return ((ProjectDirectories) get()).cacheDir;
+  }
+  // not letting ProjectDirectories leak in the signature, getting weird scalac crashes
+  // with Scala 2.12.5 (because of shading?)
+  private static Object get() {
+    GetWinDirs getWinDirs;
+    if (Util.useJni()) {
+      getWinDirs = new GetWinDirs() {
+        public String[] getWinDirs(String ...guids) {
+          ArrayList<String> l = new ArrayList<>();
+          for (int idx = 0; idx < guids.length; idx++) {
+            l.add(WindowsKnownFolders.knownFolderPath("{" + guids[idx] + "}"));
+          }
+          return l.toArray(new String[l.size()]);
+        }
+      };
+    } else {
+      getWinDirs = GetWinDirs.powerShellBased;
+    }
+    return ProjectDirectories.from("", "", "bloop", getWinDirs);
+  }
+}

--- a/modules/cli/src/main/scala/scala/cli/ScalaCliCommands.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCliCommands.scala
@@ -33,6 +33,8 @@ class ScalaCliCommands(
     BloopOutput,
     BloopStart,
     Bsp,
+    CacheExport,
+    CacheImport,
     Clean,
     Compile,
     Config,

--- a/modules/cli/src/main/scala/scala/cli/commands/CacheExport.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/CacheExport.scala
@@ -1,0 +1,122 @@
+package scala.cli.commands
+
+import caseapp._
+import coursier.cache.FileCache
+import coursier.paths.CoursierPaths
+import coursier.util.Task
+
+import scala.build.internal.CsLoggerUtil.CsJavaHomeExtensions
+import scala.build.internal.{Constants, OsLibc}
+import scala.build.options.BuildOptions
+import scala.build.{Inputs, Logger, Os}
+import scala.cli.CurrentParams
+import scala.cli.commands.util.SharedOptionsUtil._
+import scala.cli.internal.BloopCache
+import scala.util.control.NonFatal
+
+object CacheExport extends ScalaCommand[CacheExportOptions] {
+  override def group = "Main"
+
+  override def names: List[List[String]] = List(
+    List("cache", "export")
+  )
+
+  def run(options: CacheExportOptions, args: RemainingArgs): Unit = {
+    maybePrintGroupHelp(options)
+    CurrentParams.verbosity = options.runOptions.shared.logging.verbosity
+
+    val inputs = options.runOptions.shared.inputsOrExit(args)
+    CurrentParams.workspaceOpt = Some(inputs.workspace)
+    val logger                 = options.runOptions.shared.logger
+    val cache: FileCache[Task] = options.runOptions.shared.coursierCache
+
+    val buildOptions = options.runOptions.shared.buildOptions()
+    val dest         = options.output.getOrElse("cache.tar.gz")
+    val destPath     = os.Path(dest, Os.pwd)
+
+    // clean workspace .scala-build
+    cleanWorkspace(logger, inputs)
+    // restart bloop to force download bloop class path
+    exitBloop(options.runOptions.shared, args)
+    // run sources to force download all dependencies
+    downloadAppDependencies(options.runOptions, args)
+    // force to download java to arch cache dir
+    downloadJava(cache, buildOptions)
+
+    val csCachePath       = os.Path(CoursierPaths.cacheDirectory())
+    val csArchPath        = os.Path(CoursierPaths.archiveCacheDirectory())
+    val bloopCacheDirPath = os.Path(BloopCache.cacheDir())
+
+    val tmpCacheDir = os.temp.dir(prefix = "scala-cli-cache")
+
+    println(s"Starting exporting caches to $destPath")
+    println(s"Exporting coursier cache")
+    compressOs(coursierCachePath(tmpCacheDir), csCachePath)
+    println(s"Exported coursier cache")
+
+    println(s"Exporting coursier archive cache")
+    compressOs(coursierArchiveCachePath(tmpCacheDir), csArchPath)
+    println(s"Exported coursier archive cache")
+
+    println(s"Exporting bloop cache")
+    compressOs(bloopCachePath(tmpCacheDir), bloopCacheDirPath)
+    println(s"Exported bloop cache")
+
+    compressOs(destPath, tmpCacheDir)
+    println(s"Exported caches to $destPath")
+
+    os.remove.all(tmpCacheDir)
+  }
+
+  private def cleanWorkspace(logger: Logger, inputs: Inputs) = {
+    val workDir = inputs.workspace / Constants.workspaceDirName
+    if (os.isDir(workDir)) {
+      logger.message(s"Removing $workDir")
+      os.remove.all(workDir)
+    }
+    else
+      logger.message(s"$workDir is not a directory, ignoring it.")
+  }
+
+  private def downloadAppDependencies(runOptions: RunOptions, args: RemainingArgs) = Run.run(
+    runOptions,
+    args.remaining,
+    args.unparsed,
+    () => Inputs.default(),
+    allowTerminate = false
+  )
+
+  private def exitBloop(shared: SharedOptions, args: RemainingArgs) = {
+    val bloopExitOptions = BloopExitOptions(
+      logging = shared.logging,
+      compilationServer = shared.compilationServer,
+      directories = shared.directories,
+      coursier = shared.coursier
+    )
+
+    BloopExit.run(bloopExitOptions, args)
+  }
+
+  private def downloadJava(cache: FileCache[Task], buildOptions: BuildOptions) = {
+    val jvmId            = OsLibc.baseDefaultJvm(OsLibc.jvmIndexOs, OsLibc.defaultJvmVersion)
+    val javaHomeManager0 = buildOptions.javaHomeManager.withMessage(s"Downloading JVM $jvmId")
+
+    implicit val ec = cache.ec
+    cache.logger.use {
+      try javaHomeManager0.get(jvmId).unsafeRun()
+      catch {
+        case NonFatal(e) => throw new Exception(e)
+      }
+    }
+  }
+
+  def compressOs(zipFilepath: os.Path, dirPath: os.Path) =
+    os.proc("tar", "czf", zipFilepath, "-C", dirPath, ".").call(
+      cwd = os.pwd
+    )
+
+  def coursierCachePath(cacheDir: os.Path): os.Path        = cacheDir / "csCache.tar.gz"
+  def coursierArchiveCachePath(cacheDir: os.Path): os.Path = cacheDir / "csArch.tar.gz"
+  def bloopCachePath(cacheDir: os.Path): os.Path           = cacheDir / "bloopCache.tar.gz"
+
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/CacheImport.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/CacheImport.scala
@@ -1,0 +1,64 @@
+package scala.cli.commands
+
+import caseapp._
+import coursier.paths.CoursierPaths
+
+import scala.build.Os
+import scala.cli.CurrentParams
+import scala.cli.internal.BloopCache
+object CacheImport extends ScalaCommand[CacheImportOptions] {
+  override def group = "Main"
+
+  override def names: List[List[String]] = List(
+    List("cache", "import")
+  )
+
+  def run(options: CacheImportOptions, args: RemainingArgs): Unit = {
+    maybePrintGroupHelp(options)
+    CurrentParams.verbosity = options.logging.verbosity
+
+    val cache = options.cachePath.getOrElse {
+      System.err.println(
+        "To specify path to the zipped cache file by scala-cli pass --cache-path or -c."
+      )
+      sys.exit(1)
+    }
+    val cachePath = os.Path(cache, Os.pwd)
+
+    if (!os.exists(cachePath)) {
+      System.err.println(
+        s"""|Warning: No zipped cache file found.
+            |To specify path to the zipped cache file by scala-cli pass --cache-path or -c""".stripMargin
+      )
+      sys.exit(1)
+    }
+
+    val csCachePath       = os.Path(CoursierPaths.cacheDirectory())
+    val csArchPath        = os.Path(CoursierPaths.archiveCacheDirectory())
+    val bloopCacheDirPath = os.Path(BloopCache.cacheDir())
+
+    // tmp dir to unpack zipped cache file and then copy file to default cache directories
+    val cacheDir = os.pwd / "tmp"
+    os.makeDir.all(cacheDir)
+
+    os.makeDir.all(csCachePath)
+    os.makeDir.all(csArchPath)
+    os.makeDir.all(bloopCacheDirPath)
+
+    println("Starting importing cache")
+    unZipArchiveOs(cachePath, cacheDir)
+    unZipArchiveOs(CacheExport.coursierCachePath(cacheDir), csCachePath)
+    unZipArchiveOs(CacheExport.coursierArchiveCachePath(cacheDir), csArchPath)
+    unZipArchiveOs(CacheExport.bloopCachePath(cacheDir), bloopCacheDirPath)
+    println("Successfully imported cache")
+
+    // clean cache dir
+    os.remove.all(cacheDir)
+  }
+
+  private def unZipArchiveOs(zipPath: os.Path, dest: os.Path) =
+    os.proc("tar", "-xzvf", zipPath, "-C", dest, "--skip-old-files").call(
+      cwd = os.pwd
+    )
+
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -50,7 +50,8 @@ object Run extends ScalaCommand[RunOptions] {
     options: RunOptions,
     inputArgs: Seq[String],
     programArgs: Seq[String],
-    defaultInputs: () => Option[Inputs]
+    defaultInputs: () => Option[Inputs],
+    allowTerminate: Boolean = true
   ): Unit = {
     CurrentParams.verbosity = options.shared.logging.verbosity
     val initialBuildOptions = buildOptions(options)
@@ -167,7 +168,7 @@ object Run extends ScalaCommand[RunOptions] {
           .orExit(logger)
       builds.main match {
         case s: Build.Successful =>
-          val (process, onExit) = maybeRun(s, allowTerminate = true)
+          val (process, onExit) = maybeRun(s, allowTerminate = allowTerminate)
             .orExit(logger).getOrElse(sys.exit(1))
           ProcUtil.waitForProcess(process, onExit)
         case _: Build.Failed =>

--- a/modules/core/src/main/scala/scala/build/internals/OsLibc.scala
+++ b/modules/core/src/main/scala/scala/build/internals/OsLibc.scala
@@ -60,7 +60,7 @@ object OsLibc {
     else default
   }
 
-  private def defaultJvmVersion = "17"
+  def defaultJvmVersion = "17"
 
   def baseDefaultJvm(os: String, jvmVersion: String): String = {
     def java17OrHigher = Try(jvmVersion.takeWhile(_.isDigit).toInt)

--- a/modules/integration/src/test/scala/scala/cli/integration/CacheTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CacheTests.scala
@@ -1,0 +1,78 @@
+package scala.cli.integration
+
+import com.eed3si9n.expecty.Expecty.expect
+
+import scala.util.Properties
+
+class CacheTests extends munit.FunSuite {
+
+  protected lazy val extraOptions: Seq[String] = TestUtil.extraOptions
+
+  protected val ciOpt: Seq[String] =
+    Option(System.getenv("CI")).map(v => Seq("-e", s"CI=$v")).getOrElse(Nil)
+
+  def cacheTest(): Unit = {
+    val fileName = "Hello.scala"
+    val message  = "Hello"
+    val inputs = TestInputs(
+      Seq(
+        os.rel / fileName ->
+          s"""object Hello extends App {
+             |  println("$message")
+             |}
+             |""".stripMargin
+      )
+    )
+    inputs.fromRoot { root =>
+      val baseImage     = Constants.dockerTestImage
+      val cacheFileName = "cache.tar.gz"
+      val cacheZip      = root / cacheFileName
+      val tmpDir        = os.temp.dir()
+
+      val cacheExportOutput =
+        os.proc(TestUtil.cli, "cache", "export", extraOptions, "--output", cacheZip, fileName).call(
+          cwd =
+            root,
+          env = Map(
+            "COURSIER_CACHE"         -> (tmpDir / "cache" / "coursier").toString,
+            "COURSIER_ARCHIVE_CACHE" -> (tmpDir / "cache" / "arch").toString,
+            "XDG_CACHE_HOME"         -> (tmpDir / "cache" / "bloop").toString
+          )
+        ).out.text().trim
+
+      println(cacheExportOutput)
+      assert(os.exists(cacheZip))
+
+      os.copy(os.Path(TestUtil.cliPath, os.pwd), root / "scala")
+      val script =
+        s"""#!/usr/bin/env sh
+           |./scala cache import -c $cacheFileName
+           |./scala ${extraOptions.mkString(" ") /* meh escaping */} $fileName | tee output
+           |""".stripMargin
+      os.write(root / "script.sh", script)
+      os.perms.set(root / "script.sh", "rwxr-xr-x")
+      val termOpt = if (System.console() == null) Nil else Seq("-t")
+
+      // format: off
+      val cmd = Seq[os.Shellable](
+        "docker", "run", "--rm", termOpt,
+        "-v", s"$root:/data",
+        "-w", "/data",
+        "--network", "none",
+        ciOpt,
+        baseImage,
+        "/data/script.sh"
+      )
+      // format: on
+      os.proc(cmd).call(cwd = root, stdout = os.Inherit)
+      val rootOutput = os.read(root / "output").trim
+      expect(rootOutput == message)
+    }
+  }
+
+  if (Properties.isLinux && TestUtil.isNativeCli)
+    test("cache test") {
+      cacheTest()
+    }
+
+}

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -32,6 +32,7 @@ Aliases: `-q`
 ## Benchmarking options
 
 Available in commands:
+- [`cache export`](./commands.md#cache-export)
 - [`run`](./commands.md#run)
 - [`shebang`](./commands.md#shebang)
 
@@ -91,6 +92,32 @@ Aliases: `--name`
 
 Name of BSP
 
+## Cache export options
+
+Available in commands:
+- [`cache export`](./commands.md#cache-export)
+
+
+<!-- Automatically generated, DO NOT EDIT MANUALLY -->
+
+#### `--output`
+
+Aliases: `-o`
+
+Set the destination path
+
+## Cache import options
+
+Available in commands:
+- [`cache import`](./commands.md#cache-import)
+
+
+<!-- Automatically generated, DO NOT EDIT MANUALLY -->
+
+#### `--cache-path`
+
+Aliases: `-c`, `--cache`
+
 ## Compilation server options
 
 Available in commands:
@@ -98,6 +125,7 @@ Available in commands:
 - [`bloop output`](./commands.md#bloop-output)
 - [`bloop start`](./commands.md#bloop-start)
 - [`bsp`](./commands.md#bsp)
+- [`cache export`](./commands.md#cache-export)
 - [`compile`](./commands.md#compile)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
@@ -200,6 +228,7 @@ Compile test scope
 ## Compile cross options
 
 Available in commands:
+- [`cache export`](./commands.md#cache-export)
 - [`package`](./commands.md#package)
 - [`publish`](./commands.md#publish)
 - [`publish local`](./commands.md#publish-local)
@@ -249,6 +278,7 @@ Available in commands:
 - [`bloop exit`](./commands.md#bloop-exit)
 - [`bloop start`](./commands.md#bloop-start)
 - [`bsp`](./commands.md#bsp)
+- [`cache export`](./commands.md#cache-export)
 - [`compile`](./commands.md#compile)
 - [`config`](./commands.md#config)
 - [`doc`](./commands.md#doc)
@@ -321,6 +351,7 @@ Force overwriting destination files
 
 Available in commands:
 - [`bsp`](./commands.md#bsp)
+- [`cache export`](./commands.md#cache-export)
 - [`compile`](./commands.md#compile)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
@@ -363,6 +394,7 @@ Available in commands:
 - [`bloop output`](./commands.md#bloop-output)
 - [`bloop start`](./commands.md#bloop-start)
 - [`bsp`](./commands.md#bsp)
+- [`cache export`](./commands.md#cache-export)
 - [`clean`](./commands.md#clean)
 - [`compile`](./commands.md#compile)
 - [`config`](./commands.md#config)
@@ -483,6 +515,8 @@ Available in commands:
 - [`bloop output`](./commands.md#bloop-output)
 - [`bloop start`](./commands.md#bloop-start)
 - [`bsp`](./commands.md#bsp)
+- [`cache export`](./commands.md#cache-export)
+- [`cache import`](./commands.md#cache-import)
 - [`clean`](./commands.md#clean)
 - [`compile`](./commands.md#compile)
 - [`config`](./commands.md#config)
@@ -538,6 +572,7 @@ Print help message, including hidden options, and exit
 
 Available in commands:
 - [`bsp`](./commands.md#bsp)
+- [`cache export`](./commands.md#cache-export)
 - [`compile`](./commands.md#compile)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
@@ -630,6 +665,7 @@ Binary directory
 ## Java options
 
 Available in commands:
+- [`cache export`](./commands.md#cache-export)
 - [`console` / `repl`](./commands.md#console)
 - [`run`](./commands.md#run)
 - [`shebang`](./commands.md#shebang)
@@ -653,6 +689,7 @@ Set Java properties
 Available in commands:
 - [`bloop start`](./commands.md#bloop-start)
 - [`bsp`](./commands.md#bsp)
+- [`cache export`](./commands.md#cache-export)
 - [`compile`](./commands.md#compile)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
@@ -713,6 +750,8 @@ Available in commands:
 - [`bloop output`](./commands.md#bloop-output)
 - [`bloop start`](./commands.md#bloop-start)
 - [`bsp`](./commands.md#bsp)
+- [`cache export`](./commands.md#cache-export)
+- [`cache import`](./commands.md#cache-import)
 - [`clean`](./commands.md#clean)
 - [`compile`](./commands.md#compile)
 - [`config`](./commands.md#config)
@@ -751,6 +790,7 @@ Use progress bars
 ## Main class options
 
 Available in commands:
+- [`cache export`](./commands.md#cache-export)
 - [`export`](./commands.md#export)
 - [`package`](./commands.md#package)
 - [`publish`](./commands.md#publish)
@@ -1282,6 +1322,7 @@ Don't actually run the REPL, just fetch it
 
 Available in commands:
 - [`bsp`](./commands.md#bsp)
+- [`cache export`](./commands.md#cache-export)
 - [`compile`](./commands.md#compile)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
@@ -1377,6 +1418,7 @@ Whether to run the Scala.js CLI on the JVM or using a native executable
 
 Available in commands:
 - [`bsp`](./commands.md#bsp)
+- [`cache export`](./commands.md#cache-export)
 - [`compile`](./commands.md#compile)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
@@ -1438,6 +1480,7 @@ Use default compile options
 
 Available in commands:
 - [`bsp`](./commands.md#bsp)
+- [`cache export`](./commands.md#cache-export)
 - [`compile`](./commands.md#compile)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
@@ -1508,6 +1551,7 @@ Available in commands:
 
 Available in commands:
 - [`bsp`](./commands.md#bsp)
+- [`cache export`](./commands.md#cache-export)
 - [`compile`](./commands.md#compile)
 - [`doc`](./commands.md#doc)
 - [`export`](./commands.md#export)
@@ -1634,6 +1678,8 @@ Available in commands:
 - [`bloop output`](./commands.md#bloop-output)
 - [`bloop start`](./commands.md#bloop-start)
 - [`bsp`](./commands.md#bsp)
+- [`cache export`](./commands.md#cache-export)
+- [`cache import`](./commands.md#cache-import)
 - [`clean`](./commands.md#clean)
 - [`compile`](./commands.md#compile)
 - [`config`](./commands.md#config)
@@ -1679,6 +1725,7 @@ Interactive mode
 ## Watch options
 
 Available in commands:
+- [`cache export`](./commands.md#cache-export)
 - [`compile`](./commands.md#compile)
 - [`package`](./commands.md#package)
 - [`publish`](./commands.md#publish)
@@ -1707,6 +1754,7 @@ Run your application in background and automatically restart if sources have bee
 
 Available in commands:
 - [`bsp`](./commands.md#bsp)
+- [`cache export`](./commands.md#cache-export)
 - [`clean`](./commands.md#clean)
 - [`compile`](./commands.md#compile)
 - [`doc`](./commands.md#doc)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -11,6 +11,40 @@ Accepts options:
 - [about](./cli-options.md#about-options)
 - [verbosity](./cli-options.md#verbosity-options)
 
+## `cache export`
+
+Export Coursier Cache
+
+Accepts options:
+- [benchmarking](./cli-options.md#benchmarking-options)
+- [cache export](./cli-options.md#cache-export-options)
+- [compilation server](./cli-options.md#compilation-server-options)
+- [compile cross](./cli-options.md#compile-cross-options)
+- [coursier](./cli-options.md#coursier-options)
+- [dependency](./cli-options.md#dependency-options)
+- [directories](./cli-options.md#directories-options)
+- [help group](./cli-options.md#help-group-options)
+- [java](./cli-options.md#java-options)
+- [jvm](./cli-options.md#jvm-options)
+- [logging](./cli-options.md#logging-options)
+- [main class](./cli-options.md#main-class-options)
+- [Scala.js](./cli-options.md#scalajs-options)
+- [Scala Native](./cli-options.md#scala-native-options)
+- [scalac](./cli-options.md#scalac-options)
+- [shared](./cli-options.md#shared-options)
+- [verbosity](./cli-options.md#verbosity-options)
+- [watch](./cli-options.md#watch-options)
+- [workspace](./cli-options.md#workspace-options)
+
+## `cache import`
+
+Import Coursier Cache
+
+Accepts options:
+- [cache import](./cli-options.md#cache-import-options)
+- [logging](./cli-options.md#logging-options)
+- [verbosity](./cli-options.md#verbosity-options)
+
 ## `clean`
 
 Clean the workspace


### PR DESCRIPTION
 To export cache items that are required on per-project basis in scala-cli users should run following commands:
```
export COURSIER_CACHE="$(pwd)/cache/coursier"
export COURSIER_ARCHIVE_CACHE="$(pwd)/cache/arch"
export XDG_CACHE_HOME="$(pwd)/cache/bloop"

scala-cli cache export -o cache.tar.gz ${options which will be used in scala-cli after importing cache, for example `-S 3 Hello.scala`}
```

and then, users have to run:
```
scala-cli cache import --cache-path cache.tar.gz
```
to import coursier and bloop caches

Cache export and import commands requires installed `tar` application. 