### PR TITLE
Force push updating scala-cli in scala-cli-setup

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1128,14 +1128,20 @@ private def setupGithubRepo(repoDir: os.Path) = {
   os.proc("git", "config", "user.email", gitEmail).call(cwd = repoDir)
 }
 
-private def commitChanges(name: String, branch: String, repoDir: os.Path): Unit = {
+private def commitChanges(
+  name: String,
+  branch: String,
+  repoDir: os.Path,
+  force: Boolean = false
+): Unit = {
   if (os.proc("git", "status").call(cwd = repoDir).out.text().trim.contains("nothing to commit"))
     println("Nothing Changes")
   else {
     os.proc("git", "add", "-A").call(cwd = repoDir)
     os.proc("git", "commit", "-am", name).call(cwd = repoDir)
     println(s"Trying to push on $branch branch")
-    os.proc("git", "push", "origin", branch).call(cwd = repoDir)
+    val pushExtraOptions = if (force) Seq("--force") else Seq.empty
+    os.proc("git", "push", "origin", branch, pushExtraOptions).call(cwd = repoDir)
     println(s"Push successfully on $branch branch")
   }
 }
@@ -1172,7 +1178,7 @@ object ci extends Module {
     os.write.over(setupScriptPath, updatedSetupScriptPath)
 
     os.proc("git", "switch", "-c", targetBranch).call(cwd = mainDir)
-    commitChanges(s"Update scala-cli version to $version", targetBranch, mainDir)
+    commitChanges(s"Update scala-cli version to $version", targetBranch, mainDir, force = true)
   }
   def updateStandaloneLauncher() = T.command {
     val version = cli.publishVersion()


### PR DESCRIPTION
CI release failed because updating scala-cli-setup ended with fail, it throws the following error:

```
[5/5] ci.updateScalaCliSetup 
Switched to a new branch 'update-scala-cli-setup'
Trying to push on update-scala-cli-setup branch
To key-f5a0852352c44de463821de26cb784392b387173251baf8d68680158a138ca54.github.com:VirtusLab/scala-cli-setup.git
 ! [rejected]        update-scala-cli-setup -> update-scala-cli-setup (non-fast-forward)
error: failed to push some refs to 'key-f5a0852352c44de463821de26cb784392b387173251baf8d68680158a138ca54.github.com:VirtusLab/scala-cli-setup.git'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. Integrate the remote changes (e.g.
hint: 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
1 targets failed
ci.updateScalaCliSetup os.SubprocessException: CommandResult 1
    os.proc.call(ProcessOps.scala:85)
    ammonite.$file.build.ammonite$$file$build$$commitChanges(build.sc:1138)
    ammonite.$file.build$ci$.$anonfun$updateScalaCliSetup$2(build.sc:1175)
    scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
```

to fix it, we should `push` changes with `--force` to override old changes. 


