### PR TITLE
Make inputs optional when `-classpath` and `--main-class` are passed

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -57,7 +57,8 @@ object Build {
     def outputOpt: Some[os.Path]          = Some(output)
     def dependencyClassPath: Seq[os.Path] = sources.resourceDirs ++ artifacts.classPath
     def fullClassPath: Seq[os.Path]       = Seq(output) ++ dependencyClassPath
-    def foundMainClasses(): Seq[String]   = MainClass.find(output)
+    def foundMainClasses(): Seq[String] =
+      MainClass.find(output) ++ options.classPathOptions.extraClassPath.flatMap(MainClass.find)
     def retainedMainClass(
       mainClasses: Seq[String],
       commandString: String,

--- a/modules/build/src/main/scala/scala/build/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/Inputs.scala
@@ -302,10 +302,11 @@ object Inputs {
     directories: Directories,
     forcedWorkspace: Option[os.Path],
     enableMarkdown: Boolean,
-    allowRestrictedFeatures: Boolean
+    allowRestrictedFeatures: Boolean,
+    extraClasspathWasPassed: Boolean
   ): Inputs = {
 
-    assert(validElems.nonEmpty)
+    assert(extraClasspathWasPassed || validElems.nonEmpty)
 
     val (inferredWorkspace, inferredNeedsHash, workspaceOrigin) = {
       val settingsFiles = projectSettingsFiles(validElems)
@@ -490,7 +491,8 @@ object Inputs {
     acceptFds: Boolean,
     forcedWorkspace: Option[os.Path],
     enableMarkdown: Boolean,
-    allowRestrictedFeatures: Boolean
+    allowRestrictedFeatures: Boolean,
+    extraClasspathWasPassed: Boolean
   ): Either[BuildException, Inputs] = {
     val validatedArgs: Seq[Either[String, Seq[Element]]] =
       validateArgs(args, cwd, download, stdinOpt, acceptFds)
@@ -504,7 +506,7 @@ object Inputs {
       val validElems = validatedArgsAndSnippets.collect {
         case Right(elem) => elem
       }.flatten
-      assert(validElems.nonEmpty)
+      assert(extraClasspathWasPassed || validElems.nonEmpty)
 
       Right(forValidatedElems(
         validElems,
@@ -512,7 +514,8 @@ object Inputs {
         directories,
         forcedWorkspace,
         enableMarkdown,
-        allowRestrictedFeatures
+        allowRestrictedFeatures,
+        extraClasspathWasPassed
       ))
     }
     else
@@ -533,10 +536,11 @@ object Inputs {
     acceptFds: Boolean = false,
     forcedWorkspace: Option[os.Path] = None,
     enableMarkdown: Boolean = false,
-    allowRestrictedFeatures: Boolean
+    allowRestrictedFeatures: Boolean,
+    extraClasspathWasPassed: Boolean
   ): Either[BuildException, Inputs] =
     if (
-      args.isEmpty && scriptSnippetList.isEmpty && scalaSnippetList.isEmpty && javaSnippetList.isEmpty
+      args.isEmpty && scriptSnippetList.isEmpty && scalaSnippetList.isEmpty && javaSnippetList.isEmpty && !extraClasspathWasPassed
     )
       defaultInputs().toRight(new InputsException(
         "No inputs provided (expected files with .scala, .sc, .java or .md extensions, and / or directories)."
@@ -555,7 +559,8 @@ object Inputs {
         acceptFds,
         forcedWorkspace,
         enableMarkdown,
-        allowRestrictedFeatures
+        allowRestrictedFeatures,
+        extraClasspathWasPassed
       )
 
   def default(): Option[Inputs] =

--- a/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
@@ -43,7 +43,8 @@ final case class TestInputs(
         tmpDir,
         Directories.under(tmpDir / ".data"),
         forcedWorkspace = forcedWorkspaceOpt.map(_.resolveFrom(tmpDir)),
-        allowRestrictedFeatures = true
+        allowRestrictedFeatures = true,
+        extraClasspathWasPassed = false
       )
       res match {
         case Left(err)     => throw new Exception(err)

--- a/modules/cli/src/main/scala/scala/cli/commands/Clean.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Clean.scala
@@ -17,7 +17,8 @@ object Clean extends ScalaCommand[CleanOptions] {
       options.directories.directories,
       defaultInputs = () => Inputs.default(),
       forcedWorkspace = options.workspace.forcedWorkspaceOpt,
-      allowRestrictedFeatures = ScalaCli.allowRestrictedFeatures
+      allowRestrictedFeatures = ScalaCli.allowRestrictedFeatures,
+      extraClasspathWasPassed = false
     ) match {
       case Left(message) =>
         System.err.println(message)

--- a/modules/cli/src/main/scala/scala/cli/commands/Default.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Default.scala
@@ -34,7 +34,8 @@ class Default(
       {
         val shouldDefaultToRun =
           args.remaining.nonEmpty || options.shared.snippet.executeScript.nonEmpty ||
-          options.shared.snippet.executeScala.nonEmpty || options.shared.snippet.executeJava.nonEmpty
+          options.shared.snippet.executeScala.nonEmpty || options.shared.snippet.executeJava.nonEmpty ||
+          (options.shared.extraJarsAndClasspath.nonEmpty && options.sharedRun.mainClass.mainClass.nonEmpty)
         if shouldDefaultToRun then RunOptions.parser else ReplOptions.parser
       }.parse(rawArgs) match
         case Left(e)                              => error(e)

--- a/modules/cli/src/main/scala/scala/cli/commands/util/SharedOptionsUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/SharedOptionsUtil.scala
@@ -60,7 +60,8 @@ object SharedOptionsUtil extends CommandHelpers {
     scriptSnippetList: List[String],
     scalaSnippetList: List[String],
     javaSnippetList: List[String],
-    enableMarkdown: Boolean = false
+    enableMarkdown: Boolean = false,
+    extraClasspathWasPassed: Boolean = false
   ): Either[BuildException, Inputs] = {
     val resourceInputs = resourceDirs
       .map(os.Path(_, Os.pwd))
@@ -83,7 +84,8 @@ object SharedOptionsUtil extends CommandHelpers {
       acceptFds = !Properties.isWin,
       forcedWorkspace = forcedWorkspaceOpt,
       enableMarkdown = enableMarkdown,
-      allowRestrictedFeatures = ScalaCli.allowRestrictedFeatures
+      allowRestrictedFeatures = ScalaCli.allowRestrictedFeatures,
+      extraClasspathWasPassed = extraClasspathWasPassed
     )
     maybeInputs.map { inputs =>
       val forbiddenDirs =
@@ -349,7 +351,8 @@ object SharedOptionsUtil extends CommandHelpers {
         scriptSnippetList = allScriptSnippets,
         scalaSnippetList = allScalaSnippets,
         javaSnippetList = allJavaSnippets,
-        enableMarkdown = v.markdown.enableMarkdown
+        enableMarkdown = v.markdown.enableMarkdown,
+        extraClasspathWasPassed = v.extraJarsAndClasspath.nonEmpty
       )
 
     def allScriptSnippets: List[String] = v.snippet.scriptSnippet ++ v.snippet.executeScript


### PR DESCRIPTION
## Context

The `scala` command allows to do the following:
```
▶ ls
Main.scala
▶ mkdir out
▶ scalac Main.scala -d out
▶ scala Main -classpath out
Hello
```

Meanwhile, Scala CLI:

  - passing the `-classpath` option out of the blue will just start the repl with the relevant classpath. this still allows to run whatever you want in the repl. We are keeping this behaviour.
```
▶ scala-cli -classpath out
Welcome to Scala 3.2.0 (17.0.2, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                                         
scala> Main.main(Array.empty)
Hello
```

  - it becomes more confusing if you try to pass the main class with the `--main-class` option, similarly to how the `scala` command allows to pass it as an input.
```
▶ scala-cli --main-class Main -classpath out
Unrecognized argument: --main-class

To list all available options, run
  scala-cli --help
```
This fails, as `--main-class` isn't an option for the repl, and we are defaulting to the repl.
Still, if we pass the `run` sub-command explicitly, it fails as well.








```
▶ scala-cli run --main-class Main -classpath out
[error]  No inputs provided (expected files with .scala, .sc, .java or .md extensions, and / or directories).
```
Even though the main class is specified and it is indeed passed on the classpath, `scala-cli` fails because it expects inputs.

# After the changes
TL;DR the following syntax becomes available:
  -  if the `run` sub-command is passed explicitly, it's sufficient to have a main class on the classpath, inputs aren't necessary then 
```
▶ scala-cli run -classpath out          
Hello
```
  - when using the default command, `--main-class` has to be passed explicitly (even if there's only one main class on the classpath) to indicate the intent of running it instead of defaulting to the repl
```
▶ scala-cli --main-class Main -classpath out
Hello
```
  - just passing the `-classpath` still defaults to the `repl`
```
▶ scala-cli -classpath out                  
Welcome to Scala 3.1.3 (17.0.2, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                                         
scala> Main.main(Array.empty)
Hello
```