### PR TITLE
Improve the error message for unsupported Scala version with Ammonite

### DIFF
--- a/modules/core/src/main/scala/scala/build/errors/CantDownloadAmmoniteError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/CantDownloadAmmoniteError.scala
@@ -1,0 +1,28 @@
+package scala.build.errors
+
+import coursier.error.ResolutionError
+
+import scala.build.Position
+
+final class CantDownloadAmmoniteError(
+  ammoniteVersion: String,
+  scalaVersion: String,
+  underlying: ResolutionError.CantDownloadModule,
+  override val positions: Seq[Position]
+) extends BuildException(
+      s"""Can't download Ammonite $ammoniteVersion for Scala $scalaVersion.
+         |Ammonite with this Scala version might not yet be supported.
+         |Try passing a different Scala version with the -S option.""".stripMargin,
+      positions,
+      underlying
+    )
+
+object CantDownloadAmmoniteError {
+  def apply(
+    ammoniteVersion: String,
+    scalaVersion: String,
+    underlying: ResolutionError.CantDownloadModule,
+    positions: Seq[Position]
+  ): CantDownloadAmmoniteError =
+    new CantDownloadAmmoniteError(ammoniteVersion, scalaVersion, underlying, positions)
+}

--- a/modules/core/src/main/scala/scala/build/errors/FetchingDependenciesError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/FetchingDependenciesError.scala
@@ -5,10 +5,15 @@ import coursier.error.CoursierError
 import scala.build.Position
 
 final class FetchingDependenciesError(
-  underlying: CoursierError,
-  positions: Seq[Position]
+  val underlying: CoursierError,
+  override val positions: Seq[Position]
 ) extends BuildException(
       underlying.getMessage,
       positions,
       underlying
     )
+
+object FetchingDependenciesError {
+  def unapply(e: FetchingDependenciesError): Option[(CoursierError, Seq[Position])] =
+    Some(e.underlying -> e.positions)
+}


### PR DESCRIPTION
Before
```
▶ scala-cli --ammonite -S 3.2.0
Downloading Ammonite 2.5.4-15-f4a8969b
Downloading Ammonite 2.5.4-15-f4a8969b sources
[error]  Error downloading com.lihaoyi:ammonite_3.2.0:2.5.4-15-f4a8969b
  not found: /Users/pchabelski/.ivy2/local/com.lihaoyi/ammonite_3.2.0/2.5.4-15-f4a8969b/ivys/ivy.xml
  not found: https://repo1.maven.org/maven2/com/lihaoyi/ammonite_3.2.0/2.5.4-15-f4a8969b/ammonite_3.2.0-2.5.4-15-f4a8969b.pom
  not found: /Users/pchabelski/Library/Caches/ScalaCli/local-repo/v0.1.12/com.lihaoyi/ammonite_3.2.0/2.5.4-15-f4a8969b/ivys/ivy.xml
  No fallback URL found
```

After
```
▶ scala-cli --ammonite -S 3.2.0
Downloading Ammonite 2.5.4-19-cd76521f
Downloading Ammonite 2.5.4-19-cd76521f sources
[error]  Can't download Ammonite 2.5.4-19-cd76521f for Scala 3.2.0.
Ammonite with this Scala version might not yet be supported.
Try passing a different Scala version with the -S option.
```