### PR TITLE
Update org name to VirtusLab for downloading scalafmt-native-image

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.5.8"
+version = "3.5.9"
 
 align.preset = more
 maxColumn = 100

--- a/modules/cli/src/main/scala/scala/cli/commands/util/FmtOptionsUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/FmtOptionsUtil.scala
@@ -5,15 +5,22 @@ import scala.cli.commands.FmtOptions
 import scala.cli.commands.util.SharedOptionsUtil._
 import scala.util.Properties
 
+import coursier.core.Version
+
 object FmtOptionsUtil {
   implicit class FmtOptionsOps(v: FmtOptions) {
     import v._
     def binaryUrl(version: String): (String, Boolean) = {
       val osArchSuffix0 = osArchSuffix.map(_.trim).filter(_.nonEmpty)
         .getOrElse(FetchExternalBinary.platformSuffix())
-      val tag0           = scalafmtTag.getOrElse("v" + version)
-      val gitHubOrgName0 = scalafmtGithubOrgName.getOrElse("alexarchambault/scalafmt-native-image")
-      val extension0     = if (Properties.isWin) ".zip" else ".gz"
+      val tag0 = scalafmtTag.getOrElse("v" + version)
+      val gitHubOrgName0 = scalafmtGithubOrgName.getOrElse {
+        if (Version(version) < Version("3.5.9"))
+          "scala-cli/scalafmt-native-image"
+        else // from version 3.5.9 scalafmt-native-image repository was moved to VirtusLab organisation
+          "virtuslab/scalafmt-native-image"
+      }
+      val extension0 = if (Properties.isWin) ".zip" else ".gz"
       val url =
         s"https://github.com/$gitHubOrgName0/releases/download/$tag0/scalafmt-$osArchSuffix0$extension0"
       (url, !tag0.startsWith("v"))

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -106,7 +106,7 @@ object Deps {
   def scala3Compiler(sv: String) = ivy"org.scala-lang:scala3-compiler_3:$sv"
   def scalaAsync         = ivy"org.scala-lang.modules::scala-async:1.0.1".exclude("*" -> "*")
   def scalac(sv: String) = ivy"org.scala-lang:scala-compiler:$sv"
-  def scalafmtCli        = ivy"org.scalameta:scalafmt-cli_2.13:3.5.8"
+  def scalafmtCli        = ivy"org.scalameta:scalafmt-cli_2.13:3.5.9"
   // Force using of 2.13 - is there a better way?
   def scalaJsEnvJsdomNodejs =
     ivy"org.scala-js:scalajs-env-jsdom-nodejs_2.13:1.1.0"


### PR DESCRIPTION
`scalafmt-native-image` is now downloaded from virtuslab organisation. Native launcher is built in fork [scalafmt-native-image](https://github.com/VirtusLab/scalafmt-native-image)