### PR TITLE
chore(ci): add in mill-github-dependency-graph

### DIFF
--- a/.github/workflows/github-dependency-graph.yml
+++ b/.github/workflows/github-dependency-graph.yml
@@ -14,10 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: coursier/cache-action@v6
-    - uses: actions/setup-java@v3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
-        distribution: 'temurin'
-        java-version: '17'
+        jvm: "temurin:17"
 
     - name: Submit dependency graph
       run: 

--- a/.github/workflows/github-dependency-graph.yml
+++ b/.github/workflows/github-dependency-graph.yml
@@ -19,5 +19,5 @@ jobs:
         jvm: "temurin:17"
 
     - name: Submit dependency graph
-      run: 
+      run:
         ./mill --import ivy:io.chris-kipp::mill-github-dependency-graph::0.0.11 io.kipp.mill.github.dependency.graph.Graph/submit

--- a/.github/workflows/github-dependency-graph.yml
+++ b/.github/workflows/github-dependency-graph.yml
@@ -1,0 +1,24 @@
+name: github-dependency-graph
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+jobs:
+  dependency-update:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: coursier/cache-action@v6
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+
+    - name: Submit dependency graph
+      run: 
+        ./mill --import ivy:io.chris-kipp::mill-github-dependency-graph::0.0.11 io.kipp.mill.github.dependency.graph.Graph/submit

--- a/.github/workflows/github-dependency-graph.yml
+++ b/.github/workflows/github-dependency-graph.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-env:
-  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
 jobs:
   dependency-update:
     runs-on: ubuntu-latest
@@ -21,3 +18,5 @@ jobs:
     - name: Submit dependency graph
       run:
         ./mill --import ivy:io.chris-kipp::mill-github-dependency-graph::0.0.11 io.kipp.mill.github.dependency.graph.Graph/submit
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
So no pressure ha, but I'm wondering if you'd be willing to be a guinea
pig for this. @adpi2 at the Scala Center has been working on
https://github.com/scalacenter/sbt-dependency-graph-action which submits
your sbt projects dependency graph to GitHub to be able to both view
your dependencies in the insights tab on GitHub and also to get
dependabot alerts about them if you'd like. I wanted to also offer this
for mill, which is what you're seeing here. You can view the project here
https://github.com/ckipp01/mill-github-dependency-graph, but
since there isn't a lot of larger Mill projects out there I'd love to
test it on some more before announcing it. Locally this works fine with
scala-cli, but it'd be great to actually see it submit. In the future the idea
is to have a shared action with `sbt-dependency-graph-action` just becoming
`scala-dependency-graph-action`. It would then just detect your build tool.
When that happens I'll update this with that.

Any interest in being a tester? :D The only thing you'd need to do is
ensure that the Dependency Graph feature is enabled, and then optionally
the dependabot alerts if you want them. These settings are under
`Settings -> Code security and analysis.`

If this isn't something you want in the repo, no worries at all! If you have no idea
what this is really about, you can check the announcement from GitHub [here](https://github.blog/2022-06-17-creating-comprehensive-dependency-graph-build-time-detection/).