### PR TITLE
Use millw launcher instead of running mill by cs

### DIFF
--- a/.mill-cs-opts
+++ b/.mill-cs-opts
@@ -1,6 +1,0 @@
-# Java 17 required for domain socket stuff
---jvm
-temurin:17
-# addresses bug in cs, that makes it fail to pick a Scala version :|
---scala
-2.13.8

--- a/mill
+++ b/mill
@@ -1,142 +1,5 @@
 #!/usr/bin/env bash
 
-# This is a wrapper script, that automatically download mill via coursier
-# You can give the required mill version with --mill-version parameter
-# If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
-#
-# Project page: https://github.com/coursier/millw
-# Original project page: https://github.com/lefou/millw
-# Script Version: 0.4.0-cs
-#
-# If you want to improve this script, please also contribute your changes back!
-#
-# Licensed under the Apache License, Version 2.0
-
-
-DEFAULT_MILL_VERSION=0.9.10
-
-set -e
-
-MILL_REPO_URL="https://github.com/com-lihaoyi/mill"
-
-if [ "x${CURL_CMD}" = "x" ] ; then
-  CURL_CMD=curl
-fi
-
-# Explicit commandline argument takes precedence over all other methods
-if [ "x$1" = "x--mill-version" ] ; then
-  shift
-  if [ "x$1" != "x" ] ; then
-    MILL_VERSION="$1"
-    shift
-  else
-    echo "You specified --mill-version without a version." 1>&2
-    echo "Please provide a version that matches one provided on" 1>&2
-    echo "${MILL_REPO_URL}/releases" 1>&2
-    false
-  fi
-fi
-
-# Please note, that if a MILL_VERSION is already set in the environment,
-# We reuse it's value and skip searching for a value.
-
-# If not already set, read .mill-version file
-if [ "x${MILL_VERSION}" = "x" ] ; then
-  if [ -f ".mill-version" ] ; then
-    MILL_VERSION="$(head -n 1 .mill-version 2> /dev/null)"
-  fi
-fi
-
-if [ "x${XDG_CACHE_HOME}" != "x" ] ; then
-  MILL_DOWNLOAD_PATH="${XDG_CACHE_HOME}/mill/download"
-else
-  MILL_DOWNLOAD_PATH="${HOME}/.cache/mill/download"
-fi
-
-# If not already set, try to fetch newest from Github
-if [ "x${MILL_VERSION}" = "x" ] ; then
-  # TODO: try to load latest version from release page
-  echo "No mill version specified." 1>&2
-  echo "You should provide a version via '.mill-version' file or --mill-version option." 1>&2
-
-  mkdir -p "${MILL_DOWNLOAD_PATH}"
-  LANG=C touch -d '1 hour ago' "${MILL_DOWNLOAD_PATH}/.expire_latest" 2>/dev/null || (
-    # we might be on OSX or BSD which don't have -d option for touch
-    # but probably a -A [-][[hh]mm]SS
-    touch "${MILL_DOWNLOAD_PATH}/.expire_latest"; touch -A -010000 "${MILL_DOWNLOAD_PATH}/.expire_latest"
-  ) || (
-    # in case we still failed, we retry the first touch command with the intention
-    # to show the (previously suppressed) error message
-    LANG=C touch -d '1 hour ago' "${MILL_DOWNLOAD_PATH}/.expire_latest"
-  )
-
-  if [ "${MILL_DOWNLOAD_PATH}/.latest" -nt "${MILL_DOWNLOAD_PATH}/.expire_latest" ] ; then
-    # we know a current latest version
-    MILL_VERSION="$(head -n 1 ${MILL_DOWNLOAD_PATH}/.latest 2> /dev/null)"
-  fi
-
-  if [ "x${MILL_VERSION}" = "x" ] ; then
-    # we don't know a current latest version
-    echo "Retrieving latest mill version ..." 1>&2
-    LANG=C ${CURL_CMD} -s -i -f -I ${MILL_REPO_URL}/releases/latest 2> /dev/null  | grep --ignore-case Location: | sed s'/^.*tag\///' | tr -d '\r\n' > "${MILL_DOWNLOAD_PATH}/.latest"
-    MILL_VERSION="$(head -n 1 ${MILL_DOWNLOAD_PATH}/.latest 2> /dev/null)"
-  fi
-
-  if [ "x${MILL_VERSION}" = "x" ] ; then
-    # Last resort
-    MILL_VERSION="${DEFAULT_MILL_VERSION}"
-    echo "Falling back to hardcoded mill version ${MILL_VERSION}" 1>&2
-  else
-    echo "Using mill version ${MILL_VERSION}" 1>&2
-  fi
-fi
-
-unset MILL_DOWNLOAD_PATH
-unset MILL_OLD_DOWNLOAD_PATH
-unset OLD_MILL
-unset MILL_VERSION_TAG
-unset MILL_REPO_URL
-
-mill_cs_opts=()
-
-# Adapted from Mill 0.10.0-M5 assembly
-init_mill_jvm_opts() {
-  if [ -z $MILL_JVM_OPTS_PATH ] ; then
-    mill_jvm_opts_file=".mill-jvm-opts"
-  else
-    mill_jvm_opts_file=$MILL_JVM_OPTS_PATH
-  fi
-
-  if [ -f "$mill_jvm_opts_file" ] ; then
-    while IFS= read line
-    do
-      case $line in
-        "-X"*) mill_cs_opts=("${mill_cs_opts[@]}" "--java-opt" "$line")
-      esac
-    done <"$mill_jvm_opts_file"
-    mill_cs_opts=("${mill_cs_opts[@]}" "--java-opt" "-Dmill.jvm_opts_applied=true")
-  fi
-}
-
-init_mill_cs_opts() {
-  if [ -z $MILL_CS_OPTS_PATH ] ; then
-    mill_cs_opts_file=".mill-cs-opts"
-  else
-    mill_cs_opts_file=$MILL_CS_OPTS_PATH
-  fi
-
-  if [ -f "$mill_cs_opts_file" ] ; then
-    while IFS= read line
-    do
-      case $line in
-        "#"*) ;;
-        *) mill_cs_opts=("${mill_cs_opts[@]}" "$line") ;;
-      esac
-    done <"$mill_cs_opts_file"
-  fi
-}
-
-
 # Adapted from
 
 coursier_version="2.1.0-M6-53-gb4f448130"
@@ -192,17 +55,10 @@ fi
 
 eval "$("$cs" java --env --jvm temurin:17 || "$cs" java --env --jvm openjdk:1.17.0)"
 
-
-init_mill_jvm_opts
-init_mill_cs_opts
-
 # temporary, until we pass JPMS options to native-image,
 # see https://www.graalvm.org/release-notes/22_2/#native-image
 export USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM=false
 
-# clear the Mill Ammonite cache, that sometimes has spurious cached data…
-if [ -n "${CI+set}" ]; then
-  rm -rf "$HOME/.mill/ammonite/cache"
-fi
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
-exec "$cs" launch "mill:$MILL_VERSION" "${mill_cs_opts[@]}" -- "$@"
+exec "$DIR/millw" "$@"

--- a/mill.bat
+++ b/mill.bat
@@ -5,7 +5,7 @@ rem You can give the required mill version with --mill-version parameter
 rem If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
 rem
 rem Project page: https://github.com/lefou/millw
-rem Script Version: 0.4.2
+rem Script Version: 0.4.3
 rem
 rem If you want to improve this script, please also contribute your changes back!
 rem
@@ -15,7 +15,9 @@ rem setlocal seems to be unavailable on Windows 95/98/ME
 rem but I don't think we need to support them in 2019
 setlocal enabledelayedexpansion
 
-set "DEFAULT_MILL_VERSION=0.10.0"
+if [!DEFAULT_MILL_VERSION!]==[] (
+    set "DEFAULT_MILL_VERSION=0.10.0"
+)
 
 set "MILL_REPO_URL=https://github.com/com-lihaoyi/mill"
 
@@ -36,6 +38,11 @@ if [%~1%]==[--mill-version] (
 if [!MILL_VERSION!]==[] (
   if exist .mill-version (
       set /p MILL_VERSION=<.mill-version
+  )
+  else (
+    if exist .config\mill-version (
+      set /p MILL_VERSION=<.config\mill-version
+    )
   )
 )
 

--- a/millw
+++ b/millw
@@ -5,16 +5,18 @@
 # If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
 #
 # Project page: https://github.com/lefou/millw
-# Script Version: 0.4.2
+# Script Version: 0.4.3
 #
 # If you want to improve this script, please also contribute your changes back!
 #
 # Licensed under the Apache License, Version 2.0
 
-
-DEFAULT_MILL_VERSION=0.10.0
-
 set -e
+
+if [ -z "${DEFAULT_MILL_VERSION}" ] ; then
+  DEFAULT_MILL_VERSION=0.10.7
+fi
+
 
 MILL_REPO_URL="https://github.com/com-lihaoyi/mill"
 
@@ -43,6 +45,8 @@ fi
 if [ -z "${MILL_VERSION}" ] ; then
   if [ -f ".mill-version" ] ; then
     MILL_VERSION="$(head -n 1 .mill-version 2> /dev/null)"
+  elif [ -f ".config/mill-version" ] ; then
+    MILL_VERSION="$(head -n 1 .config/mill-version 2> /dev/null)"
   fi
 fi
 


### PR DESCRIPTION
When IntelliJ import scala-cli BSP project it creates `mill-bsp.json` with long path to mill, because coursier update `java.class.path` and set there all jar dependencies from mill. To fix it, scala-cli uses [millw](https://github.com/lefou/millw) launcher which doesn't have so long `java.class.path`.

Mill read path to launcher from [java.class.path](https://github.com/com-lihaoyi/mill/blob/1803cb50bf3555a4d8bec3206623a06bc3ec9463/bsp/src/mill/bsp/BSP.scala#L63).