### PR TITLE
Fix backwards compat for `-e` and `--scalac-help`

### DIFF
--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedOptions.scala
@@ -42,14 +42,15 @@ final case class SharedOptions(
   @Name("scalaBin")
   @Name("B")
     scalaBinaryVersion: Option[String] = None,
-  
+
   @Group("Scala")
   @HelpMessage("Show help for scalac. This is an alias for --scalac-option -help")
+  @Name("helpScalac")
     scalacHelp: Boolean = false,
 
   @Recurse
     snippet: SnippetOptions = SnippetOptions(),
-  
+
   @Recurse
     markdown: MarkdownOptions = MarkdownOptions(),
 

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SnippetOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SnippetOptions.scala
@@ -6,21 +6,32 @@ import caseapp._
 final case class SnippetOptions(
   @Group("Scala")
   @HelpMessage("Allows to execute a passed string as a Scala script")
-  @Name("e")
-  @Name("executeScript")
-  @Name("executeScalaScript")
-  @Name("executeSc")
     scriptSnippet: List[String] = List.empty,
 
   @Group("Scala")
+  @HelpMessage("A synonym to --script-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly")
+  @Hidden
+  @Name("executeScalaScript")
+  @Name("executeSc")
+  @Name("e")
+    executeScript: List[String] = List.empty,
+
+  @Group("Scala")
   @HelpMessage("Allows to execute a passed string as Scala code")
-  @Name("executeScala")
     scalaSnippet: List[String] = List.empty,
+
+  @Group("Scala")
+  @HelpMessage("A synonym to --scala-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly")
+  @Hidden
+    executeScala: List[String] = List.empty,
 
   @Group("Java")
   @HelpMessage("Allows to execute a passed string as Java code")
-  @Name("executeJava")
     javaSnippet: List[String] = List.empty,
+
+   @Group("Java")
+  @HelpMessage("A synonym to --scala-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly")
+    executeJava: List[String] = List.empty,
 )
 // format: on
 

--- a/modules/cli/src/main/scala/scala/cli/commands/Default.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Default.scala
@@ -33,10 +33,12 @@ class Default(
     CurrentParams.verbosity = options.shared.logging.verbosity
     if options.version then println(Version.versionInfo(isSipScala))
     else
-      (
-        if args.remaining.nonEmpty then RunOptions.parser
-        else ReplOptions.parser
-      ).parse(rawArgs) match
+      {
+        val shouldDefaultToRun =
+          args.remaining.nonEmpty || options.shared.snippet.executeScript.nonEmpty ||
+          options.shared.snippet.executeScala.nonEmpty || options.shared.snippet.executeJava.nonEmpty
+        if shouldDefaultToRun then RunOptions.parser else ReplOptions.parser
+      }.parse(rawArgs) match
         case Left(e)                              => error(e)
         case Right((replOptions: ReplOptions, _)) => Repl.run(replOptions, args)
         case Right((runOptions: RunOptions, _))   => Run.run(runOptions, args)

--- a/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
@@ -9,6 +9,7 @@ import scala.build.errors.BuildException
 import scala.build.internal.Runner
 import scala.build.options.{BuildOptions, JavaOpt, Scope}
 import scala.cli.CurrentParams
+import scala.cli.commands.Run.maybePrintSimpleScalacOutput
 import scala.cli.commands.util.CommonOps._
 import scala.cli.commands.util.SharedOptionsUtil._
 import scala.util.Properties
@@ -60,7 +61,9 @@ object Repl extends ScalaCommand[ReplOptions] {
     CurrentParams.workspaceOpt = Some(inputs.workspace)
 
     val initialBuildOptions = buildOptions(options)
-    val threads             = BuildThreads.create()
+    maybePrintSimpleScalacOutput(options, initialBuildOptions)
+
+    val threads = BuildThreads.create()
 
     val compilerMaker = options.shared.compilerMaker(threads)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/util/SharedOptionsUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/SharedOptionsUtil.scala
@@ -342,11 +342,15 @@ object SharedOptionsUtil extends CommandHelpers {
         workspace.forcedWorkspaceOpt,
         input.defaultForbiddenDirectories,
         input.forbid,
-        scriptSnippetList = v.snippet.scriptSnippet,
-        scalaSnippetList = v.snippet.scalaSnippet,
-        javaSnippetList = v.snippet.javaSnippet,
+        scriptSnippetList = allScriptSnippets,
+        scalaSnippetList = allScalaSnippets,
+        javaSnippetList = allJavaSnippets,
         enableMarkdown = v.markdown.enableMarkdown
       )
+
+    def allScriptSnippets: List[String] = v.snippet.scriptSnippet ++ v.snippet.executeScript
+    def allScalaSnippets: List[String]  = v.snippet.scalaSnippet ++ v.snippet.executeScala
+    def allJavaSnippets: List[String]   = v.snippet.javaSnippet ++ v.snippet.executeJava
 
     def validateInputArgs(args: Seq[String]): Seq[Either[String, Seq[Inputs.Element]]] =
       Inputs.validateArgs(

--- a/modules/integration/src/test/scala/scala/cli/integration/DefaultTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DefaultTests.scala
@@ -34,6 +34,66 @@ class DefaultTests extends ScalaCliSuite {
     }
   }
 
+  test("default to the run sub-command when a script snippet is passed with -e") {
+    TestInputs.empty.fromRoot { root =>
+      val msg       = "Hello world"
+      val quotation = TestUtil.argQuotationMark
+      val res =
+        os.proc(TestUtil.cli, "-e", s"println($quotation$msg$quotation)", TestUtil.extraOptions)
+          .call(cwd = root)
+      expect(res.out.text().trim == msg)
+    }
+  }
+
+  test("default to the run sub-command when a scala snippet is passed with --execute-scala") {
+    TestInputs.empty.fromRoot { root =>
+      val msg       = "Hello world"
+      val quotation = TestUtil.argQuotationMark
+      val res =
+        os.proc(
+          TestUtil.cli,
+          "--execute-scala",
+          s"@main def main() = println($quotation$msg$quotation)",
+          TestUtil.extraOptions
+        )
+          .call(cwd = root)
+      expect(res.out.text().trim == msg)
+    }
+  }
+
+  test("default to the run sub-command when a java snippet is passed with --execute-java") {
+    TestInputs.empty.fromRoot { root =>
+      val msg       = "Hello world"
+      val quotation = TestUtil.argQuotationMark
+      val res =
+        os.proc(
+          TestUtil.cli,
+          "--execute-java",
+          s"public class Main { public static void main(String[] args) { System.out.println($quotation$msg$quotation); } }",
+          TestUtil.extraOptions
+        )
+          .call(cwd = root)
+      expect(res.out.text().trim == msg)
+    }
+  }
+
+  test("running scala-cli with a script snippet passed with -e shouldn't allow repl-only options") {
+    TestInputs.empty.fromRoot { root =>
+      val replSpecificOption = "--repl-dry-run"
+      val res =
+        os.proc(
+          TestUtil.cli,
+          "-e",
+          "println()",
+          replSpecificOption,
+          TestUtil.extraOptions
+        )
+          .call(cwd = root, mergeErrIntoOut = true, check = false)
+      expect(res.exitCode == 1)
+      expect(res.out.trim == unrecognizedArgMessage(replSpecificOption))
+    }
+  }
+
   private def unrecognizedArgMessage(argName: String) = {
     val scalaCli = if (TestUtil.isNativeCli) TestUtil.cliPath else "scala-cli"
     s"""

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -1968,7 +1968,13 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
       val msg       = "Hello world"
       val quotation = TestUtil.argQuotationMark
       val res =
-        os.proc(TestUtil.cli, "run", "-e", s"println($quotation$msg$quotation)", extraOptions)
+        os.proc(
+          TestUtil.cli,
+          "run",
+          "--script-snippet",
+          s"println($quotation$msg$quotation)",
+          extraOptions
+        )
           .call(cwd = root)
       expect(res.out.text().trim == msg)
     }

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1793,6 +1793,8 @@ Set the Scala binary version
 
 #### `--scalac-help`
 
+Aliases: `--help-scalac`
+
 Show help for scalac. This is an alias for --scalac-option -help
 
 #### `--extra-jars`

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1857,21 +1857,29 @@ Available in commands:
 
 #### `--script-snippet`
 
-Aliases: `-e`, `--execute-script`, `--execute-scala-script`, `--execute-sc`
-
 Allows to execute a passed string as a Scala script
+
+#### `--execute-script`
+
+Aliases: `--execute-scala-script`, `--execute-sc`, `-e`
+
+A synonym to --script-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
 #### `--scala-snippet`
 
-Aliases: `--execute-scala`
-
 Allows to execute a passed string as Scala code
+
+#### `--execute-scala`
+
+A synonym to --scala-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
 #### `--java-snippet`
 
-Aliases: `--execute-java`
-
 Allows to execute a passed string as Java code
+
+#### `--execute-java`
+
+A synonym to --scala-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
 ## Test options
 


### PR DESCRIPTION
As we now default to the `repl` sub-command when no args are passed, the `-e` option requires special handling.

Normally, adding a script snippet for the `repl` just adds it on the classpath.
```text
▶ scala-cli repl -e 'println("Hello")'
Welcome to Scala 3.1.3 (17.0.2, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                             
scala> snippet_sc.main(Array.empty)
Hello
                                                                                                                                                             
scala> 
```

However, the `scala` command's `-e` option's behaviour is closer to the `run` sub-command of Scala CLI.
And so, when `scala-cli` is being run without the `repl` sub-command passed explicitly, passing `-e` will now default to `run`.
```text
▶ scala-cli -e 'println("Hello")'
Hello
```
Using the `--script-snippet` alias instead of `-e` will still pass the snippet to the `repl`.
```text
▶ scala-cli --script-snippet 'println("Hello")'
Welcome to Scala 3.1.3 (17.0.2, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                             
scala> snippet_sc.main(Array.empty)
Hello
```

Also, this PR fixes `--scalac-help` (and other help options passed to the compiler through `--scalac-option`) and adds `--help-scalac` as an alias).