### PR TITLE
Fix snippet tests for Windows

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -2004,22 +2004,24 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("correctly run a script snippet") {
     emptyInputs.fromRoot { root =>
-      val msg =
-        "123456" // FIXME: change this to a a non-numeric string when Windows encoding is handled properly
-      val res = os.proc(TestUtil.cli, "-e", s"println($msg)", extraOptions).call(cwd = root)
+      val msg       = "Hello world"
+      val quotation = TestUtil.argQuotationMark
+      val res =
+        os.proc(TestUtil.cli, "-e", s"println($quotation$msg$quotation)", extraOptions)
+          .call(cwd = root)
       expect(res.out.text().trim == msg)
     }
   }
 
   test("correctly run a scala snippet") {
     emptyInputs.fromRoot { root =>
-      val msg =
-        "123456" // FIXME: change this to a a non-numeric string when Windows encoding is handled properly
+      val msg       = "Hello world"
+      val quotation = TestUtil.argQuotationMark
       val res =
         os.proc(
           TestUtil.cli,
           "--scala-snippet",
-          s"object Hello extends App { println($msg) }",
+          s"object Hello extends App { println($quotation$msg$quotation) }",
           extraOptions
         )
           .call(cwd = root)
@@ -2029,12 +2031,12 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("correctly run a java snippet") {
     emptyInputs.fromRoot { root =>
-      val msg =
-        "123456" // FIXME: change this to a a non-numeric string when Windows encoding is handled properly
+      val quotation = TestUtil.argQuotationMark
+      val msg       = "Hello world"
       val res = os.proc(
         TestUtil.cli,
         "--java-snippet",
-        s"public class Main { public static void main(String[] args) { System.out.println($msg); } }",
+        s"public class Main { public static void main(String[] args) { System.out.println($quotation$msg$quotation); } }",
         extraOptions
       )
         .call(cwd = root)

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -122,4 +122,10 @@ object TestUtil {
       os.Path(os.pwd.toIO.getCanonicalFile)
     else
       os.pwd
+
+  /** @return
+    *   2 quotation marks (") when run for Windows, or a single one otherwise. This is necessary to
+    *   escape the quotation marks passed in args for the Windows command line.
+    */
+  def argQuotationMark: String = if (Properties.isWin) "\"\"" else "\""
 }


### PR DESCRIPTION
Turns out the issue wasn't encoding. Windows' command line handles `"` (quotation marks) as special characters, which need escaping, apparently. TIL