### PR TITLE
Make main class optional in preamble-less assemblies

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -125,6 +125,21 @@ object Build {
       else
         Left(mainClasses)
     }
+    def retainedMainClassOpt(
+      mainClasses: Seq[String],
+      logger: Logger
+    ): Option[String] = {
+      val defaultMainClassOpt = sources.defaultMainClass
+        .filter(name => mainClasses.contains(name))
+      def foundMainClass =
+        mainClasses match {
+          case Seq()          => None
+          case Seq(mainClass) => Some(mainClass)
+          case _              => inferredMainClass(mainClasses, logger).toOption
+        }
+
+      defaultMainClassOpt.orElse(foundMainClass)
+    }
 
     def crossKey: CrossKey = {
       val optKey = scalaParams.map { params =>

--- a/modules/cli-options/src/main/scala/scala/cli/commands/PackageOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/PackageOptions.scala
@@ -45,6 +45,10 @@ final case class PackageOptions(
     preamble: Boolean = true,
   @Group("Package")
   @Hidden
+  @HelpMessage("For assembly JAR, whether to specify a main class in the JAR manifest")
+    mainClassInManifest: Option[Boolean] = None,
+  @Group("Package")
+  @Hidden
   @HelpMessage("Generate an assembly JAR for Spark (assembly that doesn't contain Spark, nor any of its dependencies)")
     spark: Boolean = false,
   @Group("Package")

--- a/modules/cli/src/main/scala/scala/cli/commands/util/PackageOptionsUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/PackageOptionsUtil.scala
@@ -19,7 +19,12 @@ object PackageOptionsUtil {
       forcedPackageTypeOpt.orElse {
         if (v.library) Some(PackageType.LibraryJar)
         else if (source) Some(PackageType.SourceJar)
-        else if (assembly) Some(PackageType.Assembly(addPreamble = preamble))
+        else if (assembly) Some(
+          PackageType.Assembly(
+            addPreamble = preamble,
+            mainClassInManifest = mainClassInManifest
+          )
+        )
         else if (spark) Some(PackageType.Spark)
         else if (deb) Some(PackageType.Debian)
         else if (dmg) Some(PackageType.Dmg)

--- a/modules/options/src/main/scala/scala/build/options/PackageType.scala
+++ b/modules/options/src/main/scala/scala/build/options/PackageType.scala
@@ -16,7 +16,10 @@ object PackageType {
     override def sourceBased = true
   }
   case object DocJar extends PackageType
-  final case class Assembly(addPreamble: Boolean) extends PackageType {
+  final case class Assembly(
+    addPreamble: Boolean,
+    mainClassInManifest: Option[Boolean]
+  ) extends PackageType {
     override def runnable = Some(addPreamble)
   }
   case object Spark extends PackageType {
@@ -39,8 +42,8 @@ object PackageType {
   case object Msi    extends NativePackagerType
 
   val mapping = Seq(
-    "assembly"     -> Assembly(true),
-    "raw-assembly" -> Assembly(false),
+    "assembly"     -> Assembly(true, None),
+    "raw-assembly" -> Assembly(false, Some(false)),
     "bootstrap"    -> Bootstrap,
     "library"      -> LibraryJar,
     "source"       -> SourceJar,

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -889,6 +889,10 @@ Generate an assembly JAR
 
 For assembly JAR, whether to add a bash / bat preamble
 
+#### `--main-class-in-manifest`
+
+For assembly JAR, whether to specify a main class in the JAR manifest
+
 #### `--spark`
 
 Generate an assembly JAR for Spark (assembly that doesn't contain Spark, nor any of its dependencies)


### PR DESCRIPTION
These changes allow one to generate an assembly, even for code that has no main class, when `--preamble=false` is passed. This can be useful for libraries, if users want to pass the assembly to tools such as proguard. This also accepts a (hidden) `--main-class-in-manifest=false` option if users want not only no preamble, but also no mention of main class in the assembly manifest (`META-INF/MANIFEST.MF` in the assembly JAR). The latter option is useful for tools, such as the `hadoop jar` command, that behave differently depending on the presence or not of a main class in the manifest.