### PR TITLE
Refactor `ScalaCommand` to enforce respecting help options

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/About.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/About.scala
@@ -8,9 +8,8 @@ import scala.cli.CurrentParams
 class About(isSipScala: Boolean) extends ScalaCommand[AboutOptions] {
 
   override def group = "Miscellaneous"
-
+  override def verbosity(options: AboutOptions): Option[Int] = Some(options.verbosity.verbosity)
   override def runCommand(options: AboutOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.verbosity.verbosity
     println(Version.versionInfo(isSipScala))
     val newestScalaCliVersion = Update.newestScalaCliVersion(options.ghToken.map(_.get()))
     val isOutdated = CommandUtils.isOutOfDateVersion(

--- a/modules/cli/src/main/scala/scala/cli/commands/About.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/About.scala
@@ -1,13 +1,13 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 
 import scala.build.internal.Constants
 import scala.cli.CurrentParams
 
 class About(isSipScala: Boolean) extends ScalaCommand[AboutOptions] {
 
-  override def group = "Miscellaneous"
+  override def group                                         = "Miscellaneous"
   override def verbosity(options: AboutOptions): Option[Int] = Some(options.verbosity.verbosity)
   override def runCommand(options: AboutOptions, args: RemainingArgs): Unit = {
     println(Version.versionInfo(isSipScala))

--- a/modules/cli/src/main/scala/scala/cli/commands/About.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/About.scala
@@ -9,7 +9,7 @@ class About(isSipScala: Boolean) extends ScalaCommand[AboutOptions] {
 
   override def group = "Miscellaneous"
 
-  def run(options: AboutOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: AboutOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.verbosity.verbosity
     println(Version.versionInfo(isSipScala))
     val newestScalaCliVersion = Update.newestScalaCliVersion(options.ghToken.map(_.get()))

--- a/modules/cli/src/main/scala/scala/cli/commands/AddPath.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/AddPath.scala
@@ -9,11 +9,10 @@ import scala.cli.CurrentParams
 import scala.util.Properties
 
 object AddPath extends ScalaCommand[AddPathOptions] {
-  override def hidden       = true
-  override def isRestricted = true
+  override def hidden                                          = true
+  override def isRestricted                                    = true
+  override def verbosity(options: AddPathOptions): Option[Int] = Some(options.verbosity)
   override def runCommand(options: AddPathOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.verbosity
-
     if (args.all.isEmpty) {
       if (!options.quiet)
         System.err.println("Nothing to do")

--- a/modules/cli/src/main/scala/scala/cli/commands/AddPath.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/AddPath.scala
@@ -11,7 +11,7 @@ import scala.util.Properties
 object AddPath extends ScalaCommand[AddPathOptions] {
   override def hidden       = true
   override def isRestricted = true
-  def run(options: AddPathOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: AddPathOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.verbosity
 
     if (args.all.isEmpty) {

--- a/modules/cli/src/main/scala/scala/cli/commands/AddPath.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/AddPath.scala
@@ -1,6 +1,6 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 import coursier.env.{EnvironmentUpdate, ProfileUpdater}
 
 import java.io.File

--- a/modules/cli/src/main/scala/scala/cli/commands/BloopExit.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/BloopExit.scala
@@ -1,12 +1,12 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 
 import scala.build.Os
 import scala.build.blooprifle.{BloopRifle, BloopRifleConfig}
 import scala.cli.CurrentParams
-import scala.cli.commands.util.CommonOps._
-import scala.cli.commands.util.SharedCompilationServerOptionsUtil._
+import scala.cli.commands.util.CommonOps.*
+import scala.cli.commands.util.SharedCompilationServerOptionsUtil.*
 
 object BloopExit extends ScalaCommand[BloopExitOptions] {
   override def hidden       = true
@@ -16,7 +16,7 @@ object BloopExit extends ScalaCommand[BloopExitOptions] {
   )
 
   private def mkBloopRifleConfig(opts: BloopExitOptions): BloopRifleConfig = {
-    import opts._
+    import opts.*
     compilationServer.bloopRifleConfig(
       logging.logger,
       coursier.coursierCache(logging.logger.coursierLogger("Downloading Bloop")),

--- a/modules/cli/src/main/scala/scala/cli/commands/BloopExit.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/BloopExit.scala
@@ -26,8 +26,10 @@ object BloopExit extends ScalaCommand[BloopExitOptions] {
     )
   }
 
+  override def loggingOptions(options: BloopExitOptions): Option[LoggingOptions] =
+    Some(options.logging)
+
   override def runCommand(options: BloopExitOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.logging.verbosity
     val bloopRifleConfig = mkBloopRifleConfig(options)
     val logger           = options.logging.logger
 

--- a/modules/cli/src/main/scala/scala/cli/commands/BloopExit.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/BloopExit.scala
@@ -26,7 +26,7 @@ object BloopExit extends ScalaCommand[BloopExitOptions] {
     )
   }
 
-  def run(options: BloopExitOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: BloopExitOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.logging.verbosity
     val bloopRifleConfig = mkBloopRifleConfig(options)
     val logger           = options.logging.logger

--- a/modules/cli/src/main/scala/scala/cli/commands/BloopStart.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/BloopStart.scala
@@ -39,8 +39,10 @@ object BloopStart extends ScalaCommand[BloopStartOptions] {
     )
   }
 
+  override def loggingOptions(options: BloopStartOptions): Option[LoggingOptions] =
+    Some(options.logging)
+
   override def runCommand(options: BloopStartOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.logging.verbosity
     val threads          = BloopThreads.create()
     val bloopRifleConfig = mkBloopRifleConfig(options)
     val logger           = options.logging.logger

--- a/modules/cli/src/main/scala/scala/cli/commands/BloopStart.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/BloopStart.scala
@@ -1,6 +1,6 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 
 import scala.build.Os
 import scala.build.bloop.BloopThreads
@@ -8,9 +8,9 @@ import scala.build.blooprifle.internal.Constants
 import scala.build.blooprifle.{BloopRifle, BloopRifleConfig}
 import scala.build.options.{BuildOptions, InternalOptions}
 import scala.cli.CurrentParams
-import scala.cli.commands.util.CommonOps._
+import scala.cli.commands.util.CommonOps.*
 import scala.cli.commands.util.JvmUtils
-import scala.cli.commands.util.SharedCompilationServerOptionsUtil._
+import scala.cli.commands.util.SharedCompilationServerOptionsUtil.*
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
@@ -22,7 +22,7 @@ object BloopStart extends ScalaCommand[BloopStartOptions] {
   )
 
   private def mkBloopRifleConfig(opts: BloopStartOptions): BloopRifleConfig = {
-    import opts._
+    import opts.*
     val buildOptions = BuildOptions(
       javaOptions = JvmUtils.javaOptions(jvm).orExit(logging.logger),
       internal = InternalOptions(

--- a/modules/cli/src/main/scala/scala/cli/commands/BloopStart.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/BloopStart.scala
@@ -39,7 +39,7 @@ object BloopStart extends ScalaCommand[BloopStartOptions] {
     )
   }
 
-  def run(options: BloopStartOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: BloopStartOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.logging.verbosity
     val threads          = BloopThreads.create()
     val bloopRifleConfig = mkBloopRifleConfig(options)

--- a/modules/cli/src/main/scala/scala/cli/commands/Bsp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Bsp.scala
@@ -1,18 +1,18 @@
 package scala.cli.commands
 
-import caseapp._
-import com.github.plokhotnyuk.jsoniter_scala.core._
+import caseapp.*
+import com.github.plokhotnyuk.jsoniter_scala.core.*
 
 import scala.build.EitherCps.{either, value}
+import scala.build.*
 import scala.build.bsp.{BspReloadableOptions, BspThreads}
 import scala.build.errors.BuildException
 import scala.build.internal.CustomCodeWrapper
 import scala.build.options.BuildOptions
-import scala.build.{Build, CrossSources, Inputs, PersistentDiagnosticLogger, Sources}
 import scala.cli.CurrentParams
-import scala.cli.commands.publish.ConfigUtil._
-import scala.cli.commands.util.CommonOps._
-import scala.cli.commands.util.SharedOptionsUtil._
+import scala.cli.commands.publish.ConfigUtil.*
+import scala.cli.commands.util.CommonOps.*
+import scala.cli.commands.util.SharedOptionsUtil.*
 import scala.cli.config.{ConfigDb, Keys}
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration

--- a/modules/cli/src/main/scala/scala/cli/commands/Bsp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Bsp.scala
@@ -29,7 +29,6 @@ object Bsp extends ScalaCommand[BspOptions] {
 
   // not reusing buildOptions here, since they should be reloaded live instead
   override def runCommand(options: BspOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.shared.logging.verbosity
     if (options.shared.logging.verbosity >= 3)
       pprint.err.log(args)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/Clean.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Clean.scala
@@ -1,10 +1,10 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 
 import scala.build.internal.Constants
 import scala.build.{Inputs, Os}
-import scala.cli.commands.util.CommonOps._
+import scala.cli.commands.util.CommonOps.*
 import scala.cli.{CurrentParams, ScalaCli}
 
 object Clean extends ScalaCommand[CleanOptions] {

--- a/modules/cli/src/main/scala/scala/cli/commands/Clean.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Clean.scala
@@ -9,7 +9,7 @@ import scala.cli.{CurrentParams, ScalaCli}
 
 object Clean extends ScalaCommand[CleanOptions] {
   override def group = "Main"
-  def run(options: CleanOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: CleanOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.logging.verbosity
     val inputs = Inputs(
       args.all,

--- a/modules/cli/src/main/scala/scala/cli/commands/Clean.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Clean.scala
@@ -9,8 +9,9 @@ import scala.cli.{CurrentParams, ScalaCli}
 
 object Clean extends ScalaCommand[CleanOptions] {
   override def group = "Main"
+  override def loggingOptions(options: CleanOptions): Option[LoggingOptions] =
+    Some(options.logging)
   override def runCommand(options: CleanOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.logging.verbosity
     val inputs = Inputs(
       args.all,
       Os.pwd,

--- a/modules/cli/src/main/scala/scala/cli/commands/Compile.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Compile.scala
@@ -17,8 +17,7 @@ object Compile extends ScalaCommand[CompileOptions] with BuildCommandHelpers {
   override def group                                                         = "Main"
   override def sharedOptions(options: CompileOptions): Option[SharedOptions] = Some(options.shared)
   override def runCommand(options: CompileOptions, args: RemainingArgs): Unit = {
-    val logger = options.shared.logger
-    CurrentParams.verbosity = options.shared.logging.verbosity
+    val logger       = options.shared.logger
     val buildOptions = buildOptionsOrExit(options)
     val inputs       = options.shared.inputs(args.all).orExit(logger)
     CurrentParams.workspaceOpt = Some(inputs.workspace)

--- a/modules/cli/src/main/scala/scala/cli/commands/Compile.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Compile.scala
@@ -1,16 +1,16 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 
 import java.io.File
 
 import scala.build.options.{BuildOptions, Scope}
 import scala.build.{Build, BuildThreads, Builds, Os}
 import scala.cli.CurrentParams
-import scala.cli.commands.publish.ConfigUtil._
+import scala.cli.commands.publish.ConfigUtil.*
 import scala.cli.commands.util.BuildCommandHelpers
 import scala.cli.commands.util.CommonOps.SharedDirectoriesOptionsOps
-import scala.cli.commands.util.SharedOptionsUtil._
+import scala.cli.commands.util.SharedOptionsUtil.*
 import scala.cli.config.{ConfigDb, Keys}
 
 object Compile extends ScalaCommand[CompileOptions] with BuildCommandHelpers {

--- a/modules/cli/src/main/scala/scala/cli/commands/Default.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Default.scala
@@ -29,7 +29,6 @@ class Default(
   }
 
   override def runCommand(options: DefaultOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.shared.logging.verbosity
     if options.version then println(Version.versionInfo(isSipScala))
     else
       {

--- a/modules/cli/src/main/scala/scala/cli/commands/Default.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Default.scala
@@ -4,6 +4,7 @@ import caseapp.core.help.RuntimeCommandsHelp
 import caseapp.core.{Error, RemainingArgs}
 
 import scala.build.internal.Constants
+import scala.build.options.BuildOptions
 import scala.cli.commands.util.SharedOptionsUtil.*
 import scala.cli.{CurrentParams, ScalaCliHelp}
 
@@ -27,7 +28,7 @@ class Default(
     sys.exit(0)
   }
 
-  def run(options: DefaultOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: DefaultOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.shared.logging.verbosity
     if options.version then println(Version.versionInfo(isSipScala))
     else
@@ -39,7 +40,7 @@ class Default(
         if shouldDefaultToRun then RunOptions.parser else ReplOptions.parser
       }.parse(rawArgs) match
         case Left(e)                              => error(e)
-        case Right((replOptions: ReplOptions, _)) => Repl.run(replOptions, args)
-        case Right((runOptions: RunOptions, _))   => Run.run(runOptions, args)
+        case Right((replOptions: ReplOptions, _)) => Repl.runCommand(replOptions, args)
+        case Right((runOptions: RunOptions, _))   => Run.runCommand(runOptions, args)
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
@@ -6,7 +6,7 @@ import os.Path
 import scala.build.actionable.ActionableDependencyHandler
 import scala.build.actionable.ActionableDiagnostic.ActionableDependencyUpdateDiagnostic
 import scala.build.internal.CustomCodeWrapper
-import scala.build.options.Scope
+import scala.build.options.{BuildOptions, Scope}
 import scala.build.{CrossSources, Logger, Position, Sources}
 import scala.cli.CurrentParams
 import scala.cli.commands.util.SharedOptionsUtil._
@@ -15,13 +15,13 @@ object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
   override def group                                           = "Main"
   override def sharedOptions(options: DependencyUpdateOptions) = Some(options.shared)
 
-  def run(options: DependencyUpdateOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: DependencyUpdateOptions, args: RemainingArgs): Unit = {
     val verbosity = options.shared.logging.verbosity
     CurrentParams.verbosity = verbosity
+    val buildOptions = buildOptionsOrExit(options)
 
-    val logger       = options.shared.logger
-    val inputs       = options.shared.inputs(args.all).orExit(logger)
-    val buildOptions = options.shared.buildOptions().orExit(logger)
+    val logger = options.shared.logger
+    val inputs = options.shared.inputs(args.all).orExit(logger)
 
     val (crossSources, _) =
       CrossSources.forInputs(
@@ -60,7 +60,7 @@ object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
       actionableUpdateDiagnostics.foreach(update =>
         println(s"   * ${update.oldDependency.render} -> ${update.newVersion}")
       )
-      println("""|To update all dependencies run: 
+      println("""|To update all dependencies run:
                  |    scala-cli dependency-update --all""".stripMargin)
     }
   }

--- a/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
@@ -1,6 +1,6 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 import os.Path
 
 import scala.build.actionable.ActionableDependencyHandler
@@ -9,11 +9,12 @@ import scala.build.internal.CustomCodeWrapper
 import scala.build.options.{BuildOptions, Scope}
 import scala.build.{CrossSources, Logger, Position, Sources}
 import scala.cli.CurrentParams
-import scala.cli.commands.util.SharedOptionsUtil._
+import scala.cli.commands.util.SharedOptionsUtil.*
 
 object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
-  override def group                                           = "Main"
-  override def sharedOptions(options: DependencyUpdateOptions) = Some(options.shared)
+  override def group = "Main"
+  override def sharedOptions(options: DependencyUpdateOptions): Option[SharedOptions] =
+    Some(options.shared)
   override def runCommand(options: DependencyUpdateOptions, args: RemainingArgs): Unit = {
     val verbosity    = options.shared.logging.verbosity
     val buildOptions = buildOptionsOrExit(options)

--- a/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
@@ -14,10 +14,8 @@ import scala.cli.commands.util.SharedOptionsUtil._
 object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
   override def group                                           = "Main"
   override def sharedOptions(options: DependencyUpdateOptions) = Some(options.shared)
-
   override def runCommand(options: DependencyUpdateOptions, args: RemainingArgs): Unit = {
-    val verbosity = options.shared.logging.verbosity
-    CurrentParams.verbosity = verbosity
+    val verbosity    = options.shared.logging.verbosity
     val buildOptions = buildOptionsOrExit(options)
 
     val logger = options.shared.logger

--- a/modules/cli/src/main/scala/scala/cli/commands/Directories.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Directories.scala
@@ -1,9 +1,9 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 
 import scala.cli.CurrentParams
-import scala.cli.commands.util.CommonOps._
+import scala.cli.commands.util.CommonOps.*
 
 object Directories extends ScalaCommand[DirectoriesOptions] {
   override def hidden: Boolean = true

--- a/modules/cli/src/main/scala/scala/cli/commands/Directories.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Directories.scala
@@ -8,9 +8,9 @@ import scala.cli.commands.util.CommonOps._
 object Directories extends ScalaCommand[DirectoriesOptions] {
   override def hidden: Boolean = true
   override def isRestricted    = true
-
+  override def verbosity(options: DirectoriesOptions): Option[Int] =
+    Some(options.verbosity.verbosity)
   override def runCommand(options: DirectoriesOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.verbosity.verbosity
     if (args.all.nonEmpty) {
       System.err.println("The directories command doesn't accept arguments.")
       sys.exit(1)

--- a/modules/cli/src/main/scala/scala/cli/commands/Directories.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Directories.scala
@@ -9,7 +9,7 @@ object Directories extends ScalaCommand[DirectoriesOptions] {
   override def hidden: Boolean = true
   override def isRestricted    = true
 
-  def run(options: DirectoriesOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: DirectoriesOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.verbosity.verbosity
     if (args.all.nonEmpty) {
       System.err.println("The directories command doesn't accept arguments.")

--- a/modules/cli/src/main/scala/scala/cli/commands/Doc.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Doc.scala
@@ -1,28 +1,28 @@
 package scala.cli.commands
 
-import caseapp._
-import dependency._
+import caseapp.*
+import dependency.*
 
 import java.io.File
 
 import scala.build.EitherCps.{either, value}
-import scala.build._
+import scala.build.*
 import scala.build.compiler.{ScalaCompilerMaker, SimpleScalaCompilerMaker}
 import scala.build.errors.BuildException
 import scala.build.interactive.InteractiveFileOps
 import scala.build.internal.Runner
 import scala.build.options.BuildOptions
 import scala.cli.CurrentParams
-import scala.cli.commands.publish.ConfigUtil._
+import scala.cli.commands.publish.ConfigUtil.*
 import scala.cli.commands.util.CommonOps.SharedDirectoriesOptionsOps
-import scala.cli.commands.util.SharedOptionsUtil._
+import scala.cli.commands.util.SharedOptionsUtil.*
 import scala.cli.config.{ConfigDb, Keys}
 import scala.cli.errors.ScaladocGenerationFailedError
 import scala.util.Properties
 
 object Doc extends ScalaCommand[DocOptions] {
-  override def group                              = "Main"
-  override def sharedOptions(options: DocOptions) = Some(options.shared)
+  override def group                                                     = "Main"
+  override def sharedOptions(options: DocOptions): Option[SharedOptions] = Some(options.shared)
   override def runCommand(options: DocOptions, args: RemainingArgs): Unit = {
     val initialBuildOptions = buildOptionsOrExit(options)
     val logger              = options.shared.logger

--- a/modules/cli/src/main/scala/scala/cli/commands/Doc.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Doc.scala
@@ -24,7 +24,6 @@ object Doc extends ScalaCommand[DocOptions] {
   override def group                              = "Main"
   override def sharedOptions(options: DocOptions) = Some(options.shared)
   override def runCommand(options: DocOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.shared.logging.verbosity
     val initialBuildOptions = buildOptionsOrExit(options)
     val logger              = options.shared.logger
     val inputs              = options.shared.inputs(args.remaining).orExit(logger)

--- a/modules/cli/src/main/scala/scala/cli/commands/Doc.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Doc.scala
@@ -11,6 +11,7 @@ import scala.build.compiler.{ScalaCompilerMaker, SimpleScalaCompilerMaker}
 import scala.build.errors.BuildException
 import scala.build.interactive.InteractiveFileOps
 import scala.build.internal.Runner
+import scala.build.options.BuildOptions
 import scala.cli.CurrentParams
 import scala.cli.commands.publish.ConfigUtil._
 import scala.cli.commands.util.CommonOps.SharedDirectoriesOptionsOps
@@ -22,14 +23,12 @@ import scala.util.Properties
 object Doc extends ScalaCommand[DocOptions] {
   override def group                              = "Main"
   override def sharedOptions(options: DocOptions) = Some(options.shared)
-  def run(options: DocOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: DocOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.shared.logging.verbosity
-    val logger = options.shared.logger
-    val inputs = options.shared.inputs(args.remaining).orExit(logger)
+    val initialBuildOptions = buildOptionsOrExit(options)
+    val logger              = options.shared.logger
+    val inputs              = options.shared.inputs(args.remaining).orExit(logger)
     CurrentParams.workspaceOpt = Some(inputs.workspace)
-
-    val initialBuildOptions =
-      options.shared.buildOptions(enableJmh = false, jmhVersion = None).orExit(logger)
     val threads = BuildThreads.create()
 
     val maker               = options.shared.compilerMaker(threads).orExit(logger)

--- a/modules/cli/src/main/scala/scala/cli/commands/Doctor.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Doctor.scala
@@ -67,7 +67,7 @@ object Doctor extends ScalaCommand[DoctorOptions] {
       println(
         s"scala-cli would not be able to update itself since it is installed in multiple directories: ${scalaCliPaths.mkString(", ")}."
       )
-    else if (Update.isScalaCLIInstalledByInstallationScript())
+    else if (Update.isScalaCLIInstalledByInstallationScript)
       println(
         s"scala-cli could update itself since it is correctly installed in only one location: ${scalaCliPaths.mkString}."
       )

--- a/modules/cli/src/main/scala/scala/cli/commands/Doctor.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Doctor.scala
@@ -29,7 +29,7 @@ import scala.cli.signing.shared.Secret
 object Doctor extends ScalaCommand[DoctorOptions] {
   override def group = "Doctor"
 
-  def run(options: DoctorOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: DoctorOptions, args: RemainingArgs): Unit = {
     checkIsVersionOutdated(options.ghToken.map(_.get()))
     checkBloopStatus()
     checkDuplicatesOnPath()

--- a/modules/cli/src/main/scala/scala/cli/commands/Export.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Export.scala
@@ -1,17 +1,17 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 import coursier.cache.FileCache
 import coursier.util.{Artifact, Task}
 
 import scala.build.EitherCps.{either, value}
+import scala.build.*
 import scala.build.errors.BuildException
 import scala.build.internal.{Constants, CustomCodeWrapper}
 import scala.build.options.{BuildOptions, Scope}
-import scala.build.{CrossSources, Inputs, Logger, Os, Sources}
 import scala.cli.CurrentParams
-import scala.cli.commands.util.SharedOptionsUtil._
-import scala.cli.exportCmd._
+import scala.cli.commands.util.SharedOptionsUtil.*
+import scala.cli.exportCmd.*
 
 object Export extends ScalaCommand[ExportOptions] {
   override def isRestricted = true

--- a/modules/cli/src/main/scala/scala/cli/commands/Export.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Export.scala
@@ -76,7 +76,6 @@ object Export extends ScalaCommand[ExportOptions] {
   override def sharedOptions(opts: ExportOptions): Option[SharedOptions] = Some(opts.shared)
 
   override def runCommand(options: ExportOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.shared.logging.verbosity
     val initialBuildOptions = buildOptionsOrExit(options)
     val logger              = options.shared.logger
 

--- a/modules/cli/src/main/scala/scala/cli/commands/Export.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Export.scala
@@ -73,9 +73,12 @@ object Export extends ScalaCommand[ExportOptions] {
     Mill(Constants.millVersion, launchers, logger)
   }
 
-  def run(options: ExportOptions, args: RemainingArgs): Unit = {
+  override def sharedOptions(opts: ExportOptions): Option[SharedOptions] = Some(opts.shared)
+
+  override def runCommand(options: ExportOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.shared.logging.verbosity
-    val logger = options.shared.logger
+    val initialBuildOptions = buildOptionsOrExit(options)
+    val logger              = options.shared.logger
 
     val output = options.output.getOrElse("dest")
     val dest   = os.Path(output, os.pwd)
@@ -102,8 +105,7 @@ object Export extends ScalaCommand[ExportOptions] {
     val inputs = options.shared.inputs(args.all).orExit(logger)
     CurrentParams.workspaceOpt = Some(inputs.workspace)
     val baseOptions =
-      options.shared.buildOptions().orExit(logger)
-        .copy(mainClass = options.mainClass.mainClass.filter(_.nonEmpty))
+      initialBuildOptions.copy(mainClass = options.mainClass.mainClass.filter(_.nonEmpty))
 
     val (sourcesMain, optionsMain0) =
       prepareBuild(inputs, baseOptions, logger, options.shared.logging.verbosity, Scope.Main)

--- a/modules/cli/src/main/scala/scala/cli/commands/Fmt.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Fmt.scala
@@ -1,16 +1,16 @@
 package scala.cli.commands
 
-import caseapp._
-import dependency._
+import caseapp.*
+import dependency.*
 
 import scala.build.internal.{Constants, ExternalBinaryParams, FetchExternalBinary, Runner}
 import scala.build.options.BuildOptions
 import scala.build.{Inputs, Logger, Sources}
 import scala.cli.CurrentParams
-import scala.cli.commands.util.FmtOptionsUtil._
-import scala.cli.commands.util.FmtUtil._
-import scala.cli.commands.util.SharedOptionsUtil._
-import scala.cli.commands.util.VerbosityOptionsUtil._
+import scala.cli.commands.util.FmtOptionsUtil.*
+import scala.cli.commands.util.FmtUtil.*
+import scala.cli.commands.util.SharedOptionsUtil.*
+import scala.cli.commands.util.VerbosityOptionsUtil.*
 
 object Fmt extends ScalaCommand[FmtOptions] {
   override def group: String                                             = "Main"
@@ -24,11 +24,10 @@ object Fmt extends ScalaCommand[FmtOptions] {
 
   override def runCommand(options: FmtOptions, args: RemainingArgs): Unit = {
     val buildOptions = buildOptionsOrExit(options)
-    val interactive  = options.shared.logging.verbosityOptions.interactiveInstance()
     val logger       = options.shared.logger
 
     // TODO If no input is given, just pass '.' to scalafmt?
-    val (sourceFiles, workspace, inputsOpt) =
+    val (sourceFiles, workspace, _) =
       if (args.all.isEmpty)
         (Seq(os.pwd), os.pwd, None)
       else {

--- a/modules/cli/src/main/scala/scala/cli/commands/Fmt.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Fmt.scala
@@ -23,7 +23,6 @@ object Fmt extends ScalaCommand[FmtOptions] {
   )
 
   override def runCommand(options: FmtOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.shared.logging.verbosity
     val buildOptions = buildOptionsOrExit(options)
     val interactive  = options.shared.logging.verbosityOptions.interactiveInstance()
     val logger       = options.shared.logger

--- a/modules/cli/src/main/scala/scala/cli/commands/HelpCmd.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/HelpCmd.scala
@@ -1,6 +1,6 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 import caseapp.core.help.RuntimeCommandsHelp
 
 import scala.cli.ScalaCliHelp

--- a/modules/cli/src/main/scala/scala/cli/commands/HelpCmd.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/HelpCmd.scala
@@ -8,6 +8,6 @@ import scala.cli.ScalaCliHelp
 class HelpCmd(actualHelp: => RuntimeCommandsHelp) extends ScalaCommand[HelpOptions] {
   override def names = List(List("help"))
 
-  def run(options: HelpOptions, args: RemainingArgs) =
+  override def runCommand(options: HelpOptions, args: RemainingArgs) =
     println(actualHelp.help(ScalaCliHelp.helpFormat))
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/InstallCompletions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/InstallCompletions.scala
@@ -17,7 +17,7 @@ object InstallCompletions extends ScalaCommand[InstallCompletionsOptions] {
     List("install", "completions"),
     List("install-completions")
   )
-  def run(options: InstallCompletionsOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: InstallCompletionsOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.logging.verbosity
     val interactive = options.logging.verbosityOptions.interactiveInstance()
     lazy val completionsDir =

--- a/modules/cli/src/main/scala/scala/cli/commands/InstallCompletions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/InstallCompletions.scala
@@ -17,8 +17,9 @@ object InstallCompletions extends ScalaCommand[InstallCompletionsOptions] {
     List("install", "completions"),
     List("install-completions")
   )
+  override def loggingOptions(options: InstallCompletionsOptions): Option[LoggingOptions] =
+    Some(options.logging)
   override def runCommand(options: InstallCompletionsOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.logging.verbosity
     val interactive = options.logging.verbosityOptions.interactiveInstance()
     lazy val completionsDir =
       options.output

--- a/modules/cli/src/main/scala/scala/cli/commands/InstallCompletions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/InstallCompletions.scala
@@ -1,15 +1,15 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 import caseapp.core.complete.{Bash, Zsh}
 
 import java.io.File
 import java.nio.charset.Charset
-import java.util.Arrays
+import java.util
 
 import scala.cli.CurrentParams
-import scala.cli.commands.util.CommonOps._
-import scala.cli.commands.util.VerbosityOptionsUtil._
+import scala.cli.commands.util.CommonOps.*
+import scala.cli.commands.util.VerbosityOptionsUtil.*
 import scala.cli.internal.{Argv0, ProfileFileUpdater}
 
 object InstallCompletions extends ScalaCommand[InstallCompletionsOptions] {
@@ -55,7 +55,7 @@ object InstallCompletions extends ScalaCommand[InstallCompletionsOptions] {
         val completionScriptDest = dir / s"_$name"
         val content              = completionScript.getBytes(Charset.defaultCharset())
         val needsWrite = !os.exists(completionScriptDest) ||
-          !Arrays.equals(os.read.bytes(completionScriptDest), content)
+          !util.Arrays.equals(os.read.bytes(completionScriptDest), content)
         if (needsWrite) {
           logger.log(s"Writing $completionScriptDest")
           os.write.over(completionScriptDest, content, createFolders = true)
@@ -95,7 +95,7 @@ object InstallCompletions extends ScalaCommand[InstallCompletionsOptions] {
     }
   }
 
-  def getName(name: Option[String]) =
+  def getName(name: Option[String]): String =
     name.getOrElse {
       val baseName = (new Argv0).get("scala-cli")
       val idx      = baseName.lastIndexOf(File.separator)
@@ -103,7 +103,7 @@ object InstallCompletions extends ScalaCommand[InstallCompletionsOptions] {
       else baseName.drop(idx + 1)
     }
 
-  def getFormat(format: Option[String]) =
+  def getFormat(format: Option[String]): Option[String] =
     format.map(_.trim).filter(_.nonEmpty)
       .orElse {
         Option(System.getenv("SHELL")).map(_.split(File.separator).last).map {

--- a/modules/cli/src/main/scala/scala/cli/commands/InstallHome.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/InstallHome.scala
@@ -42,7 +42,7 @@ object InstallHome extends ScalaCommand[InstallHomeOptions] {
       sys.exit(1)
     }
 
-  def run(options: InstallHomeOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: InstallHomeOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.verbosity.verbosity
     val binDirPath =
       options.binDirPath.getOrElse(scala.build.Directories.default().binRepoDir / "scala-cli")

--- a/modules/cli/src/main/scala/scala/cli/commands/InstallHome.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/InstallHome.scala
@@ -1,6 +1,6 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 import coursier.env.{EnvironmentUpdate, ProfileUpdater}
 
 import scala.cli.CurrentParams
@@ -18,14 +18,14 @@ object InstallHome extends ScalaCommand[InstallHomeOptions] {
     sys.exit(0)
   }
 
-  private def logUpdate(env: Boolean, newVersion: String, oldVersion: String) =
+  private def logUpdate(env: Boolean, newVersion: String, oldVersion: String): Unit =
     if (!env) println(
       s"""scala-cli $oldVersion is already installed and out-of-date.
          |scala-cli will be updated to version $newVersion
          |""".stripMargin
     )
 
-  private def logDowngrade(env: Boolean, newVersion: String, oldVersion: String) =
+  private def logDowngrade(env: Boolean, newVersion: String, oldVersion: String): Unit =
     if (!env && coursier.paths.Util.useAnsiOutput()) {
       println(s"scala-cli $oldVersion is already installed and up-to-date.")
       println(s"Do you want to downgrade scala-cli to version $newVersion [Y/n]")

--- a/modules/cli/src/main/scala/scala/cli/commands/InstallHome.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/InstallHome.scala
@@ -42,8 +42,10 @@ object InstallHome extends ScalaCommand[InstallHomeOptions] {
       sys.exit(1)
     }
 
+  override def verbosity(options: InstallHomeOptions): Option[Int] =
+    Some(options.verbosity.verbosity)
+
   override def runCommand(options: InstallHomeOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.verbosity.verbosity
     val binDirPath =
       options.binDirPath.getOrElse(scala.build.Directories.default().binRepoDir / "scala-cli")
     val destBinPath = binDirPath / options.binaryName

--- a/modules/cli/src/main/scala/scala/cli/commands/Metabrowse.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Metabrowse.scala
@@ -56,7 +56,6 @@ object Metabrowse extends ScalaCommand[MetabrowseOptions] {
     }
 
   override def runCommand(options: MetabrowseOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.shared.logging.verbosity
     val initialBuildOptions = buildOptionsOrExit(options)
     val logger              = options.shared.logger
     val inputs              = options.shared.inputs(args.all).orExit(logger)

--- a/modules/cli/src/main/scala/scala/cli/commands/Metabrowse.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Metabrowse.scala
@@ -1,7 +1,7 @@
 package scala.cli.commands
 
-import caseapp._
-import dependency._
+import caseapp.*
+import dependency.*
 
 import java.io.File
 
@@ -9,9 +9,9 @@ import scala.build.internal.{Constants, ExternalBinaryParams, FetchExternalBinar
 import scala.build.options.BuildOptions
 import scala.build.{Build, BuildThreads, Logger}
 import scala.cli.CurrentParams
-import scala.cli.commands.publish.ConfigUtil._
+import scala.cli.commands.publish.ConfigUtil.*
 import scala.cli.commands.util.CommonOps.SharedDirectoriesOptionsOps
-import scala.cli.commands.util.SharedOptionsUtil._
+import scala.cli.commands.util.SharedOptionsUtil.*
 import scala.cli.config.{ConfigDb, Keys}
 import scala.cli.packaging.Library
 import scala.util.Properties
@@ -25,7 +25,8 @@ object Metabrowse extends ScalaCommand[MetabrowseOptions] {
     List("metabrowse")
   )
 
-  override def sharedOptions(options: MetabrowseOptions) = Some(options.shared)
+  override def sharedOptions(options: MetabrowseOptions): Option[SharedOptions] =
+    Some(options.shared)
 
   private def metabrowseBinaryUrl(
     scalaVersion: String,
@@ -140,9 +141,7 @@ object Metabrowse extends ScalaCommand[MetabrowseOptions] {
         val rtJarLocation =
           successfulBuild.options.javaHomeLocation().value / "jre" / "lib" / "rt.jar"
 
-        val rtJarOpt =
-          if (os.isFile(rtJarLocation)) Some(rtJarLocation)
-          else None
+        val rtJarOpt = Some(rtJarLocation).filter(os.isFile)
 
         if (rtJarOpt.isEmpty && options.shared.logging.verbosity >= 0)
           System.err.println(s"Warning: could not find $rtJarLocation")

--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -49,7 +49,6 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
   override def buildOptions(options: PackageOptions): Option[BuildOptions] =
     Option(options.baseBuildOptions.orExit(options.shared.logger))
   override def runCommand(options: PackageOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.shared.logging.verbosity
     val logger = options.shared.logger
     val inputs = options.shared.inputs(args.remaining).orExit(logger)
     CurrentParams.workspaceOpt = Some(inputs.workspace)

--- a/modules/cli/src/main/scala/scala/cli/commands/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Package.scala
@@ -924,7 +924,7 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
     val dest = build.inputs.nativeWorkDir / s"main${if (Properties.isWin) ".exe" else ""}"
 
     val cliOptions =
-      build.options.scalaNativeOptions.configCliOptions(!build.sources.resourceDirs.isEmpty)
+      build.options.scalaNativeOptions.configCliOptions(build.sources.resourceDirs.nonEmpty)
 
     val setupPython = build.options.notForBloopOptions.doSetupPython.getOrElse(false)
     val pythonLdFlags =

--- a/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
@@ -27,7 +27,7 @@ object Repl extends ScalaCommand[ReplOptions] {
   )
   override def sharedOptions(options: ReplOptions): Option[SharedOptions] = Some(options.shared)
 
-  def buildOptions(ops: ReplOptions): BuildOptions = {
+  override def buildOptions(ops: ReplOptions): Option[BuildOptions] = Option {
     import ops._
     import ops.sharedRepl._
     val baseOptions = shared.buildOptions().orExit(ops.shared.logger)
@@ -52,9 +52,9 @@ object Repl extends ScalaCommand[ReplOptions] {
     )
   }
 
-  def run(options: ReplOptions, args: RemainingArgs): Unit = {
-    maybePrintGroupHelp(options)
+  override def runCommand(options: ReplOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.shared.logging.verbosity
+    val initialBuildOptions = buildOptionsOrExit(options)
     def default = Inputs.default().getOrElse {
       Inputs.empty(Os.pwd, options.shared.markdown.enableMarkdown)
     }
@@ -63,9 +63,6 @@ object Repl extends ScalaCommand[ReplOptions] {
       options.shared.inputs(args.remaining, defaultInputs = () => Some(default)).orExit(logger)
     val programArgs = args.unparsed
     CurrentParams.workspaceOpt = Some(inputs.workspace)
-
-    val initialBuildOptions = buildOptions(options)
-    maybePrintSimpleScalacOutput(options, initialBuildOptions)
 
     val threads = BuildThreads.create()
 

--- a/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
@@ -53,7 +53,6 @@ object Repl extends ScalaCommand[ReplOptions] {
   }
 
   override def runCommand(options: ReplOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.shared.logging.verbosity
     val initialBuildOptions = buildOptionsOrExit(options)
     def default = Inputs.default().getOrElse {
       Inputs.empty(Os.pwd, options.shared.markdown.enableMarkdown)

--- a/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Repl.scala
@@ -1,21 +1,21 @@
 package scala.cli.commands
 
 import ai.kien.python.Python
-import caseapp._
+import caseapp.*
 import coursier.cache.FileCache
 import coursier.error.{FetchError, ResolutionError}
-import dependency._
+import dependency.*
 
 import scala.build.EitherCps.{either, value}
-import scala.build._
+import scala.build.*
 import scala.build.errors.{BuildException, CantDownloadAmmoniteError, FetchingDependenciesError}
 import scala.build.internal.{Constants, Runner}
 import scala.build.options.{BuildOptions, JavaOpt, Scope}
 import scala.cli.CurrentParams
 import scala.cli.commands.Run.{maybePrintSimpleScalacOutput, orPythonDetectionError}
-import scala.cli.commands.publish.ConfigUtil._
-import scala.cli.commands.util.CommonOps._
-import scala.cli.commands.util.SharedOptionsUtil._
+import scala.cli.commands.publish.ConfigUtil.*
+import scala.cli.commands.util.CommonOps.*
+import scala.cli.commands.util.SharedOptionsUtil.*
 import scala.cli.config.{ConfigDb, Keys}
 import scala.util.Properties
 
@@ -28,8 +28,8 @@ object Repl extends ScalaCommand[ReplOptions] {
   override def sharedOptions(options: ReplOptions): Option[SharedOptions] = Some(options.shared)
 
   override def buildOptions(ops: ReplOptions): Option[BuildOptions] = Option {
-    import ops._
-    import ops.sharedRepl._
+    import ops.*
+    import ops.sharedRepl.*
     val baseOptions = shared.buildOptions().orExit(ops.shared.logger)
     baseOptions.copy(
       javaOptions = baseOptions.javaOptions.copy(

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -12,7 +12,7 @@ import scala.build.errors.BuildException
 import scala.build.internal.{Constants, Runner, ScalaJsLinkerConfig}
 import scala.build.options.{BuildOptions, JavaOpt, Platform, ScalacOpt}
 import scala.cli.CurrentParams
-import scala.cli.commands.publish.ConfigUtil._
+import scala.cli.commands.publish.ConfigUtil.*
 import scala.cli.commands.run.RunMode
 import scala.cli.commands.util.CommonOps.SharedDirectoriesOptionsOps
 import scala.cli.commands.util.MainClassOptionsUtil.*

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -45,17 +45,15 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
       .filter(_.trim.nonEmpty)
       .map(os.Path(_, os.pwd))
 
-  def run(options: RunOptions, args: RemainingArgs): Unit = {
-    maybePrintGroupHelp(options)
-    run(
+  override def runCommand(options: RunOptions, args: RemainingArgs): Unit =
+    scalaCliRun(
       options,
       args.remaining,
       args.unparsed,
       () => Inputs.default()
     )
-  }
 
-  def buildOptions(options: RunOptions): BuildOptions = {
+  override def buildOptions(options: RunOptions): Option[BuildOptions] = Option {
     import options.*
     import options.sharedRun.*
     val logger = options.shared.logger
@@ -101,15 +99,14 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
     )
   }
 
-  def run(
+  def scalaCliRun(
     options: RunOptions,
     inputArgs: Seq[String],
     programArgs: Seq[String],
     defaultInputs: () => Option[Inputs]
   ): Unit = {
     CurrentParams.verbosity = options.shared.logging.verbosity
-    val initialBuildOptions = buildOptions(options)
-    maybePrintSimpleScalacOutput(options, initialBuildOptions)
+    val initialBuildOptions = buildOptionsOrExit(options)
 
     val logger = options.shared.logger
     val inputs = options.shared.inputs(inputArgs, defaultInputs = defaultInputs).orExit(logger)
@@ -180,6 +177,7 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
       options.shared,
       inputs,
       logger,
+      initialBuildOptions,
       Some(name),
       inputArgs
     )

--- a/modules/cli/src/main/scala/scala/cli/commands/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Run.scala
@@ -105,7 +105,6 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
     programArgs: Seq[String],
     defaultInputs: () => Option[Inputs]
   ): Unit = {
-    CurrentParams.verbosity = options.shared.logging.verbosity
     val initialBuildOptions = buildOptionsOrExit(options)
 
     val logger = options.shared.logger

--- a/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
@@ -1,24 +1,24 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 import ch.epfl.scala.bsp4j.BspConnectionDetails
-import com.github.plokhotnyuk.jsoniter_scala.core._
+import com.github.plokhotnyuk.jsoniter_scala.core.*
 import com.google.gson.GsonBuilder
 
 import java.nio.charset.Charset
 
 import scala.build.EitherCps.{either, value}
 import scala.build.Inputs.WorkspaceOrigin
+import scala.build.*
 import scala.build.bsp.IdeInputs
 import scala.build.errors.{BuildException, WorkspaceError}
 import scala.build.internal.{Constants, CustomCodeWrapper}
 import scala.build.options.{BuildOptions, Scope}
-import scala.build.{Artifacts, CrossSources, Inputs, Logger, Os, Sources}
 import scala.cli.CurrentParams
-import scala.cli.commands.util.CommonOps._
-import scala.cli.commands.util.SharedOptionsUtil._
+import scala.cli.commands.util.CommonOps.*
+import scala.cli.commands.util.SharedOptionsUtil.*
 import scala.cli.errors.FoundVirtualInputsError
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 object SetupIde extends ScalaCommand[SetupIdeOptions] {
 
@@ -185,7 +185,7 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
   }
 
   def bspDetails(workspace: os.Path, ops: SharedBspFileOptions): (String, os.Path) = {
-    import ops._
+    import ops.*
     val dir = bspDirectory
       .filter(_.nonEmpty)
       .map(os.Path(_, Os.pwd))

--- a/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
@@ -53,7 +53,6 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
   }
 
   override def runCommand(options: SetupIdeOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.shared.logging.verbosity
     val buildOptions = buildOptionsOrExit(options)
     val logger       = options.shared.logging.logger
     val inputs       = options.shared.inputs(args.all).orExit(logger)

--- a/modules/cli/src/main/scala/scala/cli/commands/Shebang.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Shebang.scala
@@ -2,14 +2,15 @@ package scala.cli.commands
 
 import caseapp.RemainingArgs
 
+import scala.build.options.BuildOptions
 import scala.cli.CurrentParams
 
 object Shebang extends ScalaCommand[ShebangOptions] {
   override def stopAtFirstUnrecognized: Boolean = true
 
-  def run(options: ShebangOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: ShebangOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.runOptions.shared.logging.verbosity
-    Run.run(
+    Run.scalaCliRun(
       options.runOptions,
       args.remaining.headOption.toSeq,
       args.remaining.drop(1).toSeq,

--- a/modules/cli/src/main/scala/scala/cli/commands/Shebang.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Shebang.scala
@@ -7,14 +7,13 @@ import scala.cli.CurrentParams
 
 object Shebang extends ScalaCommand[ShebangOptions] {
   override def stopAtFirstUnrecognized: Boolean = true
-
-  override def runCommand(options: ShebangOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.runOptions.shared.logging.verbosity
+  override def sharedOptions(options: ShebangOptions): Option[SharedOptions] =
+    Run.sharedOptions(options.runOptions)
+  override def runCommand(options: ShebangOptions, args: RemainingArgs): Unit =
     Run.scalaCliRun(
       options.runOptions,
       args.remaining.headOption.toSeq,
       args.remaining.drop(1).toSeq,
       () => None
     )
-  }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/Shebang.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Shebang.scala
@@ -13,7 +13,7 @@ object Shebang extends ScalaCommand[ShebangOptions] {
     Run.scalaCliRun(
       options.runOptions,
       args.remaining.headOption.toSeq,
-      args.remaining.drop(1).toSeq,
+      args.remaining.drop(1),
       () => None
     )
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -43,7 +43,6 @@ object Test extends ScalaCommand[TestOptions] {
   }
 
   override def runCommand(options: TestOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.shared.logging.verbosity
     val initialBuildOptions = buildOptionsOrExit(options)
     val logger              = options.shared.logger
     val inputs              = options.shared.inputs(args.remaining).orExit(logger)

--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -24,7 +24,7 @@ object Test extends ScalaCommand[TestOptions] {
   private def gray  = "\u001b[90m"
   private def reset = Console.RESET
 
-  def buildOptions(opts: TestOptions): BuildOptions = {
+  override def buildOptions(opts: TestOptions): Option[BuildOptions] = Option {
     import opts._
     val baseOptions = shared.buildOptions().orExit(opts.shared.logger)
     baseOptions.copy(
@@ -42,20 +42,17 @@ object Test extends ScalaCommand[TestOptions] {
     )
   }
 
-  def run(options: TestOptions, args: RemainingArgs): Unit = {
-    maybePrintGroupHelp(options)
+  override def runCommand(options: TestOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.shared.logging.verbosity
-
-    val initialBuildOptions = buildOptions(options)
-    maybePrintSimpleScalacOutput(options, initialBuildOptions)
-
-    val logger = options.shared.logger
-    val inputs = options.shared.inputs(args.remaining).orExit(logger)
+    val initialBuildOptions = buildOptionsOrExit(options)
+    val logger              = options.shared.logger
+    val inputs              = options.shared.inputs(args.remaining).orExit(logger)
     CurrentParams.workspaceOpt = Some(inputs.workspace)
     SetupIde.runSafe(
       options.shared,
       inputs,
       logger,
+      initialBuildOptions,
       Some(name),
       args.remaining
     )

--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -1,20 +1,20 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 
 import java.nio.file.Path
 
 import scala.build.EitherCps.{either, value}
-import scala.build.Ops._
+import scala.build.Ops.*
+import scala.build.*
 import scala.build.errors.{BuildException, CompositeBuildException}
 import scala.build.internal.{Constants, Runner}
 import scala.build.options.{BuildOptions, JavaOpt, Platform, Scope}
 import scala.build.testrunner.AsmTestRunner
-import scala.build.{Build, BuildThreads, Builds, CrossKey, Logger, Positioned}
 import scala.cli.CurrentParams
-import scala.cli.commands.publish.ConfigUtil._
+import scala.cli.commands.publish.ConfigUtil.*
 import scala.cli.commands.util.CommonOps.SharedDirectoriesOptionsOps
-import scala.cli.commands.util.SharedOptionsUtil._
+import scala.cli.commands.util.SharedOptionsUtil.*
 import scala.cli.config.{ConfigDb, Keys}
 
 object Test extends ScalaCommand[TestOptions] {
@@ -25,7 +25,7 @@ object Test extends ScalaCommand[TestOptions] {
   private def reset = Console.RESET
 
   override def buildOptions(opts: TestOptions): Option[BuildOptions] = Option {
-    import opts._
+    import opts.*
     val baseOptions = shared.buildOptions().orExit(opts.shared.logger)
     baseOptions.copy(
       javaOptions = baseOptions.javaOptions.copy(

--- a/modules/cli/src/main/scala/scala/cli/commands/Uninstall.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Uninstall.scala
@@ -7,7 +7,7 @@ import scala.cli.commands.util.CommonOps._
 import scala.cli.commands.util.VerbosityOptionsUtil._
 
 object Uninstall extends ScalaCommand[UninstallOptions] {
-  def run(options: UninstallOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: UninstallOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.bloopExit.logging.verbosityOptions.verbosity
     val interactive =
       options.bloopExit.logging.verbosityOptions.interactiveInstance(forceEnable = true)

--- a/modules/cli/src/main/scala/scala/cli/commands/Uninstall.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Uninstall.scala
@@ -7,8 +7,9 @@ import scala.cli.commands.util.CommonOps._
 import scala.cli.commands.util.VerbosityOptionsUtil._
 
 object Uninstall extends ScalaCommand[UninstallOptions] {
+  override def loggingOptions(options: UninstallOptions): Option[LoggingOptions] =
+    Some(options.bloopExit.logging)
   override def runCommand(options: UninstallOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.bloopExit.logging.verbosityOptions.verbosity
     val interactive =
       options.bloopExit.logging.verbosityOptions.interactiveInstance(forceEnable = true)
     val logger = options.bloopExit.logging.logger

--- a/modules/cli/src/main/scala/scala/cli/commands/Uninstall.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Uninstall.scala
@@ -1,10 +1,10 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 
 import scala.cli.CurrentParams
-import scala.cli.commands.util.CommonOps._
-import scala.cli.commands.util.VerbosityOptionsUtil._
+import scala.cli.commands.util.CommonOps.*
+import scala.cli.commands.util.VerbosityOptionsUtil.*
 
 object Uninstall extends ScalaCommand[UninstallOptions] {
   override def loggingOptions(options: UninstallOptions): Option[LoggingOptions] =
@@ -20,7 +20,7 @@ object Uninstall extends ScalaCommand[UninstallOptions] {
     val cacheDir    = scala.build.Directories.default().cacheDir
 
     if (
-      !Update.isScalaCLIInstalledByInstallationScript() && (options.binDir.isEmpty || !options.force)
+      !Update.isScalaCLIInstalledByInstallationScript && (options.binDir.isEmpty || !options.force)
     ) {
       logger.error(
         "Scala CLI was not installed by the installation script, please use your package manager to uninstall scala-cli."

--- a/modules/cli/src/main/scala/scala/cli/commands/UninstallCompletions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/UninstallCompletions.scala
@@ -13,7 +13,7 @@ object UninstallCompletions extends ScalaCommand[UninstallCompletionsOptions] {
     List("uninstall", "completions"),
     List("uninstall-completions")
   )
-  def run(options: UninstallCompletionsOptions, args: RemainingArgs) = {
+  override def runCommand(options: UninstallCompletionsOptions, args: RemainingArgs) = {
     CurrentParams.verbosity = options.logging.verbosity
     val logger = options.logging.logger
     val name   = InstallCompletions.getName(options.shared.name)

--- a/modules/cli/src/main/scala/scala/cli/commands/UninstallCompletions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/UninstallCompletions.scala
@@ -1,11 +1,11 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 
 import java.nio.charset.Charset
 
 import scala.cli.CurrentParams
-import scala.cli.commands.util.CommonOps._
+import scala.cli.commands.util.CommonOps.*
 import scala.cli.internal.ProfileFileUpdater
 
 object UninstallCompletions extends ScalaCommand[UninstallCompletionsOptions] {
@@ -15,7 +15,7 @@ object UninstallCompletions extends ScalaCommand[UninstallCompletionsOptions] {
   )
   override def loggingOptions(options: UninstallCompletionsOptions): Option[LoggingOptions] =
     Some(options.logging)
-  override def runCommand(options: UninstallCompletionsOptions, args: RemainingArgs) = {
+  override def runCommand(options: UninstallCompletionsOptions, args: RemainingArgs): Unit = {
     val logger = options.logging.logger
     val name   = InstallCompletions.getName(options.shared.name)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/UninstallCompletions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/UninstallCompletions.scala
@@ -13,8 +13,9 @@ object UninstallCompletions extends ScalaCommand[UninstallCompletionsOptions] {
     List("uninstall", "completions"),
     List("uninstall-completions")
   )
+  override def loggingOptions(options: UninstallCompletionsOptions): Option[LoggingOptions] =
+    Some(options.logging)
   override def runCommand(options: UninstallCompletionsOptions, args: RemainingArgs) = {
-    CurrentParams.verbosity = options.logging.verbosity
     val logger = options.logging.logger
     val name   = InstallCompletions.getName(options.shared.name)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/Update.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Update.scala
@@ -150,10 +150,8 @@ object Update extends ScalaCommand[UpdateOptions] {
       update(options, getCurrentVersion(scalaCliBinPath))
   }
 
-  override def runCommand(options: UpdateOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.verbosity.verbosity
-    checkUpdate(options)
-  }
+  override def verbosity(options: UpdateOptions): Option[Int] = Some(options.verbosity.verbosity)
+  override def runCommand(options: UpdateOptions, args: RemainingArgs): Unit = checkUpdate(options)
 
   def checkUpdateSafe(logger: Logger): Unit =
     try

--- a/modules/cli/src/main/scala/scala/cli/commands/Update.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Update.scala
@@ -1,13 +1,14 @@
 package scala.cli.commands
 
-import caseapp._
-import com.github.plokhotnyuk.jsoniter_scala.core._
-import com.github.plokhotnyuk.jsoniter_scala.macros._
+import caseapp.*
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+import com.github.plokhotnyuk.jsoniter_scala.macros.*
+import coursier.core
 
 import scala.build.Logger
-import scala.build.internal.Constants.{ghName, ghOrg, version => scalaCliVersion}
+import scala.build.internal.Constants.{ghName, ghOrg, version as scalaCliVersion}
 import scala.cli.CurrentParams
-import scala.cli.commands.util.VerbosityOptionsUtil._
+import scala.cli.commands.util.VerbosityOptionsUtil.*
 import scala.cli.internal.ProcUtil
 import scala.cli.signing.shared.Secret
 import scala.util.Properties
@@ -20,7 +21,7 @@ object Update extends ScalaCommand[UpdateOptions] {
     prerelease: Boolean,
     tag_name: String
   ) {
-    lazy val version =
+    lazy val version: core.Version =
       coursier.core.Version(tag_name.stripPrefix("v"))
     def actualRelease: Boolean =
       !draft && !prerelease
@@ -28,7 +29,7 @@ object Update extends ScalaCommand[UpdateOptions] {
 
   private lazy val releaseListCodec: JsonValueCodec[List[Release]] = JsonCodecMaker.make
 
-  def newestScalaCliVersion(tokenOpt: Option[Secret[String]]) = {
+  def newestScalaCliVersion(tokenOpt: Option[Secret[String]]): String = {
 
     // FIXME Do we need paging here?
     val url = s"https://api.github.com/repos/$ghOrg/$ghName/releases"
@@ -58,7 +59,7 @@ object Update extends ScalaCommand[UpdateOptions] {
       scala.build.Directories.default().binRepoDir / options.binaryName
     )
 
-  private def updateScalaCli(options: UpdateOptions, newVersion: String) = {
+  private def updateScalaCli(options: UpdateOptions, newVersion: String): Unit = {
     val interactive = options.verbosity.interactiveInstance(forceEnable = true)
     if (!options.force) {
       val fallbackAction = () => {
@@ -118,7 +119,7 @@ object Update extends ScalaCommand[UpdateOptions] {
       )
   }
 
-  def checkUpdate(options: UpdateOptions) = {
+  def checkUpdate(options: UpdateOptions): Unit = {
 
     val scalaCliBinPath = installDirPath(options) / options.binaryName
 
@@ -156,14 +157,14 @@ object Update extends ScalaCommand[UpdateOptions] {
   def checkUpdateSafe(logger: Logger): Unit =
     try
       // log about update only if scala-cli was installed from installation script
-      if (isScalaCLIInstalledByInstallationScript())
+      if (isScalaCLIInstalledByInstallationScript)
         checkUpdate(UpdateOptions(isInternalRun = true))
     catch {
       case NonFatal(ex) =>
         logger.debug(s"Ignoring error during checking update: $ex")
     }
 
-  def isScalaCLIInstalledByInstallationScript(): Boolean = {
+  def isScalaCLIInstalledByInstallationScript: Boolean = {
     val classesDir =
       getClass.getProtectionDomain.getCodeSource.getLocation.toURI.toString
     val binRepoDir = build.Directories.default().binRepoDir.toString()

--- a/modules/cli/src/main/scala/scala/cli/commands/Update.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Update.scala
@@ -150,7 +150,7 @@ object Update extends ScalaCommand[UpdateOptions] {
       update(options, getCurrentVersion(scalaCliBinPath))
   }
 
-  def run(options: UpdateOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: UpdateOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.verbosity.verbosity
     checkUpdate(options)
   }

--- a/modules/cli/src/main/scala/scala/cli/commands/Version.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Version.scala
@@ -7,8 +7,9 @@ import scala.cli.CurrentParams
 
 class Version(isSipScala: Boolean) extends ScalaCommand[VersionOptions] {
   override def group = "Miscellaneous"
+  override def verbosity(options: VersionOptions): Option[Int] =
+    Some(options.verbosity.verbosity)
   override def runCommand(options: VersionOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.verbosity.verbosity
     if (options.cliVersion)
       println(Constants.version)
     else if (options.scalaVersion)

--- a/modules/cli/src/main/scala/scala/cli/commands/Version.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Version.scala
@@ -7,7 +7,7 @@ import scala.cli.CurrentParams
 
 class Version(isSipScala: Boolean) extends ScalaCommand[VersionOptions] {
   override def group = "Miscellaneous"
-  def run(options: VersionOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: VersionOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.verbosity.verbosity
     if (options.cliVersion)
       println(Constants.version)

--- a/modules/cli/src/main/scala/scala/cli/commands/Version.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Version.scala
@@ -1,6 +1,6 @@
 package scala.cli.commands
 
-import caseapp._
+import caseapp.*
 
 import scala.build.internal.Constants
 import scala.cli.CurrentParams
@@ -20,7 +20,7 @@ class Version(isSipScala: Boolean) extends ScalaCommand[VersionOptions] {
 }
 
 object Version {
-  def versionInfo(isSipScala: Boolean) =
+  def versionInfo(isSipScala: Boolean): String =
     val version            = Constants.version
     val detailedVersionOpt = Constants.detailedVersion.filter(_ != version).fold("")(" (" + _ + ")")
     val appName =

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/Bloop.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/Bloop.scala
@@ -8,9 +8,9 @@ import scala.build.blooprifle.internal.{Constants, Operations}
 import scala.build.blooprifle.{BloopRifle, BloopRifleConfig}
 import scala.build.internal.OsLibc
 import scala.cli.CurrentParams
-import scala.cli.commands.util.CommonOps._
-import scala.cli.commands.util.SharedCompilationServerOptionsUtil._
-import scala.cli.commands.util.SharedOptionsUtil._
+import scala.cli.commands.util.CommonOps.*
+import scala.cli.commands.util.SharedCompilationServerOptionsUtil.*
+import scala.cli.commands.util.SharedOptionsUtil.*
 import scala.cli.commands.{LoggingOptions, ScalaCommand, SharedOptions}
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/Bloop.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/Bloop.scala
@@ -11,13 +11,13 @@ import scala.cli.CurrentParams
 import scala.cli.commands.util.CommonOps._
 import scala.cli.commands.util.SharedCompilationServerOptionsUtil._
 import scala.cli.commands.util.SharedOptionsUtil._
-import scala.cli.commands.{ScalaCommand, SharedOptions}
+import scala.cli.commands.{LoggingOptions, ScalaCommand, SharedOptions}
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
 object Bloop extends ScalaCommand[BloopOptions] {
-  override def hidden     = true
-  override def isRestricted = true
+  override def hidden                  = true
+  override def isRestricted            = true
   override def stopAtFirstUnrecognized = true
 
   private def bloopRifleConfig0(opts: BloopOptions): BloopRifleConfig = {
@@ -58,9 +58,9 @@ object Bloop extends ScalaCommand[BloopOptions] {
     )
   }
 
+  override def loggingOptions(options: BloopOptions): Option[LoggingOptions] =
+    Some(options.logging)
   override def runCommand(options: BloopOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.logging.verbosity
-
     val threads          = BloopThreads.create()
     val logger           = options.logging.logger
     val bloopRifleConfig = bloopRifleConfig0(options)
@@ -89,7 +89,7 @@ object Bloop extends ScalaCommand[BloopOptions] {
         // FIXME Give more details?
         logger.message("Bloop server is running.")
       case Seq(cmd, args @ _*) =>
-        val assumeTty = System.console() != null
+        val assumeTty  = System.console() != null
         val workingDir = options.workDirOpt.getOrElse(os.pwd).toNIO
         Operations.run(
           command = cmd,

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/Bloop.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/Bloop.scala
@@ -58,7 +58,7 @@ object Bloop extends ScalaCommand[BloopOptions] {
     )
   }
 
-  def run(options: BloopOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: BloopOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.logging.verbosity
 
     val threads          = BloopThreads.create()

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOutput.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOutput.scala
@@ -6,17 +6,17 @@ import scala.build.blooprifle.BloopRifleConfig
 import scala.cli.CurrentParams
 import scala.cli.commands.util.CommonOps._
 import scala.cli.commands.util.SharedCompilationServerOptionsUtil._
-import scala.cli.commands.{CoursierOptions, ScalaCommand}
+import scala.cli.commands.{CoursierOptions, LoggingOptions, ScalaCommand}
 
 object BloopOutput extends ScalaCommand[BloopOutputOptions] {
-  override def hidden     = true
+  override def hidden       = true
   override def isRestricted = true
   override def names: List[List[String]] = List(
     List("bloop", "output")
   )
-
+  override def loggingOptions(options: BloopOutputOptions): Option[LoggingOptions] =
+    Some(options.logging)
   override def runCommand(options: BloopOutputOptions, args: RemainingArgs): Unit = {
-    CurrentParams.verbosity = options.logging.verbosity
     val logger = options.logging.logger
     val bloopRifleConfig = options.compilationServer.bloopRifleConfig(
       logger,

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOutput.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOutput.scala
@@ -4,8 +4,8 @@ import caseapp.core.RemainingArgs
 
 import scala.build.blooprifle.BloopRifleConfig
 import scala.cli.CurrentParams
-import scala.cli.commands.util.CommonOps._
-import scala.cli.commands.util.SharedCompilationServerOptionsUtil._
+import scala.cli.commands.util.CommonOps.*
+import scala.cli.commands.util.SharedCompilationServerOptionsUtil.*
 import scala.cli.commands.{CoursierOptions, LoggingOptions, ScalaCommand}
 
 object BloopOutput extends ScalaCommand[BloopOutputOptions] {

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOutput.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOutput.scala
@@ -15,7 +15,7 @@ object BloopOutput extends ScalaCommand[BloopOutputOptions] {
     List("bloop", "output")
   )
 
-  def run(options: BloopOutputOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: BloopOutputOptions, args: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.logging.verbosity
     val logger = options.logging.logger
     val bloopRifleConfig = options.compilationServer.bloopRifleConfig(

--- a/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
@@ -15,7 +15,7 @@ object Config extends ScalaCommand[ConfigOptions] {
   override def hidden       = true
   override def isRestricted = true
 
-  def run(options: ConfigOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: ConfigOptions, args: RemainingArgs): Unit = {
 
     val logger      = options.logging.logger
     val directories = options.directories.directories

--- a/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
@@ -6,8 +6,8 @@ import coursier.cache.ArchiveCache
 import java.util.Base64
 
 import scala.cli.commands.ScalaCommand
-import scala.cli.commands.publish.ConfigUtil._
-import scala.cli.commands.util.CommonOps._
+import scala.cli.commands.publish.ConfigUtil.*
+import scala.cli.commands.util.CommonOps.*
 import scala.cli.commands.util.JvmUtils
 import scala.cli.config.{ConfigDb, Keys, PasswordOption, Secret}
 

--- a/modules/cli/src/main/scala/scala/cli/commands/default/DefaultFile.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/DefaultFile.scala
@@ -56,7 +56,7 @@ object DefaultFile extends ScalaCommand[DefaultFileOptions] {
     sys.exit(1)
   }
 
-  def run(options: DefaultFileOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: DefaultFileOptions, args: RemainingArgs): Unit = {
 
     val logger = options.logging.logger
 

--- a/modules/cli/src/main/scala/scala/cli/commands/default/DefaultFile.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/DefaultFile.scala
@@ -6,7 +6,7 @@ import java.io.File
 
 import scala.build.Logger
 import scala.cli.commands.ScalaCommand
-import scala.cli.commands.util.CommonOps._
+import scala.cli.commands.util.CommonOps.*
 import scala.cli.internal.Constants
 import scala.util.Using
 
@@ -28,7 +28,7 @@ object DefaultFile extends ScalaCommand[DefaultFileOptions] {
     path: os.SubPath,
     content: () => Array[Byte]
   ) {
-    def printablePath = path.segments.mkString(File.separator)
+    def printablePath: String = path.segments.mkString(File.separator)
   }
 
   def defaultWorkflow: Array[Byte] =
@@ -40,7 +40,7 @@ object DefaultFile extends ScalaCommand[DefaultFileOptions] {
     "workflow"  -> DefaultFile(os.sub / ".github" / "workflows" / "ci.yml", () => defaultWorkflow),
     "gitignore" -> DefaultFile(os.sub / ".gitignore", () => defaultGitignore)
   )
-  val defaultFilesByRelPath = defaultFiles.flatMap {
+  val defaultFilesByRelPath: Map[String, DefaultFile] = defaultFiles.flatMap {
     case (_, d) =>
       // d.path.toString and d.printablePath differ on Windows (one uses '/', the other '\')
       Seq(

--- a/modules/cli/src/main/scala/scala/cli/commands/github/SecretCreate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/SecretCreate.scala
@@ -1,9 +1,9 @@
 package scala.cli.commands.github
 
 import caseapp.core.RemainingArgs
-import com.github.plokhotnyuk.jsoniter_scala.core._
+import com.github.plokhotnyuk.jsoniter_scala.core.*
 import coursier.cache.ArchiveCache
-import sttp.client3._
+import sttp.client3.*
 
 import java.nio.charset.StandardCharsets
 import java.util.Base64
@@ -11,8 +11,8 @@ import java.util.Base64
 import scala.build.EitherCps.{either, value}
 import scala.build.Logger
 import scala.cli.commands.ScalaCommand
-import scala.cli.commands.publish.ConfigUtil._
-import scala.cli.commands.util.CommonOps._
+import scala.cli.commands.publish.ConfigUtil.*
+import scala.cli.commands.util.CommonOps.*
 import scala.cli.commands.util.ScalaCliSttpBackend
 import scala.cli.config.{PasswordOption, Secret}
 import scala.cli.errors.GitHubApiError

--- a/modules/cli/src/main/scala/scala/cli/commands/github/SecretCreate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/SecretCreate.scala
@@ -132,7 +132,7 @@ object SecretCreate extends ScalaCommand[SecretCreateOptions] {
     }
   }
 
-  def run(options: SecretCreateOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: SecretCreateOptions, args: RemainingArgs): Unit = {
 
     val logger = options.shared.logging.logger
 

--- a/modules/cli/src/main/scala/scala/cli/commands/github/SecretList.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/SecretList.scala
@@ -1,14 +1,14 @@
 package scala.cli.commands.github
 
 import caseapp.core.RemainingArgs
-import com.github.plokhotnyuk.jsoniter_scala.core._
-import sttp.client3._
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+import sttp.client3.*
 
 import scala.build.EitherCps.{either, value}
 import scala.build.Logger
 import scala.cli.commands.ScalaCommand
-import scala.cli.commands.publish.ConfigUtil._
-import scala.cli.commands.util.CommonOps._
+import scala.cli.commands.publish.ConfigUtil.*
+import scala.cli.commands.util.CommonOps.*
 import scala.cli.commands.util.ScalaCliSttpBackend
 import scala.cli.config.Secret
 import scala.cli.errors.GitHubApiError

--- a/modules/cli/src/main/scala/scala/cli/commands/github/SecretList.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/SecretList.scala
@@ -55,7 +55,7 @@ object SecretList extends ScalaCommand[ListSecretsOptions] {
     readFromString(body)(GitHubApi.secretListCodec)
   }
 
-  def run(options: ListSecretsOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: ListSecretsOptions, args: RemainingArgs): Unit = {
 
     val logger = options.shared.logging.logger
 

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpCreate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpCreate.scala
@@ -11,6 +11,6 @@ object PgpCreate extends ScalaCommand[PgpCreateOptions] {
   override def hidden       = true
   override def names        = PgpCommandNames.pgpCreate
 
-  def run(options: PgpCreateOptions, args: RemainingArgs): Unit =
+  override def runCommand(options: PgpCreateOptions, args: RemainingArgs): Unit =
     OriginalPgpCreate.run(options, args)
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpKeyId.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpKeyId.scala
@@ -11,6 +11,6 @@ object PgpKeyId extends ScalaCommand[PgpKeyIdOptions] {
   override def hidden       = true
   override def names        = PgpCommandNames.pgpKeyId
 
-  def run(options: PgpKeyIdOptions, args: RemainingArgs): Unit =
+  override def runCommand(options: PgpKeyIdOptions, args: RemainingArgs): Unit =
     OriginalPgpKeyId.run(options, args)
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpKeyId.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpKeyId.scala
@@ -7,9 +7,9 @@ import scala.cli.signing.commands.{PgpKeyId => OriginalPgpKeyId, PgpKeyIdOptions
 
 object PgpKeyId extends ScalaCommand[PgpKeyIdOptions] {
 
-  override def isRestricted = true
-  override def hidden       = true
-  override def names        = PgpCommandNames.pgpKeyId
+  override def isRestricted              = true
+  override def hidden                    = true
+  override def names: List[List[String]] = PgpCommandNames.pgpKeyId
 
   override def runCommand(options: PgpKeyIdOptions, args: RemainingArgs): Unit =
     OriginalPgpKeyId.run(options, args)

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPull.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPull.scala
@@ -4,7 +4,7 @@ import caseapp.core.RemainingArgs
 
 import scala.cli.commands.ScalaCommand
 import scala.cli.commands.pgp.KeyServer
-import scala.cli.commands.util.CommonOps._
+import scala.cli.commands.util.CommonOps.*
 import scala.cli.commands.util.ScalaCliSttpBackend
 
 object PgpPull extends ScalaCommand[PgpPullOptions] {

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPull.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPull.scala
@@ -15,7 +15,7 @@ object PgpPull extends ScalaCommand[PgpPullOptions] {
     List("pgp", "pull")
   )
 
-  def run(options: PgpPullOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: PgpPullOptions, args: RemainingArgs): Unit = {
 
     val logger  = options.logging.logger
     val backend = ScalaCliSttpBackend.httpURLConnection(logger)

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPush.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPush.scala
@@ -5,7 +5,7 @@ import coursier.cache.ArchiveCache
 
 import scala.cli.commands.ScalaCommand
 import scala.cli.commands.pgp.{KeyServer, PgpProxyMaker}
-import scala.cli.commands.util.CommonOps._
+import scala.cli.commands.util.CommonOps.*
 import scala.cli.commands.util.{JvmUtils, ScalaCliSttpBackend}
 import scala.cli.internal.PgpProxyMakerSubst
 

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPush.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPush.scala
@@ -17,7 +17,7 @@ object PgpPush extends ScalaCommand[PgpPushOptions] {
     List("pgp", "push")
   )
 
-  def run(options: PgpPushOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: PgpPushOptions, args: RemainingArgs): Unit = {
 
     val logger  = options.logging.logger
     val backend = ScalaCliSttpBackend.httpURLConnection(logger)

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpSign.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpSign.scala
@@ -11,6 +11,6 @@ object PgpSign extends ScalaCommand[PgpSignOptions] {
   override def hidden       = true
   override def names        = PgpCommandNames.pgpSign
 
-  def run(options: PgpSignOptions, args: RemainingArgs): Unit =
+  override def runCommand(options: PgpSignOptions, args: RemainingArgs): Unit =
     OriginalPgpSign.run(options, args)
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpVerify.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpVerify.scala
@@ -11,6 +11,6 @@ object PgpVerify extends ScalaCommand[PgpVerifyOptions] {
   override def hidden       = true
   override def names        = PgpCommandNames.pgpVerify
 
-  def run(options: PgpVerifyOptions, args: RemainingArgs): Unit =
+  override def runCommand(options: PgpVerifyOptions, args: RemainingArgs): Unit =
     OriginalPgpVerify.run(options, args)
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -33,7 +33,7 @@ import scala.build.options.publish.{ComputeVersion, Developer, License, Signer =
 import scala.build.options.{BuildOptions, ConfigMonoid, PublishContextualOptions, Scope}
 import scala.cli.CurrentParams
 import scala.cli.commands.pgp.PgpExternalCommand
-import scala.cli.commands.publish.ConfigUtil._
+import scala.cli.commands.publish.ConfigUtil.*
 import scala.cli.commands.publish.{PublishParamsOptions, PublishRepositoryOptions}
 import scala.cli.commands.util.CommonOps.SharedDirectoriesOptionsOps
 import scala.cli.commands.util.MainClassOptionsUtil.*

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -66,14 +66,13 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
     Some(options.shared)
 
   def mkBuildOptions(
-    shared: SharedOptions,
+    baseOptions: BuildOptions,
     publishParams: PublishParamsOptions,
     sharedPublish: SharedPublishOptions,
     publishRepo: PublishRepositoryOptions,
     mainClass: MainClassOptions,
     ivy2LocalLike: Option[Boolean]
   ): Either[BuildException, BuildOptions] = either {
-    val baseOptions = shared.buildOptions().orExit(shared.logger)
     val contextualOptions = PublishContextualOptions(
       repository = publishRepo.publishRepository.filter(_.trim.nonEmpty),
       repositoryIsIvy2LocalLike = ivy2LocalLike,
@@ -169,19 +168,18 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
       sys.exit(0)
     }
 
-  def run(options: PublishOptions, args: RemainingArgs): Unit = {
-    maybePrintGroupHelp(options)
-
+  override def runCommand(options: PublishOptions, args: RemainingArgs): Unit = {
     maybePrintLicensesAndExit(options.publishParams)
     maybePrintChecksumsAndExit(options.sharedPublish)
 
     CurrentParams.verbosity = options.shared.logging.verbosity
-    val logger = options.shared.logger
-    val inputs = options.shared.inputs(args.all).orExit(logger)
+    val baseOptions = buildOptionsOrExit(options)
+    val logger      = options.shared.logger
+    val inputs      = options.shared.inputs(args.all).orExit(logger)
     CurrentParams.workspaceOpt = Some(inputs.workspace)
 
     val initialBuildOptions = mkBuildOptions(
-      options.shared,
+      baseOptions,
       options.publishParams,
       options.sharedPublish,
       options.publishRepo,

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -172,7 +172,6 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
     maybePrintLicensesAndExit(options.publishParams)
     maybePrintChecksumsAndExit(options.sharedPublish)
 
-    CurrentParams.verbosity = options.shared.logging.verbosity
     val baseOptions = buildOptionsOrExit(options)
     val logger      = options.shared.logger
     val inputs      = options.shared.inputs(args.all).orExit(logger)

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
@@ -3,8 +3,9 @@ package scala.cli.commands.publish
 import caseapp.core.RemainingArgs
 
 import scala.build.BuildThreads
+import scala.build.options.BuildOptions
 import scala.cli.CurrentParams
-import scala.cli.commands.util.SharedOptionsUtil._
+import scala.cli.commands.util.SharedOptionsUtil.*
 import scala.cli.commands.{ScalaCommand, SharedOptions}
 import scala.cli.config.ConfigDb
 
@@ -19,19 +20,18 @@ object PublishLocal extends ScalaCommand[PublishLocalOptions] {
     List("publish", "local")
   )
 
-  def run(options: PublishLocalOptions, args: RemainingArgs): Unit = {
-    maybePrintGroupHelp(options)
-
+  override def runCommand(options: PublishLocalOptions, args: RemainingArgs): Unit = {
     Publish.maybePrintLicensesAndExit(options.publishParams)
     Publish.maybePrintChecksumsAndExit(options.sharedPublish)
 
     CurrentParams.verbosity = options.shared.logging.verbosity
-    val logger = options.shared.logger
-    val inputs = options.shared.inputs(args.all).orExit(logger)
+    val baseOptions = buildOptionsOrExit(options)
+    val logger      = options.shared.logger
+    val inputs      = options.shared.inputs(args.all).orExit(logger)
     CurrentParams.workspaceOpt = Some(inputs.workspace)
 
     val initialBuildOptions = Publish.mkBuildOptions(
-      options.shared,
+      baseOptions,
       options.publishParams,
       options.sharedPublish,
       PublishRepositoryOptions(),

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
@@ -24,7 +24,6 @@ object PublishLocal extends ScalaCommand[PublishLocalOptions] {
     Publish.maybePrintLicensesAndExit(options.publishParams)
     Publish.maybePrintChecksumsAndExit(options.sharedPublish)
 
-    CurrentParams.verbosity = options.shared.logging.verbosity
     val baseOptions = buildOptionsOrExit(options)
     val logger      = options.shared.logger
     val inputs      = options.shared.inputs(args.all).orExit(logger)

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
@@ -276,8 +276,7 @@ object PublishSetup extends ScalaCommand[PublishSetupOptions] {
         val hasWorkflows = os.isDir(workflowDir) &&
           os.list(workflowDir)
             .filter(_.last.endsWith(".yml")) // FIXME Accept more extensions?
-            .filter(os.isFile(_))
-            .nonEmpty
+            .exists(os.isFile)
         if (hasWorkflows)
           logger.message(
             s"Found some workflow files under ${CommandUtils.printablePath(workflowDir)}, not writing Scala CLI workflow"

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
@@ -28,7 +28,7 @@ object PublishSetup extends ScalaCommand[PublishSetupOptions] {
     List("publish", "setup")
   )
 
-  def run(options: PublishSetupOptions, args: RemainingArgs): Unit = {
+  override def runCommand(options: PublishSetupOptions, args: RemainingArgs): Unit = {
 
     Publish.maybePrintLicensesAndExit(options.publishParams)
 

--- a/modules/cli/src/test/scala/cli/commands/tests/ReplOptionsTests.scala
+++ b/modules/cli/src/test/scala/cli/commands/tests/ReplOptionsTests.scala
@@ -15,7 +15,7 @@ class ReplOptionsTests extends munit.FunSuite {
         )
       )
     )
-    val buildOptions = Repl.buildOptions(replOptions)
+    val Some(buildOptions) = Repl.buildOptions(replOptions)
     expect(buildOptions.notForBloopOptions.scalaPyVersion.contains(ver))
   }
 

--- a/modules/cli/src/test/scala/cli/commands/tests/RunOptionsTests.scala
+++ b/modules/cli/src/test/scala/cli/commands/tests/RunOptionsTests.scala
@@ -15,7 +15,7 @@ class RunOptionsTests extends munit.FunSuite {
         )
       )
     )
-    val buildOptions = Run.buildOptions(runOptions)
+    val Some(buildOptions) = Run.buildOptions(runOptions)
     expect(buildOptions.notForBloopOptions.scalaPyVersion.contains(ver))
   }
 


### PR DESCRIPTION
The following sub-commands will now respect help options (`--help-native`, `--help-js`, `--scalac-help`, other compiler options printing an ouptut regardless of inputs, etc):
- `metabrowse`
- `export`
- `fmt`
- `setup-ide`
- `doc`

The idea is to prevent us from having to fix bugs like #1407 over and over again in the future.
It is now a lot easier to centralise certain pieces of logic in `ScalaCommand`, if they apply for each and every `sub-command`.