### PR TITLE
Fix a typo in the `--server` option reference doc

### DIFF
--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedCompilationServerOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedCompilationServerOptions.scala
@@ -80,7 +80,7 @@ final case class SharedCompilationServerOptions(
     bloopWorkingDir: Option[String] = None,
 
   @Group("Compilation server")
-  @HelpMessage("Enable / disable usage of Bloop compilation server. Bloop is used by default so use `--server:false` to disable it. Disabling compilation server allows to test compilation in more controlled mannter (no caching or incremental compiler) but has a detrimental effect of performance.")
+  @HelpMessage("Enable / disable usage of Bloop compilation server. Bloop is used by default so use `--server=false` to disable it. Disabling compilation server allows to test compilation in more controlled mannter (no caching or incremental compiler) but has a detrimental effect of performance.")
     server: Option[Boolean] = None
 )
 // format: on

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -103,7 +103,7 @@ Working directory for Bloop, if it needs to be started
 
 ### `--server`
 
-Enable / disable usage of Bloop compilation server. Bloop is used by default so use `--server:false` to disable it. Disabling compilation server allows to test compilation in more controlled mannter (no caching or incremental compiler) but has a detrimental effect of performance.
+Enable / disable usage of Bloop compilation server. Bloop is used by default so use `--server=false` to disable it. Disabling compilation server allows to test compilation in more controlled mannter (no caching or incremental compiler) but has a detrimental effect of performance.
 
 ## Compile options
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -87,7 +87,7 @@ Working directory for Bloop, if it needs to be started
 
 ### `--server`
 
-Enable / disable usage of Bloop compilation server. Bloop is used by default so use `--server:false` to disable it. Disabling compilation server allows to test compilation in more controlled mannter (no caching or incremental compiler) but has a detrimental effect of performance.
+Enable / disable usage of Bloop compilation server. Bloop is used by default so use `--server=false` to disable it. Disabling compilation server allows to test compilation in more controlled mannter (no caching or incremental compiler) but has a detrimental effect of performance.
 
 ## Compile options
 


### PR DESCRIPTION
Thanks to [**satorg**](https://discord.com/channels/632150470000902164/901153021638082660/1037961125402255382) who caught this on discord