### PR TITLE
Detect sip when installed by coursier

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -28,7 +28,8 @@ object ScalaCli {
     val baseProgName = if (Properties.isWin) progName.stripSuffix(".exe") else progName
     baseProgName == name ||
     baseProgName.endsWith(s"/$name") ||
-    baseProgName.endsWith(File.separator + name)
+    baseProgName.endsWith(File.separator + name) ||
+    baseProgName.endsWith(s"${File.separator}.$name.aux") // cs install binaries under .app-name.aux
   }
 
   private var isSipScala      = checkName("scala") || checkName("scala-cli-sip")


### PR DESCRIPTION
Coursier stores the binary file under the name .scala-cli-sip.aux or .scala.aux,
  therefore the sip detection mechanism does not work.
Added new filter to detect files installed by coursier.