### PR TITLE
Add repositories-related keys in config module

### DIFF
--- a/modules/config/src/main/scala/scala/cli/config/Keys.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Keys.scala
@@ -23,6 +23,9 @@ object Keys {
   val proxyUser     = new Key.PasswordEntry(Seq("httpProxy"), "user")
   val proxyPassword = new Key.PasswordEntry(Seq("httpProxy"), "password")
 
+  val repositoriesMirrors = new Key.StringListEntry(Seq("repositories"), "mirrors")
+  val defaultRepositories = new Key.StringListEntry(Seq("repositories"), "default")
+
   // setting indicating if the global interactive mode was suggested
   val globalInteractiveWasSuggested = new Key.BooleanEntry(Seq.empty, "interactive-was-suggested")
 


### PR DESCRIPTION
So that https://github.com/coursier/coursier/pull/2541 can benefit from it, via the next Scala CLI release.