### PR TITLE
Update scala-js-cli to 1.1.1-sc5

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -49,7 +49,7 @@ object InternalDeps {
   object Versions {
     def mill          = os.read(os.pwd / ".mill-version").trim
     def lefouMillwRef = "166bcdf5741de8569e0630e18c3b2ef7e252cd96"
-    def scalaJsCli    = "1.1.1-sc4.1"
+    def scalaJsCli    = "1.1.1-sc5"
   }
 }
 


### PR DESCRIPTION
Required for Scala.js 1.10.1