### PR TITLE
Use Scala CLI 0.1.9 in build

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -148,7 +148,7 @@ object Deps {
 }
 
 object BuildDeps {
-  def scalaCliVersion = "0.1.7"
+  def scalaCliVersion = "0.1.9"
 }
 
 def graalVmVersion     = "22.1.0"


### PR DESCRIPTION
That fixes compiling the project on Windows in particular (0.1.7 suffers from the libsodium.dll issue IIRC)