### PR TITLE
Create empty class to enforce resolving ivy deps by mill for dummy modules

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -142,10 +142,6 @@ object dummy extends Module {
     def ivyDeps = Agg(
       Deps.ammonite
     )
-    def compile = T {
-      resolvedRunIvyDeps()
-      null: mill.scalalib.api.CompilationResult
-    }
   }
   object scalafmt extends ScalaModule with Bloop.Module {
     def skipBloop    = true
@@ -153,10 +149,6 @@ object dummy extends Module {
     def ivyDeps = Agg(
       Deps.scalafmtCli
     )
-    def compile = T {
-      resolvedRunIvyDeps()
-      null: mill.scalalib.api.CompilationResult
-    }
   }
 }
 

--- a/modules/dummy/amm/src/main/scala/AmmDummy.scala
+++ b/modules/dummy/amm/src/main/scala/AmmDummy.scala
@@ -1,0 +1,3 @@
+/** Create an empty class to enforce resolving ivy deps by mill for `amm` module
+  */
+class AmmDummy

--- a/modules/dummy/scalafmt/src/main/scala/ScalafmtDummy.scala
+++ b/modules/dummy/scalafmt/src/main/scala/ScalafmtDummy.scala
@@ -1,0 +1,3 @@
+/** Create an empty class to enforce resolving ivy deps by mill for `scalafmt` module
+  */
+class ScalafmtDummy


### PR DESCRIPTION
When IntelliJ import Scala CLI BSP project, it throws:
```
Result: null
Error: {
  "code": -32603,
  "message": "Internal error.",
  "data": "java.util.concurrent.CompletionException: java.lang.Exception: Failure during task evaluation: dummy.amm[2.13.4].bspCompileClassesPath java.lang.NullPointerException: Cannot invoke \"mill.scalalib.api.CompilationResult.classes()\" because the return value of \"scala.collection.immutable.Seq.apply(int)\" is null\n    mill.scalalib.ScalaModule.$anonfun$bspCompileClassesPath$4(ScalaModule.scala:232)\n    mill.define.Task$TraverseCtx.evaluate(Task.scala:380)\n\tat java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:332)\n\tat java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:347)\n\tat java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:708)\n\tat java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)\n\tat java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2162)\n\tat mill.bsp.MillBuildServer.$anonfun$completable$1(MillBuildServer.scala:722)\n\tat mill.bsp.MillBuildServer.$anonfun$completable$1$adapted(MillBuildServer.scala:710)\n\tat scala.concurrent.impl.Promise$Transformation.run(Promise.scala:484)\n\tat java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1395)\n\tat java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)\n\tat java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)\n\tat java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)\n\tat java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)\n\tat java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)\nCaused by: java.lang.Exception: Failure during task evaluation: dummy.amm[2.13.4].bspCompileClassesPath java.lang.NullPointerException: Cannot invoke \"mill.scalalib.api.CompilationResult.classes()\" because the return value of \"scala.collection.immutable.Seq.apply(int)\" is null\n    mill.scalalib.ScalaModule.$anonfun$bspCompileClassesPath$4(ScalaModule.scala:232)\n    mill.define.Task$TraverseCtx.evaluate(Task.scala:380)\n\tat mill.eval.Evaluator$.$anonfun$evalOrThrow$default$2$1(Evaluator.scala:1001)\n\tat mill.eval.Evaluator$EvalOrThrow.apply(Evaluator.scala:990)\n\tat mill.bsp.MillBuildServer.targetTasks(MillBuildServer.scala:683)\n\tat mill.bsp.MillScalaBuildServer.$anonfun$buildTargetScalacOptions$1(MillScalaBuildServer.scala:35)\n\tat mill.bsp.MillBuildServer.$anonfun$completable$1(MillBuildServer.scala:713)\n\t... 8 more\n"
}
```
To fix it, scala-cli creates dummy class to enforce compiling module by mill