### PR TITLE
Fix calculation of Scala version and turn off the `-release` flag for 2.12.x < 2.12.5

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -2380,6 +2380,20 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
 
+  if (actualScalaVersion.startsWith("2.12."))
+    test("verify that Scala version 2.12.x < 2.12.4 is respected and compiles correctly") {
+      TestInputs(os.rel / "s.sc" -> "println(util.Properties.versionNumberString)").fromRoot {
+        root =>
+          (1 until 4).foreach { scalaPatchVersion =>
+            val scala212VersionString = s"2.12.$scalaPatchVersion"
+            val res =
+              os.proc(TestUtil.cli, "run", ".", "-S", scala212VersionString, TestUtil.extraOptions)
+                .call(cwd = root)
+            expect(res.out.trim == scala212VersionString)
+          }
+      }
+    }
+
   def scalapyNativeTest(): Unit = {
     val inputs = TestInputs(
       os.rel / "helloscalapy.sc" ->

--- a/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
@@ -221,13 +221,14 @@ object ScalaVersionUtil {
         if (filtered.isEmpty) matchingStableVersions
         else filtered
       }.filter(v => isSupportedVersion(v.repr))
-      if (validMatchingVersions.isEmpty)
-        Left(new UnsupportedScalaVersionError(
-          scalaVersionStringArg,
-          latestSupportedStableVersions
-        ))
-      else
-        Right(validMatchingVersions.max.repr)
+
+      validMatchingVersions.find(_.repr == scalaVersionStringArg) match {
+        case Some(v)                                => Right(v.repr)
+        case None if validMatchingVersions.nonEmpty => Right(validMatchingVersions.max.repr)
+        case _ => Left(
+            new UnsupportedScalaVersionError(scalaVersionStringArg, latestSupportedStableVersions)
+          )
+      }
     }
   }
 

--- a/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
@@ -19,6 +19,7 @@ import scala.build.errors.{
 import scala.build.internal.Regexes.scala2NightlyRegex
 import scala.build.internal.Util
 import scala.concurrent.duration.DurationInt
+import scala.util.Try
 import scala.util.control.NonFatal
 
 object ScalaVersionUtil {
@@ -291,4 +292,10 @@ object ScalaVersionUtil {
       .distinct
   }
 
+  extension (sv: String) {
+    def maybeScalaPatchVersion: Option[Int] = sv
+      .split('.').drop(2).headOption
+      .flatMap(_.split('-').headOption)
+      .flatMap(pv => Try(pv.toInt).toOption)
+  }
 }


### PR DESCRIPTION
Fixes #1372 
Fixes #1373 

However, code still doesn't compile on Scala `2.12.0` and compiles infinitely on `2.12.4`, which should be addressed separately.