### PR TITLE
Add platform option

### DIFF
--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedOptions.scala
@@ -84,6 +84,10 @@ final case class SharedOptions(
   @Name("resourceDir")
     resourceDirs: List[String] = Nil,
 
+  @HelpMessage("Specify platform")
+  @ValueDescription("scala-js|scala-native|jvm")
+    platform: Option[String] = None,
+
   @Group("Scala")
   @Hidden
     scalaLibrary: Option[Boolean] = None,

--- a/modules/cli/src/main/scala/scala/cli/commands/Bsp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Bsp.scala
@@ -61,7 +61,7 @@ object Bsp extends ScalaCommand[BspOptions] {
       val sharedOptions = getSharedOptions()
       BspReloadableOptions(
         buildOptions = buildOptions(sharedOptions),
-        bloopRifleConfig = sharedOptions.bloopRifleConfig(),
+        bloopRifleConfig = sharedOptions.bloopRifleConfig().orExit(sharedOptions.logger),
         logger = sharedOptions.logging.logger,
         verbosity = sharedOptions.logging.verbosity
       )
@@ -96,7 +96,8 @@ object Bsp extends ScalaCommand[BspOptions] {
   }
 
   private def buildOptions(sharedOptions: SharedOptions): BuildOptions = {
-    val baseOptions = sharedOptions.buildOptions()
+    val logger      = sharedOptions.logger
+    val baseOptions = sharedOptions.buildOptions().orExit(logger)
     baseOptions.copy(
       classPathOptions = baseOptions.classPathOptions.copy(
         fetchSources = baseOptions.classPathOptions.fetchSources.orElse(Some(true))

--- a/modules/cli/src/main/scala/scala/cli/commands/Compile.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Compile.scala
@@ -20,8 +20,8 @@ object Compile extends ScalaCommand[CompileOptions] {
 
   def run(options: CompileOptions, args: RemainingArgs): Unit = {
     maybePrintGroupHelp(options)
-    maybePrintSimpleScalacOutput(options, options.shared.buildOptions())
     val logger = options.shared.logger
+    maybePrintSimpleScalacOutput(options, options.shared.buildOptions().orExit(logger))
     CurrentParams.verbosity = options.shared.logging.verbosity
     val inputs = options.shared.inputs(args.all).orExit(logger)
     CurrentParams.workspaceOpt = Some(inputs.workspace)
@@ -76,10 +76,10 @@ object Compile extends ScalaCommand[CompileOptions] {
       }
     }
 
-    val buildOptions = options.shared.buildOptions()
+    val buildOptions = options.shared.buildOptions().orExit(logger)
     val threads      = BuildThreads.create()
 
-    val compilerMaker = options.shared.compilerMaker(threads)
+    val compilerMaker = options.shared.compilerMaker(threads).orExit(logger)
     val configDb = ConfigDb.open(options.shared.directories.directories)
       .orExit(logger)
     val actionableDiagnostics =

--- a/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
@@ -21,7 +21,7 @@ object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
 
     val logger       = options.shared.logger
     val inputs       = options.shared.inputs(args.all).orExit(logger)
-    val buildOptions = options.shared.buildOptions()
+    val buildOptions = options.shared.buildOptions().orExit(logger)
 
     val (crossSources, _) =
       CrossSources.forInputs(

--- a/modules/cli/src/main/scala/scala/cli/commands/Doc.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Doc.scala
@@ -27,10 +27,11 @@ object Doc extends ScalaCommand[DocOptions] {
     val inputs = options.shared.inputs(args.remaining).orExit(logger)
     CurrentParams.workspaceOpt = Some(inputs.workspace)
 
-    val initialBuildOptions = options.shared.buildOptions(enableJmh = false, jmhVersion = None)
-    val threads             = BuildThreads.create()
+    val initialBuildOptions =
+      options.shared.buildOptions(enableJmh = false, jmhVersion = None).orExit(logger)
+    val threads = BuildThreads.create()
 
-    val maker               = options.shared.compilerMaker(threads)
+    val maker               = options.shared.compilerMaker(threads).orExit(logger)
     val compilerMaker       = ScalaCompilerMaker.IgnoreScala2(maker)
     val docCompilerMakerOpt = Some(SimpleScalaCompilerMaker("java", Nil, scaladoc = true))
 

--- a/modules/cli/src/main/scala/scala/cli/commands/Export.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Export.scala
@@ -102,7 +102,7 @@ object Export extends ScalaCommand[ExportOptions] {
     val inputs = options.shared.inputs(args.all).orExit(logger)
     CurrentParams.workspaceOpt = Some(inputs.workspace)
     val baseOptions =
-      options.shared.buildOptions()
+      options.shared.buildOptions().orExit(logger)
         .copy(mainClass = options.mainClass.mainClass.filter(_.nonEmpty))
 
     val (sourcesMain, optionsMain0) =

--- a/modules/cli/src/main/scala/scala/cli/commands/Fmt.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Fmt.scala
@@ -39,8 +39,8 @@ object Fmt extends ScalaCommand[FmtOptions] {
       }
     CurrentParams.workspaceOpt = Some(workspace)
     val (versionMaybe, dialectMaybe, pathMaybe) = readVersionAndDialect(workspace, options, logger)
-    val cache                                   = options.shared.buildOptions().archiveCache
-    val buildOptions                            = options.buildOptions
+    val cache        = options.shared.buildOptions().orExit(logger).archiveCache
+    val buildOptions = options.buildOptions
 
     if (sourceFiles.isEmpty)
       logger.debug("No source files, not formatting anything")
@@ -48,7 +48,7 @@ object Fmt extends ScalaCommand[FmtOptions] {
       val version =
         options.scalafmtVersion.getOrElse(versionMaybe.getOrElse(Constants.defaultScalafmtVersion))
       val dialectString = options.scalafmtDialect.orElse(dialectMaybe).getOrElse {
-        options.buildOptions.scalaParams.orExit(logger).map(_.scalaVersion)
+        options.buildOptions.orExit(logger).scalaParams.orExit(logger).map(_.scalaVersion)
           .getOrElse(Constants.defaultScalaVersion) match
           case v if v.startsWith("2.11.") => "scala211"
           case v if v.startsWith("2.12.") => "scala212"
@@ -87,7 +87,7 @@ object Fmt extends ScalaCommand[FmtOptions] {
             params,
             cache,
             logger,
-            () => buildOptions.javaHome().value.javaCommand
+            () => buildOptions.orExit(logger).javaHome().value.javaCommand
           )
             .orExit(logger)
             .command

--- a/modules/cli/src/main/scala/scala/cli/commands/Metabrowse.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Metabrowse.scala
@@ -46,7 +46,7 @@ object Metabrowse extends ScalaCommand[MetabrowseOptions] {
     val inputs = options.shared.inputs(args.all).orExit(logger)
     CurrentParams.workspaceOpt = Some(inputs.workspace)
 
-    val baseOptions = options.shared.buildOptions()
+    val baseOptions = options.shared.buildOptions().orExit(logger)
     val initialBuildOptions = baseOptions.copy(
       classPathOptions = baseOptions.classPathOptions.copy(
         fetchSources = Some(true)
@@ -57,7 +57,7 @@ object Metabrowse extends ScalaCommand[MetabrowseOptions] {
     )
     val threads = BuildThreads.create()
 
-    val compilerMaker = options.shared.compilerMaker(threads)
+    val compilerMaker = options.shared.compilerMaker(threads).orExit(logger)
     val configDb = ConfigDb.open(options.shared.directories.directories)
       .orExit(logger)
     val actionableDiagnostics =

--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -46,19 +46,19 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
   override def isRestricted                                                  = true
   override def sharedOptions(options: PackageOptions): Option[SharedOptions] = Some(options.shared)
   def run(options: PackageOptions, args: RemainingArgs): Unit = {
-    maybePrintGroupHelp(options)
-    maybePrintSimpleScalacOutput(options, options.baseBuildOptions)
-
     CurrentParams.verbosity = options.shared.logging.verbosity
-    val logger = options.shared.logger
-    val inputs = options.shared.inputs(args.remaining).orExit(logger)
+    val logger           = options.shared.logger
+    val baseBuildOptions = options.baseBuildOptions.orExit(logger)
+    val inputs           = options.shared.inputs(args.remaining).orExit(logger)
+    maybePrintGroupHelp(options)
+    maybePrintSimpleScalacOutput(options, baseBuildOptions)
     CurrentParams.workspaceOpt = Some(inputs.workspace)
 
     // FIXME mainClass encoding has issues with special chars, such as '-'
 
     val initialBuildOptions = buildOptions(options)
     val threads             = BuildThreads.create()
-    val compilerMaker       = options.compilerMaker(threads)
+    val compilerMaker       = options.compilerMaker(threads).orExit(logger)
     val docCompilerMakerOpt = options.docCompilerMakerOpt
 
     val cross = options.compileCross.cross.getOrElse(false)

--- a/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
@@ -29,6 +29,7 @@ object Repl extends ScalaCommand[ReplOptions] {
     import ops.sharedRepl._
     val ammoniteVersionOpt = ammoniteVersion.map(_.trim).filter(_.nonEmpty)
 
+    val logger = ops.shared.logger
     val baseOptions = shared.copy(scalaVersion =
       if (
         ammonite.contains(true) &&
@@ -41,7 +42,7 @@ object Repl extends ScalaCommand[ReplOptions] {
         Some("3.1.3")
       }
       else shared.scalaVersion
-    ).buildOptions()
+    ).buildOptions().orExit(logger)
     baseOptions.copy(
       javaOptions = baseOptions.javaOptions.copy(
         javaOpts =
@@ -77,7 +78,7 @@ object Repl extends ScalaCommand[ReplOptions] {
 
     val threads = BuildThreads.create()
 
-    val compilerMaker = options.shared.compilerMaker(threads)
+    val compilerMaker = options.shared.compilerMaker(threads).orExit(logger)
 
     val directories = options.shared.directories.directories
 

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -57,10 +57,11 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
   def buildOptions(options: RunOptions): BuildOptions = {
     import options.*
     import options.sharedRun.*
+    val logger = options.shared.logger
     val baseOptions = shared.buildOptions(
       enableJmh = benchmarking.jmh.contains(true),
       jmhVersion = benchmarking.jmhVersion
-    )
+    ).orExit(logger)
     baseOptions.copy(
       mainClass = mainClass.mainClass,
       javaOptions = baseOptions.javaOptions.copy(
@@ -115,7 +116,7 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
     CurrentParams.workspaceOpt = Some(inputs.workspace)
     val threads = BuildThreads.create()
 
-    val compilerMaker = options.shared.compilerMaker(threads)
+    val compilerMaker = options.shared.compilerMaker(threads).orExit(logger)
 
     def maybeRun(
       build: Build.Successful,

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -87,8 +87,9 @@ abstract class ScalaCommand[T](implicit myParser: Parser[T], help: Help[T])
         val candidates = arg.name.name match {
           case "dependency" =>
             state.flatMap(sharedOptions).toList.flatMap { sharedOptions =>
-              val cache = sharedOptions.coursierCache
-              val sv = sharedOptions.buildOptions()
+              val logger = sharedOptions.logger
+              val cache  = sharedOptions.coursierCache
+              val sv = sharedOptions.buildOptions().orExit(logger)
                 .scalaParams
                 .toOption
                 .flatten

--- a/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
@@ -87,7 +87,7 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
     }
 
   private def buildOptions(opts: SetupIdeOptions): BuildOptions =
-    opts.shared.buildOptions()
+    opts.shared.buildOptions().orExit(opts.shared.logger)
 
   private def writeBspConfiguration(
     options: SetupIdeOptions,

--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -25,7 +25,7 @@ object Test extends ScalaCommand[TestOptions] {
 
   def buildOptions(opts: TestOptions): BuildOptions = {
     import opts._
-    val baseOptions = shared.buildOptions()
+    val baseOptions = shared.buildOptions().orExit(opts.shared.logger)
     baseOptions.copy(
       javaOptions = baseOptions.javaOptions.copy(
         javaOpts =
@@ -63,7 +63,7 @@ object Test extends ScalaCommand[TestOptions] {
 
     val threads = BuildThreads.create()
 
-    val compilerMaker = options.shared.compilerMaker(threads)
+    val compilerMaker = options.shared.compilerMaker(threads).orExit(logger)
 
     val cross = options.compileCross.cross.getOrElse(false)
     val configDb = ConfigDb.open(options.shared.directories.directories)

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/Bloop.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/Bloop.scala
@@ -34,7 +34,7 @@ object Bloop extends ScalaCommand[BloopOptions] {
       jvm = opts.jvm,
       coursier = opts.coursier
     )
-    val options = sharedOptions.buildOptions(false, None)
+    val options = sharedOptions.buildOptions(false, None).orExit(opts.logging.logger)
     lazy val defaultJvmCmd =
       sharedOptions.downloadJvm(OsLibc.baseDefaultJvm(OsLibc.jvmIndexOs, "17"), options)
     val javaCmd = opts.compilationServer.bloopJvm

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -72,7 +72,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
     mainClass: MainClassOptions,
     ivy2LocalLike: Option[Boolean]
   ): Either[BuildException, BuildOptions] = either {
-    val baseOptions = shared.buildOptions()
+    val baseOptions = shared.buildOptions().orExit(shared.logger)
     val contextualOptions = PublishContextualOptions(
       repository = publishRepo.publishRepository.filter(_.trim.nonEmpty),
       repositoryIsIvy2LocalLike = ivy2LocalLike,
@@ -189,8 +189,8 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
     ).orExit(logger)
     val threads = BuildThreads.create()
 
-    val compilerMaker    = options.shared.compilerMaker(threads)
-    val docCompilerMaker = options.shared.compilerMaker(threads, scaladoc = true)
+    val compilerMaker    = options.shared.compilerMaker(threads).orExit(logger)
+    val docCompilerMaker = options.shared.compilerMaker(threads, scaladoc = true).orExit(logger)
 
     val cross = options.compileCross.cross.getOrElse(false)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
@@ -40,8 +40,8 @@ object PublishLocal extends ScalaCommand[PublishLocalOptions] {
     ).orExit(logger)
     val threads = BuildThreads.create()
 
-    val compilerMaker    = options.shared.compilerMaker(threads)
-    val docCompilerMaker = options.shared.compilerMaker(threads, scaladoc = true)
+    val compilerMaker    = options.shared.compilerMaker(threads).orExit(logger)
+    val docCompilerMaker = options.shared.compilerMaker(threads, scaladoc = true).orExit(logger)
 
     val cross = options.compileCross.cross.getOrElse(false)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/util/FmtOptionsUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/FmtOptionsUtil.scala
@@ -1,6 +1,8 @@
 package scala.cli.commands.util
 import coursier.core.Version
 
+import scala.build.EitherCps.{either, value}
+import scala.build.errors.BuildException
 import scala.build.internal.FetchExternalBinary
 import scala.build.options.BuildOptions
 import scala.cli.commands.FmtOptions
@@ -26,7 +28,7 @@ object FmtOptionsUtil {
       (url, !tag0.startsWith("v"))
     }
 
-    def buildOptions: BuildOptions = shared.buildOptions()
+    def buildOptions: Either[BuildException, BuildOptions] = shared.buildOptions()
 
     def scalafmtCliOptions: List[String] =
       scalafmtArg :::

--- a/modules/cli/src/main/scala/scala/cli/commands/util/PackageOptionsUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/PackageOptionsUtil.scala
@@ -47,8 +47,8 @@ object PackageOptionsUtil {
         .sequence
         .left.map(CompositeBuildException(_))
 
-    def baseBuildOptions: BuildOptions = {
-      val baseOptions = shared.buildOptions()
+    def baseBuildOptions: Either[BuildException, BuildOptions] = either {
+      val baseOptions = value(shared.buildOptions())
       baseOptions.copy(
         mainClass = mainClass.mainClass.filter(_.nonEmpty),
         notForBloopOptions = baseOptions.notForBloopOptions.copy(
@@ -110,7 +110,7 @@ object PackageOptionsUtil {
     }
 
     def finalBuildOptions: Either[BuildException, BuildOptions] = either {
-      val baseOptions = baseBuildOptions
+      val baseOptions = value(baseBuildOptions)
       baseOptions.copy(
         notForBloopOptions = baseOptions.notForBloopOptions.copy(
           packageOptions = baseOptions.notForBloopOptions.packageOptions.copy(
@@ -120,8 +120,8 @@ object PackageOptionsUtil {
       )
     }
 
-    def compilerMaker(threads: BuildThreads): ScalaCompilerMaker = {
-      val maker = shared.compilerMaker(threads)
+    def compilerMaker(threads: BuildThreads): Either[BuildException, ScalaCompilerMaker] = either {
+      val maker = value(shared.compilerMaker(threads))
       if (forcedPackageTypeOpt.contains(PackageType.DocJar))
         ScalaCompilerMaker.IgnoreScala2(maker)
       else

--- a/modules/core/src/main/scala/scala/build/errors/AmbiguousPlatformError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/AmbiguousPlatformError.scala
@@ -1,0 +1,5 @@
+package scala.build.errors
+
+final class AmbiguousPlatformError(passedPlatformTypes: Seq[String]) extends BuildException(
+      s"Ambiguous platform: more than one type of platform has been passed: ${passedPlatformTypes.mkString(", ")}."
+    )

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -206,6 +206,24 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
 
+  test("simple script JS via platform option") {
+    val message = "Hello"
+    val inputs = TestInputs(
+      os.rel / "simple.sc" ->
+        s"""//> using platform "scala-native"
+           |import scala.scalajs.js
+           |val console = js.Dynamic.global.console
+           |val msg = "$message"
+           |console.log(msg)
+           |""".stripMargin
+    )
+    inputs.fromRoot { root =>
+      val output =
+        os.proc(TestUtil.cli, extraOptions, ".", "--platform", "js").call(cwd = root).out.trim()
+      expect(output == message)
+    }
+  }
+
   def platformNl: String = if (Properties.isWin) "\\r\\n" else "\\n"
 
   def simpleNativeTests(): Unit = {

--- a/website/docs/commands/run.md
+++ b/website/docs/commands/run.md
@@ -135,6 +135,12 @@ Note that this requires `node` to be [installed](/install#scala-js) on your syst
 scala-cli Hello.scala --js
 ```
 
+It is also possible to achieve it using `--platform` option:
+
+```bash
+scala-cli Hello.scala --platform js
+```
+
 See our dedicated [Scala.js guide](../guides/scala-js.md) for more information.
 
 ## Scala Native
@@ -146,7 +152,22 @@ Note that the [Scala Native requirements](https://scala-native.readthedocs.io/en
 scala-cli Hello.scala --native -S 2.13.6
 ```
 
+It is also possible to achieve it using `--platform` option:
+
+```bash
+scala-cli Hello.scala --platform native
+```
+
 We have a dedicated [Scala Native guide](../guides/scala-native.md) as well.
+
+## Platform
+
+The `--platform` option can be used to choose the platform, which should be used to compile and run application. Available platforms are:
+* JVM (`jvm`)
+* Scala.js (`scala.js` | `scala-js` | `scalajs` | `js`)
+* Scala Native (`scala-native` | `scalanative` | `native`)
+
+Passing the `--platform` along with `--js` or `--native` is not recommended. If two different types of platform are passed, Scala CLI throws an error.
 
 ## Scala Scripts
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1260,6 +1260,10 @@ Aliases: `--resource-dir`
 
 Add a resource directory
 
+### `--platform`
+
+Specify platform
+
 ### `--scala-library`
 
 [Internal]

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -670,6 +670,10 @@ Aliases: `--resource-dir`
 
 Add a resource directory
 
+### `--platform`
+
+Specify platform
+
 ### `--scala-library`
 
 [Internal]


### PR DESCRIPTION
This adds `--platform` option, which can be used to specify, which platform (Scala.js | Scala Native | JVM) should be used to compile and run application.