### PR TITLE
chore(ci): bump version of mill-github-dependency-graph

### DIFF
--- a/.github/workflows/github-dependency-graph.yml
+++ b/.github/workflows/github-dependency-graph.yml
@@ -17,6 +17,6 @@ jobs:
 
     - name: Submit dependency graph
       run:
-        ./mill --import ivy:io.chris-kipp::mill-github-dependency-graph::0.0.11 io.kipp.mill.github.dependency.graph.Graph/submit
+        ./mill --import ivy:io.chris-kipp::mill-github-dependency-graph::0.0.13 io.kipp.mill.github.dependency.graph.Graph/submit
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This brings in a few bugfixes about "direct" vs "indirect", failing
loudly if it doesn't work, and small stats at the end when it submits.
