### PR TITLE
NIT Tweak integration tests

### DIFF
--- a/modules/integration/docker/src/test/scala/scala/cli/integration/RunDockerTests.scala
+++ b/modules/integration/docker/src/test/scala/scala/cli/integration/RunDockerTests.scala
@@ -15,12 +15,10 @@ class RunDockerTests extends munit.FunSuite {
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""val msg = "$message"
-             |println(msg)
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""val msg = "$message"
+           |println(msg)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val termOpt   = if (System.console() == null) Nil else Seq("-t")

--- a/modules/integration/src/main/scala/scala/cli/integration/TestInputs.scala
+++ b/modules/integration/src/main/scala/scala/cli/integration/TestInputs.scala
@@ -9,11 +9,9 @@ import java.util.zip.{ZipEntry, ZipOutputStream}
 import scala.cli.integration.TestInputs.compress
 import scala.util.control.NonFatal
 
-final case class TestInputs(
-  files: Seq[(os.RelPath, String)]
-) {
-  def add(extraFiles: (os.RelPath, String)*): TestInputs =
-    copy(files = files ++ extraFiles)
+final case class TestInputs(files: (os.RelPath, String)*) {
+  def add(extraFiles: (os.RelPath, String)*): TestInputs = TestInputs((files ++ extraFiles)*)
+
   private def writeIn(dir: os.Path): Unit =
     for ((relPath, content) <- files) {
       val path = dir / relPath
@@ -38,6 +36,7 @@ final case class TestInputs(
 }
 
 object TestInputs {
+  def empty: TestInputs = TestInputs()
 
   def compress(zipFilepath: os.Path, files: Seq[(os.RelPath, String)]) = {
     val zip = new ZipOutputStream(new FileOutputStream(zipFilepath.toString()))

--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -1,17 +1,18 @@
 package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
+import os.proc
 
 import scala.cli.integration.util.BloopUtil
 
 class BloopTests extends ScalaCliSuite {
 
-  def runScalaCli(args: String*) = os.proc(TestUtil.cli, args)
+  def runScalaCli(args: String*): proc = os.proc(TestUtil.cli, args)
 
   private lazy val bloopDaemonDir =
     BloopUtil.bloopDaemonDir(runScalaCli("directories").call().out.text())
 
-  val dummyInputs = TestInputs(
+  val dummyInputs: TestInputs = TestInputs(
     os.rel / "Test.scala" ->
       """//> using scala "2.13"
         |object Test {

--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -12,15 +12,13 @@ class BloopTests extends ScalaCliSuite {
     BloopUtil.bloopDaemonDir(runScalaCli("directories").call().out.text())
 
   val dummyInputs = TestInputs(
-    Seq(
-      os.rel / "Test.scala" ->
-        """//> using scala "2.13"
-          |object Test {
-          |  def main(args: Array[String]): Unit =
-          |    println("Hello " + "from test")
-          |}
-          |""".stripMargin
-    )
+    os.rel / "Test.scala" ->
+      """//> using scala "2.13"
+        |object Test {
+        |  def main(args: Array[String]): Unit =
+        |    println("Hello " + "from test")
+        |}
+        |""".stripMargin
   )
 
   def testScalaTermination(
@@ -57,7 +55,7 @@ class BloopTests extends ScalaCliSuite {
   }
 
   test("invalid bloop options passed via cli cause bloop start failure") {
-    TestInputs(Seq()).fromRoot { root =>
+    TestInputs.empty.fromRoot { root =>
       runScalaCli("bloop", "exit").call(cwd = root)
       val res = runScalaCli("bloop", "start", "--bloop-java-opt", "-zzefhjzl").call(
         cwd = root,
@@ -72,12 +70,10 @@ class BloopTests extends ScalaCliSuite {
 
   test("invalid bloop options passed via global bloop config json file cause bloop start failure") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "bloop.json" ->
-          """|{
-             | "javaOptions" : ["-Xmx1k"]
-             | }""".stripMargin
-      )
+      os.rel / "bloop.json" ->
+        """|{
+           | "javaOptions" : ["-Xmx1k"]
+           | }""".stripMargin
     )
 
     inputs.fromRoot { root =>
@@ -101,7 +97,7 @@ class BloopTests extends ScalaCliSuite {
       javaProcesses.contains("bloop.Bloop")
     }
 
-    val inputs = TestInputs(Seq.empty)
+    val inputs = TestInputs.empty
     inputs.fromRoot { _ =>
       BloopUtil.killBloop()
       TestUtil.retry()(assert(!bloopRunning()))
@@ -118,14 +114,12 @@ class BloopTests extends ScalaCliSuite {
 
   test("bloop projects and bloop compile works") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Hello.scala" ->
-          """object Hello {
-            |  def main(args: Array[String]): Unit =
-            |    println("Hello")
-            |}
-            |""".stripMargin
-      )
+      os.rel / "Hello.scala" ->
+        """object Hello {
+          |  def main(args: Array[String]): Unit =
+          |    println("Hello")
+          |}
+          |""".stripMargin
     )
     inputs.fromRoot { root =>
 

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -153,12 +153,10 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("setup-ide") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "simple.sc" ->
-          s"""val msg = "Hello"
-             |println(msg)
-             |""".stripMargin
-      )
+      os.rel / "simple.sc" ->
+        s"""val msg = "Hello"
+           |println(msg)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       os.proc(TestUtil.cli, "setup-ide", ".", extraOptions).call(cwd = root, stdout = os.Inherit)
@@ -171,12 +169,10 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
   for (command <- Seq("setup-ide", "compile", "run"))
     test(command + " should result in generated bsp file") {
       val inputs = TestInputs(
-        Seq(
-          os.rel / "simple.sc" ->
-            s"""val msg = "Hello"
-               |println(msg)
-               |""".stripMargin
-        )
+        os.rel / "simple.sc" ->
+          s"""val msg = "Hello"
+             |println(msg)
+             |""".stripMargin
       )
       inputs.fromRoot { root =>
         os.proc(TestUtil.cli, command, ".", extraOptions).call(cwd = root, stdout = os.Inherit)
@@ -197,18 +193,13 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
     }
 
   val importPprintOnlyProject: TestInputs = TestInputs(
-    Seq(
-      os.rel / "simple.sc" -> s"import $$ivy.`com.lihaoyi::pprint:${Constants.pprintVersion}`"
-    )
+    os.rel / "simple.sc" -> s"import $$ivy.`com.lihaoyi::pprint:${Constants.pprintVersion}`"
   )
 
   test("setup-ide should have only absolute paths even if relative ones were specified") {
     val path = os.rel / "directory" / "simple.sc"
-    val inputs = TestInputs(
-      Seq(
-        path -> s"import $$ivy.`com.lihaoyi::pprint:${Constants.pprintVersion}`"
-      )
-    )
+    val inputs =
+      TestInputs(path -> s"import $$ivy.`com.lihaoyi::pprint:${Constants.pprintVersion}`")
     inputs.fromRoot { root =>
       val relativeCliCommand = TestUtil.cliCommand(
         TestUtil.relPathStr(os.Path(TestUtil.cliPath).relativeTo(root))
@@ -269,12 +260,10 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("simple") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "simple.sc" ->
-          s"""val msg = "Hello"
-             |println(msg)
-             |""".stripMargin
-      )
+      os.rel / "simple.sc" ->
+        s"""val msg = "Hello"
+           |println(msg)
+           |""".stripMargin
     )
 
     withBsp(inputs, Seq(".")) { (root, _, remoteServer) =>
@@ -389,15 +378,13 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("diagnostics") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Test.scala" ->
-          s"""object Test {
-             |  val msg = "Hello"
-             |  zz
-             |  println(msg)
-             |}
-             |""".stripMargin
-      )
+      os.rel / "Test.scala" ->
+        s"""object Test {
+           |  val msg = "Hello"
+           |  zz
+           |  println(msg)
+           |}
+           |""".stripMargin
     )
 
     withBsp(inputs, Seq(".")) { (root, localClient, remoteServer) =>
@@ -448,13 +435,11 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("diagnostics in script") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "test.sc" ->
-          s"""val msg = "Hello"
-             |zz
-             |println(msg)
-             |""".stripMargin
-      )
+      os.rel / "test.sc" ->
+        s"""val msg = "Hello"
+           |zz
+           |println(msg)
+           |""".stripMargin
     )
 
     withBsp(inputs, Seq(".")) { (root, localClient, remoteServer) =>
@@ -514,13 +499,11 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("invalid diagnostics at startup") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "A.scala" ->
-          s"""//> using resource "./resources"
-             |
-             |object A {}
-             |""".stripMargin
-      )
+      os.rel / "A.scala" ->
+        s"""//> using resource "./resources"
+           |
+           |object A {}
+           |""".stripMargin
     )
 
     withBsp(inputs, Seq(".")) { (_, localClient, remoteServer) =>
@@ -547,16 +530,14 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("directive diagnostics") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Test.scala" ->
-          s"""//> using lib "com.lihaoyi::pprint:0.0.0.0.0.1"
-             |
-             |object Test {
-             |  val msg = "Hello"
-             |  println(msg)
-             |}
-             |""".stripMargin
-      )
+      os.rel / "Test.scala" ->
+        s"""//> using lib "com.lihaoyi::pprint:0.0.0.0.0.1"
+           |
+           |object Test {
+           |  val msg = "Hello"
+           |  println(msg)
+           |}
+           |""".stripMargin
     )
 
     withBsp(inputs, Seq(".")) { (root, localClient, remoteServer) =>
@@ -589,12 +570,10 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("workspace update") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "simple.sc" ->
-          s"""val msg = "Hello"
-             |println(msg)
-             |""".stripMargin
-      )
+      os.rel / "simple.sc" ->
+        s"""val msg = "Hello"
+           |println(msg)
+           |""".stripMargin
     )
     val extraArgs =
       if (Properties.isWin) Seq("-v", "-v", "-v")
@@ -701,14 +680,12 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("workspace update - new file") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Test.scala" ->
-          s"""object Test {
-             |  val msg = "Hello"
-             |  println(msg)
-             |}
-             |""".stripMargin
-      )
+      os.rel / "Test.scala" ->
+        s"""object Test {
+           |  val msg = "Hello"
+           |  println(msg)
+           |}
+           |""".stripMargin
     )
 
     withBsp(inputs, Seq(".")) { (root, localClient, remoteServer) =>
@@ -797,26 +774,24 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("test workspace update after adding file to main scope") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Messages.scala" ->
-          """//> using lib "com.lihaoyi::os-lib:0.7.8"
-            |object Messages {
-            |  def msg = "Hello"
-            |}
-            |""".stripMargin,
-        os.rel / "MyTests.test.scala" ->
-          """//> using lib "com.lihaoyi::utest::0.7.10"
-            |import utest._
-            |
-            |object MyTests extends TestSuite {
-            |  val tests = Tests {
-            |    test("foo") {
-            |      assert(Messages.msg == "Hello")
-            |    }
-            |  }
-            |}
-            |""".stripMargin
-      )
+      os.rel / "Messages.scala" ->
+        """//> using lib "com.lihaoyi::os-lib:0.7.8"
+          |object Messages {
+          |  def msg = "Hello"
+          |}
+          |""".stripMargin,
+      os.rel / "MyTests.test.scala" ->
+        """//> using lib "com.lihaoyi::utest::0.7.10"
+          |import utest._
+          |
+          |object MyTests extends TestSuite {
+          |  val tests = Tests {
+          |    test("foo") {
+          |      assert(Messages.msg == "Hello")
+          |    }
+          |  }
+          |}
+          |""".stripMargin
     )
 
     withBsp(inputs, Seq(".")) { (root, localClient, remoteServer) =>
@@ -890,11 +865,9 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("using directive") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "test.sc" ->
-          s"""// using scala "3.0"
-             |println(123)""".stripMargin
-      )
+      os.rel / "test.sc" ->
+        s"""// using scala "3.0"
+           |println(123)""".stripMargin
     )
     withBsp(inputs, Seq(".")) { (_, localClient, remoteServer) =>
       async {
@@ -921,14 +894,12 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("workspace/reload --dependency option") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "ReloadTest.scala" ->
-          s"""import os.pwd
-             |object ReloadTest {
-             |  println(pwd)
-             |}
-             |""".stripMargin
-      )
+      os.rel / "ReloadTest.scala" ->
+        s"""import os.pwd
+           |object ReloadTest {
+           |  println(pwd)
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       os.proc(TestUtil.cli, "setup-ide", ".", extraOptions)
@@ -975,14 +946,12 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
     val dir1 = "dir1"
     val dir2 = "dir2"
     val inputs = TestInputs(
-      Seq(
-        os.rel / dir1 / "ReloadTest.scala" ->
-          s"""object ReloadTest {
-             |  val container = MissingCaseClass(value = "Hello")
-             |  println(container.value)
-             |}
-             |""".stripMargin
-      )
+      os.rel / dir1 / "ReloadTest.scala" ->
+        s"""object ReloadTest {
+           |  val container = MissingCaseClass(value = "Hello")
+           |  println(container.value)
+           |}
+           |""".stripMargin
     )
     val extraInputs = inputs.add(
       os.rel / dir2 / "MissingCaseClass.scala" -> "case class MissingCaseClass(value: String)"
@@ -1027,13 +996,11 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("workspace/reload error response when no inputs json present") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "ReloadTest.scala" ->
-          s"""object ReloadTest {
-             |  println("Hello")
-             |}
-             |""".stripMargin
-      )
+      os.rel / "ReloadTest.scala" ->
+        s"""object ReloadTest {
+           |  println("Hello")
+           |}
+           |""".stripMargin
     )
     withBsp(inputs, Seq(".")) {
       (_, _, remoteServer) =>
@@ -1057,18 +1024,16 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
   test("workspace/reload when updated source element in using directive") {
     val utilsFileName = "Utils.scala"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Hello.scala" ->
-          s"""|//> using file "Utils.scala"
-              |
-              |object Hello extends App {
-              |   println("Hello World")
-              |}""".stripMargin,
-        os.rel / utilsFileName ->
-          s"""|object Utils {
-              |  val hello = "Hello World"
-              |}""".stripMargin
-      )
+      os.rel / "Hello.scala" ->
+        s"""|//> using file "Utils.scala"
+            |
+            |object Hello extends App {
+            |   println("Hello World")
+            |}""".stripMargin,
+      os.rel / utilsFileName ->
+        s"""|object Utils {
+            |  val hello = "Hello World"
+            |}""".stripMargin
     )
     withBsp(inputs, Seq("Hello.scala")) { (root, _, remoteServer) =>
       async {
@@ -1108,15 +1073,13 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("bloop projects are initialised properly for an invalid directive") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "InvalidUsingDirective.scala" ->
-          s"""//> using scala 3.1.2
-             |
-             |object InvalidUsingDirective extends App {
-             |  println("Hello")
-             |}
-             |""".stripMargin
-      )
+      os.rel / "InvalidUsingDirective.scala" ->
+        s"""//> using scala 3.1.2
+           |
+           |object InvalidUsingDirective extends App {
+           |  println("Hello")
+           |}
+           |""".stripMargin
     )
     withBsp(inputs, Seq(".")) {
       (root, localClient, remoteServer) =>
@@ -1145,15 +1108,13 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("bloop projects are initialised properly for a directive for an unfetchable dependency") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "InvalidUsingDirective.scala" ->
-          s"""//> using lib "no::lib:123"
-             |
-             |object InvalidUsingDirective extends App {
-             |  println("Hello")
-             |}
-             |""".stripMargin
-      )
+      os.rel / "InvalidUsingDirective.scala" ->
+        s"""//> using lib "no::lib:123"
+           |
+           |object InvalidUsingDirective extends App {
+           |  println("Hello")
+           |}
+           |""".stripMargin
     )
     withBsp(inputs, Seq(".")) {
       (root, localClient, remoteServer) =>

--- a/modules/integration/src/test/scala/scala/cli/integration/CleanTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CleanTests.scala
@@ -4,7 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 
 class CleanTests extends ScalaCliSuite {
 
-  override def group = ScalaCliSuite.TestGroup.First
+  override def group: ScalaCliSuite.TestGroup = ScalaCliSuite.TestGroup.First
 
   test("simple") {
     val inputs = TestInputs(

--- a/modules/integration/src/test/scala/scala/cli/integration/CleanTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CleanTests.scala
@@ -8,14 +8,12 @@ class CleanTests extends ScalaCliSuite {
 
   test("simple") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Hello.scala" ->
-          """object Hello {
-            |  def main(args: Array[String]): Unit =
-            |    println("Hello")
-            |}
-            |""".stripMargin
-      )
+      os.rel / "Hello.scala" ->
+        """object Hello {
+          |  def main(args: Array[String]): Unit =
+          |    println("Hello")
+          |}
+          |""".stripMargin
     )
 
     inputs.fromRoot { root =>

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -10,13 +10,13 @@ import scala.cli.integration.util.BloopUtil
 abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
     extends ScalaCliSuite with TestScalaVersionArgs {
 
-  protected lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
+  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
 
   private lazy val bloopDaemonDir = BloopUtil.bloopDaemonDir {
     os.proc(TestUtil.cli, "directories").call().out.text()
   }
 
-  val simpleInputs = TestInputs(
+  val simpleInputs: TestInputs = TestInputs(
     os.rel / "MyTests.test.scala" ->
       """//> using lib "com.lihaoyi::utest::0.7.10"
         |import utest._
@@ -32,7 +32,7 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
         |""".stripMargin
   )
 
-  val mainAndTestInputs = TestInputs(
+  val mainAndTestInputs: TestInputs = TestInputs(
     os.rel / "Main.scala" ->
       """//> using lib "com.lihaoyi::utest:0.7.10"
         |
@@ -201,25 +201,25 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
 
   val jvmT = new munit.Tag("jvm-resolution")
 
-  val scalaJvm8Project =
+  val scalaJvm8Project: TestInputs =
     TestInputs(os.rel / "Main.scala" -> s"object Main{java.util.Optional.of(1).isPresent}")
-  val scalaJvm11Project =
+  val scalaJvm11Project: TestInputs =
     TestInputs(os.rel / "Main.scala" -> s"object Main{java.util.Optional.of(1).isEmpty}")
-  val javaJvm8Project =
+  val javaJvm8Project: TestInputs =
     TestInputs(os.rel / "Main.java" -> """|public class Main{
                                           |  public static void main(String[] args) {
                                           |      java.util.Optional.of(1).isPresent();
                                           |  }
                                           |}""".stripMargin)
 
-  val javaJvm11Project =
+  val javaJvm11Project: TestInputs =
     TestInputs(os.rel / "Main.java" -> """|public class Main{
                                           |  public static void main(String[] args) {
                                           |      java.util.Optional.of(1).isEmpty();
                                           |  }
                                           |}""".stripMargin)
 
-  val inputs = Map(
+  val inputs: Map[(String, Int), TestInputs] = Map(
     ("scala", 8)  -> scalaJvm8Project,
     ("scala", 11) -> scalaJvm11Project,
     ("java", 8)   -> javaJvm8Project,
@@ -264,7 +264,7 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
     targetJvm: String,
     shouldSucceed: Boolean,
     inputs: TestInputs
-  ) =
+  ): Unit =
     inputs.fromRoot { root =>
       val bloop = BloopUtil.bloop(Constants.bloopVersion, bloopDaemonDir, jvm = Some(bloopJvm))
       bloop(Seq("exit")).call(
@@ -296,7 +296,7 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
           stderr = os.Pipe
         )
         val stderr = res.err.text()
-        expect(s"\\[.*warn.*\\].*Conflicting options.*".r.findFirstMatchIn(stderr).isDefined)
+        expect(s"\\[.*warn.*].*Conflicting options.*".r.findFirstMatchIn(stderr).isDefined)
 
       }
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -17,52 +17,48 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
   }
 
   val simpleInputs = TestInputs(
-    Seq(
-      os.rel / "MyTests.test.scala" ->
-        """//> using lib "com.lihaoyi::utest::0.7.10"
-          |import utest._
-          |
-          |object MyTests extends TestSuite {
-          |  val tests = Tests {
-          |    test("foo") {
-          |      assert(2 + 2 == 4)
-          |      println("Hello from " + "tests")
-          |    }
-          |  }
-          |}
-          |""".stripMargin
-    )
+    os.rel / "MyTests.test.scala" ->
+      """//> using lib "com.lihaoyi::utest::0.7.10"
+        |import utest._
+        |
+        |object MyTests extends TestSuite {
+        |  val tests = Tests {
+        |    test("foo") {
+        |      assert(2 + 2 == 4)
+        |      println("Hello from " + "tests")
+        |    }
+        |  }
+        |}
+        |""".stripMargin
   )
 
   val mainAndTestInputs = TestInputs(
-    Seq(
-      os.rel / "Main.scala" ->
-        """//> using lib "com.lihaoyi::utest:0.7.10"
-          |
-          |object Main {
-          |  val err = utest.compileError("pprint.log(2)")
-          |  def message = "Hello from " + "tests"
-          |  def main(args: Array[String]): Unit = {
-          |    println(message)
-          |    println(err)
-          |  }
-          |}
-          |""".stripMargin,
-      os.rel / "Tests.scala" ->
-        """//> using lib "com.lihaoyi::pprint:0.6.6"
-          |//> using target.scope "test"
-          |
-          |import utest._
-          |
-          |object Tests extends TestSuite {
-          |  val tests = Tests {
-          |    test("message") {
-          |      assert(Main.message.startsWith("Hello"))
-          |    }
-          |  }
-          |}
-          |""".stripMargin
-    )
+    os.rel / "Main.scala" ->
+      """//> using lib "com.lihaoyi::utest:0.7.10"
+        |
+        |object Main {
+        |  val err = utest.compileError("pprint.log(2)")
+        |  def message = "Hello from " + "tests"
+        |  def main(args: Array[String]): Unit = {
+        |    println(message)
+        |    println(err)
+        |  }
+        |}
+        |""".stripMargin,
+    os.rel / "Tests.scala" ->
+      """//> using lib "com.lihaoyi::pprint:0.6.6"
+        |//> using target.scope "test"
+        |
+        |import utest._
+        |
+        |object Tests extends TestSuite {
+        |  val tests = Tests {
+        |    test("message") {
+        |      assert(Main.message.startsWith("Hello"))
+        |    }
+        |  }
+        |}
+        |""".stripMargin
   )
 
   test("no arg") {
@@ -73,14 +69,12 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("exit code") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Main.scala" ->
-          """object Main {
-            |  def main(args: Array[String]): Unit =
-            |    println(nope)
-            |}
-            |""".stripMargin
-      )
+      os.rel / "Main.scala" ->
+        """object Main {
+          |  def main(args: Array[String]): Unit =
+          |    println(nope)
+          |}
+          |""".stripMargin
     )
     inputs.fromRoot { root =>
       val res = os.proc(TestUtil.cli, "compile", extraOptions, ".")
@@ -134,30 +128,28 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("test scope error") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Main.scala" ->
-          """object Main {
-            |  def message = "Hello from " + "tests"
-            |  def main(args: Array[String]): Unit =
-            |    println(message)
-            |}
-            |""".stripMargin,
-        os.rel / "Tests.scala" ->
-          """//> using lib "com.lihaoyi::utest:0.7.10"
-            |//> using target.scope "test"
-            |
-            |import utest._
-            |
-            |object Tests extends TestSuite {
-            |  val tests = Tests {
-            |    test("message") {
-            |      pprint.log(Main.message)
-            |      assert(Main.message.startsWith("Hello"))
-            |    }
-            |  }
-            |}
-            |""".stripMargin
-      )
+      os.rel / "Main.scala" ->
+        """object Main {
+          |  def message = "Hello from " + "tests"
+          |  def main(args: Array[String]): Unit =
+          |    println(message)
+          |}
+          |""".stripMargin,
+      os.rel / "Tests.scala" ->
+        """//> using lib "com.lihaoyi::utest:0.7.10"
+          |//> using target.scope "test"
+          |
+          |import utest._
+          |
+          |object Tests extends TestSuite {
+          |  val tests = Tests {
+          |    test("message") {
+          |      pprint.log(Main.message)
+          |      assert(Main.message.startsWith("Hello"))
+          |    }
+          |  }
+          |}
+          |""".stripMargin
     )
     inputs.fromRoot { root =>
       val res = os.proc(TestUtil.cli, "compile", "--test", extraOptions, ".")
@@ -174,17 +166,15 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("code in test error") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Main.scala" ->
-          """object Main {
-            |  def message = "Hello from " + "tests"
-            |  def main(args: Array[String]): Unit = {
-            |    zz // zz value
-            |    println(message)
-            |  }
-            |}
-            |""".stripMargin
-      )
+      os.rel / "Main.scala" ->
+        """object Main {
+          |  def message = "Hello from " + "tests"
+          |  def main(args: Array[String]): Unit = {
+          |    zz // zz value
+          |    println(message)
+          |  }
+          |}
+          |""".stripMargin
     )
     inputs.fromRoot { root =>
       val res = os.proc(TestUtil.cli, "compile", extraOptions, ".")
@@ -211,25 +201,23 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
 
   val jvmT = new munit.Tag("jvm-resolution")
 
-  val scalaJvm8Project = TestInputs(
-    Seq(os.rel / "Main.scala" -> s"object Main{java.util.Optional.of(1).isPresent}")
-  )
-  val scalaJvm11Project = TestInputs(
-    Seq(os.rel / "Main.scala" -> s"object Main{java.util.Optional.of(1).isEmpty}")
-  )
+  val scalaJvm8Project =
+    TestInputs(os.rel / "Main.scala" -> s"object Main{java.util.Optional.of(1).isPresent}")
+  val scalaJvm11Project =
+    TestInputs(os.rel / "Main.scala" -> s"object Main{java.util.Optional.of(1).isEmpty}")
   val javaJvm8Project =
-    TestInputs(Seq(os.rel / "Main.java" -> """|public class Main{
-                                              |  public static void main(String[] args) {
-                                              |      java.util.Optional.of(1).isPresent();
-                                              |  }
-                                              |}""".stripMargin))
+    TestInputs(os.rel / "Main.java" -> """|public class Main{
+                                          |  public static void main(String[] args) {
+                                          |      java.util.Optional.of(1).isPresent();
+                                          |  }
+                                          |}""".stripMargin)
 
   val javaJvm11Project =
-    TestInputs(Seq(os.rel / "Main.java" -> """|public class Main{
-                                              |  public static void main(String[] args) {
-                                              |      java.util.Optional.of(1).isEmpty();
-                                              |  }
-                                              |}""".stripMargin))
+    TestInputs(os.rel / "Main.java" -> """|public class Main{
+                                          |  public static void main(String[] args) {
+                                          |      java.util.Optional.of(1).isEmpty();
+                                          |  }
+                                          |}""".stripMargin)
 
   val inputs = Map(
     ("scala", 8)  -> scalaJvm8Project,
@@ -301,9 +289,7 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
     }
   if (actualScalaVersion.startsWith("2.12"))
     test("JVM options only for JVM platform") {
-      val inputs = TestInputs(
-        Seq(os.rel / "Main.scala" -> "//> using `java-opt` \"-Xss1g\"")
-      )
+      val inputs = TestInputs(os.rel / "Main.scala" -> "//> using `java-opt` \"-Xss1g\"")
       inputs.fromRoot { root =>
         val res = os.proc(TestUtil.cli, "compile", extraOptions, "--native", ".").call(
           cwd = root,
@@ -317,17 +303,15 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("Manual javac SemanticDB") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "foo" / "Test.java" ->
-          """package foo;
-            |
-            |public class Test {
-            |  public static void main(String[] args) {
-            |    System.err.println("Hello");
-            |  }
-            |}
-            |""".stripMargin
-      )
+      os.rel / "foo" / "Test.java" ->
+        """package foo;
+          |
+          |public class Test {
+          |  public static void main(String[] args) {
+          |    System.err.println("Hello");
+          |  }
+          |}
+          |""".stripMargin
     )
     inputs.fromRoot { root =>
       val compilerPackages = Seq(
@@ -365,17 +349,15 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("Javac SemanticDB") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "foo" / "Test.java" ->
-          """package foo;
-            |
-            |public class Test {
-            |  public static void main(String[] args) {
-            |    System.err.println("Hello");
-            |  }
-            |}
-            |""".stripMargin
-      )
+      os.rel / "foo" / "Test.java" ->
+        """package foo;
+          |
+          |public class Test {
+          |  public static void main(String[] args) {
+          |    System.err.println("Hello");
+          |  }
+          |}
+          |""".stripMargin
     )
     inputs.fromRoot { root =>
       os.proc(TestUtil.cli, "compile", extraOptions, "--semantic-db", ".")
@@ -397,14 +379,12 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
     test("generate scoverage.coverage file") {
       val fileName = "Hello.scala"
       val inputs = TestInputs(
-        Seq(
-          os.rel / fileName -> // scala version should updated to 3.3 after release
-            s"""//> using scala "3.2.0-RC1-bin-20220604-13ce496-NIGHTLY"
-               |//> using options "-coverage-out:."
-               |
-               |@main def main = ()
-               |""".stripMargin
-        )
+        os.rel / fileName -> // scala version should updated to 3.3 after release
+          s"""//> using scala "3.2.0-RC1-bin-20220604-13ce496-NIGHTLY"
+             |//> using options "-coverage-out:."
+             |
+             |@main def main = ()
+             |""".stripMargin
       )
       inputs.fromRoot { root =>
         os.proc(TestUtil.cli, "compile", extraOptions, fileName)
@@ -423,15 +403,13 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
   def noDuplicatesInClassPathTest(): Unit = {
     val sparkVersion = "3.3.0"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Hello.scala" ->
-          s"""//> using lib "org.apache.spark::spark-sql:$sparkVersion"
-             |object Hello {
-             |  def main(args: Array[String]): Unit =
-             |    println("Hello")
-             |}
-             |""".stripMargin
-      )
+      os.rel / "Hello.scala" ->
+        s"""//> using lib "org.apache.spark::spark-sql:$sparkVersion"
+           |object Hello {
+           |  def main(args: Array[String]): Unit =
+           |    println("Hello")
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val res =

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTests212.scala
@@ -7,19 +7,17 @@ class CompileTests212 extends CompileTestDefinitions(
 // format: on
 
   val pluginInputs = TestInputs(
-    Seq(
-      os.rel / "Plugin.scala" ->
-        // Copied from (https://github.com/typelevel/kind-projector/blob/00bf25cef1b7d01d61a3555cccb6cf38fe30e117/src/test/scala/polylambda.scala)
-        """object Plugin {
-          |  trait ~>[-F[_], +G[_]] {
-          |    def apply[A](x: F[A]): G[A]
-          |  }
-          |  type ToSelf[F[_]] = F ~> F
-          |  val kf5 = λ[Map[*, Int] ~> Map[*, Long]](_.map { case (k, v) => (k, v.toLong) }.toMap)
-          |  val kf6 = λ[ToSelf[Map[*, Int]]](_.map { case (k, v) => (k, v * 2) }.toMap)
-          |}
-          |""".stripMargin
-    )
+    os.rel / "Plugin.scala" ->
+      // Copied from (https://github.com/typelevel/kind-projector/blob/00bf25cef1b7d01d61a3555cccb6cf38fe30e117/src/test/scala/polylambda.scala)
+      """object Plugin {
+        |  trait ~>[-F[_], +G[_]] {
+        |    def apply[A](x: F[A]): G[A]
+        |  }
+        |  type ToSelf[F[_]] = F ~> F
+        |  val kf5 = λ[Map[*, Int] ~> Map[*, Long]](_.map { case (k, v) => (k, v.toLong) }.toMap)
+        |  val kf6 = λ[ToSelf[Map[*, Int]]](_.map { case (k, v) => (k, v * 2) }.toMap)
+        |}
+        |""".stripMargin
   )
 
   val kindProjectPlugin = "org.typelevel:::kind-projector:0.13.2"

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTests212.scala
@@ -6,7 +6,7 @@ class CompileTests212 extends CompileTestDefinitions(
 ) {
 // format: on
 
-  val pluginInputs = TestInputs(
+  val pluginInputs: TestInputs = TestInputs(
     os.rel / "Plugin.scala" ->
       // Copied from (https://github.com/typelevel/kind-projector/blob/00bf25cef1b7d01d61a3555cccb6cf38fe30e117/src/test/scala/polylambda.scala)
       """object Plugin {

--- a/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
@@ -10,7 +10,7 @@ class ConfigTests extends ScalaCliSuite {
     val homeDir    = os.rel / "home"
     val dirOptions = Seq[os.Shellable]("--home-directory", homeDir)
     val name       = "Alex"
-    TestInputs(Nil).fromRoot { root =>
+    TestInputs.empty.fromRoot { root =>
       val before = os.proc(TestUtil.cli, "config", dirOptions, "user.name").call(cwd = root)
       expect(before.out.text().trim.isEmpty)
 
@@ -28,7 +28,7 @@ class ConfigTests extends ScalaCliSuite {
     val homeDir    = os.rel / "home"
     val dirOptions = Seq[os.Shellable]("--home-directory", homeDir)
     val password   = "1234"
-    TestInputs(Nil).fromRoot { root =>
+    TestInputs.empty.fromRoot { root =>
 
       def emptyCheck(): Unit = {
         val value = os.proc(TestUtil.cli, "config", dirOptions, "sonatype.password")

--- a/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
@@ -4,7 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 
 class ConfigTests extends ScalaCliSuite {
 
-  override def group = ScalaCliSuite.TestGroup.First
+  override def group: ScalaCliSuite.TestGroup = ScalaCliSuite.TestGroup.First
 
   test("simple") {
     val homeDir    = os.rel / "home"

--- a/modules/integration/src/test/scala/scala/cli/integration/DefaultFileTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DefaultFileTests.scala
@@ -14,7 +14,7 @@ class DefaultFileTests extends ScalaCliSuite {
   }
 
   test("Write .gitignore") {
-    TestInputs(Nil).fromRoot { root =>
+    TestInputs.empty.fromRoot { root =>
       os.proc(TestUtil.cli, "default-file", ".gitignore", "--write")
         .call(cwd = root, stdout = os.Inherit)
       val dest = root / ".gitignore"

--- a/modules/integration/src/test/scala/scala/cli/integration/DefaultFileTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DefaultFileTests.scala
@@ -4,7 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 
 class DefaultFileTests extends ScalaCliSuite {
 
-  override def group = ScalaCliSuite.TestGroup.First
+  override def group: ScalaCliSuite.TestGroup = ScalaCliSuite.TestGroup.First
 
   test("Print .gitignore") {
     val res = os.proc(TestUtil.cli, "default-file", ".gitignore")

--- a/modules/integration/src/test/scala/scala/cli/integration/DependencyUpdateTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DependencyUpdateTests.scala
@@ -16,11 +16,7 @@ class DependencyUpdateTests extends ScalaCliSuite {
           |object Hello extends App {
           |  println("$message")
           |}""".stripMargin
-    val inputs = TestInputs(
-      Seq(
-        os.rel / fileName -> fileContent
-      )
-    )
+    val inputs = TestInputs(os.rel / fileName -> fileContent)
     inputs.fromRoot { root =>
       // update dependencies
       val p = os.proc(TestUtil.cli, "dependency-update", "--all", fileName)

--- a/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
@@ -10,19 +10,17 @@ abstract class DocTestDefinitions(val scalaVersionOpt: Option[String])
   test("generate static scala doc") {
     val dest = os.rel / "doc-static"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "lib" / "Messages.scala" ->
-          """package lib
-            |
-            |object Messages {
-            |  def msg = "Hello"
-            |}
-            |""".stripMargin,
-        os.rel / "simple.sc" ->
-          """val msg = lib.Messages.msg
-            |println(msg)
-            |""".stripMargin
-      )
+      os.rel / "lib" / "Messages.scala" ->
+        """package lib
+          |
+          |object Messages {
+          |  def msg = "Hello"
+          |}
+          |""".stripMargin,
+      os.rel / "simple.sc" ->
+        """val msg = lib.Messages.msg
+          |println(msg)
+          |""".stripMargin
     )
     inputs.fromRoot { root =>
       os.proc(TestUtil.cli, "doc", extraOptions, ".", "-o", dest).call(

--- a/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 abstract class DocTestDefinitions(val scalaVersionOpt: Option[String])
     extends ScalaCliSuite with TestScalaVersionArgs {
 
-  protected lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
+  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
 
   test("generate static scala doc") {
     val dest = os.rel / "doc-static"

--- a/modules/integration/src/test/scala/scala/cli/integration/DocTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DocTestsDefault.scala
@@ -6,31 +6,29 @@ class DocTestsDefault extends DocTestDefinitions(scalaVersionOpt = None) {
 
   test("javadoc") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Foo.java" ->
-          """//> using lib "org.graalvm.nativeimage:svm:22.0.0.2"
-            |
-            |import com.oracle.svm.core.annotate.TargetClass;
-            |import org.graalvm.nativeimage.Platform;
-            |import org.graalvm.nativeimage.Platforms;
-            |
-            |/**
-            | * Foo class
-            | */
-            |@TargetClass(className = "something")
-            |@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
-            |public class Foo {
-            |  /**
-            |   * Gets the value
-            |   *
-            |   * @return the value
-            |   */
-            |  public int getValue() {
-            |    return 2;
-            |  }
-            |}
-            |""".stripMargin
-      )
+      os.rel / "Foo.java" ->
+        """//> using lib "org.graalvm.nativeimage:svm:22.0.0.2"
+          |
+          |import com.oracle.svm.core.annotate.TargetClass;
+          |import org.graalvm.nativeimage.Platform;
+          |import org.graalvm.nativeimage.Platforms;
+          |
+          |/**
+          | * Foo class
+          | */
+          |@TargetClass(className = "something")
+          |@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+          |public class Foo {
+          |  /**
+          |   * Gets the value
+          |   *
+          |   * @return the value
+          |   */
+          |  public int getValue() {
+          |    return 2;
+          |  }
+          |}
+          |""".stripMargin
     )
     inputs.fromRoot { root =>
       val dest = root / "doc"

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
@@ -9,7 +9,7 @@ import scala.util.Properties
 abstract class ExportMillTestDefinitions(val scalaVersionOpt: Option[String])
     extends ScalaCliSuite with TestScalaVersionArgs {
 
-  protected lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
+  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
 
   protected def runExportTests: Boolean =
     Properties.isLinux

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestDefinitions.scala
@@ -9,7 +9,7 @@ import scala.util.Properties
 abstract class ExportSbtTestDefinitions(val scalaVersionOpt: Option[String])
     extends ScalaCliSuite with TestScalaVersionArgs {
 
-  protected lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
+  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
 
   protected def runExportTests: Boolean =
     Properties.isLinux

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportTestProjects.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportTestProjects.scala
@@ -39,30 +39,28 @@ object ExportTestProjects {
            |}
            |""".stripMargin
     TestInputs(
-      Seq(
-        os.rel / "Hello.scala" -> mainFile,
-        os.rel / "Zio.test.scala" ->
-          """|//> using lib "dev.zio::zio::1.0.8"
-             |//> using lib "dev.zio::zio-test-sbt::1.0.8"
-             |
-             |import zio._
-             |import zio.test._
-             |import zio.test.Assertion.equalTo
-             |
-             |object HelloWorldSpec extends DefaultRunnableSpec {
-             |  def spec = suite("associativity")(
-             |    testM("associativity") {
-             |      check(Gen.anyInt, Gen.anyInt, Gen.anyInt) { (x, y, z) =>
-             |        assert((x + y) + z)(equalTo(x + (y + z)))
-             |      }
-             |    }
-             |  )
-             |}
-             |""".stripMargin,
-        os.rel / "input" / "input" ->
-          """|1
-             |2""".stripMargin
-      )
+      os.rel / "Hello.scala" -> mainFile,
+      os.rel / "Zio.test.scala" ->
+        """|//> using lib "dev.zio::zio::1.0.8"
+           |//> using lib "dev.zio::zio-test-sbt::1.0.8"
+           |
+           |import zio._
+           |import zio.test._
+           |import zio.test.Assertion.equalTo
+           |
+           |object HelloWorldSpec extends DefaultRunnableSpec {
+           |  def spec = suite("associativity")(
+           |    testM("associativity") {
+           |      check(Gen.anyInt, Gen.anyInt, Gen.anyInt) { (x, y, z) =>
+           |        assert((x + y) + z)(equalTo(x + (y + z)))
+           |      }
+           |    }
+           |  )
+           |}
+           |""".stripMargin,
+      os.rel / "input" / "input" ->
+        """|1
+           |2""".stripMargin
     )
   }
 
@@ -93,11 +91,7 @@ object ExportTestProjects {
            |  }
            |}
            |""".stripMargin
-    TestInputs(
-      Seq(
-        os.rel / "Test.scala" -> testFile
-      )
-    )
+    TestInputs(os.rel / "Test.scala" -> testFile)
   }
 
   def nativeTest(scalaVersion: String): TestInputs = {
@@ -133,11 +127,7 @@ object ExportTestProjects {
            |  }
            |}
            |""".stripMargin
-    TestInputs(
-      Seq(
-        os.rel / "Test.scala" -> testFile
-      )
-    )
+    TestInputs(os.rel / "Test.scala" -> testFile)
   }
 
   def repositoryScala3Test(scalaVersion: String): TestInputs = {
@@ -151,11 +141,7 @@ object ExportTestProjects {
          |    val message = "Hello from " + "exported Scala CLI project"
          |    println(message)
          |""".stripMargin
-    TestInputs(
-      Seq(
-        os.rel / "Test.scala" -> testFile
-      )
-    )
+    TestInputs(os.rel / "Test.scala" -> testFile)
   }
 
   def mainClassScala3Test(scalaVersion: String): TestInputs = {
@@ -174,10 +160,8 @@ object ExportTestProjects {
          |    println(message)
          |""".stripMargin
     TestInputs(
-      Seq(
-        os.rel / "Test.scala"  -> testFile,
-        os.rel / "Other.scala" -> otherTestFile
-      )
+      os.rel / "Test.scala"  -> testFile,
+      os.rel / "Other.scala" -> otherTestFile
     )
   }
 
@@ -204,11 +188,7 @@ object ExportTestProjects {
          |  }
          |}
          |""".stripMargin
-    TestInputs(
-      Seq(
-        os.rel / "Test.scala" -> testFile
-      )
-    )
+    TestInputs(os.rel / "Test.scala" -> testFile)
   }
 
   def pureJavaTest: TestInputs = {
@@ -230,11 +210,7 @@ object ExportTestProjects {
          |  }
          |}
          |""".stripMargin
-    TestInputs(
-      Seq(
-        os.rel / "ScalaCliJavaTest.java" -> testFile
-      )
-    )
+    TestInputs(os.rel / "ScalaCliJavaTest.java" -> testFile)
   }
 
   def testFrameworkTest(scalaVersion: String): TestInputs = {
@@ -254,11 +230,7 @@ object ExportTestProjects {
          |  }
          |}
          |""".stripMargin
-    TestInputs(
-      Seq(
-        os.rel / "MyTests.scala" -> testFile
-      )
-    )
+    TestInputs(os.rel / "MyTests.scala" -> testFile)
   }
 
   def customJarTest(scalaVersion: String): TestInputs = {
@@ -293,10 +265,6 @@ object ExportTestProjects {
          |  }
          |}
          |""".stripMargin
-    TestInputs(
-      Seq(
-        os.rel / "Test.scala" -> testFile
-      )
-    )
+    TestInputs(os.rel / "Test.scala" -> testFile)
   }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/FmtTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FmtTests.scala
@@ -4,7 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 
 class FmtTests extends ScalaCliSuite {
 
-  override def group = ScalaCliSuite.TestGroup.First
+  override def group: ScalaCliSuite.TestGroup = ScalaCliSuite.TestGroup.First
 
   val confFileName = ".scalafmt.conf"
 

--- a/modules/integration/src/test/scala/scala/cli/integration/FmtTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FmtTests.scala
@@ -8,7 +8,7 @@ class FmtTests extends ScalaCliSuite {
 
   val confFileName = ".scalafmt.conf"
 
-  val emptyInputs: TestInputs = TestInputs(Seq(os.rel / ".placeholder" -> ""))
+  val emptyInputs: TestInputs = TestInputs(os.rel / ".placeholder" -> "")
 
   val simpleInputsUnformattedContent: String =
     """package foo
@@ -18,13 +18,11 @@ class FmtTests extends ScalaCliSuite {
       | }
       |""".stripMargin
   val simpleInputs: TestInputs = TestInputs(
-    Seq(
-      os.rel / confFileName ->
-        s"""|version = "${Constants.defaultScalafmtVersion}"
-            |runner.dialect = scala213
-            |""".stripMargin,
-      os.rel / "Foo.scala" -> simpleInputsUnformattedContent
-    )
+    os.rel / confFileName ->
+      s"""|version = "${Constants.defaultScalafmtVersion}"
+          |runner.dialect = scala213
+          |""".stripMargin,
+    os.rel / "Foo.scala" -> simpleInputsUnformattedContent
   )
   val expectedSimpleInputsFormattedContent: String = noCrLf {
     """package foo
@@ -36,30 +34,24 @@ class FmtTests extends ScalaCliSuite {
   }
 
   val simpleInputsWithFilter: TestInputs = TestInputs(
-    Seq(
-      os.rel / confFileName ->
-        s"""|version = "${Constants.defaultScalafmtVersion}"
-            |runner.dialect = scala213
-            |project.excludePaths = [ "glob:**/should/not/format/**.scala" ]
-            |""".stripMargin,
-      os.rel / "Foo.scala"                 -> expectedSimpleInputsFormattedContent,
-      os.rel / "scripts" / "SomeScript.sc" -> "println()\n",
-      os.rel / "should" / "not" / "format" / "ShouldNotFormat.scala" -> simpleInputsUnformattedContent
-    )
+    os.rel / confFileName ->
+      s"""|version = "${Constants.defaultScalafmtVersion}"
+          |runner.dialect = scala213
+          |project.excludePaths = [ "glob:**/should/not/format/**.scala" ]
+          |""".stripMargin,
+    os.rel / "Foo.scala"                 -> expectedSimpleInputsFormattedContent,
+    os.rel / "scripts" / "SomeScript.sc" -> "println()\n",
+    os.rel / "should" / "not" / "format" / "ShouldNotFormat.scala" -> simpleInputsUnformattedContent
   )
 
   val simpleInputsWithDialectOnly: TestInputs = TestInputs(
-    Seq(
-      os.rel / confFileName -> "runner.dialect = scala213".stripMargin,
-      os.rel / "Foo.scala"  -> simpleInputsUnformattedContent
-    )
+    os.rel / confFileName -> "runner.dialect = scala213".stripMargin,
+    os.rel / "Foo.scala"  -> simpleInputsUnformattedContent
   )
 
   val simpleInputsWithVersionOnly: TestInputs = TestInputs(
-    Seq(
-      os.rel / confFileName -> "version = \"3.5.5\"".stripMargin,
-      os.rel / "Foo.scala"  -> simpleInputsUnformattedContent
-    )
+    os.rel / confFileName -> "version = \"3.5.5\"".stripMargin,
+    os.rel / "Foo.scala"  -> simpleInputsUnformattedContent
   )
 
   private def noCrLf(input: String): String =

--- a/modules/integration/src/test/scala/scala/cli/integration/GitHubTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/GitHubTests.scala
@@ -23,7 +23,7 @@ class GitHubTests extends ScalaCliSuite {
     val keyId   = "the-key-id"
     val keyPair = Sodium.keyPair()
     val value   = "1234"
-    TestInputs(Nil).fromRoot { root =>
+    TestInputs.empty.fromRoot { root =>
       val pubKey = GitHubTests.PublicKey(keyId, Base64.getEncoder.encodeToString(keyPair.getPubKey))
       os.write(root / "pub-key.json", writeToArray(pubKey))
 

--- a/modules/integration/src/test/scala/scala/cli/integration/GitHubTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/GitHubTests.scala
@@ -1,7 +1,7 @@
 package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
-import com.github.plokhotnyuk.jsoniter_scala.core._
+import com.github.plokhotnyuk.jsoniter_scala.core.*
 import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 import coursier.cache.ArchiveCache
 import coursier.util.Artifact
@@ -15,7 +15,7 @@ import scala.util.Properties
 
 class GitHubTests extends ScalaCliSuite {
 
-  override def group = ScalaCliSuite.TestGroup.First
+  override def group: ScalaCliSuite.TestGroup = ScalaCliSuite.TestGroup.First
 
   def createSecretTest(): Unit = {
     GitHubTests.initSodium()
@@ -85,7 +85,7 @@ object GitHubTests {
   private def libsodiumVersion = Constants.libsodiumVersion
 
   // Warning: somehow also in settings.sc in the build, and in FetchExternalBinary
-  lazy val condaPlatform = {
+  lazy val condaPlatform: String = {
     val mambaOs =
       if (Properties.isWin) "win"
       else if (Properties.isMac) "osx"

--- a/modules/integration/src/test/scala/scala/cli/integration/InstallAndUninstallCompletionsTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/InstallAndUninstallCompletionsTests.scala
@@ -6,12 +6,12 @@ import coursier.cache.shaded.dirs.ProjectDirectories
 import scala.util.Properties
 
 class InstallAndUninstallCompletionsTests extends ScalaCliSuite {
-  val zshRcFile  = ".zshrc"
-  val bashRcFile = ".bashrc"
-  val rcContent = s"""
-                     |dummy line
-                     |dummy line""".stripMargin
-  val testInputs = TestInputs(
+  val zshRcFile: String  = ".zshrc"
+  val bashRcFile: String = ".bashrc"
+  val rcContent: String = s"""
+                             |dummy line
+                             |dummy line""".stripMargin
+  val testInputs: TestInputs = TestInputs(
     os.rel / zshRcFile  -> rcContent,
     os.rel / bashRcFile -> rcContent
   )
@@ -42,7 +42,7 @@ class InstallAndUninstallCompletionsTests extends ScalaCliSuite {
       runInstallAndUninstallCompletions()
     }
 
-  lazy val bashRcScript = {
+  lazy val bashRcScript: String = {
     val progName = "scala-cli"
     val ifs      = "\\n"
     val script =
@@ -56,7 +56,7 @@ class InstallAndUninstallCompletionsTests extends ScalaCliSuite {
     addTags(script)
   }
 
-  lazy val zshRcScript = {
+  lazy val zshRcScript: String = {
     val projDirs = ProjectDirectories.from(null, null, "ScalaCli")
     val dir      = os.Path(projDirs.dataLocalDir, TestUtil.pwd) / "completions" / "zsh"
     val script = Seq(

--- a/modules/integration/src/test/scala/scala/cli/integration/InstallAndUninstallCompletionsTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/InstallAndUninstallCompletionsTests.scala
@@ -12,10 +12,8 @@ class InstallAndUninstallCompletionsTests extends ScalaCliSuite {
                      |dummy line
                      |dummy line""".stripMargin
   val testInputs = TestInputs(
-    Seq(
-      os.rel / zshRcFile  -> rcContent,
-      os.rel / bashRcFile -> rcContent
-    )
+    os.rel / zshRcFile  -> rcContent,
+    os.rel / bashRcFile -> rcContent
   )
 
   def runInstallAndUninstallCompletions(): Unit = {

--- a/modules/integration/src/test/scala/scala/cli/integration/InstallHomeTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/InstallHomeTests.scala
@@ -6,14 +6,14 @@ import scala.util.Properties
 
 class InstallHomeTests extends ScalaCliSuite {
 
-  override def group = ScalaCliSuite.TestGroup.First
+  override def group: ScalaCliSuite.TestGroup = ScalaCliSuite.TestGroup.First
 
   val firstVersion            = "0.0.1"
   val secondVersion           = "0.0.2"
   val dummyScalaCliFirstName  = "DummyScalaCli-1.scala"
   val dummyScalaCliSecondName = "DummyScalaCli-2.scala"
   val dummyScalaCliBinName    = "scala-cli-dummy-test"
-  val testInputs = TestInputs(
+  val testInputs: TestInputs = TestInputs(
     os.rel / dummyScalaCliFirstName ->
       s"""
          |object DummyScalaCli extends App {
@@ -117,7 +117,7 @@ class InstallHomeTests extends ScalaCliSuite {
       ).out.text().trim
       expect(v1Downgrade == firstVersion)
 
-      uninstallScalaCli(root, binDirPath, true, true)
+      uninstallScalaCli(root, binDirPath, force = true, skipCache = true)
       expect(!os.exists(binDirPath))
     }
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/InstallHomeTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/InstallHomeTests.scala
@@ -14,18 +14,16 @@ class InstallHomeTests extends ScalaCliSuite {
   val dummyScalaCliSecondName = "DummyScalaCli-2.scala"
   val dummyScalaCliBinName    = "scala-cli-dummy-test"
   val testInputs = TestInputs(
-    Seq(
-      os.rel / dummyScalaCliFirstName ->
-        s"""
-           |object DummyScalaCli extends App {
-           |  println(\"$firstVersion\")
-           |}""".stripMargin,
-      os.rel / dummyScalaCliSecondName ->
-        s"""
-           |object DummyScalaCli extends App {
-           |  println(\"$secondVersion\")
-           |}""".stripMargin
-    )
+    os.rel / dummyScalaCliFirstName ->
+      s"""
+         |object DummyScalaCli extends App {
+         |  println(\"$firstVersion\")
+         |}""".stripMargin,
+    os.rel / dummyScalaCliSecondName ->
+      s"""
+         |object DummyScalaCli extends App {
+         |  println(\"$secondVersion\")
+         |}""".stripMargin
   )
 
   private def packageDummyScalaCli(root: os.Path, dummyScalaCliFileName: String, output: String) = {

--- a/modules/integration/src/test/scala/scala/cli/integration/JmhTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/JmhTests.scala
@@ -6,7 +6,7 @@ import java.nio.charset.Charset
 
 class JmhTests extends ScalaCliSuite {
 
-  override def group = ScalaCliSuite.TestGroup.First
+  override def group: ScalaCliSuite.TestGroup = ScalaCliSuite.TestGroup.First
 
   test("simple") {
     val inputs = TestInputs(

--- a/modules/integration/src/test/scala/scala/cli/integration/JmhTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/JmhTests.scala
@@ -10,28 +10,26 @@ class JmhTests extends ScalaCliSuite {
 
   test("simple") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "benchmark.scala" ->
-          s"""package bench
-             |
-             |import java.util.concurrent.TimeUnit
-             |import org.openjdk.jmh.annotations._
-             |
-             |@BenchmarkMode(Array(Mode.AverageTime))
-             |@OutputTimeUnit(TimeUnit.NANOSECONDS)
-             |@Warmup(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)
-             |@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
-             |@Fork(0)
-             |class Benchmarks {
-             |
-             |  @Benchmark
-             |  def foo(): Unit = {
-             |    (1L to 10000000L).sum
-             |  }
-             |
-             |}
-             |""".stripMargin
-      )
+      os.rel / "benchmark.scala" ->
+        s"""package bench
+           |
+           |import java.util.concurrent.TimeUnit
+           |import org.openjdk.jmh.annotations._
+           |
+           |@BenchmarkMode(Array(Mode.AverageTime))
+           |@OutputTimeUnit(TimeUnit.NANOSECONDS)
+           |@Warmup(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+           |@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+           |@Fork(0)
+           |class Benchmarks {
+           |
+           |  @Benchmark
+           |  def foo(): Unit = {
+           |    (1L to 10000000L).sum
+           |  }
+           |
+           |}
+           |""".stripMargin
     )
     val expectedInOutput = """Result "bench.Benchmarks.foo":"""
     inputs.fromRoot { root =>

--- a/modules/integration/src/test/scala/scala/cli/integration/MetaCheck.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/MetaCheck.scala
@@ -13,40 +13,38 @@ class MetaCheck extends ScalaCliSuite {
    */
   test("Scala 3 is the default") {
     val testInputs = TestInputs(
-      Seq(
-        os.rel / "PrintScalaVersion.scala" ->
-          """// https://gist.github.com/romanowski/de14691cab7340134e197419bc48919a
-            |
-            |object PrintScalaVersion extends App {
-            |  def props(url: java.net.URL): java.util.Properties = {
-            |    val properties = new java.util.Properties()
-            |    val is = url.openStream()
-            |    try {
-            |      properties.load(is)
-            |      properties
-            |    } finally is.close()
-            |  }
-            |
-            |  def scala2Version: String =
-            |    props(getClass.getResource("/library.properties")).getProperty("version.number")
-            |
-            |  def checkScala3(res: java.util.Enumeration[java.net.URL]): String =
-            |    if (!res.hasMoreElements) scala2Version else {
-            |      val manifest = props(res.nextElement)
-            |      manifest.getProperty("Specification-Title") match {
-            |        case "scala3-library-bootstrapped" =>
-            |          manifest.getProperty("Implementation-Version")
-            |        case _ => checkScala3(res)
-            |      }
-            |    }
-            |  val manifests = getClass.getClassLoader.getResources("META-INF/MANIFEST.MF")
-            |
-            |  val scalaVersion = checkScala3(manifests)
-            |
-            |  println(scalaVersion)
-            |}
-            |""".stripMargin
-      )
+      os.rel / "PrintScalaVersion.scala" ->
+        """// https://gist.github.com/romanowski/de14691cab7340134e197419bc48919a
+          |
+          |object PrintScalaVersion extends App {
+          |  def props(url: java.net.URL): java.util.Properties = {
+          |    val properties = new java.util.Properties()
+          |    val is = url.openStream()
+          |    try {
+          |      properties.load(is)
+          |      properties
+          |    } finally is.close()
+          |  }
+          |
+          |  def scala2Version: String =
+          |    props(getClass.getResource("/library.properties")).getProperty("version.number")
+          |
+          |  def checkScala3(res: java.util.Enumeration[java.net.URL]): String =
+          |    if (!res.hasMoreElements) scala2Version else {
+          |      val manifest = props(res.nextElement)
+          |      manifest.getProperty("Specification-Title") match {
+          |        case "scala3-library-bootstrapped" =>
+          |          manifest.getProperty("Implementation-Version")
+          |        case _ => checkScala3(res)
+          |      }
+          |    }
+          |  val manifests = getClass.getClassLoader.getResources("META-INF/MANIFEST.MF")
+          |
+          |  val scalaVersion = checkScala3(manifests)
+          |
+          |  println(scalaVersion)
+          |}
+          |""".stripMargin
     )
     testInputs.fromRoot { root =>
       // --ttl 0s so that we are sure we use the latest supported Scala versions listing

--- a/modules/integration/src/test/scala/scala/cli/integration/MetaCheck.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/MetaCheck.scala
@@ -4,7 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 
 class MetaCheck extends ScalaCliSuite {
 
-  override def group = ScalaCliSuite.TestGroup.First
+  override def group: ScalaCliSuite.TestGroup = ScalaCliSuite.TestGroup.First
 
   /*
    * We don't run tests with --scala 3.… any more, and only rely on those

--- a/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
@@ -6,12 +6,12 @@ import scala.util.Properties
 
 class NativePackagerTests extends ScalaCliSuite {
 
-  override def group = ScalaCliSuite.TestGroup.First
+  override def group: ScalaCliSuite.TestGroup = ScalaCliSuite.TestGroup.First
 
   val helloWorldFileName = "HelloWorldScalaCli.scala"
   val message            = "Hello, world!"
   val licencePath        = "DummyLICENSE"
-  val testInputs = TestInputs(
+  val testInputs: TestInputs = TestInputs(
     os.rel / helloWorldFileName ->
       s"""
          |object HelloWorld {
@@ -344,7 +344,7 @@ class NativePackagerTests extends ScalaCliSuite {
       finally os.proc("docker", "rmi", "-f", expectedImage).call(cwd = os.root)
     }
 
-  def hasDocker =
+  def hasDocker: Boolean =
     Properties.isLinux ||
     // no docker command or no Linux from it on Github actions macOS / Windows runners
     ((Properties.isMac || Properties.isWin) && !TestUtil.isCI)

--- a/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
@@ -12,16 +12,14 @@ class NativePackagerTests extends ScalaCliSuite {
   val message            = "Hello, world!"
   val licencePath        = "DummyLICENSE"
   val testInputs = TestInputs(
-    Seq(
-      os.rel / helloWorldFileName ->
-        s"""
-           |object HelloWorld {
-           |  def main(args: Array[String]): Unit = {
-           |    println("$message")
-           |  }
-           |}""".stripMargin,
-      os.rel / licencePath -> "LICENSE"
-    )
+    os.rel / helloWorldFileName ->
+      s"""
+         |object HelloWorld {
+         |  def main(args: Array[String]): Unit = {
+         |    println("$message")
+         |  }
+         |}""".stripMargin,
+    os.rel / licencePath -> "LICENSE"
   )
 
   private val ciOpt = Option(System.getenv("CI")).map(v => Seq("-e", s"CI=$v")).getOrElse(Nil)

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -33,12 +33,10 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""val msg = "$message"
-             |println(msg)
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""val msg = "$message"
+           |println(msg)
+           |""".stripMargin
     )
     val launcherName = {
       val ext = if (Properties.isWin) ".bat" else ""
@@ -65,12 +63,10 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""val msg = "$message"
-             |println(msg)
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""val msg = "$message"
+           |println(msg)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       os.proc(TestUtil.cli, "package", extraOptions, ".").call(
@@ -93,16 +89,14 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "hello.sc"
     val message  = "1,2,3"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""|//> using resourceDir "."
-              |import scala.io.Source
-              |
-              |val inputs = Source.fromResource("input").getLines.toSeq
-              |println(inputs.mkString)
-              |""".stripMargin,
-        os.rel / "input" -> message
-      )
+      os.rel / fileName ->
+        s"""|//> using resourceDir "."
+            |import scala.io.Source
+            |
+            |val inputs = Source.fromResource("input").getLines.toSeq
+            |println(inputs.mkString)
+            |""".stripMargin,
+      os.rel / "input" -> message
     )
     inputs.fromRoot { root =>
       os.proc(TestUtil.cli, "package", extraOptions, ".").call(
@@ -124,16 +118,14 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
     val outputLib    = "my-library.jar"
     val resourceFile = "input"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""|//> using resourceDir "."
-              |
-              |class MyLibrary {
-              |  def message = "Hello"
-              |}
-              |""".stripMargin,
-        os.rel / resourceFile -> "1,2,3"
-      )
+      os.rel / fileName ->
+        s"""|//> using resourceDir "."
+            |
+            |class MyLibrary {
+            |  def message = "Hello"
+            |}
+            |""".stripMargin,
+      os.rel / resourceFile -> "1,2,3"
     )
     inputs.fromRoot { root =>
       os.proc(TestUtil.cli, "package", extraOptions, ".", "-o", outputLib, "--library").call(
@@ -150,19 +142,17 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("Zip with Scala Script containing resource directive") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "hello.sc" ->
-          s"""//> using resourceDir "./"
-             |import scala.io.Source
-             |
-             |val inputs = Source.fromResource("input").getLines.map(_.toInt).toSeq
-             |println(inputs.mkString(","))
-             |""".stripMargin,
-        os.rel / "input" ->
-          s"""1
-             |2
-             |""".stripMargin
-      )
+      os.rel / "hello.sc" ->
+        s"""//> using resourceDir "./"
+           |import scala.io.Source
+           |
+           |val inputs = Source.fromResource("input").getLines.map(_.toInt).toSeq
+           |println(inputs.mkString(","))
+           |""".stripMargin,
+      os.rel / "input" ->
+        s"""1
+           |2
+           |""".stripMargin
     )
     inputs.asZip { (root, zipPath) =>
       val message = "1,2"
@@ -185,14 +175,12 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""import scala.scalajs.js
-             |val console = js.Dynamic.global.console
-             |val msg = "$message"
-             |console.log(msg)
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""import scala.scalajs.js
+           |val console = js.Dynamic.global.console
+           |val msg = "$message"
+           |console.log(msg)
+           |""".stripMargin
     )
     val destName = fileName.stripSuffix(".sc") + ".js"
     inputs.fromRoot { root =>
@@ -214,12 +202,10 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
   def sourceMapJsTest(): Unit = {
     val fileName = "simple.sc"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""import scala.scalajs.js
-             |println("Hello World")
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""import scala.scalajs.js
+           |println("Hello World")
+           |""".stripMargin
     )
     val destName = fileName.stripSuffix(".sc") + ".js"
     inputs.fromRoot { root =>
@@ -245,18 +231,16 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "Hello.scala"
     val message  = "Hello World from JS"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""|//> using jsModuleKind "es"
-              |//> using jsModuleSplitStyleStr "smallestmodules"
-              |
-              |case class Foo(bar: String)
-              |
-              |object Hello extends App {
-              |  println(Foo("$message").bar)
-              |}
-              |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""|//> using jsModuleKind "es"
+            |//> using jsModuleSplitStyleStr "smallestmodules"
+            |
+            |case class Foo(bar: String)
+            |
+            |object Hello extends App {
+            |  println(Foo("$message").bar)
+            |}
+            |""".stripMargin
     )
     val destDir = fileName.stripSuffix(".scala")
     inputs.fromRoot { root =>
@@ -277,21 +261,19 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "Hello.scala"
     val message  = "Hello World from JS"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""|//> using jsModuleKind "es"
-              |//> using jsModuleSplitStyleStr "smallmodulesfor"
-              |//> using jsSmallModuleForPackage "test"
-              |
-              |package test
-              |
-              |case class Foo(bar: String)
-              |
-              |object Hello extends App {
-              |  println(Foo("$message").bar)
-              |}
-              |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""|//> using jsModuleKind "es"
+            |//> using jsModuleSplitStyleStr "smallmodulesfor"
+            |//> using jsSmallModuleForPackage "test"
+            |
+            |package test
+            |
+            |case class Foo(bar: String)
+            |
+            |object Hello extends App {
+            |  println(Foo("$message").bar)
+            |}
+            |""".stripMargin
     )
     val destDir = fileName.stripSuffix(".scala")
     inputs.fromRoot { root =>
@@ -322,16 +304,14 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
     val jsHeader        = "#!/usr/bin/env node"
     val jsHeaderNewLine = s"$jsHeader\\n"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""|//> using jsHeader "$jsHeaderNewLine"
-              |//> using jsMode "release"
-              |
-              |object Hello extends App {
-              |  println("Hello")
-              |}
-              |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""|//> using jsHeader "$jsHeaderNewLine"
+            |//> using jsMode "release"
+            |
+            |object Hello extends App {
+            |  println("Hello")
+            |}
+            |""".stripMargin
     )
     val destName = fileName.stripSuffix(".sc") + ".js"
     inputs.fromRoot { root =>
@@ -370,16 +350,14 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
     val message    = "Hello"
     val platformNl = if (Properties.isWin) "\\r\\n" else "\\n"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""import scala.scalanative.libc._
-             |import scala.scalanative.unsafe._
-             |
-             |Zone { implicit z =>
-             |  stdio.printf(toCString("$message$platformNl"))
-             |}
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""import scala.scalanative.libc._
+           |import scala.scalanative.unsafe._
+           |
+           |Zone { implicit z =>
+           |  stdio.printf(toCString("$message$platformNl"))
+           |}
+           |""".stripMargin
     )
     val destName = {
       val ext = if (Properties.isWin) ".exe" else ""
@@ -410,15 +388,13 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""import $$ivy.`org.typelevel::cats-kernel:2.6.1`
-             |import cats.kernel._
-             |val m = Monoid.instance[String]("", (a, b) => a + b)
-             |val msgStuff = m.combineAll(List("$message", "", ""))
-             |println(msgStuff)
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""import $$ivy.`org.typelevel::cats-kernel:2.6.1`
+           |import cats.kernel._
+           |val m = Monoid.instance[String]("", (a, b) => a + b)
+           |val msgStuff = m.combineAll(List("$message", "", ""))
+           |println(msgStuff)
+           |""".stripMargin
     )
     val launcherName = fileName.stripSuffix(".sc") + ".jar"
     inputs.fromRoot { root =>
@@ -459,16 +435,14 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("assembly no preamble") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Hello.scala" ->
-          s"""package hello
-             |
-             |object Hello {
-             |  def main(args: Array[String]): Unit =
-             |    println("Hello from " + "assembly")
-             |}
-             |""".stripMargin
-      )
+      os.rel / "Hello.scala" ->
+        s"""package hello
+           |
+           |object Hello {
+           |  def main(args: Array[String]): Unit =
+           |    println("Hello from " + "assembly")
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       os.proc(
@@ -501,16 +475,14 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("assembly no preamble nor main class") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Hello.scala" ->
-          s"""package hello
-             |
-             |object Hello {
-             |  def message: String =
-             |    "Hello from " + "assembly"
-             |}
-             |""".stripMargin
-      )
+      os.rel / "Hello.scala" ->
+        s"""package hello
+           |
+           |object Hello {
+           |  def message: String =
+           |    "Hello from " + "assembly"
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       os.proc(
@@ -545,16 +517,14 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("assembly provided") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Hello.scala" ->
-          s"""package hello
-             |
-             |object Hello {
-             |  def main(args: Array[String]): Unit =
-             |    println("Hello from Scala " + scala.util.Properties.versionNumberString)
-             |}
-             |""".stripMargin
-      )
+      os.rel / "Hello.scala" ->
+        s"""package hello
+           |
+           |object Hello {
+           |  def main(args: Array[String]): Unit =
+           |    println("Hello from Scala " + scala.util.Properties.versionNumberString)
+           |}
+           |""".stripMargin
     )
     val providedModule =
       if (actualScalaVersion.startsWith("2.")) "org.scala-lang:scala-library"
@@ -621,24 +591,22 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("ignore test scope") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Main.scala" ->
-          """|object Main {
-             |  def main(args: Array[String]): Unit = {
-             |    println("Hello World")
-             |  }
-             |}""".stripMargin,
-        os.rel / "Tests.test.scala" ->
-          """|import utest._ // compilation error, not included test library
-             |
-             |object Tests extends TestSuite {
-             |  val tests = Tests {
-             |    test("message") {
-             |      assert(1 == 1)
-             |    }
-             |  }
-             |}""".stripMargin
-      )
+      os.rel / "Main.scala" ->
+        """|object Main {
+           |  def main(args: Array[String]): Unit = {
+           |    println("Hello World")
+           |  }
+           |}""".stripMargin,
+      os.rel / "Tests.test.scala" ->
+        """|import utest._ // compilation error, not included test library
+           |
+           |object Tests extends TestSuite {
+           |  val tests = Tests {
+           |    test("message") {
+           |      assert(1 == 1)
+           |    }
+           |  }
+           |}""".stripMargin
     )
     inputs.fromRoot { root =>
       os.proc(TestUtil.cli, "package", extraOptions, ".").call(
@@ -668,19 +636,17 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
   }
 
   private val simpleInputWithScalaAndSc = TestInputs(
-    Seq(
-      os.rel / "lib" / "Messages.scala" ->
-        """package lib
-          |
-          |object Messages {
-          |  def msg = "Hello"
-          |}
-          |""".stripMargin,
-      os.rel / "simple.sc" ->
-        """val msg = lib.Messages.msg
-          |println(msg)
-          |""".stripMargin
-    )
+    os.rel / "lib" / "Messages.scala" ->
+      """package lib
+        |
+        |object Messages {
+        |  def msg = "Hello"
+        |}
+        |""".stripMargin,
+    os.rel / "simple.sc" ->
+      """val msg = lib.Messages.msg
+        |println(msg)
+        |""".stripMargin
   )
   test("source JAR") {
     val dest = os.rel / "sources.jar"
@@ -751,14 +717,12 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
       if (Properties.isWin) "hello.exe"
       else "hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Hello.scala" ->
-          s"""object Hello {
-             |  def main(args: Array[String]): Unit =
-             |    println("$message")
-             |}
-             |""".stripMargin
-      )
+      os.rel / "Hello.scala" ->
+        s"""object Hello {
+           |  def main(args: Array[String]): Unit =
+           |    println("$message")
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       os.proc(
@@ -791,11 +755,9 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
     val (scalaFile1, scalaFile2, scriptName) = ("ScalaMainClass1", "ScalaMainClass2", "ScalaScript")
     val scriptsDir                           = "scripts"
     val inputs = TestInputs(
-      Seq(
-        os.rel / s"$scalaFile1.scala"           -> s"object $scalaFile1 extends App { println() }",
-        os.rel / s"$scalaFile2.scala"           -> s"object $scalaFile2 extends App { println() }",
-        os.rel / scriptsDir / s"$scriptName.sc" -> "println()"
-      )
+      os.rel / s"$scalaFile1.scala"           -> s"object $scalaFile1 extends App { println() }",
+      os.rel / s"$scalaFile2.scala"           -> s"object $scalaFile2 extends App { println() }",
+      os.rel / scriptsDir / s"$scriptName.sc" -> "println()"
     )
     inputs.fromRoot { root =>
       val res = os.proc(
@@ -817,14 +779,12 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
     val destFile           = if (Properties.isWin) "hello.bat" else "hello"
     val (fooProp, barProp) = ("abc", "xyz")
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""object Hello {
-             |  def main(args: Array[String]): Unit =
-             |    println(s"$${sys.props("foo")}$${sys.props("bar")}")
-             |}
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""object Hello {
+           |  def main(args: Array[String]): Unit =
+           |    println(s"$${sys.props("foo")}$${sys.props("bar")}")
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       os.proc(
@@ -849,14 +809,12 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
     val imageName          = "hello"
     val (fooProp, barProp) = ("abc", "xyz")
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""object Hello {
-             |  def main(args: Array[String]): Unit =
-             |    println(s"$${sys.props("foo")}$${sys.props("bar")}")
-             |}
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""object Hello {
+           |  def main(args: Array[String]): Unit =
+           |    println(s"$${sys.props("foo")}$${sys.props("bar")}")
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       os.proc(

--- a/modules/integration/src/test/scala/scala/cli/integration/PgpTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PgpTests.scala
@@ -5,40 +5,38 @@ import com.eed3si9n.expecty.Expecty.expect
 class PgpTests extends ScalaCliSuite {
 
   private val pubKeyInputs = TestInputs(
-    Seq(
-      os.rel / "key.pub" ->
-        """-----BEGIN PGP PUBLIC KEY BLOCK-----
-          |Version: BCPG v1.68
-          |
-          |mQENBGKDqDYDCACw/2akQ1h6NHmtcEKQThq7OMdExyJ4WUKWdr+iV3BFx/AZICRd
-          |zU/tbDzvhqnwgBQalHfkcO8d1zIhzHhb3Hq3zo3Z0Gd1DcevODU7v2/GJkV/ici2
-          |xScYqJAmxkIM8yANiHrDZ17XrZ9m44YcK7qV9Z+PP2SNh3WtDPRzR//vL2yZgYm/
-          |KfzTuOzHqmne6Z0dVnc9jZTR6e7kNTHqIPpKvqIxFoqn2t0T6QZafYD1DdDmonyj
-          |1ME33vEec2llgJmIGHIVN3EcmQnBtfRP3mEqRZHmUGSAIrdqtLBegum0q8rvEBI4
-          |VIbg+xx7/5qnlfCIaCji4r/C2FlkrSiQgr+VABEBAAG0H2FsZXhhbmRyZS5hcmNo
-          |YW1iYXVsdEBnbWFpbC5jb22JAS4EEwMCABgFAmKDqDYCGwMECwkIBwYVCAIJCgsC
-          |HgEACgkQkU0pjfj6TSARjggAgbTFf1vjvHb1lwYP6jA5g3WFKHFSbh/fid/uOygq
-          |FqdD29KoE2tqmC9sE0koYMBpSJK4as5RDBKhliw8j60eBoYjRJZIDoc5oQQ7N7ul
-          |n0t5KMwpJ1CJs8G1BnU747Efg89blb3tY6LG4L+vziQ9Uw0d/0qizT1OWxGshqpA
-          |PJk4tHwQ3aujGbmVWttietdFVndcB4BB1s7UlGHFtwcAQyz5R8B3dfnaU4czyzM8
-          |zp+ltPXjLkuGvI/Bz3f15TZiUr1zEw0/ZAMmDdZvf8tGt8hhAp8n3DXL7HV4azdv
-          |iwZUribQnr1MHadTlKmUxz7+VfYNm8gkSRmGBl4YO5dl0rkBDQRig6g2AggApW+O
-          |XrTJrWM8asyur3UDOyXpvBZ1PeLIXyTrjVOHSiqqFjI8/P3faG6MQWv9YUN3cYIL
-          |SnIX9rAgchRpEWivqaYpj2hfyLOMkDUhw0owPo7vFXAX8uUXK5Fg/krSwGukY9+Z
-          |HcjzC9+CTEYZrBcxtziOWoGyOOk1Wepi1EqTWVB/xuY+hHWrhI5ff9bOdQmfcQL3
-          |Z9r2nJR3ahe+Qu5ppNGiX2FTLBMl5XwL0pOjonLyd39EsdbCbQvMnLgYwxwKMOht
-          |OPyXJAeOolchht50FWerTdf4r8fLndCiYg7hi5i0+GxWZwBj3MXNnkyQ0jjwiO/y
-          |p64RL2gJMrFwn7bv5wARAQABiQEfBBgDAgAJBQJig6g3AhsMAAoJEJFNKY34+k0g
-          |t1QH/06YazNGeuLzc62Mamnr8kA0AakGJxPZ83rGXcdahBRd9Enga32pcEks6YPI
-          |OZBbayEoIf4CasSaz9H/Bn1l91L60AEYeBwj8CFYx2ZZrC+ywdFkgbrVFP0N1Doj
-          |TMxim2rAJ8OFH2kczmhaG9HRL6V7kjGpb/tGdVpjgdt4V4NMDGQc4AWTWVCBcQKa
-          |3cHnXDgKrCE1inUej1bJ5g2SHm+gMyF7WAgbVi9r1/suu4d1WjJuUEQ28FmjpeEd
-          |CXxI+5gGgs4H7rUbTb1DScYsb4/j/Y/7SsOqnmz/SFA9Ej0scSaVviFwS06Q5LZN
-          |mnSk2Og334LRowks7+/8CEofK/w=
-          |=RTOn
-          |-----END PGP PUBLIC KEY BLOCK-----
-          |""".stripMargin
-    )
+    os.rel / "key.pub" ->
+      """-----BEGIN PGP PUBLIC KEY BLOCK-----
+        |Version: BCPG v1.68
+        |
+        |mQENBGKDqDYDCACw/2akQ1h6NHmtcEKQThq7OMdExyJ4WUKWdr+iV3BFx/AZICRd
+        |zU/tbDzvhqnwgBQalHfkcO8d1zIhzHhb3Hq3zo3Z0Gd1DcevODU7v2/GJkV/ici2
+        |xScYqJAmxkIM8yANiHrDZ17XrZ9m44YcK7qV9Z+PP2SNh3WtDPRzR//vL2yZgYm/
+        |KfzTuOzHqmne6Z0dVnc9jZTR6e7kNTHqIPpKvqIxFoqn2t0T6QZafYD1DdDmonyj
+        |1ME33vEec2llgJmIGHIVN3EcmQnBtfRP3mEqRZHmUGSAIrdqtLBegum0q8rvEBI4
+        |VIbg+xx7/5qnlfCIaCji4r/C2FlkrSiQgr+VABEBAAG0H2FsZXhhbmRyZS5hcmNo
+        |YW1iYXVsdEBnbWFpbC5jb22JAS4EEwMCABgFAmKDqDYCGwMECwkIBwYVCAIJCgsC
+        |HgEACgkQkU0pjfj6TSARjggAgbTFf1vjvHb1lwYP6jA5g3WFKHFSbh/fid/uOygq
+        |FqdD29KoE2tqmC9sE0koYMBpSJK4as5RDBKhliw8j60eBoYjRJZIDoc5oQQ7N7ul
+        |n0t5KMwpJ1CJs8G1BnU747Efg89blb3tY6LG4L+vziQ9Uw0d/0qizT1OWxGshqpA
+        |PJk4tHwQ3aujGbmVWttietdFVndcB4BB1s7UlGHFtwcAQyz5R8B3dfnaU4czyzM8
+        |zp+ltPXjLkuGvI/Bz3f15TZiUr1zEw0/ZAMmDdZvf8tGt8hhAp8n3DXL7HV4azdv
+        |iwZUribQnr1MHadTlKmUxz7+VfYNm8gkSRmGBl4YO5dl0rkBDQRig6g2AggApW+O
+        |XrTJrWM8asyur3UDOyXpvBZ1PeLIXyTrjVOHSiqqFjI8/P3faG6MQWv9YUN3cYIL
+        |SnIX9rAgchRpEWivqaYpj2hfyLOMkDUhw0owPo7vFXAX8uUXK5Fg/krSwGukY9+Z
+        |HcjzC9+CTEYZrBcxtziOWoGyOOk1Wepi1EqTWVB/xuY+hHWrhI5ff9bOdQmfcQL3
+        |Z9r2nJR3ahe+Qu5ppNGiX2FTLBMl5XwL0pOjonLyd39EsdbCbQvMnLgYwxwKMOht
+        |OPyXJAeOolchht50FWerTdf4r8fLndCiYg7hi5i0+GxWZwBj3MXNnkyQ0jjwiO/y
+        |p64RL2gJMrFwn7bv5wARAQABiQEfBBgDAgAJBQJig6g3AhsMAAoJEJFNKY34+k0g
+        |t1QH/06YazNGeuLzc62Mamnr8kA0AakGJxPZ83rGXcdahBRd9Enga32pcEks6YPI
+        |OZBbayEoIf4CasSaz9H/Bn1l91L60AEYeBwj8CFYx2ZZrC+ywdFkgbrVFP0N1Doj
+        |TMxim2rAJ8OFH2kczmhaG9HRL6V7kjGpb/tGdVpjgdt4V4NMDGQc4AWTWVCBcQKa
+        |3cHnXDgKrCE1inUej1bJ5g2SHm+gMyF7WAgbVi9r1/suu4d1WjJuUEQ28FmjpeEd
+        |CXxI+5gGgs4H7rUbTb1DScYsb4/j/Y/7SsOqnmz/SFA9Ej0scSaVviFwS06Q5LZN
+        |mnSk2Og334LRowks7+/8CEofK/w=
+        |=RTOn
+        |-----END PGP PUBLIC KEY BLOCK-----
+        |""".stripMargin
   )
 
   test("pgp key-id") {

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishSetupTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishSetupTests.scala
@@ -36,11 +36,9 @@ class PublishSetupTests extends ScalaCliSuite {
 
   private val projDir = os.rel / projName
   private val testInputs = TestInputs(
-    Seq(
-      os.rel / projDir / "Foo.scala" ->
-        """object Foo
-          |""".stripMargin
-    )
+    os.rel / projDir / "Foo.scala" ->
+      """object Foo
+        |""".stripMargin
   )
   private val homeDir    = os.rel / "home"
   private val dirOptions = Seq[os.Shellable]("--home-directory", homeDir)

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
@@ -14,30 +14,28 @@ abstract class PublishTestDefinitions(val scalaVersionOpt: Option[String])
 
   private object TestCase {
     val testInputs = TestInputs(
-      Seq(
-        os.rel / "project" / "foo" / "Hello.scala" ->
-          """//> using publish.organization "org.virtuslab.scalacli.test"
-            |//> using publish.name "simple"
-            |//> using publish.version "0.2.0-SNAPSHOT"
-            |//> using publish.url "https://github.com/VirtusLab/scala-cli"
-            |//> using publish.license "Apache 2.0:http://opensource.org/licenses/Apache-2.0"
-            |//> using publish.developer "someone|Someone||https://github.com/someone"
-            |
-            |package foo
-            |
-            |object Hello {
-            |  def main(args: Array[String]): Unit =
-            |    println(Messages.hello)
-            |}
-            |""".stripMargin,
-        os.rel / "project" / "foo" / "Messages.scala" ->
-          """package foo
-            |
-            |object Messages {
-            |  def hello = "Hello"
-            |}
-            |""".stripMargin
-      )
+      os.rel / "project" / "foo" / "Hello.scala" ->
+        """//> using publish.organization "org.virtuslab.scalacli.test"
+          |//> using publish.name "simple"
+          |//> using publish.version "0.2.0-SNAPSHOT"
+          |//> using publish.url "https://github.com/VirtusLab/scala-cli"
+          |//> using publish.license "Apache 2.0:http://opensource.org/licenses/Apache-2.0"
+          |//> using publish.developer "someone|Someone||https://github.com/someone"
+          |
+          |package foo
+          |
+          |object Hello {
+          |  def main(args: Array[String]): Unit =
+          |    println(Messages.hello)
+          |}
+          |""".stripMargin,
+      os.rel / "project" / "foo" / "Messages.scala" ->
+        """package foo
+          |
+          |object Messages {
+          |  def hello = "Hello"
+          |}
+          |""".stripMargin
     )
     val scalaSuffix =
       if (actualScalaVersion.startsWith("3.")) "_3"
@@ -194,11 +192,9 @@ abstract class PublishTestDefinitions(val scalaVersionOpt: Option[String])
     val (scalaFile1, scalaFile2, scriptName) = ("ScalaMainClass1", "ScalaMainClass2", "ScalaScript")
     val scriptsDir                           = "scripts"
     val inputs = TestInputs(
-      Seq(
-        os.rel / s"$scalaFile1.scala"           -> s"object $scalaFile1 extends App { println() }",
-        os.rel / s"$scalaFile2.scala"           -> s"object $scalaFile2 extends App { println() }",
-        os.rel / scriptsDir / s"$scriptName.sc" -> "println()"
-      )
+      os.rel / s"$scalaFile1.scala"           -> s"object $scalaFile1 extends App { println() }",
+      os.rel / s"$scalaFile2.scala"           -> s"object $scalaFile2 extends App { println() }",
+      os.rel / scriptsDir / s"$scriptName.sc" -> "println()"
     )
     inputs.fromRoot { root =>
       val res = os.proc(

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
@@ -1,19 +1,20 @@
 package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
+import os.RelPath
 
 import java.nio.file.Paths
 import java.util.zip.ZipFile
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 abstract class PublishTestDefinitions(val scalaVersionOpt: Option[String])
     extends ScalaCliSuite with TestScalaVersionArgs {
 
-  protected def extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
+  protected def extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
 
   private object TestCase {
-    val testInputs = TestInputs(
+    val testInputs: TestInputs = TestInputs(
       os.rel / "project" / "foo" / "Hello.scala" ->
         """//> using publish.organization "org.virtuslab.scalacli.test"
           |//> using publish.name "simple"
@@ -37,10 +38,10 @@ abstract class PublishTestDefinitions(val scalaVersionOpt: Option[String])
           |}
           |""".stripMargin
     )
-    val scalaSuffix =
+    val scalaSuffix: String =
       if (actualScalaVersion.startsWith("3.")) "_3"
       else "_" + actualScalaVersion.split('.').take(2).mkString(".")
-    val expectedArtifactsDir =
+    val expectedArtifactsDir: RelPath =
       os.rel / "org" / "virtuslab" / "scalacli" / "test" / s"simple$scalaSuffix" / "0.2.0-SNAPSHOT"
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestsDefault.scala
@@ -9,23 +9,21 @@ class PublishTestsDefault extends PublishTestDefinitions(scalaVersionOpt = None)
     val testName    = "my-proj"
     val testVersion = "1.5.6"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Project.scala" ->
-          s"""//> using publish.organization "$testOrg"
-             |//> using publish.name "$testName"
-             |//> using publish.version "$testVersion"
-             |
-             |//> using scala "2.13"
-             |//> using lib "com.lihaoyi::os-lib:0.8.1"
-             |
-             |object Project {
-             |  def message = "Hello"
-             |
-             |  def main(args: Array[String]): Unit =
-             |    println(message)
-             |}
-             |""".stripMargin
-      )
+      os.rel / "Project.scala" ->
+        s"""//> using publish.organization "$testOrg"
+           |//> using publish.name "$testName"
+           |//> using publish.version "$testVersion"
+           |
+           |//> using scala "2.13"
+           |//> using lib "com.lihaoyi::os-lib:0.8.1"
+           |
+           |object Project {
+           |  def message = "Hello"
+           |
+           |  def main(args: Array[String]): Unit =
+           |    println(message)
+           |}
+           |""".stripMargin
     )
 
     val expectedFiles = {
@@ -71,40 +69,38 @@ class PublishTestsDefault extends PublishTestDefinitions(scalaVersionOpt = None)
     val testName    = "foo"
     val testVersion = "0.3.1"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Foo.java" ->
-          s"""//> using publish.organization "$testOrg"
-             |//> using publish.name "$testName"
-             |//> using publish.version "$testVersion"
-             |
-             |package foo;
-             |
-             |public class Foo {
-             |  private static boolean checkClass(String clsName) {
-             |    try {
-             |      Thread.currentThread().getContextClassLoader().loadClass(clsName);
-             |      return true;
-             |    } catch (ClassNotFoundException ex) {
-             |      return false;
-             |    }
-             |  }
-             |
-             |  public static void main(String[] args) {
-             |    boolean hasJuList = checkClass("java.util.List");
-             |    boolean hasScalaArray = checkClass("scala.Array");
-             |    if (!hasJuList) {
-             |      System.out.println("Error: java.util.List not found");
-             |      System.exit(1);
-             |    }
-             |    if (hasScalaArray) {
-             |      System.out.println("Error: unexpectedly found scala.Array");
-             |      System.exit(1);
-             |    }
-             |    System.out.println("Hello from " + "foo");
-             |  }
-             |}
-             |""".stripMargin
-      )
+      os.rel / "Foo.java" ->
+        s"""//> using publish.organization "$testOrg"
+           |//> using publish.name "$testName"
+           |//> using publish.version "$testVersion"
+           |
+           |package foo;
+           |
+           |public class Foo {
+           |  private static boolean checkClass(String clsName) {
+           |    try {
+           |      Thread.currentThread().getContextClassLoader().loadClass(clsName);
+           |      return true;
+           |    } catch (ClassNotFoundException ex) {
+           |      return false;
+           |    }
+           |  }
+           |
+           |  public static void main(String[] args) {
+           |    boolean hasJuList = checkClass("java.util.List");
+           |    boolean hasScalaArray = checkClass("scala.Array");
+           |    if (!hasJuList) {
+           |      System.out.println("Error: java.util.List not found");
+           |      System.exit(1);
+           |    }
+           |    if (hasScalaArray) {
+           |      System.out.println("Error: unexpectedly found scala.Array");
+           |      System.exit(1);
+           |    }
+           |    System.out.println("Hello from " + "foo");
+           |  }
+           |}
+           |""".stripMargin
     )
 
     val repoRelPath = os.rel / "test-repo"

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
@@ -12,13 +12,13 @@ abstract class ReplTestDefinitions(val scalaVersionOpt: Option[String])
   protected def versionNumberString = actualScalaVersion
 
   test("default dry run") {
-    TestInputs(Nil).fromRoot { root =>
+    TestInputs.empty.fromRoot { root =>
       os.proc(TestUtil.cli, "repl", extraOptions, "--repl-dry-run").call(cwd = root)
     }
   }
 
   test("repl custom repositories work") {
-    TestInputs(Nil).fromRoot { root =>
+    TestInputs.empty.fromRoot { root =>
       os.proc(
         TestUtil.cli,
         "repl",
@@ -32,7 +32,7 @@ abstract class ReplTestDefinitions(val scalaVersionOpt: Option[String])
   }
 
   test("ammonite") {
-    TestInputs(Nil).fromRoot { root =>
+    TestInputs.empty.fromRoot { root =>
       val ammArgs = Seq(
         "-c",
         """println("Hello" + " from Scala " + scala.util.Properties.versionNumberString)"""

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
@@ -9,7 +9,7 @@ abstract class ReplTestDefinitions(val scalaVersionOpt: Option[String])
 
   private lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
 
-  protected def versionNumberString = actualScalaVersion
+  protected def versionNumberString: String = actualScalaVersion
 
   test("default dry run") {
     TestInputs.empty.fromRoot { root =>

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTests.scala
@@ -2,6 +2,8 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
+import scala.collection.mutable
+
 class ReplTests extends ScalaCliSuite {
 
   test("calling repl with -Xshow-phases flag") {
@@ -11,7 +13,7 @@ class ReplTests extends ScalaCliSuite {
       "-Xshow-phases"
     )
 
-    val builder   = new StringBuilder
+    val builder   = new mutable.StringBuilder
     val readLines = os.ProcessOutput.Readlines(s => builder.append(s))
     val res       = os.proc(cmd).call(stdout = readLines, stderr = readLines)
     expect(res.exitCode == 0)

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTests213.scala
@@ -13,7 +13,7 @@ class ReplTests213 extends ReplTestDefinitions(
   private lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
 
   test("ammonite with extra JAR") {
-    TestInputs(Nil).fromRoot { root =>
+    TestInputs.empty.fromRoot { root =>
       val ammArgs = Seq(
         "-c",
         """import shapeless._; println("Here's an HList: " + (2 :: true :: "a" :: HNil))"""

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -21,12 +21,10 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""val msg = "$message"
-             |println(msg)
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""val msg = "$message"
+           |println(msg)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output =
@@ -59,12 +57,10 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""val msg = "$message"
-             |println(msg)
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""val msg = "$message"
+           |println(msg)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output =
@@ -81,29 +77,27 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
       if (actualScalaVersion.startsWith("2.12.")) "scala.collection.JavaConverters._"
       else "scala.jdk.CollectionConverters._"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Simple.scala" ->
-          s"""import java.io.File
-             |import java.util.zip.ZipFile
-             |import $converters
-             |
-             |object Simple {
-             |  private def manifestClassPathCheck(): Unit = {
-             |    val cp = sys.props("java.class.path")
-             |    assert(!cp.contains(File.pathSeparator), s"Expected single entry in class path, got $$cp")
-             |    val zf = new ZipFile(new File(cp))
-             |    val entries = zf.entries.asScala.map(_.getName).toVector
-             |    zf.close()
-             |    assert(entries == Seq("META-INF/MANIFEST.MF"), s"Expected only META-INF/MANIFEST.MF entry, got $$entries")
-             |  }
-             |  def main(args: Array[String]): Unit = {
-             |    manifestClassPathCheck()
-             |    val msg = "$message"
-             |    println(msg)
-             |  }
-             |}
-             |""".stripMargin
-      )
+      os.rel / "Simple.scala" ->
+        s"""import java.io.File
+           |import java.util.zip.ZipFile
+           |import $converters
+           |
+           |object Simple {
+           |  private def manifestClassPathCheck(): Unit = {
+           |    val cp = sys.props("java.class.path")
+           |    assert(!cp.contains(File.pathSeparator), s"Expected single entry in class path, got $$cp")
+           |    val zf = new ZipFile(new File(cp))
+           |    val entries = zf.entries.asScala.map(_.getName).toVector
+           |    zf.close()
+           |    assert(entries == Seq("META-INF/MANIFEST.MF"), s"Expected only META-INF/MANIFEST.MF entry, got $$entries")
+           |  }
+           |  def main(args: Array[String]): Unit = {
+           |    manifestClassPathCheck()
+           |    val msg = "$message"
+           |    println(msg)
+           |  }
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, extraOptions, "--use-manifest", ".")
@@ -117,14 +111,12 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""import scala.scalajs.js
-             |val console = js.Dynamic.global.console
-             |val msg = "$message"
-             |console.log(msg)
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""import scala.scalajs.js
+           |val console = js.Dynamic.global.console
+           |val msg = "$message"
+           |console.log(msg)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, extraOptions, fileName, "--js", extraArgs).call(cwd =
@@ -145,14 +137,12 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""import scala.scalajs.js
-             |val console = js.Dynamic.global.console
-             |val msg = "$message"
-             |console.log(msg)
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""import scala.scalajs.js
+           |val console = js.Dynamic.global.console
+           |val msg = "$message"
+           |console.log(msg)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output = os.proc(
@@ -175,22 +165,20 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""//> using jsModuleKind "es"
-             |import scala.scalajs.js
-             |import scala.scalajs.js.annotation._
-             |
-             |@js.native
-             |@JSImport("console", JSImport.Namespace)
-             |object console extends js.Object {
-             |  def log(msg: js.Any): Unit = js.native
-             |}
-             |
-             |val msg = "$message"
-             |console.log(msg)
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""//> using jsModuleKind "es"
+           |import scala.scalajs.js
+           |import scala.scalajs.js.annotation._
+           |
+           |@js.native
+           |@JSImport("console", JSImport.Namespace)
+           |object console extends js.Object {
+           |  def log(msg: js.Any): Unit = js.native
+           |}
+           |
+           |val msg = "$message"
+           |console.log(msg)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, extraOptions, fileName, "--js")
@@ -202,15 +190,13 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   test("simple script JS via config file") {
     val message = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "simple.sc" ->
-          s"""//> using platform "scala-js"
-             |import scala.scalajs.js
-             |val console = js.Dynamic.global.console
-             |val msg = "$message"
-             |console.log(msg)
-             |""".stripMargin
-      )
+      os.rel / "simple.sc" ->
+        s"""//> using platform "scala-js"
+           |import scala.scalajs.js
+           |val console = js.Dynamic.global.console
+           |val msg = "$message"
+           |console.log(msg)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, extraOptions, ".").call(cwd = root).out.text().trim
@@ -224,16 +210,14 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""import scala.scalanative.libc._
-             |import scala.scalanative.unsafe._
-             |
-             |Zone { implicit z =>
-             |  stdio.printf(toCString("$message$platformNl"))
-             |}
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""import scala.scalanative.libc._
+           |import scala.scalanative.unsafe._
+           |
+           |Zone { implicit z =>
+           |  stdio.printf(toCString("$message$platformNl"))
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output =
@@ -252,16 +236,14 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""import scala.scalanative.libc._
-             |import scala.scalanative.unsafe._
-             |
-             |Zone { implicit z =>
-             |  stdio.printf(toCString("$message$platformNl"))
-             |}
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""import scala.scalanative.libc._
+           |import scala.scalanative.unsafe._
+           |
+           |Zone { implicit z =>
+           |  stdio.printf(toCString("$message$platformNl"))
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output =
@@ -279,18 +261,16 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
       val message  = "using Scala 3 Native"
       val fileName = "scala3native.scala"
       val inputs = TestInputs(
-        Seq(
-          os.rel / fileName ->
-            s"""import scala.scalanative.libc._
-               |import scala.scalanative.unsafe._
-               |
-               |@main def main() =
-               |  val message = "$message"
-               |  Zone { implicit z =>
-               |    stdio.printf(toCString(message))
-               |  }
-               |""".stripMargin
-        )
+        os.rel / fileName ->
+          s"""import scala.scalanative.libc._
+             |import scala.scalanative.unsafe._
+             |
+             |@main def main() =
+             |  val message = "$message"
+             |  Zone { implicit z =>
+             |    stdio.printf(toCString(message))
+             |  }
+             |""".stripMargin
       )
       inputs.fromRoot { root =>
         val output =
@@ -304,14 +284,12 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   test("Multiple scripts") {
     val message = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "messages.sc" ->
-          s"""def msg = "$message"
-             |""".stripMargin,
-        os.rel / "print.sc" ->
-          s"""println(messages.msg)
-             |""".stripMargin
-      )
+      os.rel / "messages.sc" ->
+        s"""def msg = "$message"
+           |""".stripMargin,
+      os.rel / "print.sc" ->
+        s"""println(messages.msg)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, extraOptions, "print.sc", "messages.sc").call(cwd =
@@ -324,11 +302,9 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   test("main.sc is not a special case") {
     val message = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "main.sc" ->
-          s"""println("$message")
-             |""".stripMargin
-      )
+      os.rel / "main.sc" ->
+        s"""println("$message")
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, extraOptions, "main.sc").call(cwd =
@@ -341,14 +317,12 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   test("use method from main.sc file") {
     val message = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "message.sc" ->
-          s"""println(main.msg)
-             |""".stripMargin,
-        os.rel / "main.sc" ->
-          s"""def msg = "$message"
-             |""".stripMargin
-      )
+      os.rel / "message.sc" ->
+        s"""println(main.msg)
+           |""".stripMargin,
+      os.rel / "main.sc" ->
+        s"""def msg = "$message"
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, extraOptions, "message.sc", "main.sc").call(cwd =
@@ -361,16 +335,14 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   test("Multiple scripts JS") {
     val message = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "messages.sc" ->
-          s"""def msg = "$message"
-             |""".stripMargin,
-        os.rel / "print.sc" ->
-          s"""import scala.scalajs.js
-             |val console = js.Dynamic.global.console
-             |console.log(messages.msg)
-             |""".stripMargin
-      )
+      os.rel / "messages.sc" ->
+        s"""def msg = "$message"
+           |""".stripMargin,
+      os.rel / "print.sc" ->
+        s"""import scala.scalajs.js
+           |val console = js.Dynamic.global.console
+           |console.log(messages.msg)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, extraOptions, "print.sc", "messages.sc", "--js").call(cwd =
@@ -383,19 +355,17 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   def multipleScriptsNative(): Unit = {
     val message = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "messages.sc" ->
-          s"""def msg = "$message"
-             |""".stripMargin,
-        os.rel / "print.sc" ->
-          s"""import scala.scalanative.libc._
-             |import scala.scalanative.unsafe._
-             |
-             |Zone { implicit z =>
-             |  stdio.printf(toCString(messages.msg + "$platformNl"))
-             |}
-             |""".stripMargin
-      )
+      os.rel / "messages.sc" ->
+        s"""def msg = "$message"
+           |""".stripMargin,
+      os.rel / "print.sc" ->
+        s"""import scala.scalanative.libc._
+           |import scala.scalanative.unsafe._
+           |
+           |Zone { implicit z =>
+           |  stdio.printf(toCString(messages.msg + "$platformNl"))
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output =
@@ -413,14 +383,12 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   test("Directory") {
     val message = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "dir" / "messages.sc" ->
-          s"""def msg = "$message"
-             |""".stripMargin,
-        os.rel / "dir" / "print.sc" ->
-          s"""println(messages.msg)
-             |""".stripMargin
-      )
+      os.rel / "dir" / "messages.sc" ->
+        s"""def msg = "$message"
+           |""".stripMargin,
+      os.rel / "dir" / "print.sc" ->
+        s"""println(messages.msg)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, extraOptions, "dir", "--main-class", "print_sc").call(cwd =
@@ -432,11 +400,9 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("No default input when no explicit command is passed") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "dir" / "print.sc" ->
-          s"""println("Foo")
-             |""".stripMargin
-      )
+      os.rel / "dir" / "print.sc" ->
+        s"""println("Foo")
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val res = os.proc(TestUtil.cli, extraOptions, "--main-class", "print")
@@ -449,15 +415,13 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("Pass arguments") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Test.scala" ->
-          s"""object Test {
-             |  def main(args: Array[String]): Unit = {
-             |    println(args(0))
-             |  }
-             |}
-             |""".stripMargin
-      )
+      os.rel / "Test.scala" ->
+        s"""object Test {
+           |  def main(args: Array[String]): Unit = {
+           |    println(args(0))
+           |  }
+           |}
+           |""".stripMargin
     )
     val message = "Hello"
     inputs.fromRoot { root =>
@@ -470,14 +434,12 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   def passArgumentsScala3(): Unit = {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Test.scala" ->
-          s"""object Test:
-             |  def main(args: Array[String]): Unit =
-             |    val message = args(0)
-             |    println(message)
-             |""".stripMargin
-      )
+      os.rel / "Test.scala" ->
+        s"""object Test:
+           |  def main(args: Array[String]): Unit =
+           |    val message = args(0)
+           |    println(message)
+           |""".stripMargin
     )
     val message = "Hello"
     inputs.fromRoot { root =>
@@ -496,16 +458,14 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   test("Directory JS") {
     val message = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "dir" / "messages.sc" ->
-          s"""def msg = "$message"
-             |""".stripMargin,
-        os.rel / "dir" / "print.sc" ->
-          s"""import scala.scalajs.js
-             |val console = js.Dynamic.global.console
-             |console.log(messages.msg)
-             |""".stripMargin
-      )
+      os.rel / "dir" / "messages.sc" ->
+        s"""def msg = "$message"
+           |""".stripMargin,
+      os.rel / "dir" / "print.sc" ->
+        s"""import scala.scalajs.js
+           |val console = js.Dynamic.global.console
+           |console.log(messages.msg)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, extraOptions, "dir", "--js", "--main-class", "print_sc")
@@ -518,19 +478,17 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   def directoryNative(): Unit = {
     val message = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "dir" / "messages.sc" ->
-          s"""def msg = "$message"
-             |""".stripMargin,
-        os.rel / "dir" / "print.sc" ->
-          s"""import scala.scalanative.libc._
-             |import scala.scalanative.unsafe._
-             |
-             |Zone { implicit z =>
-             |  stdio.printf(toCString(messages.msg + "$platformNl"))
-             |}
-             |""".stripMargin
-      )
+      os.rel / "dir" / "messages.sc" ->
+        s"""def msg = "$message"
+           |""".stripMargin,
+      os.rel / "dir" / "print.sc" ->
+        s"""import scala.scalanative.libc._
+           |import scala.scalanative.unsafe._
+           |
+           |Zone { implicit z =>
+           |  stdio.printf(toCString(messages.msg + "$platformNl"))
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output =
@@ -552,11 +510,9 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     val expectedClassName = fileName.stripSuffix(".sc") + "$"
     val scriptPath        = os.rel / "something" / fileName
     val inputs = TestInputs(
-      Seq(
-        scriptPath ->
-          s"""println(getClass.getName)
-             |""".stripMargin
-      )
+      scriptPath ->
+        s"""println(getClass.getName)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, extraOptions, scriptPath.toString)
@@ -572,22 +528,20 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     val expectedClassName = fileName.stripSuffix(".sc") + "$"
     val scriptPath        = os.rel / "something" / fileName
     val inputs = TestInputs(
-      Seq(
-        os.rel / "dir" / "Messages.scala" ->
-          s"""object Messages {
-             |  def msg = "Hello"
-             |}
-             |""".stripMargin,
-        os.rel / "dir" / "Print.scala" ->
-          s"""object Print {
-             |  def main(args: Array[String]): Unit =
-             |    println(Messages.msg)
-             |}
-             |""".stripMargin,
-        scriptPath ->
-          s"""println(getClass.getName)
-             |""".stripMargin
-      )
+      os.rel / "dir" / "Messages.scala" ->
+        s"""object Messages {
+           |  def msg = "Hello"
+           |}
+           |""".stripMargin,
+      os.rel / "dir" / "Print.scala" ->
+        s"""object Print {
+           |  def main(args: Array[String]): Unit =
+           |    println(Messages.msg)
+           |}
+           |""".stripMargin,
+      scriptPath ->
+        s"""println(getClass.getName)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, extraOptions, "dir", scriptPath.toString)
@@ -604,20 +558,18 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("stack traces") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Throws.scala" ->
-          s"""object Throws {
-             |  def something(): String =
-             |    sys.error("nope")
-             |  def main(args: Array[String]): Unit =
-             |    try something()
-             |    catch {
-             |      case e: Exception =>
-             |        throw new Exception("Caught exception during processing", e)
-             |    }
-             |}
-             |""".stripMargin
-      )
+      os.rel / "Throws.scala" ->
+        s"""object Throws {
+           |  def something(): String =
+           |    sys.error("nope")
+           |  def main(args: Array[String]): Unit =
+           |    try something()
+           |    catch {
+           |      case e: Exception =>
+           |        throw new Exception("Caught exception during processing", e)
+           |    }
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       // format: off
@@ -666,17 +618,15 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   def stackTraceInScriptScala2(): Unit = {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "throws.sc" ->
-          s"""def something(): String =
-             |  sys.error("nope")
-             |try something()
-             |catch {
-             |  case e: Exception =>
-             |    throw new Exception("Caught exception during processing", e)
-             |}
-             |""".stripMargin
-      )
+      os.rel / "throws.sc" ->
+        s"""def something(): String =
+           |  sys.error("nope")
+           |try something()
+           |catch {
+           |  case e: Exception =>
+           |    throw new Exception("Caught exception during processing", e)
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       // format: off
@@ -738,19 +688,17 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   def scriptStackTraceScala3(): Unit = {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "throws.sc" ->
-          s"""def something(): String =
-             |  val message = "nope"
-             |  sys.error(message)
-             |
-             |try something()
-             |catch {
-             |  case e: Exception =>
-             |    throw new Exception("Caught exception during processing", e)
-             |}
-             |""".stripMargin
-      )
+      os.rel / "throws.sc" ->
+        s"""def something(): String =
+           |  val message = "nope"
+           |  sys.error(message)
+           |
+           |try something()
+           |catch {
+           |  case e: Exception =>
+           |    throw new Exception("Caught exception during processing", e)
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       // format: off
@@ -792,7 +740,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
       scriptStackTraceScala3()
     }
 
-  val emptyInputs: TestInputs = TestInputs(Seq(os.rel / ".placeholder" -> ""))
+  val emptyInputs: TestInputs = TestInputs(os.rel / ".placeholder" -> "")
 
   def piping(): Unit = {
     emptyInputs.fromRoot { root =>
@@ -835,8 +783,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
            |  val data = SomeData(value = "$expectedOutput")
            |  println(data.value)
            |}""".stripMargin
-      val inputs =
-        TestInputs(Seq(os.rel / "SomeData.scala" -> "case class SomeData(value: String)"))
+      val inputs = TestInputs(os.rel / "SomeData.scala" -> "case class SomeData(value: String)")
       inputs.fromRoot { root =>
         val output = os.proc(TestUtil.cli, ".", "_.scala", extraOptions)
           .call(cwd = root, stdin = pipedInput)
@@ -898,7 +845,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
         s"public class JavaSnippet { public static String exclamation = \"$exclamation\"; }"
       val pipedInput = s"def hello = \"$hello\""
       val inputs =
-        TestInputs(Seq(os.rel / "Main.scala" ->
+        TestInputs(os.rel / "Main.scala" ->
           s"""object Main extends App {
              |  val hello = stdin.hello
              |  val comma = ScalaSnippetData(value = "$comma").value
@@ -906,7 +853,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
              |  val exclamation = JavaSnippet.exclamation
              |  println(hello + comma + world + exclamation)
              |}
-             |""".stripMargin))
+             |""".stripMargin)
       inputs.fromRoot { root =>
         val output =
           os.proc(
@@ -928,14 +875,12 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     }
     test("pick .scala main class over in-context scripts, including piped ones") {
       val inputs = TestInputs(
-        Seq(
-          os.rel / "Hello.scala" ->
-            """object Hello extends App {
-              |  println(s"${stdin.hello} ${scripts.Script.world}")
-              |}
-              |""".stripMargin,
-          os.rel / "scripts" / "Script.sc" -> """def world: String = "world""""
-        )
+        os.rel / "Hello.scala" ->
+          """object Hello extends App {
+            |  println(s"${stdin.hello} ${scripts.Script.world}")
+            |}
+            |""".stripMargin,
+        os.rel / "scripts" / "Script.sc" -> """def world: String = "world""""
       )
       val pipedInput = """def hello: String = "Hello""""
       inputs.fromRoot { root =>
@@ -952,14 +897,12 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     }
     test("pick piped .scala main class over in-context scripts") {
       val inputs = TestInputs(
-        Seq(
-          os.rel / "Hello.scala" ->
-            """object Hello {
-              |  def hello: String = "Hello"
-              |}
-              |""".stripMargin,
-          os.rel / "scripts" / "Script.sc" -> """def world: String = "world""""
-        )
+        os.rel / "Hello.scala" ->
+          """object Hello {
+            |  def hello: String = "Hello"
+            |}
+            |""".stripMargin,
+        os.rel / "scripts" / "Script.sc" -> """def world: String = "world""""
       )
       val pipedInput =
         """object Main extends App {
@@ -1049,18 +992,16 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("Zip with multiple Scala files") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Hello.scala" ->
-          s"""object Hello extends App {
-             |  println(Messages.hello)
-             |}
-             |""".stripMargin,
-        os.rel / "Messages.scala" ->
-          s"""object Messages {
-             |  def hello: String = "Hello"
-             |}
-             |""".stripMargin
-      )
+      os.rel / "Hello.scala" ->
+        s"""object Hello extends App {
+           |  println(Messages.hello)
+           |}
+           |""".stripMargin,
+      os.rel / "Messages.scala" ->
+        s"""object Messages {
+           |  def hello: String = "Hello"
+           |}
+           |""".stripMargin
     )
     inputs.asZip { (root, zipPath) =>
       val message = "Hello"
@@ -1073,21 +1014,19 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("Zip with Scala containing resource directive") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Hello.scala" ->
-          s"""//> using resourceDir "./"
-             |import scala.io.Source
-             |
-             |object Hello extends App {
-             |    val inputs = Source.fromResource("input").getLines.map(_.toInt).toSeq
-             |    println(inputs.mkString(","))
-             |}
-             |""".stripMargin,
-        os.rel / "input" ->
-          s"""1
-             |2
-             |""".stripMargin
-      )
+      os.rel / "Hello.scala" ->
+        s"""//> using resourceDir "./"
+           |import scala.io.Source
+           |
+           |object Hello extends App {
+           |    val inputs = Source.fromResource("input").getLines.map(_.toInt).toSeq
+           |    println(inputs.mkString(","))
+           |}
+           |""".stripMargin,
+      os.rel / "input" ->
+        s"""1
+           |2
+           |""".stripMargin
     )
     inputs.asZip { (root, zipPath) =>
       val message = "1,2"
@@ -1101,19 +1040,17 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("Zip with Scala Script containing resource directive") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "hello.sc" ->
-          s"""//> using resourceDir "./"
-             |import scala.io.Source
-             |
-             |val inputs = Source.fromResource("input").getLines.map(_.toInt).toSeq
-             |println(inputs.mkString(","))
-             |""".stripMargin,
-        os.rel / "input" ->
-          s"""1
-             |2
-             |""".stripMargin
-      )
+      os.rel / "hello.sc" ->
+        s"""//> using resourceDir "./"
+           |import scala.io.Source
+           |
+           |val inputs = Source.fromResource("input").getLines.map(_.toInt).toSeq
+           |println(inputs.mkString(","))
+           |""".stripMargin,
+      os.rel / "input" ->
+        s"""1
+           |2
+           |""".stripMargin
     )
     inputs.asZip { (root, zipPath) =>
       val message = "1,2"
@@ -1137,20 +1074,18 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     expect(os.isFile(os.Path(shapelessJar, os.pwd)))
 
     val inputs = TestInputs(
-      Seq(
-        os.rel / "test.sc" ->
-          """val shapelessFound =
-            |  try Thread.currentThread().getContextClassLoader.loadClass("shapeless.HList") != null
-            |  catch { case _: ClassNotFoundException => false }
-            |println(if (shapelessFound) "Hello with " + "shapeless" else "Hello from " + "test")
-            |""".stripMargin,
-        os.rel / "Other.scala" ->
-          """object Other {
-            |  import shapeless._
-            |  val l = 2 :: "a" :: HNil
-            |}
-            |""".stripMargin
-      )
+      os.rel / "test.sc" ->
+        """val shapelessFound =
+          |  try Thread.currentThread().getContextClassLoader.loadClass("shapeless.HList") != null
+          |  catch { case _: ClassNotFoundException => false }
+          |println(if (shapelessFound) "Hello with " + "shapeless" else "Hello from " + "test")
+          |""".stripMargin,
+      os.rel / "Other.scala" ->
+        """object Other {
+          |  import shapeless._
+          |  val l = 2 :: "a" :: HNil
+          |}
+          |""".stripMargin
     )
     inputs.fromRoot { root =>
       val baseOutput = os.proc(TestUtil.cli, extraOptions, ".", "--extra-jar", shapelessJar)
@@ -1172,17 +1107,15 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   def commandLineScalacXOption(): Unit = {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Test.scala" ->
-          """object Test {
-            |  def main(args: Array[String]): Unit = {
-            |    val msg = "Hello"
-            |    val foo = List("Not printed", 2, true, new Object)
-            |    println(msg)
-            |  }
-            |}
-            |""".stripMargin
-      )
+      os.rel / "Test.scala" ->
+        """object Test {
+          |  def main(args: Array[String]): Unit = {
+          |    val msg = "Hello"
+          |    val foo = List("Not printed", 2, true, new Object)
+          |    println(msg)
+          |  }
+          |}
+          |""".stripMargin
     )
     inputs.fromRoot { root =>
       def run(warnAny: Boolean) = {
@@ -1222,16 +1155,14 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   def commandLineScalacYOption(): Unit = {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Delambdafy.scala" ->
-          """object Delambdafy {
-            |  def main(args: Array[String]): Unit = {
-            |    val l = List(0, 1, 2)
-            |    println(l.map(_ + 1).mkString)
-            |  }
-            |}
-            |""".stripMargin
-      )
+      os.rel / "Delambdafy.scala" ->
+        """object Delambdafy {
+          |  def main(args: Array[String]): Unit = {
+          |    val l = List(0, 1, 2)
+          |    println(l.map(_ + 1).mkString)
+          |  }
+          |}
+          |""".stripMargin
     )
     inputs.fromRoot { root =>
       // FIXME We don't really use the run command here, in spite of being in RunTests…
@@ -1274,12 +1205,10 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
       val fileName = "simple.sc"
       val message  = "Hello"
       val inputs = TestInputs(
-        Seq(
-          os.rel / fileName ->
-            s"""val msg = "$message"
-               |println(msg)
-               |""".stripMargin
-        )
+        os.rel / fileName ->
+          s"""val msg = "$message"
+             |println(msg)
+             |""".stripMargin
       )
       inputs.fromRoot { root =>
         val baseImage =
@@ -1316,13 +1245,11 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   test("Java options in config file") {
     val message = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "simple.sc" ->
-          s"""//> using javaOpt "-Dtest.message=$message"
-             |val msg = sys.props("test.message")
-             |println(msg)
-             |""".stripMargin
-      )
+      os.rel / "simple.sc" ->
+        s"""//> using javaOpt "-Dtest.message=$message"
+           |val msg = sys.props("test.message")
+           |println(msg)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, extraOptions, ".").call(cwd = root).out.text().trim
@@ -1332,13 +1259,11 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("Main class in config file") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "simple.scala" ->
-          s"""//> using `main-class` "hello"
-             |object hello extends App { println("hello") }
-             |object world extends App { println("world") }
-             |""".stripMargin
-      )
+      os.rel / "simple.scala" ->
+        s"""//> using `main-class` "hello"
+           |object hello extends App { println("hello") }
+           |object world extends App { println("world") }
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, extraOptions, ".").call(cwd = root).out.text().trim
@@ -1350,14 +1275,12 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""val msg = "$message"
-             |println(msg)
-             |""".stripMargin,
-        os.rel / "Dockerfile" ->
-          os.read(os.Path(Constants.mostlyStaticDockerfile, os.pwd))
-      )
+      os.rel / fileName ->
+        s"""val msg = "$message"
+           |println(msg)
+           |""".stripMargin,
+      os.rel / "Dockerfile" ->
+        os.read(os.Path(Constants.mostlyStaticDockerfile, os.pwd))
     )
     inputs.fromRoot { root =>
       os.copy(os.Path(TestUtil.cli.head), root / "scala-cli")
@@ -1399,16 +1322,14 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     }
 
   private def simpleDirInputs = TestInputs(
-    Seq(
-      os.rel / "dir" / "Hello.scala" ->
-        """object Hello {
-          |  def main(args: Array[String]): Unit = {
-          |    val p = java.nio.file.Paths.get(getClass.getProtectionDomain.getCodeSource.getLocation.toURI)
-          |    println(p)
-          |  }
-          |}
-          |""".stripMargin
-    )
+    os.rel / "dir" / "Hello.scala" ->
+      """object Hello {
+        |  def main(args: Array[String]): Unit = {
+        |    val p = java.nio.file.Paths.get(getClass.getProtectionDomain.getCodeSource.getLocation.toURI)
+        |    println(p)
+        |  }
+        |}
+        |""".stripMargin
   )
   private def nonWritableTest(): Unit = {
     simpleDirInputs.fromRoot { root =>
@@ -1455,20 +1376,18 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   private def resourcesInputs(directive: String = "") = {
     val resourceContent = "Hello from resources"
     TestInputs(
-      Seq(
-        os.rel / "src" / "proj" / "resources" / "test" / "data" -> resourceContent,
-        os.rel / "src" / "proj" / "Test.scala" ->
-          s"""$directive
-             |object Test {
-             |  def main(args: Array[String]): Unit = {
-             |    val cl = Thread.currentThread().getContextClassLoader
-             |    val is = cl.getResourceAsStream("test/data")
-             |    val content = scala.io.Source.fromInputStream(is)(scala.io.Codec.UTF8).mkString
-             |    assert(content == "$resourceContent")
-             |  }
-             |}
-             |""".stripMargin
-      )
+      os.rel / "src" / "proj" / "resources" / "test" / "data" -> resourceContent,
+      os.rel / "src" / "proj" / "Test.scala" ->
+        s"""$directive
+           |object Test {
+           |  def main(args: Array[String]): Unit = {
+           |    val cl = Thread.currentThread().getContextClassLoader
+           |    val is = cl.getResourceAsStream("test/data")
+           |    val content = scala.io.Source.fromInputStream(is)(scala.io.Codec.UTF8).mkString
+           |    assert(content == "$resourceContent")
+           |  }
+           |}
+           |""".stripMargin
     )
   }
   test("resources") {
@@ -1486,15 +1405,13 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   def argsAsIsTest(): Unit = {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "MyScript.scala" ->
-          """#!/usr/bin/env -S scala-cli shebang
-            |object MyScript {
-            |  def main(args: Array[String]): Unit =
-            |    println("Hello" + args.map(" " + _).mkString)
-            |}
-            |""".stripMargin
-      )
+      os.rel / "MyScript.scala" ->
+        """#!/usr/bin/env -S scala-cli shebang
+          |object MyScript {
+          |  def main(args: Array[String]): Unit =
+          |    println("Hello" + args.map(" " + _).mkString)
+          |}
+          |""".stripMargin
     )
     val launcherPath = TestUtil.cli match {
       case Seq(cli) => os.Path(cli, os.pwd)
@@ -1519,34 +1436,32 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("test scope") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Main.scala" ->
-          """//> using lib "com.lihaoyi::utest:0.7.10"
-            |
-            |object Main {
-            |  val err = utest.compileError("pprint.log(2)")
-            |  def message = "Hello from " + "tests"
-            |  def main(args: Array[String]): Unit = {
-            |    println(message)
-            |    println(err)
-            |  }
-            |}
-            |""".stripMargin,
-        os.rel / "Tests.scala" ->
-          """//> using lib "com.lihaoyi::pprint:0.6.6"
-            |//> using target.scope "test"
-            |
-            |import utest._
-            |
-            |object Tests extends TestSuite {
-            |  val tests = Tests {
-            |    test("message") {
-            |      assert(Main.message.startsWith("Hello"))
-            |    }
-            |  }
-            |}
-            |""".stripMargin
-      )
+      os.rel / "Main.scala" ->
+        """//> using lib "com.lihaoyi::utest:0.7.10"
+          |
+          |object Main {
+          |  val err = utest.compileError("pprint.log(2)")
+          |  def message = "Hello from " + "tests"
+          |  def main(args: Array[String]): Unit = {
+          |    println(message)
+          |    println(err)
+          |  }
+          |}
+          |""".stripMargin,
+      os.rel / "Tests.scala" ->
+        """//> using lib "com.lihaoyi::pprint:0.6.6"
+          |//> using target.scope "test"
+          |
+          |import utest._
+          |
+          |object Tests extends TestSuite {
+          |  val tests = Tests {
+          |    test("message") {
+          |      assert(Main.message.startsWith("Hello"))
+          |    }
+          |  }
+          |}
+          |""".stripMargin
     )
     inputs.fromRoot { root =>
       val res = os.proc(TestUtil.cli, extraOptions, ".").call(cwd = root)
@@ -1556,10 +1471,8 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   }
   test("interconnection between scripts") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "f.sc"     -> "def f(x: String) = println(x + x + x)",
-        os.rel / "main0.sc" -> "f.f(args(0))"
-      )
+      os.rel / "f.sc"     -> "def f(x: String) = println(x + x + x)",
+      os.rel / "main0.sc" -> "f.f(args(0))"
     )
     inputs.fromRoot { root =>
       val p =
@@ -1569,11 +1482,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
   test("CLI args passed to script") {
-    val inputs = TestInputs(
-      Seq(
-        os.rel / "f.sc" -> "println(args(0))"
-      )
-    )
+    val inputs = TestInputs(os.rel / "f.sc" -> "println(args(0))")
     inputs.fromRoot { root =>
       val p = os.proc(TestUtil.cli, "f.sc", "--", "16").call(cwd = root)
       expect(p.out.text().trim == "16")
@@ -1583,11 +1492,9 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   if (!Properties.isWin) {
     test("CLI args passed to shebang script") {
       val inputs = TestInputs(
-        Seq(
-          os.rel / "f.sc" -> s"""|#!/usr/bin/env -S ${TestUtil.cli.mkString(" ")} shebang -S 2.13
-                                 |//> using scala "$actualScalaVersion"
-                                 |println(args.toList)""".stripMargin
-        )
+        os.rel / "f.sc" -> s"""|#!/usr/bin/env -S ${TestUtil.cli.mkString(" ")} shebang -S 2.13
+                               |//> using scala "$actualScalaVersion"
+                               |println(args.toList)""".stripMargin
       )
       inputs.fromRoot { root =>
         os.perms.set(root / "f.sc", os.PermSet.fromString("rwx------"))
@@ -1597,15 +1504,13 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     }
     test("CLI args passed to shebang in Scala file") {
       val inputs = TestInputs(
-        Seq(
-          os.rel / "f.scala" -> s"""|#!/usr/bin/env -S ${TestUtil.cli.mkString(" ")} shebang
-                                    |object Hello {
-                                    |    def main(args: Array[String]) = {
-                                    |        println(args.toList)
-                                    |    }
-                                    |}
-                                    |""".stripMargin
-        )
+        os.rel / "f.scala" -> s"""|#!/usr/bin/env -S ${TestUtil.cli.mkString(" ")} shebang
+                                  |object Hello {
+                                  |    def main(args: Array[String]) = {
+                                  |        println(args.toList)
+                                  |    }
+                                  |}
+                                  |""".stripMargin
       )
       inputs.fromRoot { root =>
         os.perms.set(root / "f.scala", os.PermSet.fromString("rwx------"))
@@ -1616,11 +1521,8 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   }
 
   test("Runs with JVM 8") {
-    val inputs = TestInputs(
-      Seq(
-        os.rel / "run.scala" -> """object Main extends App { println("hello")}"""
-      )
-    )
+    val inputs =
+      TestInputs(os.rel / "run.scala" -> """object Main extends App { println("hello")}""")
     inputs.fromRoot { root =>
       val p = os.proc(TestUtil.cli, "run.scala", "--jvm", "8").call(cwd = root)
       expect(p.out.text().trim == "hello")
@@ -1629,14 +1531,12 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("workspace dir") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Hello.scala" ->
-          """|//> using lib "com.lihaoyi::os-lib:0.7.8"
-             |
-             |object Hello extends App {
-             |  println(os.pwd)
-             |}""".stripMargin
-      )
+      os.rel / "Hello.scala" ->
+        """|//> using lib "com.lihaoyi::os-lib:0.7.8"
+           |
+           |object Hello extends App {
+           |  println(os.pwd)
+           |}""".stripMargin
     )
     inputs.fromRoot { root =>
       val p = os.proc(TestUtil.cli, "Hello.scala").call(cwd = root)
@@ -1681,11 +1581,9 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("-D.. options passed to the child app") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Hello.scala" -> """object ClassHello extends App {
-                                    |  print(System.getProperty("foo"))
-                                    |}""".stripMargin
-      )
+      os.rel / "Hello.scala" -> """object ClassHello extends App {
+                                  |  print(System.getProperty("foo"))
+                                  |}""".stripMargin
     )
     inputs.fromRoot { root =>
       val res = os.proc(TestUtil.cli, "Hello.scala", "--java-opt", "-Dfoo=bar").call(
@@ -1699,23 +1597,21 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName       = "Hello.scala"
     val (hello, world) = ("Hello", "World")
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          """|//> using file "Utils.scala", "helper"
-             |
-             |object Hello extends App {
-             |   println(s"${Utils.hello}${helper.Helper.world}")
-             |}""".stripMargin,
-        os.rel / "Utils.scala" ->
-          s"""|object Utils {
-              |  val hello = "$hello"
-              |}""".stripMargin,
-        os.rel / "helper" / "Helper.scala" ->
-          s"""|package helper
-              |object Helper {
-              |  val world = "$world"
-              |}""".stripMargin
-      )
+      os.rel / fileName ->
+        """|//> using file "Utils.scala", "helper"
+           |
+           |object Hello extends App {
+           |   println(s"${Utils.hello}${helper.Helper.world}")
+           |}""".stripMargin,
+      os.rel / "Utils.scala" ->
+        s"""|object Utils {
+            |  val hello = "$hello"
+            |}""".stripMargin,
+      os.rel / "helper" / "Helper.scala" ->
+        s"""|package helper
+            |object Helper {
+            |  val world = "$world"
+            |}""".stripMargin
     )
     inputs.fromRoot { root =>
       val res = os.proc(TestUtil.cli, "Hello.scala")
@@ -1725,11 +1621,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   }
 
   test("-X.. options passed to the child app") {
-    val inputs = TestInputs(
-      Seq(
-        os.rel / "Hello.scala" -> "object Hello extends App {}"
-      )
-    )
+    val inputs = TestInputs(os.rel / "Hello.scala" -> "object Hello extends App {}")
     inputs.fromRoot { root =>
       // Binaries generated with Graal's native-image are run under SubstrateVM
       // that cuts some -X.. java options, so they're not passed
@@ -1748,12 +1640,10 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""val msg = "$message"
-             |println(msg)
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""val msg = "$message"
+           |println(msg)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val baseImage = Constants.dockerTestImage
@@ -1810,7 +1700,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
               |}
               |""".stripMargin
         )
-      }
+      }*
     )
     def authProperties(host: String, port: Int, user: String, password: String): Seq[String] =
       Seq("http", "https").flatMap { scheme =>
@@ -1873,18 +1763,16 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   def jsDomTest(): Unit = {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "JsDom.scala" ->
-          s"""|//> using lib "org.scala-js::scalajs-dom::2.1.0"
-              |
-              |import org.scalajs.dom.document
-              |
-              |object JsDom extends App {
-              |  val pSize = document.querySelectorAll("p")
-              |  println("Hello from js dom")
-              |}
-              |""".stripMargin
-      )
+      os.rel / "JsDom.scala" ->
+        s"""|//> using lib "org.scala-js::scalajs-dom::2.1.0"
+            |
+            |import org.scalajs.dom.document
+            |
+            |object JsDom extends App {
+            |  val pSize = document.querySelectorAll("p")
+            |  println("Hello from js dom")
+            |}
+            |""".stripMargin
     )
     inputs.fromRoot { root =>
       // install jsdom library
@@ -1908,15 +1796,13 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     val message  = "Hello from TestÅÄÖåäö"
     val fileName = "TestÅÄÖåäö.scala"
     val inputs = TestInputs(
-      Seq(
-        os.rel / fileName ->
-          s"""object TestÅÄÖåäö {
-             |  def main(args: Array[String]): Unit = {
-             |    println("$message")
-             |  }
-             |}
-             |""".stripMargin
-      )
+      os.rel / fileName ->
+        s"""object TestÅÄÖåäö {
+           |  def main(args: Array[String]): Unit = {
+           |    println("$message")
+           |  }
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val res = os.proc(
@@ -1981,14 +1867,12 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("pick .scala main class over in-context scripts") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Hello.scala" ->
-          """object Hello extends App {
-            |  println(s"Hello ${scripts.Script.world}")
-            |}
-            |""".stripMargin,
-        os.rel / "scripts" / "Script.sc" -> """def world: String = "world"""".stripMargin
-      )
+      os.rel / "Hello.scala" ->
+        """object Hello extends App {
+          |  println(s"Hello ${scripts.Script.world}")
+          |}
+          |""".stripMargin,
+      os.rel / "scripts" / "Script.sc" -> """def world: String = "world"""".stripMargin
     )
     inputs.fromRoot { root =>
       val res = os.proc(
@@ -2006,11 +1890,9 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     val (scalaFile1, scalaFile2, scriptName) = ("ScalaMainClass1", "ScalaMainClass2", "ScalaScript")
     val scriptsDir                           = "scritps"
     val inputs = TestInputs(
-      Seq(
-        os.rel / s"$scalaFile1.scala"           -> s"object $scalaFile1 extends App { println() }",
-        os.rel / s"$scalaFile2.scala"           -> s"object $scalaFile2 extends App { println() }",
-        os.rel / scriptsDir / s"$scriptName.sc" -> "println()"
-      )
+      os.rel / s"$scalaFile1.scala"           -> s"object $scalaFile1 extends App { println() }",
+      os.rel / s"$scalaFile2.scala"           -> s"object $scalaFile2 extends App { println() }",
+      os.rel / scriptsDir / s"$scriptName.sc" -> "println()"
     )
     inputs.fromRoot { root =>
       val res = os.proc(
@@ -2031,7 +1913,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   test(
     "return relevant error when main classes list is requested, but no main classes are present"
   ) {
-    val inputs = TestInputs(Seq(os.rel / "Main.scala" -> "object Main { println() }"))
+    val inputs = TestInputs(os.rel / "Main.scala" -> "object Main { println() }")
     inputs.fromRoot { root =>
       val res = os.proc(
         TestUtil.cli,
@@ -2050,11 +1932,9 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     val (scalaFile1, scalaFile2, scriptName) = ("ScalaMainClass1", "ScalaMainClass2", "ScalaScript")
     val scriptsDir                           = "scripts"
     val inputs = TestInputs(
-      Seq(
-        os.rel / s"$scalaFile1.scala"           -> s"object $scalaFile1 extends App { println() }",
-        os.rel / s"$scalaFile2.scala"           -> s"object $scalaFile2 extends App { println() }",
-        os.rel / scriptsDir / s"$scriptName.sc" -> "println()"
-      )
+      os.rel / s"$scalaFile1.scala"           -> s"object $scalaFile1 extends App { println() }",
+      os.rel / s"$scalaFile2.scala"           -> s"object $scalaFile2 extends App { println() }",
+      os.rel / scriptsDir / s"$scriptName.sc" -> "println()"
     )
     inputs.fromRoot { root =>
       val res = os.proc(

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTests212.scala
@@ -9,11 +9,7 @@ class RunTests212 extends RunTestDefinitions(
   // format: on
 
   test("Descriptive error message for unsupported native/script configurations") {
-    val inputs = TestInputs(
-      Seq(
-        os.rel / "a.sc" -> "println(1)"
-      )
-    )
+    val inputs        = TestInputs(os.rel / "a.sc" -> "println(1)")
     val nativeVersion = "0.4.2"
     inputs.fromRoot { root =>
       val output = os.proc(

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
@@ -28,7 +28,7 @@ class RunTestsDefault extends RunTestDefinitions(scalaVersionOpt = None) {
       val cmd = Seq[os.Shellable](
         "docker", "run", "--rm", termOpt,
         "-e", "SCALA_CLI_VENDORED_ZIS=true",
-        "-v", s"${root}:/data",
+        "-v", s"$root:/data",
         "-w", "/data",
         ciOpt,
         Constants.dockerArchLinuxImage,

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
@@ -9,11 +9,9 @@ class RunTestsDefault extends RunTestDefinitions(scalaVersionOpt = None) {
   def archLinuxTest(): Unit = {
     val message = "Hello from Scala CLI on Arch Linux"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "hello.sc" ->
-          s"""println("$message")
-             |""".stripMargin
-      )
+      os.rel / "hello.sc" ->
+        s"""println("$message")
+           |""".stripMargin
     )
     val extraOptsStr = extraOptions.mkString(" ") /* meh escaping */
     inputs.fromRoot { root =>

--- a/modules/integration/src/test/scala/scala/cli/integration/SharedRunTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SharedRunTests.scala
@@ -4,12 +4,12 @@ import com.eed3si9n.expecty.Expecty.expect
 
 class SharedRunTests extends ScalaCliSuite {
 
-  val printScalaVersionInputs = TestInputs(
+  val printScalaVersionInputs: TestInputs = TestInputs(
     os.rel / "print.sc" ->
       s"""println(scala.util.Properties.versionNumberString)
          |""".stripMargin
   )
-  val printScalaVersionInputs3 = TestInputs(
+  val printScalaVersionInputs3: TestInputs = TestInputs(
     os.rel / "print.sc" ->
       s"""def printStuff(): Unit =
          |  val toPrint = scala.util.Properties.versionNumberString

--- a/modules/integration/src/test/scala/scala/cli/integration/SharedRunTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SharedRunTests.scala
@@ -5,21 +5,17 @@ import com.eed3si9n.expecty.Expecty.expect
 class SharedRunTests extends ScalaCliSuite {
 
   val printScalaVersionInputs = TestInputs(
-    Seq(
-      os.rel / "print.sc" ->
-        s"""println(scala.util.Properties.versionNumberString)
-           |""".stripMargin
-    )
+    os.rel / "print.sc" ->
+      s"""println(scala.util.Properties.versionNumberString)
+         |""".stripMargin
   )
   val printScalaVersionInputs3 = TestInputs(
-    Seq(
-      os.rel / "print.sc" ->
-        s"""def printStuff(): Unit =
-           |  val toPrint = scala.util.Properties.versionNumberString
-           |  println(toPrint)
-           |printStuff()
-           |""".stripMargin
-    )
+    os.rel / "print.sc" ->
+      s"""def printStuff(): Unit =
+         |  val toPrint = scala.util.Properties.versionNumberString
+         |  println(toPrint)
+         |printStuff()
+         |""".stripMargin
   )
   test("Scala version 2.12") {
     printScalaVersionInputs.fromRoot { root =>
@@ -58,12 +54,10 @@ class SharedRunTests extends ScalaCliSuite {
   test("Scala version in config file") {
     val confSv = "2.13.1"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "test.sc" ->
-          s"""//> using scala "$confSv"
-             |println(scala.util.Properties.versionNumberString)
-             |""".stripMargin
-      )
+      os.rel / "test.sc" ->
+        s"""//> using scala "$confSv"
+           |println(scala.util.Properties.versionNumberString)
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val output =

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -7,7 +7,7 @@ import scala.util.Properties
 class SipScalaTests extends ScalaCliSuite {
 
   def noDirectoriesCommandTest(binaryName: String): Unit =
-    TestInputs(Nil).fromRoot { root =>
+    TestInputs.empty.fromRoot { root =>
       val cliPath = os.Path(TestUtil.cliPath, os.pwd)
 
       os.proc(cliPath, "directories").call(cwd = root)

--- a/modules/integration/src/test/scala/scala/cli/integration/SparkTests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SparkTests212.scala
@@ -53,7 +53,7 @@ object SparkTests212 {
 
 class SparkTests212 extends SparkTestDefinitions {
 
-  import SparkTests212._
+  import SparkTests212.*
 
   private val spark30 = new Spark(
     "3.0.3",

--- a/modules/integration/src/test/scala/scala/cli/integration/SparkTests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SparkTests212.scala
@@ -75,28 +75,26 @@ class SparkTests212 extends SparkTestDefinitions {
   def simplePackageSparkJobTest(spark: Spark): Unit = {
     val master = "local[4]"
     val inputs = TestInputs(
-      Seq(
-        os.rel / "SparkJob.scala" ->
-          s"""//> using lib "org.apache.spark::spark-sql:${spark.sparkVersion}"
-             |//> using scala "${spark.scalaVersion}"
-             |
-             |import org.apache.spark._
-             |import org.apache.spark.sql._
-             |
-             |object SparkJob {
-             |  def main(args: Array[String]): Unit = {
-             |    val spark = SparkSession.builder()
-             |      .appName("Test job")
-             |      .getOrCreate()
-             |    import spark.implicits._
-             |    def sc    = spark.sparkContext
-             |    val accum = sc.longAccumulator
-             |    sc.parallelize(1 to 10).foreach(x => accum.add(x))
-             |    println("Result: " + accum.value)
-             |  }
-             |}
-             |""".stripMargin
-      )
+      os.rel / "SparkJob.scala" ->
+        s"""//> using lib "org.apache.spark::spark-sql:${spark.sparkVersion}"
+           |//> using scala "${spark.scalaVersion}"
+           |
+           |import org.apache.spark._
+           |import org.apache.spark.sql._
+           |
+           |object SparkJob {
+           |  def main(args: Array[String]): Unit = {
+           |    val spark = SparkSession.builder()
+           |      .appName("Test job")
+           |      .getOrCreate()
+           |    import spark.implicits._
+           |    def sc    = spark.sparkContext
+           |    val accum = sc.longAccumulator
+           |    sc.parallelize(1 to 10).foreach(x => accum.add(x))
+           |    println("Result: " + accum.value)
+           |  }
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       val dest = os.rel / "SparkJob.jar"

--- a/modules/integration/src/test/scala/scala/cli/integration/TestBspClient.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestBspClient.scala
@@ -78,7 +78,7 @@ object TestBspClient {
     in: InputStream,
     out: OutputStream,
     es: ExecutorService
-  ): (TestBspClient, b.BuildServer with b.ScalaBuildServer with b.JavaBuildServer, Future[Unit]) = {
+  ): (TestBspClient, b.BuildServer & b.ScalaBuildServer & b.JavaBuildServer, Future[Unit]) = {
 
     val localClient = new TestBspClient
 

--- a/modules/integration/src/test/scala/scala/cli/integration/TestNativeImageOnScala3.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestNativeImageOnScala3.scala
@@ -13,7 +13,7 @@ class TestNativeImageOnScala3 extends ScalaCliSuite {
       if (Properties.isWin) "testApp.exe"
       else "testApp"
 
-    val inputs = TestInputs(Seq(os.rel / "Hello.scala" -> code))
+    val inputs = TestInputs(os.rel / "Hello.scala" -> code)
     inputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,

--- a/modules/integration/src/test/scala/scala/cli/integration/TestNativeImageOnScala3.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestNativeImageOnScala3.scala
@@ -6,7 +6,7 @@ import scala.util.Properties
 
 class TestNativeImageOnScala3 extends ScalaCliSuite {
 
-  override def group = ScalaCliSuite.TestGroup.First
+  override def group: ScalaCliSuite.TestGroup = ScalaCliSuite.TestGroup.First
 
   def runTest(args: String*)(expectedLines: String*)(code: String): Unit = {
     val dest =

--- a/modules/integration/src/test/scala/scala/cli/integration/TestScalaVersionArgs.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestScalaVersionArgs.scala
@@ -9,11 +9,11 @@ trait TestScalaVersionArgs extends ScalaCliSuite {
 
   def scalaVersionOpt: Option[String]
 
-  lazy val scalaVersionArgs = scalaVersionOpt match {
+  lazy val scalaVersionArgs: Seq[String] = scalaVersionOpt match {
     case None     => Nil
     case Some(sv) => Seq("--scala", sv)
   }
 
-  lazy val actualScalaVersion = scalaVersionOpt.getOrElse(Constants.defaultScala)
+  lazy val actualScalaVersion: String = scalaVersionOpt.getOrElse(Constants.defaultScala)
 
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -15,174 +15,156 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
   private lazy val extraOptions       = scalaVersionArgs ++ baseExtraOptions
 
   val successfulTestInputs = TestInputs(
-    Seq(
-      os.rel / "MyTests.scala" ->
-        """//> using lib "org.scalameta::munit::0.7.29"
-          |
-          |class MyTests extends munit.FunSuite {
-          |  test("foo") {
-          |    assert(2 + 2 == 4)
-          |    println("Hello from " + "tests")
-          |  }
-          |}
-          |""".stripMargin
-    )
+    os.rel / "MyTests.scala" ->
+      """//> using lib "org.scalameta::munit::0.7.29"
+        |
+        |class MyTests extends munit.FunSuite {
+        |  test("foo") {
+        |    assert(2 + 2 == 4)
+        |    println("Hello from " + "tests")
+        |  }
+        |}
+        |""".stripMargin
   )
 
   val failingTestInputs = TestInputs(
-    Seq(
-      os.rel / "MyTests.scala" ->
-        """//> using lib "org.scalameta::munit::0.7.29"
-          |
-          |class MyTests extends munit.FunSuite {
-          |  test("foo") {
-          |    assert(2 + 2 == 5, "Hello from " + "tests")
-          |  }
-          |}
-          |""".stripMargin
-    )
+    os.rel / "MyTests.scala" ->
+      """//> using lib "org.scalameta::munit::0.7.29"
+        |
+        |class MyTests extends munit.FunSuite {
+        |  test("foo") {
+        |    assert(2 + 2 == 5, "Hello from " + "tests")
+        |  }
+        |}
+        |""".stripMargin
   )
 
   val successfulUtestInputs = TestInputs(
-    Seq(
-      os.rel / "MyTests.scala" ->
-        """//> using lib "com.lihaoyi::utest::0.7.10"
-          |import utest._
-          |
-          |object MyTests extends TestSuite {
-          |  val tests = Tests {
-          |    test("foo") {
-          |      assert(2 + 2 == 4)
-          |      println("Hello from " + "tests")
-          |    }
-          |  }
-          |}
-          |""".stripMargin
-    )
+    os.rel / "MyTests.scala" ->
+      """//> using lib "com.lihaoyi::utest::0.7.10"
+        |import utest._
+        |
+        |object MyTests extends TestSuite {
+        |  val tests = Tests {
+        |    test("foo") {
+        |      assert(2 + 2 == 4)
+        |      println("Hello from " + "tests")
+        |    }
+        |  }
+        |}
+        |""".stripMargin
   )
 
   val successfulUtestJsInputs = TestInputs(
-    Seq(
-      os.rel / "MyTests.scala" ->
-        """//> using lib "com.lihaoyi::utest::0.7.10"
-          |import utest._
-          |import scala.scalajs.js
-          |
-          |object MyTests extends TestSuite {
-          |  val tests = Tests {
-          |    test("foo") {
-          |      assert(2 + 2 == 4)
-          |      val console = js.Dynamic.global.console
-          |      console.log("Hello from " + "tests")
-          |    }
-          |  }
-          |}
-          |""".stripMargin
-    )
+    os.rel / "MyTests.scala" ->
+      """//> using lib "com.lihaoyi::utest::0.7.10"
+        |import utest._
+        |import scala.scalajs.js
+        |
+        |object MyTests extends TestSuite {
+        |  val tests = Tests {
+        |    test("foo") {
+        |      assert(2 + 2 == 4)
+        |      val console = js.Dynamic.global.console
+        |      console.log("Hello from " + "tests")
+        |    }
+        |  }
+        |}
+        |""".stripMargin
   )
 
   val successfulUtestNativeInputs = TestInputs(
-    Seq(
-      os.rel / "MyTests.scala" ->
-        """//> using lib "com.lihaoyi::utest::0.7.10"
-          |import utest._
-          |import scala.scalanative.libc._
-          |import scala.scalanative.unsafe._
-          |
-          |object MyTests extends TestSuite {
-          |  val tests = Tests {
-          |    test("foo") {
-          |      assert(2 + 2 == 4)
-          |      Zone { implicit z =>
-          |        stdio.printf(toCString("Hello from " + "tests\n"))
-          |      }
-          |    }
-          |  }
-          |}
-          |""".stripMargin
-    )
+    os.rel / "MyTests.scala" ->
+      """//> using lib "com.lihaoyi::utest::0.7.10"
+        |import utest._
+        |import scala.scalanative.libc._
+        |import scala.scalanative.unsafe._
+        |
+        |object MyTests extends TestSuite {
+        |  val tests = Tests {
+        |    test("foo") {
+        |      assert(2 + 2 == 4)
+        |      Zone { implicit z =>
+        |        stdio.printf(toCString("Hello from " + "tests\n"))
+        |      }
+        |    }
+        |  }
+        |}
+        |""".stripMargin
   )
 
   val successfulScalaCheckFromCatsNativeInputs = TestInputs(
-    Seq(
-      os.rel / "MyTests.scala" ->
-        """//> using scala "2.13.8"
-          |//> using platform "native"
-          |//> using lib "org.typelevel::cats-kernel-laws::2.8.0"
-          |
-          |import org.scalacheck._
-          |import Prop.forAll
-          |    
-          |class TestSpec extends Properties("spec") {
-          |  property("startsWith") = forAll { (a: String, b: String) =>
-          |    (a+b).startsWith(a)
-          |  }
-          |  println("Hello from " + "tests")
-          |}""".stripMargin
-    )
+    os.rel / "MyTests.scala" ->
+      """//> using scala "2.13.8"
+        |//> using platform "native"
+        |//> using lib "org.typelevel::cats-kernel-laws::2.8.0"
+        |
+        |import org.scalacheck._
+        |import Prop.forAll
+        |
+        |class TestSpec extends Properties("spec") {
+        |  property("startsWith") = forAll { (a: String, b: String) =>
+        |    (a+b).startsWith(a)
+        |  }
+        |  println("Hello from " + "tests")
+        |}""".stripMargin
   )
 
   val successfulJunitInputs = TestInputs(
-    Seq(
-      os.rel / "MyTests.scala" ->
-        """//> using lib "com.novocode:junit-interface:0.11"
-          |import org.junit.Test
-          |
-          |class MyTests {
-          |
-          |  @Test
-          |  def foo(): Unit = {
-          |    assert(2 + 2 == 4)
-          |    println("Hello from " + "tests")
-          |  }
-          |}
-          |""".stripMargin
-    )
+    os.rel / "MyTests.scala" ->
+      """//> using lib "com.novocode:junit-interface:0.11"
+        |import org.junit.Test
+        |
+        |class MyTests {
+        |
+        |  @Test
+        |  def foo(): Unit = {
+        |    assert(2 + 2 == 4)
+        |    println("Hello from " + "tests")
+        |  }
+        |}
+        |""".stripMargin
   )
 
   val severalTestsInputs = TestInputs(
-    Seq(
-      os.rel / "MyTests.scala" ->
-        """//> using lib "org.scalameta::munit::0.7.29"
-          |
-          |class MyTests extends munit.FunSuite {
-          |  test("foo") {
-          |    assert(2 + 2 == 4)
-          |    println("Hello from " + "tests1")
-          |  }
-          |}
-          |""".stripMargin,
-      os.rel / "OtherTests.scala" ->
-        """//> using lib "org.scalameta::munit::0.7.29"
-          |
-          |class OtherTests extends munit.FunSuite {
-          |  test("bar") {
-          |    assert(1 + 1 == 2)
-          |    println("Hello from " + "tests2")
-          |  }
-          |}
-          |""".stripMargin
-    )
+    os.rel / "MyTests.scala" ->
+      """//> using lib "org.scalameta::munit::0.7.29"
+        |
+        |class MyTests extends munit.FunSuite {
+        |  test("foo") {
+        |    assert(2 + 2 == 4)
+        |    println("Hello from " + "tests1")
+        |  }
+        |}
+        |""".stripMargin,
+    os.rel / "OtherTests.scala" ->
+      """//> using lib "org.scalameta::munit::0.7.29"
+        |
+        |class OtherTests extends munit.FunSuite {
+        |  test("bar") {
+        |    assert(1 + 1 == 2)
+        |    println("Hello from " + "tests2")
+        |  }
+        |}
+        |""".stripMargin
   )
 
   val successfulWeaverInputs = TestInputs(
-    Seq(
-      os.rel / "MyTests.scala" ->
-        """//> using libs "com.disneystreaming::weaver-cats:0.7.6", "com.eed3si9n.expecty::expecty:0.15.4+5-f1d8927e-SNAPSHOT"
-          |import weaver._
-          |import cats.effect.IO
-          |
-          |object MyTests extends SimpleIOSuite {
-          |  test("bar") {
-          |    IO.println("Hello from " + "tests").map(_ => expect(1 + 1 == 2))
-          |  }
-          |}
-          |""".stripMargin
-    )
+    os.rel / "MyTests.scala" ->
+      """//> using libs "com.disneystreaming::weaver-cats:0.7.6", "com.eed3si9n.expecty::expecty:0.15.4+5-f1d8927e-SNAPSHOT"
+        |import weaver._
+        |import cats.effect.IO
+        |
+        |object MyTests extends SimpleIOSuite {
+        |  test("bar") {
+        |    IO.println("Hello from " + "tests").map(_ => expect(1 + 1 == 2))
+        |  }
+        |}
+        |""".stripMargin
   )
 
   val successfulESModuleTestInputs = TestInputs(
-    Seq(os.rel / "MyTests.scala" ->
+    os.rel / "MyTests.scala" ->
       """//> using lib "org.scalameta::munit::0.7.29"
         |//> using jsModuleKind "esmodule"
         |import scala.scalajs.js
@@ -200,7 +182,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
         |    console.log("Hello from " + "tests")
         |  }
         |}
-        |""".stripMargin)
+        |""".stripMargin
   )
 
   test("successful test") {
@@ -374,20 +356,18 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
   for ((platformName, platformArgs) <- platforms)
     test(s"test framework arguments $platformName") {
       val inputs = TestInputs(
-        Seq(
-          os.rel / "MyTests.scala" ->
-            """//> using lib "org.scalatest::scalatest::3.2.9"
-              |import org.scalatest._
-              |import org.scalatest.flatspec._
-              |import org.scalatest.matchers._
-              |
-              |class Tests extends AnyFlatSpec with should.Matchers {
-              |  "A thing" should "thing" in {
-              |    assert(2 + 2 == 4)
-              |  }
-              |}
-              |""".stripMargin
-        )
+        os.rel / "MyTests.scala" ->
+          """//> using lib "org.scalatest::scalatest::3.2.9"
+            |import org.scalatest._
+            |import org.scalatest.flatspec._
+            |import org.scalatest.matchers._
+            |
+            |class Tests extends AnyFlatSpec with should.Matchers {
+            |  "A thing" should "thing" in {
+            |    assert(2 + 2 == 4)
+            |  }
+            |}
+            |""".stripMargin
       )
       inputs.fromRoot { root =>
         val baseRes = os.proc(TestUtil.cli, "test", extraOptions, platformArgs, ".")
@@ -418,31 +398,29 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
   for ((platformName, platformArgs) <- platforms)
     test(s"custom test framework $platformName") {
       val inputs = TestInputs(
-        Seq(
-          os.rel / "MyTests.scala" ->
-            """//> using lib "com.lihaoyi::utest::0.7.10"
-              |
-              |package mytests
-              |import utest._
-              |
-              |object MyTests extends TestSuite {
-              |  val tests = Tests {
-              |    test("foo") {
-              |      assert(2 + 2 == 4)
-              |      println("Hello from " + "tests")
-              |    }
-              |  }
-              |}
-              |""".stripMargin,
-          os.rel / "CustomFramework.scala" ->
-            """package custom
-              |
-              |class CustomFramework extends utest.runner.Framework {
-              |  override def setup(): Unit =
-              |    println("Hello from CustomFramework")
-              |}
-              |""".stripMargin
-        )
+        os.rel / "MyTests.scala" ->
+          """//> using lib "com.lihaoyi::utest::0.7.10"
+            |
+            |package mytests
+            |import utest._
+            |
+            |object MyTests extends TestSuite {
+            |  val tests = Tests {
+            |    test("foo") {
+            |      assert(2 + 2 == 4)
+            |      println("Hello from " + "tests")
+            |    }
+            |  }
+            |}
+            |""".stripMargin,
+        os.rel / "CustomFramework.scala" ->
+          """package custom
+            |
+            |class CustomFramework extends utest.runner.Framework {
+            |  override def setup(): Unit =
+            |    println("Hello from CustomFramework")
+            |}
+            |""".stripMargin
       )
       inputs.fromRoot { root =>
         val baseRes = os.proc(TestUtil.cli, "test", extraOptions, platformArgs, ".")
@@ -467,13 +445,11 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
   for ((platformName, platformArgs) <- platforms)
     test(s"Fail if no tests were run $platformName") {
       val inputs = TestInputs(
-        Seq(
-          os.rel / "MyTests.scala" ->
-            """//> using lib "org.scalameta::munit::0.7.29"
-              |
-              |object MyTests
-              |""".stripMargin
-        )
+        os.rel / "MyTests.scala" ->
+          """//> using lib "org.scalameta::munit::0.7.29"
+            |
+            |object MyTests
+            |""".stripMargin
       )
 
       inputs.fromRoot { root =>
@@ -508,36 +484,34 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
     }
     val inputs = {
       var inputs0 = TestInputs(
-        Seq(
-          os.rel / "MyTests.scala" ->
-            s"""//> using lib "org.scalameta::munit::0.7.29"
-               |//> using platform $platforms
-               |
-               |class MyTests extends munit.FunSuite {
-               |  test("shared") {
-               |    println("Hello from " + "shared")
-               |  }
-               |}
-               |""".stripMargin,
-          os.rel / "MyJvmTests.scala" ->
-            """//> using target.platform "jvm"
-              |
-              |class MyJvmTests extends munit.FunSuite {
-              |  test("jvm") {
-              |    println("Hello from " + "jvm")
-              |  }
-              |}
-              |""".stripMargin,
-          os.rel / "MyJsTests.scala" ->
-            """//> using target.platform "js"
-              |
-              |class MyJsTests extends munit.FunSuite {
-              |  test("js") {
-              |    println("Hello from " + "js")
-              |  }
-              |}
-              |""".stripMargin
-        )
+        os.rel / "MyTests.scala" ->
+          s"""//> using lib "org.scalameta::munit::0.7.29"
+             |//> using platform $platforms
+             |
+             |class MyTests extends munit.FunSuite {
+             |  test("shared") {
+             |    println("Hello from " + "shared")
+             |  }
+             |}
+             |""".stripMargin,
+        os.rel / "MyJvmTests.scala" ->
+          """//> using target.platform "jvm"
+            |
+            |class MyJvmTests extends munit.FunSuite {
+            |  test("jvm") {
+            |    println("Hello from " + "jvm")
+            |  }
+            |}
+            |""".stripMargin,
+        os.rel / "MyJsTests.scala" ->
+          """//> using target.platform "js"
+            |
+            |class MyJsTests extends munit.FunSuite {
+            |  test("js") {
+            |    println("Hello from " + "js")
+            |  }
+            |}
+            |""".stripMargin
       )
       if (supportsNative)
         inputs0 = inputs0.add(
@@ -567,25 +541,23 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
 
   def jsDomTest(): Unit = {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "JsDom.scala" ->
-          s"""//> using lib "com.lihaoyi::utest::0.7.10"
-             |//> using lib "org.scala-js::scalajs-dom::2.1.0"
-             |
-             |import utest._
-             |
-             |import org.scalajs.dom.document
-             |
-             |object MyTests extends TestSuite {
-             |  val tests = Tests {
-             |    test("Hello World") {
-             |      assert(document.querySelectorAll("p").size == 0)
-             |      println("Hello from tests")
-             |    }
-             |  }
-             |}
-             |""".stripMargin
-      )
+      os.rel / "JsDom.scala" ->
+        s"""//> using lib "com.lihaoyi::utest::0.7.10"
+           |//> using lib "org.scala-js::scalajs-dom::2.1.0"
+           |
+           |import utest._
+           |
+           |import org.scalajs.dom.document
+           |
+           |object MyTests extends TestSuite {
+           |  val tests = Tests {
+           |    test("Hello World") {
+           |      assert(document.querySelectorAll("p").size == 0)
+           |      println("Hello from tests")
+           |    }
+           |  }
+           |}
+           |""".stripMargin
     )
     inputs.fromRoot { root =>
       // install jsdom library

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -7,14 +7,14 @@ import scala.annotation.tailrec
 abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
     extends ScalaCliSuite with TestScalaVersionArgs {
 
-  protected val jvmOptions =
+  protected val jvmOptions: Seq[String] =
     // seems munit requires this with Scala 3
     if (actualScalaVersion.startsWith("3.")) Seq("--jvm", "11")
     else Nil
-  protected lazy val baseExtraOptions = TestUtil.extraOptions ++ jvmOptions
-  private lazy val extraOptions       = scalaVersionArgs ++ baseExtraOptions
+  protected lazy val baseExtraOptions: Seq[String] = TestUtil.extraOptions ++ jvmOptions
+  private lazy val extraOptions: Seq[String]       = scalaVersionArgs ++ baseExtraOptions
 
-  val successfulTestInputs = TestInputs(
+  val successfulTestInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
       """//> using lib "org.scalameta::munit::0.7.29"
         |
@@ -27,7 +27,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
         |""".stripMargin
   )
 
-  val failingTestInputs = TestInputs(
+  val failingTestInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
       """//> using lib "org.scalameta::munit::0.7.29"
         |
@@ -39,7 +39,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
         |""".stripMargin
   )
 
-  val successfulUtestInputs = TestInputs(
+  val successfulUtestInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
       """//> using lib "com.lihaoyi::utest::0.7.10"
         |import utest._
@@ -55,7 +55,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
         |""".stripMargin
   )
 
-  val successfulUtestJsInputs = TestInputs(
+  val successfulUtestJsInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
       """//> using lib "com.lihaoyi::utest::0.7.10"
         |import utest._
@@ -73,7 +73,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
         |""".stripMargin
   )
 
-  val successfulUtestNativeInputs = TestInputs(
+  val successfulUtestNativeInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
       """//> using lib "com.lihaoyi::utest::0.7.10"
         |import utest._
@@ -93,7 +93,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
         |""".stripMargin
   )
 
-  val successfulScalaCheckFromCatsNativeInputs = TestInputs(
+  val successfulScalaCheckFromCatsNativeInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
       """//> using scala "2.13.8"
         |//> using platform "native"
@@ -110,7 +110,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
         |}""".stripMargin
   )
 
-  val successfulJunitInputs = TestInputs(
+  val successfulJunitInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
       """//> using lib "com.novocode:junit-interface:0.11"
         |import org.junit.Test
@@ -126,7 +126,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
         |""".stripMargin
   )
 
-  val severalTestsInputs = TestInputs(
+  val severalTestsInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
       """//> using lib "org.scalameta::munit::0.7.29"
         |
@@ -149,7 +149,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
         |""".stripMargin
   )
 
-  val successfulWeaverInputs = TestInputs(
+  val successfulWeaverInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
       """//> using libs "com.disneystreaming::weaver-cats:0.7.6", "com.eed3si9n.expecty::expecty:0.15.4+5-f1d8927e-SNAPSHOT"
         |import weaver._
@@ -163,7 +163,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
         |""".stripMargin
   )
 
-  val successfulESModuleTestInputs = TestInputs(
+  val successfulESModuleTestInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
       """//> using lib "org.scalameta::munit::0.7.29"
         |//> using jsModuleKind "esmodule"
@@ -343,7 +343,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
 
-  val platforms = {
+  val platforms: Seq[(String, Seq[String])] = {
     val maybeJs = Seq("JS" -> Seq("--js"))
     val maybeNative =
       if (actualScalaVersion.startsWith("2."))

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
@@ -8,30 +8,28 @@ class TestTestsDefault extends TestTestDefinitions(scalaVersionOpt = None) {
 
   test("Pure Java with Scala tests") {
     val inputs = TestInputs(
-      Seq(
-        os.rel / "Messages.java" ->
-          """package messages;
-            |
-            |public final class Messages {
-            |  public final static String HELLO = "Hello";
-            |}
-            |""".stripMargin,
-        os.rel / "test" / "MessagesTests.scala" ->
-          """//> using scala "2.13"
-            |//> using lib "com.lihaoyi::utest::0.7.10"
-            |package messages
-            |package tests
-            |import utest._
-            |
-            |object MessagesTests extends TestSuite {
-            |  val tests = Tests {
-            |    test("hello") {
-            |      assert(Messages.HELLO == "Hello")
-            |    }
-            |  }
-            |}
-            |""".stripMargin
-      )
+      os.rel / "Messages.java" ->
+        """package messages;
+          |
+          |public final class Messages {
+          |  public final static String HELLO = "Hello";
+          |}
+          |""".stripMargin,
+      os.rel / "test" / "MessagesTests.scala" ->
+        """//> using scala "2.13"
+          |//> using lib "com.lihaoyi::utest::0.7.10"
+          |package messages
+          |package tests
+          |import utest._
+          |
+          |object MessagesTests extends TestSuite {
+          |  val tests = Tests {
+          |    test("hello") {
+          |      assert(Messages.HELLO == "Hello")
+          |    }
+          |  }
+          |}
+          |""".stripMargin
     )
 
     inputs.fromRoot { root =>

--- a/modules/integration/src/test/scala/scala/cli/integration/UpdateTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/UpdateTests.scala
@@ -10,13 +10,11 @@ class UpdateTests extends ScalaCliSuite {
   val dummyScalaCliFirstName = "DummyScalaCli-1.scala"
   val dummyScalaCliBinName   = "scala-cli-dummy-test"
   val testInputs = TestInputs(
-    Seq(
-      os.rel / dummyScalaCliFirstName ->
-        s"""
-           |object DummyScalaCli extends App {
-           |  println(\"$firstVersion\")
-           |}""".stripMargin
-    )
+    os.rel / dummyScalaCliFirstName ->
+      s"""
+         |object DummyScalaCli extends App {
+         |  println(\"$firstVersion\")
+         |}""".stripMargin
   )
 
   private def packageDummyScalaCli(root: os.Path, dummyScalaCliFileName: String, output: String) = {

--- a/modules/integration/src/test/scala/scala/cli/integration/UpdateTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/UpdateTests.scala
@@ -9,7 +9,7 @@ class UpdateTests extends ScalaCliSuite {
   val firstVersion           = "0.0.1"
   val dummyScalaCliFirstName = "DummyScalaCli-1.scala"
   val dummyScalaCliBinName   = "scala-cli-dummy-test"
-  val testInputs = TestInputs(
+  val testInputs: TestInputs = TestInputs(
     os.rel / dummyScalaCliFirstName ->
       s"""
          |object DummyScalaCli extends App {

--- a/modules/integration/src/test/scala/scala/cli/integration/util/BloopUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/util/BloopUtil.scala
@@ -31,7 +31,7 @@ object BloopUtil {
   private def bloopOrg(currentBloopVersion: String): String =
     currentBloopVersion.split("[-.]") match {
       case Array(majStr, minStr, patchStr, _*) =>
-        import scala.math.Ordering.Implicits._
+        import scala.math.Ordering.Implicits.*
         val maj   = majStr.toInt
         val min   = minStr.toInt
         val patch = patchStr.toInt
@@ -70,7 +70,7 @@ object BloopUtil {
         args
       )
   }
-  def killBloop() = {
+  def killBloop(): Unit = {
     val javaProcesses = os.proc("jps", "-l").call().out.text().linesIterator
     val bloopPidReg   = "(\\d+).*bloop[.]Bloop".r
     val bloopPids = javaProcesses.flatMap { l =>
@@ -79,6 +79,6 @@ object BloopUtil {
         case _                => None
       }
     }.toList
-    bloopPids.foreach(TestUtil.kill _)
+    bloopPids.foreach(TestUtil.kill)
   }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/util/DockerServer.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/util/DockerServer.scala
@@ -5,7 +5,7 @@ package scala.cli.integration.util
 import com.spotify.docker.client.DefaultDockerClient
 import com.spotify.docker.client.messages.{ContainerConfig, HostConfig, PortBinding}
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Try
 
 final case class DockerServer(
@@ -39,7 +39,7 @@ object DockerServer {
     val containerConfig = ContainerConfig.builder()
       .hostConfig(hostConfig)
       .image(image)
-      .exposedPorts(portBindings.keys.toSeq: _*)
+      .exposedPorts(portBindings.keys.toSeq*)
       .build()
 
     var idOpt = Option.empty[String]


### PR DESCRIPTION
Nothing truly important, but removing close to 300 lines in `Seq` constructions and unnecessary brackets was something I thought about doing for a while now. 
That's 117 unnecessary lines in `RunTestDefinitions.scala` alone. 🤯 