### PR TITLE
Make `-d` and `-classpath` options backwards compatible with the `scala` command

### DIFF
--- a/modules/cli-options/src/main/scala/scala/cli/commands/CompileOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/CompileOptions.scala
@@ -14,9 +14,9 @@ final case class CompileOptions(
     cross: CrossOptions = CrossOptions(),
 
   @Name("p")
-  @Name("classpath")
+  @Name("printClasspath")
   @HelpMessage("Print the resulting class path")
-    classPath: Boolean = false,
+    printClassPath: Boolean = false,
 
   @Name("output-directory")
   @HelpMessage("Copy compilation results to output directory using either relative or absolute path")

--- a/modules/cli-options/src/main/scala/scala/cli/commands/CompileOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/CompileOptions.scala
@@ -18,13 +18,6 @@ final case class CompileOptions(
   @HelpMessage("Print the resulting class path")
     printClassPath: Boolean = false,
 
-  @Name("output-directory")
-  @Name("d")
-  @Name("destination")
-  @HelpMessage("Copy compilation results to output directory using either relative or absolute path")
-  @ValueDescription("/example/path")
-    output: Option[String] = None,
-
   @HelpMessage("Compile test scope")
     test: Boolean = false
 )

--- a/modules/cli-options/src/main/scala/scala/cli/commands/CompileOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/CompileOptions.scala
@@ -19,6 +19,8 @@ final case class CompileOptions(
     printClassPath: Boolean = false,
 
   @Name("output-directory")
+  @Name("d")
+  @Name("destination")
   @HelpMessage("Copy compilation results to output directory using either relative or absolute path")
   @ValueDescription("/example/path")
     output: Option[String] = None,

--- a/modules/cli-options/src/main/scala/scala/cli/commands/ScalacOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/ScalacOptions.scala
@@ -41,6 +41,12 @@ object ScalacOptions {
   val ScalacPrintOptions: Set[String] =
     scalacOptionsPurePrefixes ++ Set("-help", "-Xshow-phases", "-Vphases")
 
+  /** This includes all the scalac options which are redirected to native Scala CLI options. */
+  val ScalaCliRedirectedOptions = Set(
+    "-classpath", // redirected to --extra-jars
+    "-d"          // redirected to --compilation-output
+  )
+
   private val scalacOptionsArgument: Argument[List[String]] =
     new Argument[List[String]] {
 

--- a/modules/cli-options/src/main/scala/scala/cli/commands/ScalacOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/ScalacOptions.scala
@@ -13,6 +13,7 @@ final case class ScalacOptions(
   @HelpMessage("Add a scalac option")
   @ValueDescription("option")
   @Name("scala-opt")
+  @Name("scala-option")
   @Name("O")
     scalacOption: List[String] = Nil
 )
@@ -21,7 +22,7 @@ final case class ScalacOptions(
 object ScalacOptions {
 
   private val scalacOptionsArg = Arg("scalacOption")
-    .withExtraNames(Seq(Name("scala-opt"), Name("O")))
+    .withExtraNames(Seq(Name("scala-opt"), Name("O"), Name("scala-option")))
     .withValueDescription(Some(ValueDescription("option")))
     .withHelpMessage(Some(HelpMessage(
       "Add a `scalac` option. Note that options starting with `-g`, `-language`, `-opt`, `-P`, `-target`, `-V`, `-W`, `-X`, and `-Y` are assumed to be Scala compiler options and don't require to be passed after `-O` or `--scalac-option`."

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedDependencyOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedDependencyOptions.scala
@@ -9,7 +9,6 @@ final case class SharedDependencyOptions(
   @Group("Dependency")
   @HelpMessage("Add dependencies")
   @Name("dep")
-  @Name("d")
     dependency: List[String] = Nil,
 
   @Group("Dependency")

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedOptions.scala
@@ -117,6 +117,15 @@ final case class SharedOptions(
 
   @Hidden
     strictBloopJsonCheck: Option[Boolean] = None,
+
+  @Name("output-directory")
+  @Name("d")
+  @Name("destination")
+  @Name("compileOutput")
+  @Name("compileOut")
+  @HelpMessage("Copy compilation results to output directory using either relative or absolute path")
+  @ValueDescription("/example/path")
+    compilationOutput: Option[String] = None,
 )
   // format: on
 

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedOptions.scala
@@ -55,11 +55,19 @@ final case class SharedOptions(
     markdown: MarkdownOptions = MarkdownOptions(),
 
   @Group("Java")
-  @HelpMessage("Add extra JARs in the class path")
+  @HelpMessage("Add extra JARs and compiled classes to the class path")
   @ValueDescription("paths")
   @Name("jar")
   @Name("jars")
   @Name("extraJar")
+  @Name("class")
+  @Name("extraClass")
+  @Name("classes")
+  @Name("extraClasses")
+  @Name("-classpath")
+  @Name("classpath")
+  @Name("classPath")
+  @Name("extraClassPath")
     extraJars: List[String] = Nil,
 
   @Group("Java")

--- a/modules/cli/src/main/scala/scala/cli/commands/Compile.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Compile.scala
@@ -7,16 +7,14 @@ import java.io.File
 import scala.build.options.Scope
 import scala.build.{Build, BuildThreads, Builds, Os}
 import scala.cli.CurrentParams
+import scala.cli.commands.util.BuildCommandHelpers
 import scala.cli.commands.util.CommonOps.SharedDirectoriesOptionsOps
 import scala.cli.commands.util.SharedOptionsUtil._
 import scala.cli.config.{ConfigDb, Keys}
 
-object Compile extends ScalaCommand[CompileOptions] {
+object Compile extends ScalaCommand[CompileOptions] with BuildCommandHelpers {
   override def group                                                         = "Main"
   override def sharedOptions(options: CompileOptions): Option[SharedOptions] = Some(options.shared)
-
-  def outputPath(options: CompileOptions): Option[os.Path] =
-    options.output.filter(_.nonEmpty).map(p => os.Path(p, Os.pwd))
 
   def run(options: CompileOptions, args: RemainingArgs): Unit = {
     maybePrintGroupHelp(options)
@@ -71,8 +69,7 @@ object Compile extends ScalaCommand[CompileOptions] {
             val cp = s.fullClassPath.map(_.toString).mkString(File.pathSeparator)
             println(cp)
           }
-        for (output <- outputPath(options); s <- successulBuildOpt)
-          os.copy.over(s.output, output)
+        successulBuildOpt.foreach(_.copyOutput(options.shared))
       }
     }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/Compile.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Compile.scala
@@ -36,8 +36,8 @@ object Compile extends ScalaCommand[CompileOptions] {
       Update.checkUpdateSafe(logger)
 
     val cross = options.cross.cross.getOrElse(false)
-    if (options.classPath && cross) {
-      System.err.println(s"Error: cannot specify both --class-path and --cross")
+    if (options.printClassPath && cross) {
+      System.err.println(s"Error: cannot specify both --print-class-path and --cross")
       sys.exit(1)
     }
 
@@ -66,7 +66,7 @@ object Compile extends ScalaCommand[CompileOptions] {
             build <- builds.get(Scope.Test).orElse(builds.get(Scope.Main))
             s     <- build.successfulOpt
           } yield s
-        if (options.classPath)
+        if (options.printClassPath)
           for (s <- successulBuildOpt) {
             val cp = s.fullClassPath.map(_.toString).mkString(File.pathSeparator)
             println(cp)

--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -85,6 +85,7 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
       ) { res =>
         res.orReport(logger).map(_.main).foreach {
           case s: Build.Successful =>
+            s.copyOutput(options.shared)
             val mtimeDestPath = doPackage(
               logger = logger,
               outputOpt = options.output.filter(_.nonEmpty),
@@ -124,6 +125,7 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
           .orExit(logger)
       builds.main match {
         case s: Build.Successful =>
+          s.copyOutput(options.shared)
           val res0 = doPackage(
             logger = logger,
             outputOpt = options.output.filter(_.nonEmpty),

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -223,6 +223,7 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
             )
               .orReport(logger)
               .flatten
+            s.copyOutput(options.shared)
             if (options.sharedRun.watch.restart)
               processOpt = maybeProcess
             else
@@ -251,6 +252,7 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
           .orExit(logger)
       builds.main match {
         case s: Build.Successful =>
+          s.copyOutput(options.shared)
           val res = maybeRun(
             s,
             allowTerminate = true,

--- a/modules/cli/src/main/scala/scala/cli/commands/util/ScalacOptionsUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/ScalacOptionsUtil.scala
@@ -7,13 +7,15 @@ object ScalacOptionsUtil {
   extension (opts: List[String]) {
     def toScalacOptShadowingSeq: ShadowingSeq[ScalacOpt] =
       ShadowingSeq.from(opts.filter(_.nonEmpty).map(ScalacOpt(_)))
+
   }
 
   extension (opts: ShadowingSeq[ScalacOpt]) {
-    def getScalacOption(key: String): Option[String] =
-      opts.get(ScalacOpt(key)).headOption.map(_.value)
-
     def filterScalacOptionKeys(f: String => Boolean): ShadowingSeq[ScalacOpt] =
       opts.filterKeys(_.key.exists(f))
+    def filterNonRedirected: ShadowingSeq[ScalacOpt] =
+      opts.filterScalacOptionKeys(!ScalacOptions.ScalaCliRedirectedOptions.contains(_))
+    def getScalacOption(key: String): Option[String] =
+      opts.get(ScalacOpt(key)).headOption.map(_.value)
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/util/ScalacOptionsUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/ScalacOptionsUtil.scala
@@ -1,0 +1,19 @@
+package scala.cli.commands.util
+
+import scala.build.options.{ScalacOpt, ShadowingSeq}
+import scala.cli.commands.ScalacOptions
+
+object ScalacOptionsUtil {
+  extension (opts: List[String]) {
+    def toScalacOptShadowingSeq: ShadowingSeq[ScalacOpt] =
+      ShadowingSeq.from(opts.filter(_.nonEmpty).map(ScalacOpt(_)))
+  }
+
+  extension (opts: ShadowingSeq[ScalacOpt]) {
+    def getScalacOption(key: String): Option[String] =
+      opts.get(ScalacOpt(key)).headOption.map(_.value)
+
+    def filterScalacOptionKeys(f: String => Boolean): ShadowingSeq[ScalacOpt] =
+      opts.filterKeys(_.key.exists(f))
+  }
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/util/SharedOptionsUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/SharedOptionsUtil.scala
@@ -22,6 +22,7 @@ import scala.build.options as bo
 import scala.cli.ScalaCli
 import scala.cli.commands.ScalaJsOptions
 import scala.cli.commands.util.CommonOps.*
+import scala.cli.commands.util.ScalacOptionsUtil.*
 import scala.cli.commands.util.SharedCompilationServerOptionsUtil.*
 import scala.cli.config.{ConfigDb, Keys}
 import scala.concurrent.ExecutionContextExecutorService
@@ -169,12 +170,12 @@ object SharedOptionsUtil extends CommandHelpers {
           scalaBinaryVersion = scalaBinaryVersion.map(_.trim).filter(_.nonEmpty),
           addScalaLibrary = scalaLibrary.orElse(java.map(!_)),
           generateSemanticDbs = semanticDb,
-          scalacOptions = ShadowingSeq.from(
-            scalac.scalacOption
-              .filter(_.nonEmpty)
-              .map(ScalacOpt(_))
-              .map(Positioned.commandLine)
-          ),
+          scalacOptions = scalac
+            .scalacOption
+            .toScalacOptShadowingSeq
+            // -O -classpath should be redirected as --extra-jars instead
+            .filterScalacOptionKeys(key => key != "-classpath")
+            .map(Positioned.commandLine),
           compilerPlugins =
             SharedOptionsUtil.parseDependencies(
               dependencies.compilerPlugin.map(Positioned.none),
@@ -199,7 +200,7 @@ object SharedOptionsUtil extends CommandHelpers {
           runJmh = if (enableJmh) Some(true) else None
         ),
         classPathOptions = bo.ClassPathOptions(
-          extraClassPath = extraJars
+          extraClassPath = extraJarsAndClasspath
             .flatMap(_.split(File.pathSeparator).toSeq)
             .filter(_.nonEmpty)
             .map(os.Path(_, os.pwd)),
@@ -227,6 +228,9 @@ object SharedOptionsUtil extends CommandHelpers {
         )
       )
     }
+
+    def extraJarsAndClasspath: List[String] =
+      extraJars ++ scalac.scalacOption.toScalacOptShadowingSeq.getScalacOption("-classpath")
 
     def globalInteractiveWasSuggested: Option[Boolean] =
       configDb.getOrNone(Keys.globalInteractiveWasSuggested, logger)

--- a/modules/cli/src/main/scala/scala/cli/commands/util/SharedOptionsUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/SharedOptionsUtil.scala
@@ -173,8 +173,7 @@ object SharedOptionsUtil extends CommandHelpers {
           scalacOptions = scalac
             .scalacOption
             .toScalacOptShadowingSeq
-            // -O -classpath should be redirected as --extra-jars instead
-            .filterScalacOptionKeys(key => key != "-classpath")
+            .filterNonRedirected
             .map(Positioned.commandLine),
           compilerPlugins =
             SharedOptionsUtil.parseDependencies(

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -109,7 +109,7 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
           "--test",
           "--output",
           tempOutput,
-          "--class-path",
+          "--print-class-path",
           extraOptions,
           "."
         ).call(cwd =
@@ -416,7 +416,7 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
         os.proc(
           TestUtil.cli,
           "compile",
-          "--class-path",
+          "--print-class-path",
           extraOptions,
           "."
         ).call(cwd = root)

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -94,7 +94,9 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
   test("copy compile output") {
     mainAndTestInputs.fromRoot { root =>
       val tempOutput = root / "output"
-      os.proc(TestUtil.cli, "compile", "--output", tempOutput, extraOptions, ".").call(cwd = root)
+      os.proc(TestUtil.cli, "compile", "--compile-output", tempOutput, extraOptions, ".").call(cwd =
+        root
+      )
       checkIfCompileOutputIsCopied("Main", tempOutput)
     }
   }
@@ -107,7 +109,7 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
           TestUtil.cli,
           "compile",
           "--test",
-          "--output",
+          "--compile-output",
           tempOutput,
           "--print-class-path",
           extraOptions,

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -1267,7 +1267,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
         // format: off
         val cmd = Seq[os.Shellable](
           TestUtil.cli, "compile", extraOptions,
-          "--class-path", ".",
+          "--print-class-path", ".",
           if (inlineDelambdafy) Seq("-Ydelambdafy:inline") else Nil
         )
         // format: on

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -2251,6 +2251,19 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
         extraOptions
       ).call(cwd = root / runDir)
       expect(runRes.out.trim == expectedOutput)
+
+      // ensure the same behaviour can be expected when passing -classpath with -O
+      val runRes2 = os.proc(
+        TestUtil.cli,
+        "run",
+        mainInput,
+        "-O",
+        "-classpath",
+        "-O",
+        (os.rel / os.up / preCompileDir / preCompileOutputDir).toString,
+        extraOptions
+      ).call(cwd = root / runDir)
+      expect(runRes2.out.trim == expectedOutput)
     }
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
@@ -33,7 +33,7 @@ class TestTestsDefault extends TestTestDefinitions(scalaVersionOpt = None) {
     )
 
     inputs.fromRoot { root =>
-      val compileRes = os.proc(TestUtil.cli, "compile", "--class-path", baseExtraOptions, ".")
+      val compileRes = os.proc(TestUtil.cli, "compile", "--print-class-path", baseExtraOptions, ".")
         .call(cwd = root)
       val cp = compileRes.out.trim().split(File.pathSeparator)
       expect(cp.length == 1) // only class dir, no scala JARs

--- a/website/docs/commands/compile.md
+++ b/website/docs/commands/compile.md
@@ -254,16 +254,16 @@ scala-cli compile Hello.scala --compiler-plugin org.typelevel:::kind-projector:0
 
 ## Printing a class path
 
-`--class-path` makes `scala-cli compile` print a class path:
+`--print-class-path` makes `scala-cli compile` print a class path:
 ```bash
-scala-cli compile --class-path Hello.scala
+scala-cli compile --print-class-path Hello.scala
 # /work/.scala/project-cef76d561e/classes:~/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.12.14/scala-library-2.12.14.jar:~/Library/Caches/ScalaCli/local-repo/0.1.0/org.virtuslab.scala-cli/runner_2.12/0.0.1-SNAPSHOT/jars/runner_2.12.jar:~/Library/Caches/ScalaCli/local-repo/0.1.0/org.virtuslab.scala-cli/stubs/0.0.1-SNAPSHOT/jars/stubs.jar
 ```
 
 This is handy when working with other tools.
 For example, you can pass this class path to `java -cp`:
 ```bash
-java -cp "$(scala-cli compile --class-path Hello.scala)" Hello
+java -cp "$(scala-cli compile --print-class-path Hello.scala)" Hello
 # Hello
 ```
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1172,7 +1172,7 @@ Available in commands:
 
 ### `--scalac-option`
 
-Aliases: `--scala-opt`, `-O`
+Aliases: `--scala-opt`, `-O`, `--scala-option`
 
 Add a `scalac` option. Note that options starting with `-g`, `-language`, `-opt`, `-P`, `-target`, `-V`, `-W`, `-X`, and `-Y` are assumed to be Scala compiler options and don't require to be passed after `-O` or `--scalac-option`.
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -119,12 +119,6 @@ Aliases: `-p`, `--print-classpath`
 
 Print the resulting class path
 
-### `--output`
-
-Aliases: `--output-directory`, `-d`, `--destination`
-
-Copy compilation results to output directory using either relative or absolute path
-
 ### `--test`
 
 Compile test scope
@@ -1286,6 +1280,12 @@ Add dependency for stubs needed to make $ivy and $dep imports to work.
 ### `--strict-bloop-json-check`
 
 [Internal]
+### `--compilation-output`
+
+Aliases: `--output-directory`, `-d`, `--destination`, `--compile-output`, `--compile-out`
+
+Copy compilation results to output directory using either relative or absolute path
+
 ## Snippet options
 
 Available in commands:

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -121,7 +121,7 @@ Print the resulting class path
 
 ### `--output`
 
-Aliases: `--output-directory`
+Aliases: `--output-directory`, `-d`, `--destination`
 
 Copy compilation results to output directory using either relative or absolute path
 
@@ -151,7 +151,7 @@ Available in commands:
 
 ### `--dependency`
 
-Aliases: `--dep`, `-d`
+Aliases: `--dep`
 
 Add dependencies
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1238,9 +1238,9 @@ Show help for scalac. This is an alias for --scalac-option -help
 
 ### `--extra-jars`
 
-Aliases: `--jar`, `--jars`, `--extra-jar`
+Aliases: `--jar`, `--jars`, `--extra-jar`, `--class`, `--extra-class`, `--classes`, `--extra-classes`, `-classpath`, `--classpath`, `--class-path`, `--extra-class-path`
 
-Add extra JARs in the class path
+Add extra JARs and compiled classes to the class path
 
 ### `--extra-compile-only-jars`
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -113,9 +113,9 @@ Available in commands:
 
 <!-- Automatically generated, DO NOT EDIT MANUALLY -->
 
-### `--class-path`
+### `--print-class-path`
 
-Aliases: `-p`, `--classpath`
+Aliases: `-p`, `--print-classpath`
 
 Print the resulting class path
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -615,7 +615,7 @@ Available in commands:
 
 ### `--scalac-option`
 
-Aliases: `--scala-opt`, `-O`
+Aliases: `--scala-opt`, `-O`, `--scala-option`
 
 Add a `scalac` option. Note that options starting with `-g`, `-language`, `-opt`, `-P`, `-target`, `-V`, `-W`, `-X`, and `-Y` are assumed to be Scala compiler options and don't require to be passed after `-O` or `--scalac-option`.
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -648,9 +648,9 @@ Show help for scalac. This is an alias for --scalac-option -help
 
 ### `--extra-jars`
 
-Aliases: `--jar`, `--jars`, `--extra-jar`
+Aliases: `--jar`, `--jars`, `--extra-jar`, `--class`, `--extra-class`, `--classes`, `--extra-classes`, `-classpath`, `--classpath`, `--class-path`, `--extra-class-path`
 
-Add extra JARs in the class path
+Add extra JARs and compiled classes to the class path
 
 ### `--extra-compile-only-jars`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -97,9 +97,9 @@ Available in commands:
 
 <!-- Automatically generated, DO NOT EDIT MANUALLY -->
 
-### `--class-path`
+### `--print-class-path`
 
-Aliases: `-p`, `--classpath`
+Aliases: `-p`, `--print-classpath`
 
 Print the resulting class path
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -105,7 +105,7 @@ Print the resulting class path
 
 ### `--output`
 
-Aliases: `--output-directory`
+Aliases: `--output-directory`, `-d`, `--destination`
 
 Copy compilation results to output directory using either relative or absolute path
 
@@ -123,7 +123,7 @@ Available in commands:
 
 ### `--dependency`
 
-Aliases: `--dep`, `-d`
+Aliases: `--dep`
 
 Add dependencies
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -103,12 +103,6 @@ Aliases: `-p`, `--print-classpath`
 
 Print the resulting class path
 
-### `--output`
-
-Aliases: `--output-directory`, `-d`, `--destination`
-
-Copy compilation results to output directory using either relative or absolute path
-
 ### `--test`
 
 Compile test scope
@@ -696,6 +690,12 @@ Add dependency for stubs needed to make $ivy and $dep imports to work.
 ### `--strict-bloop-json-check`
 
 [Internal]
+### `--compilation-output`
+
+Aliases: `--output-directory`, `-d`, `--destination`, `--compile-output`, `--compile-out`
+
+Copy compilation results to output directory using either relative or absolute path
+
 ## Snippet options
 
 Available in commands:


### PR DESCRIPTION
Context: #1310

Summary of changes (most of them, breaking changes):
- the `compile` sub-command's `--output` option has been renamed to `--compilation-output`
  - the `--compilation-output` option is now also available from the `run` and `package` sub-commands
  - the rename is necessary to prevent a clash with the `--output` option of the `package` sub-command
- the `-d` option is no longer an alias for `--dependency`, but for `--compilation-output`
  - the aim of that change is to be backwards compatible with `scala` command's `-d`
- `-O -d -O path/to/compilation/output` now defaults to `-d path/to/compilation/output`
- the old `--classpath` option has been renamed to `--print-classpath`, to better reflect what it actually does
  - the rename is necessary to prevent the near-clash between `scala-cli`'s `--classpath` and `scala` command's `-classpath` options (which have radically different meanings, BTW)
-  `--classpath`, `--class-path` and `-classpath` options are now aliases for the `--extra jars` option
 - `-O -classpath -O path/to/classpath` now defaults to `--extra-jars path/to/classpath`

Reference docs have been generated for each of the commits, separately. 