### PR TITLE
Correct using directives on configuration.md 

### DIFF
--- a/website/docs/guides/configuration.md
+++ b/website/docs/guides/configuration.md
@@ -46,8 +46,8 @@ This is achieved by specifying `using` directives inside comments at the top of 
 
 ```scala
 //> using scala "2.13"
-//> using scala-js
-//> using options -Xasync
+//> using platform "scala-js"
+//> using options "-Xasync"
 
 // package and import statements follow here ...
 ```


### PR DESCRIPTION
I came across the `//> using`-style directive in this page and it didn't work. The syntax on https://scala-cli.virtuslab.org/docs/guides/using-directives/ seems to work so I updated them here.