### PR TITLE
Split integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         if-no-files-found: error
         retention-days: 2
 
-  native-linux-tests:
+  native-linux-tests-1:
     needs: generate-linux-launcher
     timeout-minutes: 120
     runs-on: "ubuntu-latest"
@@ -97,6 +97,55 @@ jobs:
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 1
+
+  native-linux-tests-2:
+    needs: generate-linux-launcher
+    timeout-minutes: 120
+    runs-on: "ubuntu-latest"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - uses: actions/download-artifact@v3
+      with:
+        name: linux-launchers
+        path: artifacts/
+    - name: Native integration tests
+      run: ./mill -i nativeIntegrationTests
+      env:
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 2
+
+  native-linux-tests-3:
+    needs: generate-linux-launcher
+    timeout-minutes: 120
+    runs-on: "ubuntu-latest"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - uses: actions/download-artifact@v3
+      with:
+        name: linux-launchers
+        path: artifacts/
+    - name: Native integration tests
+      run: ./mill -i nativeIntegrationTests
+      env:
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 3
 
   generate-macos-launcher:
     timeout-minutes: 120
@@ -125,7 +174,7 @@ jobs:
         if-no-files-found: error
         retention-days: 2
 
-  native-macos-tests:
+  native-macos-tests-1:
     needs: generate-macos-launcher
     timeout-minutes: 120
     runs-on: "macos-latest"
@@ -147,6 +196,55 @@ jobs:
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 1
+
+  native-macos-tests-2:
+    needs: generate-macos-launcher
+    timeout-minutes: 120
+    runs-on: "macos-latest"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - uses: actions/download-artifact@v3
+      with:
+        name: macos-launchers
+        path: artifacts/
+    - name: Native integration tests
+      run: ./mill -i nativeIntegrationTests
+      env:
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 2
+
+  native-macos-tests-3:
+    needs: generate-macos-launcher
+    timeout-minutes: 120
+    runs-on: "macos-latest"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - uses: actions/download-artifact@v3
+      with:
+        name: macos-launchers
+        path: artifacts/
+    - name: Native integration tests
+      run: ./mill -i nativeIntegrationTests
+      env:
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 3
 
   generate-windows-launcher:
     timeout-minutes: 120
@@ -180,7 +278,7 @@ jobs:
         if-no-files-found: error
         retention-days: 2
 
-  native-windows-tests:
+  native-windows-tests-1:
     needs: generate-windows-launcher
     timeout-minutes: 120
     runs-on: "windows-latest"
@@ -206,6 +304,63 @@ jobs:
         COURSIER_JNI: force
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 1
+
+  native-windows-tests-2:
+    needs: generate-windows-launcher
+    timeout-minutes: 120
+    runs-on: "windows-latest"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - name: Get latest coursier launcher
+      run: .github/scripts/get-latest-cs.sh
+      shell: bash
+    - uses: actions/download-artifact@v3
+      with:
+        name: windows-launchers
+        path: artifacts/
+    - name: Native integration tests
+      run: ./mill -i nativeIntegrationTests
+      env:
+        COURSIER_JNI: force
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 2
+
+  native-windows-tests-3:
+    needs: generate-windows-launcher
+    timeout-minutes: 120
+    runs-on: "windows-latest"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - name: Get latest coursier launcher
+      run: .github/scripts/get-latest-cs.sh
+      shell: bash
+    - uses: actions/download-artifact@v3
+      with:
+        name: windows-launchers
+        path: artifacts/
+    - name: Native integration tests
+      run: ./mill -i nativeIntegrationTests
+      env:
+        COURSIER_JNI: force
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 3
 
   generate-mostly-static-launcher:
     timeout-minutes: 120
@@ -231,7 +386,7 @@ jobs:
         if-no-files-found: error
         retention-days: 2
 
-  native-mostly-static-tests:
+  native-mostly-static-tests-1:
     needs: generate-mostly-static-launcher
     timeout-minutes: 120
     runs-on: ubuntu-latest
@@ -255,6 +410,7 @@ jobs:
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 1
     - name: Docker integration tests
       run: ./mill integration.docker-slim.test
     - name: Login to GitHub Container Registry
@@ -266,6 +422,54 @@ jobs:
     - name: Push slim scala-cli image to github container registry
       if: startsWith(github.ref, 'refs/tags/v')
       run: .github/scripts/publish-slim-docker-images.sh
+
+  native-mostly-static-tests-2:
+    needs: generate-mostly-static-launcher
+    timeout-minutes: 120
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - uses: actions/download-artifact@v3
+      with:
+        name: mostly-static-launchers
+        path: artifacts/
+    - name: Native integration tests
+      run: ./mill -i integration.test.nativeMostlyStatic
+      env:
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 2
+
+  native-mostly-static-tests-3:
+    needs: generate-mostly-static-launcher
+    timeout-minutes: 120
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - uses: actions/download-artifact@v3
+      with:
+        name: mostly-static-launchers
+        path: artifacts/
+    - name: Native integration tests
+      run: ./mill -i integration.test.nativeMostlyStatic
+      env:
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 3
 
   generate-static-launcher:
     timeout-minutes: 120
@@ -291,7 +495,7 @@ jobs:
         if-no-files-found: error
         retention-days: 2
 
-  native-static-tests:
+  native-static-tests-1:
     needs: generate-static-launcher
     timeout-minutes: 120
     runs-on: ubuntu-latest
@@ -315,6 +519,7 @@ jobs:
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 1
     - name: Docker integration tests
       run: ./mill integration.docker.test
     - name: Login to GitHub Container Registry
@@ -326,6 +531,58 @@ jobs:
     - name: Push scala-cli to github container registry
       if: startsWith(github.ref, 'refs/tags/v')
       run: .github/scripts/publish-docker-images.sh
+
+  native-static-tests-2:
+    needs: generate-static-launcher
+    timeout-minutes: 120
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - uses: actions/download-artifact@v3
+      with:
+        name: static-launchers
+        path: artifacts/
+    - name: Build docker image
+      run: .github/scripts/generate-docker-image.sh
+    - name: Native integration tests
+      run: ./mill -i integration.test.nativeStatic
+      env:
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 2
+
+  native-static-tests-3:
+    needs: generate-static-launcher
+    timeout-minutes: 120
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - uses: actions/download-artifact@v3
+      with:
+        name: static-launchers
+        path: artifacts/
+    - name: Build docker image
+      run: .github/scripts/generate-docker-image.sh
+    - name: Native integration tests
+      run: ./mill -i integration.test.nativeStatic
+      env:
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 3
 
   docs-tests:
     # for now, lets run those tests only on ubuntu
@@ -499,7 +756,27 @@ jobs:
 
   launchers:
     timeout-minutes: 20
-    needs: [jvm-tests, native-linux-tests, native-macos-tests, native-windows-tests, native-mostly-static-tests, native-static-tests, vc-redist, format, checks, reference-doc]
+    needs:
+      - jvm-tests
+      - native-linux-tests-1
+      - native-linux-tests-2
+      - native-linux-tests-3
+      - native-macos-tests-1
+      - native-macos-tests-2
+      - native-macos-tests-3
+      - native-windows-tests-1
+      - native-windows-tests-2
+      - native-windows-tests-3
+      - native-mostly-static-tests-1
+      - native-mostly-static-tests-2
+      - native-mostly-static-tests-3
+      - native-static-tests-1
+      - native-static-tests-2
+      - native-static-tests-3
+      - vc-redist
+      - format
+      - checks
+      - reference-doc
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -50,7 +49,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -67,7 +65,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -84,7 +81,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -101,7 +97,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -129,7 +124,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -153,7 +147,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -177,7 +170,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -200,7 +192,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -228,7 +219,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -252,7 +242,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -276,7 +265,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -299,7 +287,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -332,7 +319,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -360,7 +346,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -388,7 +373,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -415,7 +399,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -440,7 +423,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -477,7 +459,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -501,7 +482,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -524,7 +504,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -549,7 +528,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -586,7 +564,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -612,7 +589,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -637,7 +613,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -663,7 +638,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -689,7 +663,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -704,7 +677,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -725,7 +697,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -749,7 +720,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -771,7 +741,6 @@ jobs:
         fetch-depth: 0
         submodules: true
         ssh-key: ${{ secrets.SSH_PRIVATE_KEY_SCALA_CLI }}
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -832,7 +801,6 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
       with:
         jvm: "temurin:17"
@@ -882,7 +850,6 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - uses: coursier/cache-action@v6.3
       - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
         with:
           jvm: "temurin:17"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,9 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  jvm-tests:
+  unit-tests:
     timeout-minutes: 120
-    runs-on: ${{ matrix.OS }}
-    strategy:
-      fail-fast: false
-      matrix:
-        OS: ["ubuntu-latest"]
+    runs-on: "ubuntu-latest"
     steps:
     - uses: actions/checkout@v3
       with:
@@ -45,8 +41,57 @@ jobs:
       run: |
         ./mill -i unitTests
         ./mill -i bloop-rifle._.test
+
+  jvm-tests-1:
+    timeout-minutes: 120
+    runs-on: "ubuntu-latest"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
     - name: JVM integration tests
       run: ./mill -i integration.test.jvm
+      env:
+        SCALA_CLI_IT_GROUP: 1
+
+  jvm-tests-2:
+    timeout-minutes: 120
+    runs-on: "ubuntu-latest"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - name: JVM integration tests
+      run: ./mill -i integration.test.jvm
+      env:
+        SCALA_CLI_IT_GROUP: 2
+
+  jvm-tests-3:
+    timeout-minutes: 120
+    runs-on: "ubuntu-latest"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - name: JVM integration tests
+      run: ./mill -i integration.test.jvm
+      env:
+        SCALA_CLI_IT_GROUP: 3
 
   generate-linux-launcher:
     timeout-minutes: 120
@@ -717,7 +762,7 @@ jobs:
         retention-days: 2
 
   publish:
-    needs: [jvm-tests, format, checks, reference-doc]
+    needs: [unit-tests, jvm-tests-1, jvm-tests-2, jvm-tests-3, format, checks, reference-doc]
     if: github.event_name == 'push' && github.repository == 'VirtusLab/scala-cli'
     runs-on: ubuntu-latest
     steps:
@@ -757,7 +802,10 @@ jobs:
   launchers:
     timeout-minutes: 20
     needs:
-      - jvm-tests
+      - unit-tests
+      - jvm-tests-1
+      - jvm-tests-2
+      - jvm-tests-3
       - native-linux-tests-1
       - native-linux-tests-2
       - native-linux-tests-3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,109 @@ jobs:
     - name: JVM integration tests
       run: ./mill -i integration.test.jvm
 
-  native-tests:
+  generate-linux-launcher:
     timeout-minutes: 120
-    runs-on: ${{ matrix.OS }}
-    strategy:
-      fail-fast: false
-      matrix:
-        OS: ["ubuntu-latest", "macos-latest", "windows-latest"]
+    runs-on: "ubuntu-latest"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - name: Generate native launcher
+      run: .github/scripts/generate-native-image.sh
+    - run: ./mill -i ci.setShouldPublish
+    - name: Build OS packages
+      if: env.SHOULD_PUBLISH == 'true'
+      run: .github/scripts/generate-os-packages.sh
+    - name: Copy artifacts
+      run: ./mill -i copyDefaultLauncher artifacts/
+    - uses: actions/upload-artifact@v3
+      with:
+        name: linux-launchers
+        path: artifacts/
+        if-no-files-found: error
+        retention-days: 2
+
+  native-linux-tests:
+    needs: generate-linux-launcher
+    timeout-minutes: 120
+    runs-on: "ubuntu-latest"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - uses: actions/download-artifact@v3
+      with:
+        name: linux-launchers
+        path: artifacts/
+    - name: Native integration tests
+      run: ./mill -i nativeIntegrationTests
+      env:
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+
+  generate-macos-launcher:
+    timeout-minutes: 120
+    runs-on: "macos-latest"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - name: Generate native launcher
+      run: .github/scripts/generate-native-image.sh
+    - run: ./mill -i ci.setShouldPublish
+    - name: Build OS packages
+      if: env.SHOULD_PUBLISH == 'true'
+      run: .github/scripts/generate-os-packages.sh
+    - name: Copy artifacts
+      run: ./mill -i copyDefaultLauncher artifacts/
+    - uses: actions/upload-artifact@v3
+      with:
+        name: macos-launchers
+        path: artifacts/
+        if-no-files-found: error
+        retention-days: 2
+
+  native-macos-tests:
+    needs: generate-macos-launcher
+    timeout-minutes: 120
+    runs-on: "macos-latest"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - uses: actions/download-artifact@v3
+      with:
+        name: macos-launchers
+        path: artifacts/
+    - name: Native integration tests
+      run: ./mill -i nativeIntegrationTests
+      env:
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+
+  generate-windows-launcher:
+    timeout-minutes: 120
+    runs-on: "windows-latest"
     steps:
     - uses: actions/checkout@v3
       with:
@@ -67,7 +163,6 @@ jobs:
     - name: Get latest coursier launcher
       run: .github/scripts/get-latest-cs.sh
       shell: bash
-      if: runner.os == 'Windows'
     - name: Generate native launcher
       run: .github/scripts/generate-native-image.sh
       shell: bash
@@ -80,17 +175,39 @@ jobs:
       run: ./mill -i copyDefaultLauncher artifacts/
     - uses: actions/upload-artifact@v3
       with:
-        name: launchers
+        name: windows-launchers
         path: artifacts/
         if-no-files-found: error
         retention-days: 2
+
+  native-windows-tests:
+    needs: generate-windows-launcher
+    timeout-minutes: 120
+    runs-on: "windows-latest"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - name: Get latest coursier launcher
+      run: .github/scripts/get-latest-cs.sh
+      shell: bash
+    - uses: actions/download-artifact@v3
+      with:
+        name: windows-launchers
+        path: artifacts/
     - name: Native integration tests
       run: ./mill -i nativeIntegrationTests
       env:
         COURSIER_JNI: force
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
 
-  native-mostly-static-tests:
+  generate-mostly-static-launcher:
     timeout-minutes: 120
     runs-on: ubuntu-latest
     steps:
@@ -107,18 +224,37 @@ jobs:
       shell: bash
     - name: Copy artifacts
       run: ./mill -i copyMostlyStaticLauncher artifacts/
-    - name: Build slim docker image
-      run: .github/scripts/generate-slim-docker-image.sh
     - uses: actions/upload-artifact@v3
       with:
-        name: launchers
+        name: mostly-static-launchers
         path: artifacts/
         if-no-files-found: error
         retention-days: 2
+
+  native-mostly-static-tests:
+    needs: generate-mostly-static-launcher
+    timeout-minutes: 120
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - uses: actions/download-artifact@v3
+      with:
+        name: mostly-static-launchers
+        path: artifacts/
+    - name: Build slim docker image
+      run: .github/scripts/generate-slim-docker-image.sh
     - name: Native integration tests
       run: ./mill -i integration.test.nativeMostlyStatic
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
     - name: Docker integration tests
       run: ./mill integration.docker-slim.test
     - name: Login to GitHub Container Registry
@@ -131,7 +267,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/v')
       run: .github/scripts/publish-slim-docker-images.sh
 
-  native-static-tests:
+  generate-static-launcher:
     timeout-minutes: 120
     runs-on: ubuntu-latest
     steps:
@@ -148,18 +284,37 @@ jobs:
       shell: bash
     - name: Copy artifacts
       run: ./mill -i copyStaticLauncher artifacts/
-    - name: Build docker image
-      run: .github/scripts/generate-docker-image.sh
     - uses: actions/upload-artifact@v3
       with:
-        name: launchers
+        name: static-launchers
         path: artifacts/
         if-no-files-found: error
         retention-days: 2
+
+  native-static-tests:
+    needs: generate-static-launcher
+    timeout-minutes: 120
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: coursier/cache-action@v6.3
+    - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
+      with:
+        jvm: "temurin:17"
+    - uses: actions/download-artifact@v3
+      with:
+        name: static-launchers
+        path: artifacts/
+    - name: Build docker image
+      run: .github/scripts/generate-docker-image.sh
     - name: Native integration tests
       run: ./mill -i integration.test.nativeStatic
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
     - name: Docker integration tests
       run: ./mill integration.docker.test
     - name: Login to GitHub Container Registry
@@ -344,7 +499,7 @@ jobs:
 
   launchers:
     timeout-minutes: 20
-    needs: [jvm-tests, native-tests, native-mostly-static-tests, native-static-tests, vc-redist, format, checks, reference-doc]
+    needs: [jvm-tests, native-linux-tests, native-macos-tests, native-windows-tests, native-mostly-static-tests, native-static-tests, vc-redist, format, checks, reference-doc]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
@@ -357,6 +512,31 @@ jobs:
       with:
         jvm: "temurin:17"
     - run: ./mill -i ci.setShouldPublish
+    - uses: actions/download-artifact@v3
+      if: env.SHOULD_PUBLISH == 'true'
+      with:
+        name: linux-launchers
+        path: artifacts/
+    - uses: actions/download-artifact@v3
+      if: env.SHOULD_PUBLISH == 'true'
+      with:
+        name: macos-launchers
+        path: artifacts/
+    - uses: actions/download-artifact@v3
+      if: env.SHOULD_PUBLISH == 'true'
+      with:
+        name: windows-launchers
+        path: artifacts/
+    - uses: actions/download-artifact@v3
+      if: env.SHOULD_PUBLISH == 'true'
+      with:
+        name: mostly-static-launchers
+        path: artifacts/
+    - uses: actions/download-artifact@v3
+      if: env.SHOULD_PUBLISH == 'true'
+      with:
+        name: static-launchers
+        path: artifacts/
     - uses: actions/download-artifact@v3
       if: env.SHOULD_PUBLISH == 'true'
       with:
@@ -381,6 +561,26 @@ jobs:
       - uses: VirtusLab/scala-cli-setup@07b6783a2d71fbf9e834faa234cd51626d76cba5
         with:
           jvm: "temurin:17"
+      - uses: actions/download-artifact@v3
+        with:
+          name: linux-launchers
+          path: artifacts/
+      - uses: actions/download-artifact@v3
+        with:
+          name: macos-launchers
+          path: artifacts/
+      - uses: actions/download-artifact@v3
+        with:
+          name: windows-launchers
+          path: artifacts/
+      - uses: actions/download-artifact@v3
+        with:
+          name: mostly-static-launchers
+          path: artifacts/
+      - uses: actions/download-artifact@v3
+        with:
+          name: static-launchers
+          path: artifacts/
       - uses: actions/download-artifact@v3
         with:
           name: launchers

--- a/build.sc
+++ b/build.sc
@@ -698,7 +698,7 @@ trait Cli extends SbtModule with ProtoBuildModule with CliLaunchers
       mainArgs = Seq(cache.toNIO.toString, classpath),
       workingDir = os.pwd
     )
-    val cp = res.out.text.trim
+    val cp = res.out.text().trim
     cp.split(File.pathSeparator).toSeq.map(p => mill.PathRef(os.Path(p)))
   }
 

--- a/build.sc
+++ b/build.sc
@@ -859,6 +859,49 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
     def test(args: String*) =
       jvm(args: _*)
 
+    def forcedLauncher = T.persistent {
+      val ext      = if (Properties.isWin) ".exe" else ""
+      val launcher = T.dest / s"scala-cli$ext"
+      if (!os.exists(launcher)) {
+        val dir = Option(System.getenv("SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY")).getOrElse {
+          sys.error("SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY not set")
+        }
+        val content = importedLauncher(dir)
+        os.write(
+          launcher,
+          content,
+          createFolders = true,
+          perms = if (Properties.isWin) null else "rwxr-xr-x"
+        )
+      }
+      PathRef(launcher)
+    }
+
+    def forcedStaticLauncher = T.persistent {
+      val launcher = T.dest / "scala-cli"
+      if (!os.exists(launcher)) {
+        val dir = Option(System.getenv("SCALA_CLI_IT_FORCED_STATIC_LAUNCHER_DIRECTORY")).getOrElse {
+          sys.error("SCALA_CLI_IT_FORCED_STATIC_LAUNCHER_DIRECTORY not set")
+        }
+        val content = importedLauncher(dir)
+        os.write(launcher, content, createFolders = true)
+      }
+      PathRef(launcher)
+    }
+
+    def forcedMostlyStaticLauncher = T.persistent {
+      val launcher = T.dest / "scala-cli"
+      if (!os.exists(launcher)) {
+        val dir =
+          Option(System.getenv("SCALA_CLI_IT_FORCED_MOSTLY_STATIC_LAUNCHER_DIRECTORY")).getOrElse {
+            sys.error("SCALA_CLI_IT_FORCED_MOSTLY_STATIC_LAUNCHER_DIRECTORY not set")
+          }
+        val content = importedLauncher(dir)
+        os.write(launcher, content, createFolders = true)
+      }
+      PathRef(launcher)
+    }
+
     def jvm(args: String*) =
       new TestHelper(
         cli.standaloneLauncher,
@@ -866,17 +909,22 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
       ).test(args: _*)
     def native(args: String*) =
       new TestHelper(
-        cli.nativeImage,
+        if (System.getenv("SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY") == null) cli.nativeImage
+        else forcedLauncher,
         "native"
       ).test(args: _*)
     def nativeStatic(args: String*) =
       new TestHelper(
-        cli.nativeImageStatic,
+        if (System.getenv("SCALA_CLI_IT_FORCED_STATIC_LAUNCHER_DIRECTORY") == null)
+          cli.nativeImageStatic
+        else forcedStaticLauncher,
         "native-static"
       ).test(args: _*)
     def nativeMostlyStatic(args: String*) =
       new TestHelper(
-        cli.nativeImageMostlyStatic,
+        if (System.getenv("SCALA_CLI_IT_FORCED_MOSTLY_STATIC_LAUNCHER_DIRECTORY") == null)
+          cli.nativeImageMostlyStatic
+        else forcedMostlyStaticLauncher,
         "native-mostly-static"
       ).test(args: _*)
   }
@@ -1037,6 +1085,34 @@ def writeShortPackageVersionTo(dest: os.Path) = T.command {
   val rawVersion = cli.publishVersion()
   val version    = rawVersion.takeWhile(c => c != '-' && c != '+')
   os.write.over(dest, version)
+}
+
+def importedLauncher(directory: String = "artifacts"): Array[Byte] = {
+  val ext  = if (Properties.isWin) ".zip" else ".gz"
+  val from = os.Path(directory, os.pwd) / s"scala-cli-${Upload.platformSuffix}$ext"
+  System.err.println(s"Importing launcher from $from")
+  if (!os.exists(from))
+    sys.error(s"$from not found")
+
+  if (Properties.isWin) {
+    import java.util.zip.ZipFile
+    Using.resource(new ZipFile(from.toIO)) { zf =>
+      val ent = zf.getEntry("scala-cli.exe")
+      Using.resource(zf.getInputStream(ent)) { is =>
+        is.readAllBytes()
+      }
+    }
+  }
+  else {
+    import java.io.ByteArrayInputStream
+    import java.util.zip.GZIPInputStream
+
+    val compressed = os.read.bytes(from)
+    val bais       = new ByteArrayInputStream(compressed)
+    Using.resource(new GZIPInputStream(bais)) { gzis =>
+      gzis.readAllBytes()
+    }
+  }
 }
 
 def copyLauncher(directory: String = "artifacts") = T.command {

--- a/mill
+++ b/mill
@@ -196,4 +196,9 @@ init_mill_cs_opts
 # see https://www.graalvm.org/release-notes/22_2/#native-image
 export USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM=false
 
+# clear the Mill Ammonite cache, that sometimes has spurious cached data…
+if [ -n "${CI+set}" ]; then
+  rm -rf "$HOME/.mill/ammonite/cache"
+fi
+
 exec "$cs" launch "$MILL_APP_NAME:$MILL_VERSION" "${mill_cs_opts[@]}" -- "$@"

--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -4,7 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import scala.cli.integration.util.BloopUtil
 
-class BloopTests extends munit.FunSuite {
+class BloopTests extends ScalaCliSuite {
 
   def runScalaCli(args: String*) = os.proc(TestUtil.cli, args)
 

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -23,7 +23,7 @@ import scala.util.control.NonFatal
 import scala.util.{Failure, Properties, Success, Try}
 
 abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
-    extends munit.FunSuite with TestScalaVersionArgs {
+    extends ScalaCliSuite with TestScalaVersionArgs {
 
   private lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
 

--- a/modules/integration/src/test/scala/scala/cli/integration/CleanTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CleanTests.scala
@@ -2,7 +2,9 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-class CleanTests extends munit.FunSuite {
+class CleanTests extends ScalaCliSuite {
+
+  override def group = ScalaCliSuite.TestGroup.First
 
   test("simple") {
     val inputs = TestInputs(

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -401,7 +401,7 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
           os.rel / fileName -> // scala version should updated to 3.3 after release
             s"""//> using scala "3.2.0-RC1-bin-20220604-13ce496-NIGHTLY"
                |//> using options "-coverage-out:."
-               | 
+               |
                |@main def main = ()
                |""".stripMargin
         )

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -8,7 +8,7 @@ import java.util.regex.Pattern
 import scala.cli.integration.util.BloopUtil
 
 abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
-    extends munit.FunSuite with TestScalaVersionArgs {
+    extends ScalaCliSuite with TestScalaVersionArgs {
 
   protected lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
 

--- a/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
@@ -2,7 +2,9 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-class ConfigTests extends munit.FunSuite {
+class ConfigTests extends ScalaCliSuite {
+
+  override def group = ScalaCliSuite.TestGroup.First
 
   test("simple") {
     val homeDir    = os.rel / "home"

--- a/modules/integration/src/test/scala/scala/cli/integration/DefaultFileTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DefaultFileTests.scala
@@ -2,7 +2,9 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-class DefaultFileTests extends munit.FunSuite {
+class DefaultFileTests extends ScalaCliSuite {
+
+  override def group = ScalaCliSuite.TestGroup.First
 
   test("Print .gitignore") {
     val res = os.proc(TestUtil.cli, "default-file", ".gitignore")

--- a/modules/integration/src/test/scala/scala/cli/integration/DependencyUpdateTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DependencyUpdateTests.scala
@@ -2,7 +2,7 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-class DependencyUpdateTests extends munit.FunSuite {
+class DependencyUpdateTests extends ScalaCliSuite {
 
   test("dependency update test") {
     val fileName = "Hello.scala"

--- a/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
@@ -3,7 +3,7 @@ package scala.cli.integration
 import com.eed3si9n.expecty.Expecty.expect
 
 abstract class DocTestDefinitions(val scalaVersionOpt: Option[String])
-    extends munit.FunSuite with TestScalaVersionArgs {
+    extends ScalaCliSuite with TestScalaVersionArgs {
 
   protected lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
 

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
@@ -7,7 +7,7 @@ import java.nio.charset.Charset
 import scala.util.Properties
 
 abstract class ExportMillTestDefinitions(val scalaVersionOpt: Option[String])
-    extends munit.FunSuite with TestScalaVersionArgs {
+    extends ScalaCliSuite with TestScalaVersionArgs {
 
   protected lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
 

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestDefinitions.scala
@@ -7,7 +7,7 @@ import java.nio.charset.Charset
 import scala.util.Properties
 
 abstract class ExportSbtTestDefinitions(val scalaVersionOpt: Option[String])
-    extends munit.FunSuite with TestScalaVersionArgs {
+    extends ScalaCliSuite with TestScalaVersionArgs {
 
   protected lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
 

--- a/modules/integration/src/test/scala/scala/cli/integration/FmtTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FmtTests.scala
@@ -2,7 +2,9 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-class FmtTests extends munit.FunSuite {
+class FmtTests extends ScalaCliSuite {
+
+  override def group = ScalaCliSuite.TestGroup.First
 
   val confFileName = ".scalafmt.conf"
 

--- a/modules/integration/src/test/scala/scala/cli/integration/GitHubTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/GitHubTests.scala
@@ -13,7 +13,9 @@ import java.util.{Base64, Locale}
 
 import scala.util.Properties
 
-class GitHubTests extends munit.FunSuite {
+class GitHubTests extends ScalaCliSuite {
+
+  override def group = ScalaCliSuite.TestGroup.First
 
   def createSecretTest(): Unit = {
     GitHubTests.initSodium()

--- a/modules/integration/src/test/scala/scala/cli/integration/InstallAndUninstallCompletionsTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/InstallAndUninstallCompletionsTests.scala
@@ -5,7 +5,7 @@ import coursier.cache.shaded.dirs.ProjectDirectories
 
 import scala.util.Properties
 
-class InstallAndUninstallCompletionsTests extends munit.FunSuite {
+class InstallAndUninstallCompletionsTests extends ScalaCliSuite {
   val zshRcFile  = ".zshrc"
   val bashRcFile = ".bashrc"
   val rcContent = s"""

--- a/modules/integration/src/test/scala/scala/cli/integration/InstallHomeTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/InstallHomeTests.scala
@@ -4,7 +4,9 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import scala.util.Properties
 
-class InstallHomeTests extends munit.FunSuite {
+class InstallHomeTests extends ScalaCliSuite {
+
+  override def group = ScalaCliSuite.TestGroup.First
 
   val firstVersion            = "0.0.1"
   val secondVersion           = "0.0.2"

--- a/modules/integration/src/test/scala/scala/cli/integration/JmhTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/JmhTests.scala
@@ -4,7 +4,9 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import java.nio.charset.Charset
 
-class JmhTests extends munit.FunSuite {
+class JmhTests extends ScalaCliSuite {
+
+  override def group = ScalaCliSuite.TestGroup.First
 
   test("simple") {
     val inputs = TestInputs(

--- a/modules/integration/src/test/scala/scala/cli/integration/MetaCheck.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/MetaCheck.scala
@@ -2,7 +2,10 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-class MetaCheck extends munit.FunSuite {
+class MetaCheck extends ScalaCliSuite {
+
+  override def group = ScalaCliSuite.TestGroup.First
+
   /*
    * We don't run tests with --scala 3.… any more, and only rely on those
    * with no --scala option.

--- a/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
@@ -4,7 +4,9 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import scala.util.Properties
 
-class NativePackagerTests extends munit.FunSuite {
+class NativePackagerTests extends ScalaCliSuite {
+
+  override def group = ScalaCliSuite.TestGroup.First
 
   val helloWorldFileName = "HelloWorldScalaCli.scala"
   val message            = "Hello, world!"

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -13,7 +13,7 @@ import scala.jdk.CollectionConverters._
 import scala.util.{Properties, Using}
 
 abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
-    extends munit.FunSuite with TestScalaVersionArgs {
+    extends ScalaCliSuite with TestScalaVersionArgs {
 
   private lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
 

--- a/modules/integration/src/test/scala/scala/cli/integration/PgpTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PgpTests.scala
@@ -2,7 +2,7 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-class PgpTests extends munit.FunSuite {
+class PgpTests extends ScalaCliSuite {
 
   private val pubKeyInputs = TestInputs(
     Seq(

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishSetupTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishSetupTests.scala
@@ -10,7 +10,7 @@ import org.eclipse.jgit.transport.URIish
 
 import scala.jdk.CollectionConverters._
 
-class PublishSetupTests extends munit.FunSuite {
+class PublishSetupTests extends ScalaCliSuite {
 
   private def ghUserName = "foo"
   private def projName   = "project-name"

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
@@ -8,7 +8,7 @@ import java.util.zip.ZipFile
 import scala.jdk.CollectionConverters._
 
 abstract class PublishTestDefinitions(val scalaVersionOpt: Option[String])
-    extends munit.FunSuite with TestScalaVersionArgs {
+    extends ScalaCliSuite with TestScalaVersionArgs {
 
   protected def extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
 

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import scala.util.Properties
 
 abstract class ReplTestDefinitions(val scalaVersionOpt: Option[String])
-    extends munit.FunSuite with TestScalaVersionArgs {
+    extends ScalaCliSuite with TestScalaVersionArgs {
 
   private lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
 

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTests.scala
@@ -2,7 +2,7 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-class ReplTests extends munit.FunSuite {
+class ReplTests extends ScalaCliSuite {
 
   test("calling repl with -Xshow-phases flag") {
     val cmd = Seq[os.Shellable](

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -10,7 +10,7 @@ import scala.io.Codec
 import scala.util.Properties
 
 abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
-    extends munit.FunSuite with TestScalaVersionArgs {
+    extends ScalaCliSuite with TestScalaVersionArgs {
 
   protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
 

--- a/modules/integration/src/test/scala/scala/cli/integration/ScalaCliSuite.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ScalaCliSuite.scala
@@ -1,0 +1,19 @@
+package scala.cli.integration
+
+abstract class ScalaCliSuite extends munit.FunSuite {
+  def group: ScalaCliSuite.TestGroup = ScalaCliSuite.TestGroup.Third
+
+  override def munitIgnore: Boolean =
+    Option(System.getenv("SCALA_CLI_IT_GROUP"))
+      .flatMap(_.toIntOption)
+      .exists(_ != group.idx)
+}
+
+object ScalaCliSuite {
+  sealed abstract class TestGroup(val idx: Int) extends Product with Serializable
+  object TestGroup {
+    case object First  extends TestGroup(1)
+    case object Second extends TestGroup(2)
+    case object Third  extends TestGroup(3)
+  }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/SharedRunTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SharedRunTests.scala
@@ -2,7 +2,7 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-class SharedRunTests extends munit.FunSuite {
+class SharedRunTests extends ScalaCliSuite {
 
   val printScalaVersionInputs = TestInputs(
     Seq(

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -4,7 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import scala.util.Properties
 
-class SipScalaTests extends munit.FunSuite {
+class SipScalaTests extends ScalaCliSuite {
 
   def noDirectoriesCommandTest(binaryName: String): Unit =
     TestInputs(Nil).fromRoot { root =>

--- a/modules/integration/src/test/scala/scala/cli/integration/SparkTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SparkTestDefinitions.scala
@@ -1,6 +1,6 @@
 package scala.cli.integration
 
-class SparkTestDefinitions extends munit.FunSuite {
+class SparkTestDefinitions extends ScalaCliSuite {
 
   protected lazy val extraOptions: Seq[String] = TestUtil.extraOptions
 

--- a/modules/integration/src/test/scala/scala/cli/integration/TestNativeImageOnScala3.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestNativeImageOnScala3.scala
@@ -4,7 +4,9 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import scala.util.Properties
 
-class TestNativeImageOnScala3 extends munit.FunSuite {
+class TestNativeImageOnScala3 extends ScalaCliSuite {
+
+  override def group = ScalaCliSuite.TestGroup.First
 
   def runTest(args: String*)(expectedLines: String*)(code: String): Unit = {
     val dest =

--- a/modules/integration/src/test/scala/scala/cli/integration/TestNativeImageOnScala3.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestNativeImageOnScala3.scala
@@ -55,7 +55,7 @@ class TestNativeImageOnScala3 extends ScalaCliSuite {
         |enum Ala:
         |  case A
         |  case B
-        |@main def add1(i: String) = 
+        |@main def add1(i: String) =
         | println(A(i).b)
         | println(Ala.valueOf("A"))
         |""".stripMargin

--- a/modules/integration/src/test/scala/scala/cli/integration/TestScalaVersionArgs.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestScalaVersionArgs.scala
@@ -1,6 +1,11 @@
 package scala.cli.integration
 
-trait TestScalaVersionArgs {
+trait TestScalaVersionArgs extends ScalaCliSuite {
+
+  override def group: ScalaCliSuite.TestGroup =
+    if (actualScalaVersion.startsWith("2.12.")) ScalaCliSuite.TestGroup.Third
+    else if (actualScalaVersion.startsWith("2.13.")) ScalaCliSuite.TestGroup.Second
+    else ScalaCliSuite.TestGroup.First
 
   def scalaVersionOpt: Option[String]
 

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import scala.annotation.tailrec
 
 abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
-    extends munit.FunSuite with TestScalaVersionArgs {
+    extends ScalaCliSuite with TestScalaVersionArgs {
 
   protected val jvmOptions =
     // seems munit requires this with Scala 3

--- a/modules/integration/src/test/scala/scala/cli/integration/UpdateTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/UpdateTests.scala
@@ -4,7 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import scala.util.Properties
 
-class UpdateTests extends munit.FunSuite {
+class UpdateTests extends ScalaCliSuite {
 
   val firstVersion           = "0.0.1"
   val dummyScalaCliFirstName = "DummyScalaCli-1.scala"


### PR DESCRIPTION
These often take more than an hour to run on the CI… Let's see if splitting them helps here.

This will probably make the workflow definition more verbose. Indeed, keeping the OS-based build matrix and naively splitting the `native-tests` job into `generate-launchers` (to generate the native images), and `native-tests-1` and `native-tests-2` (running each half the ITs with the launchers generated by the previous job) might be a problem: for example, it makes the Windows image generation block starting the ITs on Linux and macOS, even if there launchers are done being generated. And if the Windows launcher generation fails, no IT is run at all. That is, no ITs start running until launchers are successfully generated for all 3 OSes.

That means, we should replace the matrix-based `native-tests` by 12 non matrix-based jobs:
- `generate-linux-launcher`
- `generate-macos-launcher`
- `generate-windows-launcher`
- `native-linux-tests-1`
- `native-linux-tests-2`
- `native-linux-tests-3`
- `native-macos-tests-1`
- `native-macos-tests-2`
- `native-macos-tests-3`
- `native-windows-tests-1`
- `native-windows-tests-2`
- `native-windows-tests-3`

And `jvm-tests` by:
- `jvm-tests-1`
- `jvm-tests-2`
- `jvm-tests-3`

And `native-static-tests` and `native-mostly-static-tests` by:
- `generate-static-launcher`
- `generate-mostly-static-launcher`
- `native-static-tests-1`
- `native-static-tests-2`
- `native-static-tests-3`
- `native-mostly-static-tests-1`
- `native-mostly-static-tests-2`
- `native-mostly-static-tests-3`