### PR TITLE
Add Scoop to Windows installation methods

### DIFF
--- a/website/docs/_advanced_install.mdx
+++ b/website/docs/_advanced_install.mdx
@@ -165,6 +165,7 @@ values={[
 {label: 'Installer', value: 'installer'},
 {label: 'SDKMAN', value: 'sdkman'},
 {label: 'Chocolatey', value: 'choco'},
+{label: 'Scoop', value: 'scoop'},
 ]}
 >
 
@@ -228,6 +229,16 @@ Third-party Chocolatey packages may not provide the latest version.
 :::
 
 </TabItem>
+<TabItem value="scoop">
+
+To install Scala CLI via [Scoop](https://scoop.sh), run the following command from the command line or from PowerShell:
+
+```bash
+scoop install scala-cli
+```
+
+</TabItem>
+
 </Tabs>
 
 </TabItem>


### PR DESCRIPTION
With https://github.com/ScoopInstaller/Main/pull/3994 scala-cli can now be installed via Scoop. The version will always be the most current one, due to Scoop's updating mechanism.