### PR TITLE
Fix generating pkg package for M1

### DIFF
--- a/.github/scripts/generate-os-packages.sh
+++ b/.github/scripts/generate-os-packages.sh
@@ -133,7 +133,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   generate_rpm
   generate_sdk
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-  if [ "$(uname -m)" == "aarch64" ]; then
+  if [ "$(uname -m)" == "arm" ]; then
     generate_pkg "aarch64"
   else
     generate_pkg "x86_64"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
       - name: Generate native launcher
         run: .github/scripts/generate-native-image.sh
       - run: ./mill -i ci.setShouldPublish
-      - name: Build OS packages TODO generate os packages for M1
+      - name: Build OS packages
         if: env.SHOULD_PUBLISH == 'true'
         run: .github/scripts/generate-os-packages.sh
       - name: Copy artifacts


### PR DESCRIPTION
Fix detecting ARM6 Macs architecture when generating `pkg` packages. In M1 command `uname -m` return value `arm`.