### PR TITLE
Use manifest JARs in "run" command if needed

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -50,11 +50,12 @@ object Build {
     generatedSources: Seq[GeneratedSource],
     isPartial: Boolean
   ) extends Build {
-    def success: Boolean                = true
-    def successfulOpt: Some[this.type]  = Some(this)
-    def outputOpt: Some[os.Path]        = Some(output)
-    def fullClassPath: Seq[os.Path]     = Seq(output) ++ sources.resourceDirs ++ artifacts.classPath
-    def foundMainClasses(): Seq[String] = MainClass.find(output)
+    def success: Boolean                  = true
+    def successfulOpt: Some[this.type]    = Some(this)
+    def outputOpt: Some[os.Path]          = Some(output)
+    def dependencyClassPath: Seq[os.Path] = sources.resourceDirs ++ artifacts.classPath
+    def fullClassPath: Seq[os.Path]       = Seq(output) ++ dependencyClassPath
+    def foundMainClasses(): Seq[String]   = MainClass.find(output)
     def retainedMainClass(
       mainClasses: Seq[String],
       logger: Logger

--- a/modules/build/src/main/scala/scala/build/compiler/SimpleScalaCompiler.scala
+++ b/modules/build/src/main/scala/scala/build/compiler/SimpleScalaCompiler.scala
@@ -93,7 +93,7 @@ final case class SimpleScalaCompiler(
     Runner.runJvm(
       javaCommand,
       javaOptions,
-      compilerClassPath.map(_.toIO),
+      compilerClassPath,
       mainClass,
       args,
       logger,

--- a/modules/build/src/main/scala/scala/build/internal/ManifestJar.scala
+++ b/modules/build/src/main/scala/scala/build/internal/ManifestJar.scala
@@ -1,0 +1,84 @@
+package scala.build.internal
+
+import java.io.OutputStream
+
+object ManifestJar {
+
+  /** Creates a manifest JAR, in a temporary directory or in the passed scratched directory
+    *
+    * @param classPath
+    *   Entries that should be put in the manifest class path
+    * @param wrongSimplePaths
+    *   Write paths slightly differently in manifest, so that tools such as native-image accept them
+    *   (but the manifest JAR can't be passed to 'java -cp' any more on Windows)
+    * @param scratchDirOpt
+    *   an optional scratch directory to write the manifest JAR under
+    */
+  def create(
+    classPath: Seq[os.Path],
+    wrongSimplePaths: Boolean = false,
+    scratchDirOpt: Option[os.Path] = None
+  ): os.Path = {
+    import java.util.jar._
+    val manifest   = new Manifest
+    val attributes = manifest.getMainAttributes
+    attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0")
+    attributes.put(
+      Attributes.Name.CLASS_PATH,
+      if (wrongSimplePaths)
+        // For tools, such as native-image, that don't correctly handle paths in manifests…
+        classPath.map(_.toString).mkString(" ")
+      else
+        // Paths are encoded this weird way in manifest JARs. This matters on Windows in particular,
+        // where paths like "C:\…" don't work fine.
+        classPath.map(_.toNIO.toUri.getRawPath).mkString(" ")
+    )
+    val jarFile = scratchDirOpt match {
+      case Some(scratchDir) =>
+        os.makeDir.all(scratchDir)
+        os.temp(dir = scratchDir, prefix = "classpathJar", suffix = ".jar", deleteOnExit = false)
+      case None =>
+        os.temp(prefix = "classpathJar", suffix = ".jar")
+    }
+    var os0: OutputStream    = null
+    var jos: JarOutputStream = null
+    try {
+      os0 = os.write.outputStream(jarFile)
+      jos = new JarOutputStream(os0, manifest)
+    }
+    finally {
+      if (jos != null)
+        jos.close()
+      if (os0 != null)
+        os0.close()
+    }
+    jarFile
+  }
+
+  /** Runs a block of code using a manifest JAR.
+    *
+    * See [[create]] for details about the parameters.
+    */
+  def maybeWithManifestClassPath[T](
+    createManifest: Boolean,
+    classPath: Seq[os.Path],
+    wrongSimplePathsInManifest: Boolean = false
+  )(
+    f: Seq[os.Path] => T
+  ): T =
+    if (createManifest) {
+      var toDeleteOpt = Option.empty[os.Path]
+
+      try {
+        val manifestJar = create(classPath, wrongSimplePaths = wrongSimplePathsInManifest)
+        toDeleteOpt = Some(manifestJar)
+        f(Seq(manifestJar))
+      }
+      finally
+        for (toDelete <- toDeleteOpt)
+          os.remove(toDelete)
+    }
+    else
+      f(classPath)
+
+}

--- a/modules/build/src/main/scala/scala/build/internal/Runner.scala
+++ b/modules/build/src/main/scala/scala/build/internal/Runner.scala
@@ -108,7 +108,7 @@ object Runner {
   def jvmCommand(
     javaCommand: String,
     javaArgs: Seq[String],
-    classPath: Seq[File],
+    classPath: Seq[os.Path],
     mainClass: String,
     args: Seq[String],
     extraEnv: Map[String, String] = Map.empty
@@ -119,7 +119,7 @@ object Runner {
         javaArgs ++
         Seq(
           "-cp",
-          classPath.iterator.map(_.getAbsolutePath).mkString(File.pathSeparator),
+          classPath.iterator.map(_.toString).mkString(File.pathSeparator),
           mainClass
         ) ++
         args
@@ -130,7 +130,7 @@ object Runner {
   def runJvm(
     javaCommand: String,
     javaArgs: Seq[String],
-    classPath: Seq[File],
+    classPath: Seq[os.Path],
     mainClass: String,
     args: Seq[String],
     logger: Logger,

--- a/modules/cli-options/src/main/scala/scala/cli/commands/RunOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/RunOptions.scala
@@ -29,7 +29,11 @@ final case class RunOptions(
     command: Boolean = false,
   @Group("Run")
   @HelpMessage("Temporary / working directory where to write generated launchers")
-    scratchDir: Option[String] = None
+    scratchDir: Option[String] = None,
+  @Group("Run")
+  @Hidden
+  @HelpMessage("Run Java commands using a manifest-based class path (shortens command length)")
+    useManifest: Option[Boolean] = None
 )
 // format: on
 

--- a/modules/cli/src/main/scala/scala/cli/commands/Doc.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Doc.scala
@@ -155,7 +155,7 @@ object Doc extends ScalaCommand[DocOptions] {
         val retCode = Runner.runJvm(
           (build.options.javaHomeLocation().value / "bin" / s"java$ext").toString,
           Nil, // FIXME Allow to customize that?
-          res.files,
+          res.files.map(os.Path(_, os.pwd)),
           "dotty.tools.scaladoc.Main",
           args,
           logger,

--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -940,7 +940,7 @@ object Package extends ScalaCommand[PackageOptions] {
           Runner.runJvm(
             build.options.javaHome().value.javaCommand,
             build.options.javaOptions.javaOpts.toSeq.map(_.value.value),
-            scalaNativeCli.map(_.toIO),
+            scalaNativeCli,
             "scala.scalanative.cli.ScalaNativeLd",
             args,
             logger

--- a/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
@@ -230,7 +230,7 @@ object Repl extends ScalaCommand[ReplOptions] {
       Runner.runJvm(
         options.javaHome().value.javaCommand,
         replArtifacts.replJavaOpts ++ options.javaOptions.javaOpts.toSeq.map(_.value.value),
-        classDir.map(_.toIO).toSeq ++ replArtifacts.replClassPath.map(_.toIO),
+        classDir.toSeq ++ replArtifacts.replClassPath,
         replArtifacts.replMainClass,
         if (Properties.isWin)
           replArgs.map { a =>

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -47,6 +47,9 @@ object Run extends ScalaCommand[RunOptions] {
         javaOpts =
           baseOptions.javaOptions.javaOpts ++
             sharedJava.allJavaOpts.map(JavaOpt(_)).map(Positioned.commandLine)
+      ),
+      notForBloopOptions = baseOptions.notForBloopOptions.copy(
+        runWithManifest = options.useManifest
       )
     )
   }
@@ -323,7 +326,8 @@ object Run extends ScalaCommand[RunOptions] {
             build.options.javaOptions.javaOpts.toSeq.map(_.value.value),
             build.fullClassPath,
             mainClass,
-            args
+            args,
+            useManifest = build.options.notForBloopOptions.runWithManifest
           )
           Left(command)
         }
@@ -335,7 +339,8 @@ object Run extends ScalaCommand[RunOptions] {
             mainClass,
             args,
             logger,
-            allowExecve = allowExecve
+            allowExecve = allowExecve,
+            useManifest = build.options.notForBloopOptions.runWithManifest
           )
           Right(proc)
         }

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -321,7 +321,7 @@ object Run extends ScalaCommand[RunOptions] {
           val command = Runner.jvmCommand(
             build.options.javaHome().value.javaCommand,
             build.options.javaOptions.javaOpts.toSeq.map(_.value.value),
-            build.fullClassPath.map(_.toIO),
+            build.fullClassPath,
             mainClass,
             args
           )
@@ -331,7 +331,7 @@ object Run extends ScalaCommand[RunOptions] {
           val proc = Runner.runJvm(
             build.options.javaHome().value.javaCommand,
             build.options.javaOptions.javaOpts.toSeq.map(_.value.value),
-            build.fullClassPath.map(_.toIO),
+            build.fullClassPath,
             mainClass,
             args,
             logger,

--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -223,7 +223,7 @@ object Test extends ScalaCommand[TestOptions] {
         Runner.runJvm(
           build.options.javaHome().value.javaCommand,
           build.options.javaOptions.javaOpts.toSeq.map(_.value.value),
-          classPath.map(_.toIO),
+          classPath,
           Constants.testRunnerMainClass,
           extraArgs,
           logger,

--- a/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
@@ -44,10 +44,10 @@ object LauncherCli {
           sys.exit(1)
       }
 
-    val scalaCli =
-      fetchedScalaCli.fullDetailedArtifacts.collect { case (_, _, _, Some(f)) =>
-        f.toPath.toFile
-      }
+    val scalaCli = fetchedScalaCli.fullDetailedArtifacts.collect {
+      case (_, _, _, Some(f)) =>
+        os.Path(f, os.pwd)
+    }
 
     val buildOptions = BuildOptions(
       javaOptions = JavaOptions(

--- a/modules/cli/src/main/scala/scala/cli/packaging/NativeImage.scala
+++ b/modules/cli/src/main/scala/scala/cli/packaging/NativeImage.scala
@@ -229,10 +229,10 @@ object NativeImage {
     if (cacheData.changed)
       Library.withLibraryJar(build, dest.last.stripSuffix(".jar")) { mainJar =>
 
-        val originalClasspath = build.fullClassPath :+ mainJar
+        val originalClassPath = mainJar +: build.dependencyClassPath
         maybeWithManifestClassPath(
           createManifest = Properties.isWin,
-          classPath = originalClasspath
+          classPath = originalClassPath
         ) { processedClassPath =>
           val needsProcessing = build.scalaParams.exists(_.scalaVersion.startsWith("3."))
           val (classPath, toClean, scala3extraOptions) =

--- a/modules/options/src/main/scala/scala/build/options/PostBuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/PostBuildOptions.scala
@@ -6,7 +6,8 @@ final case class PostBuildOptions(
   packageOptions: PackageOptions = PackageOptions(),
   replOptions: ReplOptions = ReplOptions(),
   publishOptions: PublishOptions = PublishOptions(),
-  scalaJsLinkerOptions: ScalaJsLinkerOptions = ScalaJsLinkerOptions()
+  scalaJsLinkerOptions: ScalaJsLinkerOptions = ScalaJsLinkerOptions(),
+  runWithManifest: Option[Boolean] = None
 )
 
 object PostBuildOptions {

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1357,6 +1357,10 @@ Print the command that would have been run (one argument per line), rather than 
 
 Temporary / working directory where to write generated launchers
 
+#### `--use-manifest`
+
+Run Java commands using a manifest-based class path (shortens command length)
+
 ## Scala.js options
 
 Available in commands:


### PR DESCRIPTION
When running `java -cp …` commands under-the-hood in `scala-cli run`, the class path passed to it may be too long on Windows. A common workaround for this consists in using "manifest JARs", that is JARs consisting only of a manifest file, with the class path encoded in that file.

This PR enables manifest JARs automatically when needed (and fixes how we generate them too).