### PR TITLE
Run and test ESModule scripts as ES Modules

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/Runner.scala
+++ b/modules/build/src/main/scala/scala/build/internal/Runner.scala
@@ -161,7 +161,8 @@ object Runner {
     logger: Logger,
     allowExecve: Boolean = false,
     jsDom: Boolean = false,
-    sourceMap: Boolean = false
+    sourceMap: Boolean = false,
+    esModule: Boolean = false
   ): Process = {
 
     import logger.{log, debug}
@@ -201,7 +202,10 @@ object Runner {
       sys.error("should not happen")
     }
     else {
-      val inputs = Seq(Input.Script(entrypoint.toPath))
+      val inputs = Seq(
+        if (esModule) Input.ESModule(entrypoint.toPath)
+        else Input.Script(entrypoint.toPath)
+      )
 
       val config    = RunConfig().withLogger(logger.scalaJsLogger)
       val processJs = envJs.start(inputs, config)
@@ -309,7 +313,8 @@ object Runner {
     args: Seq[String],
     testFrameworkOpt: Option[String],
     logger: Logger,
-    jsDom: Boolean
+    jsDom: Boolean,
+    esModule: Boolean
   ): Either[TestError, Int] = either {
     import org.scalajs.jsenv.Input
     import org.scalajs.jsenv.nodejs.NodeJSEnv
@@ -330,8 +335,11 @@ object Runner {
           .withEnv(Map.empty)
           .withSourceMap(NodeJSEnv.SourceMap.Disable)
       )
-    val adapterConfig        = TestAdapter.Config().withLogger(logger.scalaJsLogger)
-    val inputs               = Seq(Input.Script(entrypoint.toPath))
+    val adapterConfig = TestAdapter.Config().withLogger(logger.scalaJsLogger)
+    val inputs = Seq(
+      if (esModule) Input.ESModule(entrypoint.toPath)
+      else Input.Script(entrypoint.toPath)
+    )
     var adapter: TestAdapter = null
 
     logger.debug(s"JS tests class path: $classPath")

--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -165,6 +165,8 @@ object Test extends ScalaCommand[TestOptions] {
     build.options.platform.value match {
       case Platform.JS =>
         val linkerConfig = build.options.scalaJsOptions.linkerConfig(logger)
+        val esModule =
+          build.options.scalaJsOptions.moduleKindStr.exists(m => m == "es" || m == "esmodule")
         value {
           Run.withLinkedJs(
             build,
@@ -173,7 +175,8 @@ object Test extends ScalaCommand[TestOptions] {
             linkerConfig,
             build.options.scalaJsOptions.fullOpt,
             build.options.scalaJsOptions.noOpt.getOrElse(false),
-            logger
+            logger,
+            esModule
           ) { js =>
             Runner.testJs(
               build.fullClassPath.map(_.toNIO),
@@ -182,9 +185,10 @@ object Test extends ScalaCommand[TestOptions] {
               args,
               testFrameworkOpt,
               logger,
-              build.options.scalaJsOptions.dom.getOrElse(false)
+              build.options.scalaJsOptions.dom.getOrElse(false),
+              esModule
             )
-          }.flatMap(e => e)
+          }.flatten
         }
       case Platform.Native =>
         value {

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -83,6 +83,34 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     simpleJsTest("--js-mode", "release")
   }
 
+  test("esmodule import JS") {
+    val fileName = "simple.sc"
+    val message  = "Hello"
+    val inputs = TestInputs(
+      Seq(
+        os.rel / fileName ->
+          s"""//> using jsModuleKind "es"
+             |import scala.scalajs.js
+             |import scala.scalajs.js.annotation._
+             |
+             |@js.native
+             |@JSImport("console", JSImport.Namespace)
+             |object console extends js.Object {
+             |  def log(msg: js.Any): Unit = js.native
+             |}
+             |
+             |val msg = "$message"
+             |console.log(msg)
+             |""".stripMargin
+      )
+    )
+    inputs.fromRoot { root =>
+      val output = os.proc(TestUtil.cli, extraOptions, fileName, "--js")
+        .call(cwd = root).out.text().trim()
+      expect(output == message)
+    }
+  }
+
   test("simple script JS via config file") {
     val message = "Hello"
     val inputs = TestInputs(

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -162,6 +162,28 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
     )
   )
 
+  val successfulESModuleTestInputs = TestInputs(
+    Seq(os.rel / "MyTests.scala" ->
+      """//> using lib "org.scalameta::munit::0.7.29"
+        |//> using jsModuleKind "esmodule"
+        |import scala.scalajs.js
+        |import scala.scalajs.js.annotation._
+        |
+        |@js.native
+        |@JSImport("console", JSImport.Namespace)
+        |object console extends js.Object {
+        |  def log(msg: js.Any): Unit = js.native
+        |}
+        |
+        |class MyTests extends munit.FunSuite {
+        |  test("foo") {
+        |    assert(2 + 2 == 4)
+        |    console.log("Hello from " + "tests")
+        |  }
+        |}
+        |""".stripMargin)
+  )
+
   test("successful test") {
     successfulTestInputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, "test", extraOptions, ".").call(cwd = root).out.text()
@@ -180,6 +202,15 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("successful test JS") {
     successfulTestInputs.fromRoot { root =>
+      val output = os.proc(TestUtil.cli, "test", extraOptions, ".", "--js")
+        .call(cwd = root)
+        .out.text()
+      expect(output.contains("Hello from tests"))
+    }
+  }
+
+  test("successful test esmodule import JS") {
+    successfulESModuleTestInputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, "test", extraOptions, ".", "--js")
         .call(cwd = root)
         .out.text()


### PR DESCRIPTION
Fixes #1104

`Input.Script` loads scripts with `require`, which does not work with ES modules. With this change `Script.ESModule` is used for es modules, as well as the file extension is changed to let Nodejs know we're working with an ES Module

This probably needs some tests, but I am not sure where to start with them
