### PR TITLE
Turn the sip mode also for `scala-cli-sip` binary

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -18,10 +18,12 @@ object ScalaCli {
 
   val progName = (new Argv0).get("scala-cli")
 
-  private var isSipScala =
-    progName == "scala" ||
-    progName.endsWith("/scala") ||
-    progName.endsWith(File.separator + "scala")
+  private def checkName(name: String) =
+    progName == name ||
+    progName.endsWith(s"/$name") ||
+    progName.endsWith(File.separator + name)
+
+  private var isSipScala = checkName("scala") || checkName("scala-cli-sip")
 
   private def isGraalvmNativeImage: Boolean =
     sys.props.contains("org.graalvm.nativeimage.imagecode")

--- a/modules/cli/src/main/scala/scala/cli/commands/Export.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Export.scala
@@ -14,6 +14,7 @@ import scala.cli.commands.util.SharedOptionsUtil._
 import scala.cli.exportCmd._
 
 object Export extends ScalaCommand[ExportOptions] {
+  override def inSipScala = false
 
   private def prepareBuild(
     inputs: Inputs,

--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -41,6 +41,7 @@ import scala.util.Properties
 object Package extends ScalaCommand[PackageOptions] {
   override def name                                                          = "package"
   override def group                                                         = "Main"
+  override def inSipScala                                                    = false
   override def sharedOptions(options: PackageOptions): Option[SharedOptions] = Some(options.shared)
   def run(options: PackageOptions, args: RemainingArgs): Unit = {
     maybePrintGroupHelp(options)

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -6,7 +6,7 @@ import scala.util.Properties
 
 class SipScalaTests extends munit.FunSuite {
 
-  def noDirectoriesCommandTest(): Unit =
+  def noDirectoriesCommandTest(binaryName: String): Unit =
     TestInputs(Nil).fromRoot { root =>
       val cliPath = os.Path(TestUtil.cliPath, os.pwd)
 
@@ -14,25 +14,29 @@ class SipScalaTests extends munit.FunSuite {
       os.proc(cliPath, "compile", "--help").call(cwd = root)
       os.proc(cliPath, "run", "--help").call(cwd = root)
 
-      os.copy(cliPath, root / "scala")
-      os.perms.set(root / "scala", "rwxr-xr-x")
+      os.copy(cliPath, root / binaryName)
+      os.perms.set(root / binaryName, "rwxr-xr-x")
 
-      os.proc(root / "scala", "compile", "--help").call(cwd = root)
-      os.proc(root / "scala", "run", "--help").call(cwd = root)
+      os.proc(root / binaryName, "compile", "--help").call(cwd = root)
+      os.proc(root / binaryName, "run", "--help").call(cwd = root)
 
-      val res = os.proc(root / "scala", "directories").call(
+      val res = os.proc(root / binaryName, "directories").call(
         cwd = root,
         check = false,
         mergeErrIntoOut = true
       )
       expect(res.exitCode == 1)
       val output = res.out.text()
-      expect(output.contains("directories: not found"))
+      expect(output.contains(s"directories: not found"))
+
     }
 
-  if (TestUtil.isNativeCli && !Properties.isWin)
+  if (TestUtil.isNativeCli && !Properties.isWin) {
     test("no directories command when run as scala") {
-      noDirectoriesCommandTest()
+      noDirectoriesCommandTest("scala")
     }
-
+    test("no directories command when run as scala-cli-sip") {
+      noDirectoriesCommandTest("scala-cli-sip")
+    }
+  }
 }


### PR DESCRIPTION
Export and Package for now are excluded from the 'sip' mode.