### PR TITLE
Add version of Scala to the output of version command

### DIFF
--- a/modules/cli-options/src/main/scala/scala/cli/commands/VersionOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/VersionOptions.scala
@@ -6,7 +6,13 @@ import caseapp._
 @HelpMessage("Print `scala-cli` version")
 final case class VersionOptions(
   @Recurse
-    verbosity: VerbosityOptions = VerbosityOptions()
+    verbosity: VerbosityOptions = VerbosityOptions(),
+  @HelpMessage("Show only plain scala-cli version")
+  @Name("cli")
+    cliVersion: Boolean = false,
+  @HelpMessage("Show only plain scala version") 
+  @Name("scala")
+    scalaVersion: Boolean = false
 )
 // format: on
 

--- a/modules/cli/src/main/java/scala/cli/internal/Argv0SubstWindows.java
+++ b/modules/cli/src/main/java/scala/cli/internal/Argv0SubstWindows.java
@@ -1,0 +1,19 @@
+package scala.cli.internal;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
+import java.nio.file.Path;
+
+@TargetClass(className = "scala.cli.internal.Argv0")
+@Platforms({Platform.WINDOWS.class})
+final class Argv0SubstWindows {
+
+    @Substitute
+    String get(String defaultValue) {
+        return coursier.jniutils.ModuleFileName.get();
+    }
+
+}

--- a/modules/cli/src/main/scala/scala/cli/ScalaCliCommands.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCliCommands.scala
@@ -18,7 +18,7 @@ class ScalaCliCommands(
   isSipScala: Boolean
 ) extends CommandsEntryPoint {
 
-  lazy val actualDefaultCommand = new Default(help)
+  lazy val actualDefaultCommand = new Default(help, isSipScala)
 
   // for debugging purposes - allows to run the scala-cli-signing binary from the Scala CLI JVM launcher
   private lazy val pgpUseBinaryCommands =
@@ -64,7 +64,7 @@ class ScalaCliCommands(
     Uninstall,
     UninstallCompletions,
     Update,
-    Version
+    new Version(isSipScala = isSipScala)
   ) ++ (if (pgpUseBinaryCommands) Nil else pgpCommands.allScalaCommands.toSeq) ++
     (if (pgpUseBinaryCommands) pgpBinaryCommands.allScalaCommands.toSeq else Nil)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/About.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/About.scala
@@ -11,12 +11,7 @@ class About(isSipScala: Boolean) extends ScalaCommand[AboutOptions] {
 
   def run(options: AboutOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.verbosity.verbosity
-    val version            = Constants.version
-    val detailedVersionOpt = Constants.detailedVersion.filter(_ != version)
-    val appName =
-      if (isSipScala) "Scala command"
-      else "Scala CLI"
-    println(s"$appName version $version" + detailedVersionOpt.fold("")(" (" + _ + ")"))
+    println(Version.versionInfo(isSipScala))
     val newestScalaCliVersion = Update.newestScalaCliVersion(options.ghToken.map(_.get()))
     val isOutdated = CommandUtils.isOutOfDateVersion(
       newestScalaCliVersion,

--- a/modules/cli/src/main/scala/scala/cli/commands/Default.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Default.scala
@@ -7,7 +7,8 @@ import scala.build.internal.Constants
 import scala.cli.{CurrentParams, ScalaCliHelp}
 
 class Default(
-  actualHelp: => RuntimeCommandsHelp
+  actualHelp: => RuntimeCommandsHelp,
+  isSipScala: Boolean
 ) extends ScalaCommand[DefaultOptions] {
 
   private def defaultHelp: String     = actualHelp.help(ScalaCliHelp.helpFormat)
@@ -30,7 +31,7 @@ class Default(
   def run(options: DefaultOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.runOptions.shared.logging.verbosity
     if (options.version)
-      println(Constants.version)
+      println(Version.versionInfo(isSipScala))
     else if (anyArgs)
       Run.run(
         options.runOptions,

--- a/modules/cli/src/main/scala/scala/cli/commands/InstallHome.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/InstallHome.scala
@@ -51,12 +51,12 @@ object InstallHome extends ScalaCommand[InstallHomeOptions] {
     val newScalaCliBinPath = os.Path(options.scalaCliBinaryPath, os.pwd)
 
     val newVersion: String =
-      os.proc(newScalaCliBinPath, "version").call(cwd = os.pwd).out.text().trim
+      os.proc(newScalaCliBinPath, "version", "--cli-version").call(cwd = os.pwd).out.text().trim
 
     // Backward compatibility - previous versions not have the `--version` parameter
     val oldVersion: String =
       if (os.isFile(destBinPath)) {
-        val res = os.proc(destBinPath, "version").call(cwd = os.pwd, check = false)
+        val res = os.proc(destBinPath, "version", "--cli-version").call(cwd = os.pwd, check = false)
         if (res.exitCode == 0)
           res.out.text().trim
         else

--- a/modules/cli/src/main/scala/scala/cli/commands/Update.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Update.scala
@@ -95,7 +95,7 @@ object Update extends ScalaCommand[UpdateOptions] {
   }
 
   private def getCurrentVersion(scalaCliBinPath: os.Path): String = {
-    val res = os.proc(scalaCliBinPath, "version").call(cwd = os.pwd, check = false)
+    val res = os.proc(scalaCliBinPath, "version", "--cli-version").call(cwd = os.pwd, check = false)
     if (res.exitCode == 0)
       res.out.text().trim
     else

--- a/modules/cli/src/main/scala/scala/cli/commands/Version.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Version.scala
@@ -5,10 +5,26 @@ import caseapp._
 import scala.build.internal.Constants
 import scala.cli.CurrentParams
 
-object Version extends ScalaCommand[VersionOptions] {
+class Version(isSipScala: Boolean) extends ScalaCommand[VersionOptions] {
   override def group = "Miscellaneous"
   def run(options: VersionOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.verbosity.verbosity
-    println(Constants.version)
+    if (options.cliVersion)
+      println(Constants.version)
+    else if (options.scalaVersion)
+      println(Constants.defaultScalaVersion)
+    else
+      println(Version.versionInfo(isSipScala))
   }
+}
+
+object Version {
+  def versionInfo(isSipScala: Boolean) =
+    val version            = Constants.version
+    val detailedVersionOpt = Constants.detailedVersion.filter(_ != version).fold("")(" (" + _ + ")")
+    val appName =
+      if (isSipScala) "Scala code runner"
+      else "Scala CLI"
+    s"""$appName version: $version$detailedVersionOpt
+       |Scala version (default): ${Constants.defaultScalaVersion}""".stripMargin
 }

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1973,6 +1973,26 @@ Interactive mode
 
 Enable actionable diagnostics
 
+## Version options
+
+Available in commands:
+- [`version`](./commands.md#version)
+
+
+<!-- Automatically generated, DO NOT EDIT MANUALLY -->
+
+#### `--cli-version`
+
+Aliases: `--cli`
+
+Show only plain scala-cli version
+
+#### `--scala-version`
+
+Aliases: `--scala`
+
+Show only plain scala version
+
 ## Watch options
 
 Available in commands:

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -475,6 +475,7 @@ Print `scala-cli` version
 
 Accepts options:
 - [verbosity](./cli-options.md#verbosity-options)
+- [version](./cli-options.md#version-options)
 
 ## Hidden commands
 


### PR DESCRIPTION
I added support for printing info about version of Scala CLI and Scala, the following commands return output:

```
$ scala-cli --version
Scala CLI version 0.1.11
Default Scala version: 3.1.3
$ scala-cli -version
Scala CLI version 0.1.11
Default Scala version: 3.1.3
$ scala-cli version
Scala CLI version 0.1.11
Default Scala version: 3.1.3
```

I skipped added support for printing version for the following command:
```
$ scala-cli -v
```

now `-v` allows user to increase verbosity, to avoid double meaning of `-v`, I skip adding support for this case