### PR TITLE
Ensure compiler options relevant to syntax rewriting don't require being passed after `-O`

### DIFF
--- a/modules/cli-options/src/main/scala/scala/cli/commands/ScalacOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/ScalacOptions.scala
@@ -33,11 +33,20 @@ object ScalacOptions {
   private val scalacOptionsPurePrefixes =
     Set("-V", "-W", "-X", "-Y")
   private val scalacOptionsPrefixes =
-    Set("-g", "-language", "-opt", "-P", "-target") ++ scalacOptionsPurePrefixes
+    Set("-g", "-language", "-opt", "-P", "-target", "-source") ++ scalacOptionsPurePrefixes
   private val scalacAliasedOptions = // these options don't require being passed after -O and accept an arg
     Set("-encoding", "-release", "-color")
   private val scalacNoArgAliasedOptions = // these options don't require being passed after -O and don't accept an arg
-    Set("-nowarn", "-feature", "-deprecation")
+    Set(
+      "-nowarn",
+      "-feature",
+      "-deprecation",
+      "-rewrite",
+      "-old-syntax",
+      "-new-syntax",
+      "-indent",
+      "-no-indent"
+    )
 
   /** This includes all the scalac options which disregard inputs and print a help and/or context
     * message instead.


### PR DESCRIPTION
Inspired by https://github.com/scala/improvement-proposals/pull/46#discussion_r1001666054

With these changes, the following `scalac` options don't require being passed with `-O`.
- `-rewrite`
- `-new-syntax`
- `-old-syntax`
- `-source:<target>`
- `-indent`
- `-no-indent`

This allows for simpler commands when automatically migrating to newer Scala 3 syntax.
i.e. instead of
```scala
scala-cli . -O -indent -O -new-syntax -O -rewrite -O -source -O 3.2-migration
```
one can just use
```scala
scala-cli . -indent -new-syntax -rewrite -source:3.2-migration
```