### PR TITLE
Fix finding main classes in external jars

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/MainClass.scala
+++ b/modules/build/src/main/scala/scala/build/internal/MainClass.scala
@@ -3,6 +3,12 @@ package scala.build.internal
 import org.objectweb.asm
 import org.objectweb.asm.ClassReader
 
+import java.io.{ByteArrayInputStream, InputStream}
+import java.util.zip.ZipEntry
+
+import scala.build.Inputs.{Element, resolve}
+import scala.build.internal.zip.WrappedZipInputStream
+
 object MainClass {
 
   private def stringArrayDescriptor = "([Ljava/lang/String;)V"
@@ -37,8 +43,9 @@ object MainClass {
       if (foundMainClass) nameOpt else None
   }
 
-  def findInClass(path: os.Path): Iterator[String] = {
-    val is = os.read.inputStream(path)
+  def findInClass(path: os.Path): Iterator[String] =
+    findInClass(os.read.inputStream(path))
+  def findInClass(is: InputStream): Iterator[String] =
     try {
       val reader  = new ClassReader(is)
       val checker = new MainMethodChecker
@@ -46,17 +53,35 @@ object MainClass {
       checker.mainClassOpt.iterator
     }
     finally is.close()
+
+  def findInJar(path: os.Path): Iterator[String] = {
+    val content        = os.read.bytes(path)
+    val jarInputStream = WrappedZipInputStream.create(new ByteArrayInputStream(content))
+    jarInputStream.entries().flatMap(ent =>
+      if !ent.isDirectory && ent.getName.endsWith(".class") then {
+        val content     = jarInputStream.readAllBytes()
+        val inputStream = new ByteArrayInputStream(content)
+        findInClass(inputStream)
+      }
+      else Iterator.empty
+    )
   }
+
   def find(output: os.Path): Seq[String] =
     output match {
       case o if os.isFile(o) && o.last.endsWith(".class") =>
         findInClass(o).toVector
+      case o if os.isFile(o) && o.last.endsWith(".jar") =>
+        findInJar(o).toVector
       case o if os.isDir(o) =>
         os.walk(o)
           .iterator
-          .filter(os.isFile(_))
-          .filter(_.last.endsWith(".class"))
-          .flatMap(findInClass)
+          .filter(os.isFile)
+          .flatMap {
+            case classFilePath if classFilePath.last.endsWith(".class") =>
+              findInClass(classFilePath)
+            case _ => Iterator.empty
+          }
           .toVector
       case _ => Vector.empty
     }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedOptions.scala
@@ -65,6 +65,7 @@ final case class SharedOptions(
   @Name("classes")
   @Name("extraClasses")
   @Name("-classpath")
+  @Name("-cp")
   @Name("classpath")
   @Name("classPath")
   @Name("extraClassPath")

--- a/modules/cli/src/main/scala/scala/cli/commands/Default.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Default.scala
@@ -35,7 +35,7 @@ class Default(
         val shouldDefaultToRun =
           args.remaining.nonEmpty || options.shared.snippet.executeScript.nonEmpty ||
           options.shared.snippet.executeScala.nonEmpty || options.shared.snippet.executeJava.nonEmpty ||
-          (options.shared.extraJarsAndClasspath.nonEmpty && options.sharedRun.mainClass.mainClass.nonEmpty)
+          (options.shared.extraJarsAndClassPath.nonEmpty && options.sharedRun.mainClass.mainClass.nonEmpty)
         if shouldDefaultToRun then RunOptions.parser else ReplOptions.parser
       }.parse(rawArgs) match
         case Left(e)                              => error(e)

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -2392,7 +2392,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
       val runRes = os.proc(
         TestUtil.cli,
         "run",
-        "-classpath",
+        "-cp",
         jarParentDirectory,
         extraOptions
       ).call(cwd = root)

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -2341,6 +2341,65 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
 
+  test("run main class from a jar even when no explicit inputs are passed") {
+    val expectedOutput = "Hello"
+    TestInputs(
+      os.rel / "Main.scala" -> s"""object Main extends App { println("$expectedOutput") }"""
+    ).fromRoot { (root: os.Path) =>
+      // first, package the code to a jar with a main class
+      val jarPath = os.rel / "Main.jar"
+      os.proc(
+        TestUtil.cli,
+        "package",
+        ".",
+        "--library",
+        "-o",
+        jarPath,
+        extraOptions
+      ).call(cwd = root)
+
+      // next, run while relying on the jar instead of passing inputs
+      val runRes = os.proc(
+        TestUtil.cli,
+        "run",
+        "-classpath",
+        jarPath,
+        extraOptions
+      ).call(cwd = root)
+      expect(runRes.out.trim == expectedOutput)
+    }
+  }
+
+  test("run main class from a jar in a directory even when no explicit inputs are passed") {
+    val expectedOutput = "Hello"
+    TestInputs(
+      os.rel / "Main.scala" -> s"""object Main extends App { println("$expectedOutput") }"""
+    ).fromRoot { (root: os.Path) =>
+      // first, package the code to a jar with a main class
+      val jarParentDirectory = os.rel / "out"
+      val jarPath            = jarParentDirectory / "Main.jar"
+      os.proc(
+        TestUtil.cli,
+        "package",
+        ".",
+        "--library",
+        "-o",
+        jarPath,
+        extraOptions
+      ).call(cwd = root)
+
+      // next, run while relying on the jar instead of passing inputs
+      val runRes = os.proc(
+        TestUtil.cli,
+        "run",
+        "-classpath",
+        jarParentDirectory,
+        extraOptions
+      ).call(cwd = root)
+      expect(runRes.out.trim == expectedOutput)
+    }
+  }
+
   if (actualScalaVersion.startsWith("3"))
     test("should throw exception for code compiled by scala 3.1.3") {
       val exceptionMsg = "Throw exception in Scala"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1232,7 +1232,7 @@ Show help for scalac. This is an alias for --scalac-option -help
 
 ### `--extra-jars`
 
-Aliases: `--jar`, `--jars`, `--extra-jar`, `--class`, `--extra-class`, `--classes`, `--extra-classes`, `-classpath`, `--classpath`, `--class-path`, `--extra-class-path`
+Aliases: `--jar`, `--jars`, `--extra-jar`, `--class`, `--extra-class`, `--classes`, `--extra-classes`, `-classpath`, `-cp`, `--classpath`, `--class-path`, `--extra-class-path`
 
 Add extra JARs and compiled classes to the class path
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -642,7 +642,7 @@ Show help for scalac. This is an alias for --scalac-option -help
 
 ### `--extra-jars`
 
-Aliases: `--jar`, `--jars`, `--extra-jar`, `--class`, `--extra-class`, `--classes`, `--extra-classes`, `-classpath`, `--classpath`, `--class-path`, `--extra-class-path`
+Aliases: `--jar`, `--jars`, `--extra-jar`, `--class`, `--extra-class`, `--classes`, `--extra-classes`, `-classpath`, `-cp`, `--classpath`, `--class-path`, `--extra-class-path`
 
 Add extra JARs and compiled classes to the class path
 


### PR DESCRIPTION
This fixes finding main classes in external jars, enabling the following syntax:
```
$ scala-cli run -cp Main.jar --list-main-classes
Main
$ scala-cli run -cp Main.jar
Hello
$ scala-cli --main-class Main -cp Main.jar
Hello
$ ls jarDir
Main.jar
$ scala-cli run -cp jarDir
Hello
$ scala-cli --main-class Main -cp jarDir
Hello
```

BTW do note that this enables to pass `.jar` files in a directory, which formerly wasn't being handled.
Also, `-cp` was added as an alias to `-classpath`, as part of the `SIP` backwards compat.