### PR TITLE
Detect ARM64 macs when downloading coursier launcher

### DIFF
--- a/mill
+++ b/mill
@@ -150,7 +150,12 @@ if [ "$(expr substr $(uname -s) 1 5 2>/dev/null)" == "Linux" ]; then
   fi
   cache_base="$HOME/.cache/coursier/v1"
 elif [ "$(uname)" == "Darwin" ]; then
-  cs_url="https://github.com/coursier/coursier/releases/download/v$coursier_version/cs-x86_64-apple-darwin.gz"
+  # TODO: remove once coursier-m1 and coursier mainline are merged
+  if [ "$(uname -p)" == "arm" ]; then 
+    cs_url="https://github.com/VirtusLab/coursier-m1/releases/download/v$coursier_version/cs-aarch64-apple-darwin.gz"
+  else 
+    cs_url="https://github.com/coursier/coursier/releases/download/v$coursier_version/cs-x86_64-apple-darwin.gz"
+  fi
   cache_base="$HOME/Library/Caches/Coursier/v1"
 else
   # assuming Windows…


### PR DESCRIPTION
This has knock off effects on the JDK that will be downloaded, and subsequently ability to build native image.

With this change I was able to built native image using `./.github/scripts/generate-native-image.sh` and it seems to have the correct architecture.