### PR TITLE
Add support for BSP's `buildTarget/outputPaths` and update bsp4j to 2…

### DIFF
--- a/modules/build/src/main/scala/scala/build/bsp/BuildServerProxy.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BuildServerProxy.scala
@@ -73,6 +73,9 @@ class BuildServerProxy(
   override def buildTargetWrappedSources(params: WrappedSourcesParams)
     : CompletableFuture[WrappedSourcesResult] = bspServer().buildTargetWrappedSources(params)
 
+  override def buildTargetOutputPaths(params: b.OutputPathsParams)
+    : CompletableFuture[b.OutputPathsResult] =
+    bspServer().buildTargetOutputPaths(params)
   override def workspaceReload(): CompletableFuture[AnyRef] =
     onReload()
 

--- a/modules/build/src/main/scala/scala/build/bsp/HasGeneratedSourcesImpl.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/HasGeneratedSourcesImpl.scala
@@ -2,6 +2,7 @@ package scala.build.bsp
 
 import ch.epfl.scala.{bsp4j => b}
 
+import scala.build.internal.Constants
 import scala.build.options.Scope
 import scala.build.{GeneratedSource, Inputs}
 import scala.collection.mutable
@@ -43,6 +44,11 @@ trait HasGeneratedSourcesImpl extends HasGeneratedSources {
     generatedSources(scope) = GeneratedSources(sources)
   }
 
+  protected def targetWorkspaceDirOpt(id: b.BuildTargetIdentifier): Option[String] =
+    projectNames.collectFirst {
+      case (_, projName) if projName.targetUriOpt.contains(id.getUri) =>
+        (projName.bloopWorkspace / Constants.workspaceDirName).toIO.toURI.toASCIIString
+    }
   protected def targetScopeOpt(id: b.BuildTargetIdentifier): Option[Scope] =
     projectNames.collectFirst {
       case (scope, projName) if projName.targetUriOpt.contains(id.getUri) =>

--- a/modules/build/src/main/scala/scala/build/bsp/LoggingBuildServerAll.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/LoggingBuildServerAll.scala
@@ -14,4 +14,8 @@ class LoggingBuildServerAll(
     : CompletableFuture[WrappedSourcesResult] =
     underlying.buildTargetWrappedSources(pprint.err.log(params)).logF
 
+  override def buildTargetOutputPaths(params: b.OutputPathsParams)
+    : CompletableFuture[b.OutputPathsResult] =
+    underlying.buildTargetOutputPaths(pprint.err.log(params)).logF
+
 }

--- a/modules/cli/src/main/resources/META-INF/native-image/org.virtuslab/scala-cli-core/reflect-config.json
+++ b/modules/cli/src/main/resources/META-INF/native-image/org.virtuslab/scala-cli-core/reflect-config.json
@@ -343,6 +343,41 @@
     "allDeclaredFields": true
   },
   {
+    "name": "ch.epfl.scala.bsp4j.OutputPathItem",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ch.epfl.scala.bsp4j.OutputPathItemKind",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ch.epfl.scala.bsp4j.OutputPathsItem",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ch.epfl.scala.bsp4j.OutputPathsParams",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ch.epfl.scala.bsp4j.OutputPathsResult",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
     "name": "ch.epfl.scala.bsp4j.Position",
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -76,7 +76,7 @@ object Deps {
   def asm      = ivy"org.ow2.asm:asm:9.3"
   // Force using of 2.13 - is there a better way?
   def bloopConfig      = ivy"io.github.alexarchambault.bleep:bloop-config_2.13:1.5.3-sc-1"
-  def bsp4j            = ivy"ch.epfl.scala:bsp4j:2.1.0-M1"
+  def bsp4j            = ivy"ch.epfl.scala:bsp4j:2.1.0-M2"
   def caseApp          = ivy"com.github.alexarchambault:case-app_2.13:2.1.0-M17"
   def collectionCompat = ivy"org.scala-lang.modules::scala-collection-compat:2.8.1"
   // Force using of 2.13 - is there a better way?


### PR DESCRIPTION
….1.0-M2

This PR added support for BSP's `buildTarget/outputPaths` which was introduced in https://github.com/build-server-protocol/build-server-protocol/pull/269. 


Only one path `$SCALA_CLI_WORKSPACE/.scala-build` is returned by scala-cli.