### PR TITLE
Make ammonite repl default to Scala `3.1.3` instead of `3.2.0`, temporarily

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
@@ -28,9 +28,21 @@ object Repl extends ScalaCommand[ReplOptions] {
   def buildOptions(ops: ReplOptions): BuildOptions = {
     import ops._
     import ops.sharedRepl._
-    def ammoniteVersionOpt = ammoniteVersion.map(_.trim).filter(_.nonEmpty)
+    val ammoniteVersionOpt = ammoniteVersion.map(_.trim).filter(_.nonEmpty)
 
-    val baseOptions = shared.buildOptions()
+    val baseOptions = shared.copy(scalaVersion =
+      if (
+        ammonite.contains(true) &&
+        (shared.scalaVersion.isEmpty || shared.scalaVersion.contains("3.2.0")) &&
+        ammoniteVersionOpt.isEmpty
+      ) {
+        // TODO remove this once ammonite adds support for 3.2.0
+        System.err.println("Scala 3.2.0 is not yet supported with this version of ammonite")
+        System.err.println("Defaulting to Scala 3.1.3")
+        Some("3.1.3")
+      }
+      else shared.scalaVersion
+    ).buildOptions()
     baseOptions.copy(
       javaOptions = baseOptions.javaOptions.copy(
         javaOpts =


### PR DESCRIPTION
This should fix the `ammonite` repl defaulting to `3.2.0`and failing.
It will now fallback to `3.1.3`, temporarily.
It will still be possible to try using `3.2.0` with a different version of ammonite, when it comes out.

Before:
```
▶ scala-cli --cli-version nightly --cli-scala-version 3.2.0 --ammonite
Downloading Ammonite 2.5.4-22-4a9e6989
Downloading Ammonite 2.5.4-22-4a9e6989 sources
[error]  Can't download Ammonite 2.5.4-22-4a9e6989 for Scala 3.2.0.
Ammonite with this Scala version might not yet be supported.
Try passing a different Scala version with the -S option.
```
After:
```
▶ scala-cli-src --ammonite --S 3.2.0
Scala 3.2.0 is not yet supported with this version of ammonite
Defaulting to Scala 3.1.3
Loading...
Welcome to the Ammonite Repl 2.5.4-22-4a9e6989 (Scala 3.1.3 Java 17.0.2)
@  
```
