### PR TITLE
Rename some publish config keys

### DIFF
--- a/modules/config/src/main/scala/scala/cli/config/Keys.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Keys.scala
@@ -7,9 +7,9 @@ import scala.collection.mutable.ListBuffer
 
 object Keys {
 
-  val userName  = new Key.StringEntry(Seq("user"), "name")
-  val userEmail = new Key.StringEntry(Seq("user"), "email")
-  val userUrl   = new Key.StringEntry(Seq("user"), "url")
+  val userName  = new Key.StringEntry(Seq("publish", "user"), "name")
+  val userEmail = new Key.StringEntry(Seq("publish", "user"), "email")
+  val userUrl   = new Key.StringEntry(Seq("publish", "user"), "url")
 
   val ghToken = new Key.PasswordEntry(Seq("github"), "token")
 

--- a/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
@@ -16,15 +16,15 @@ class ConfigTests extends ScalaCliSuite {
     val dirOptions = Seq[os.Shellable]("--home-directory", homeDir)
     val name       = "Alex"
     TestInputs.empty.fromRoot { root =>
-      val before = os.proc(TestUtil.cli, "config", dirOptions, "user.name").call(cwd = root)
+      val before = os.proc(TestUtil.cli, "config", dirOptions, "publish.user.name").call(cwd = root)
       expect(before.out.trim().isEmpty)
 
-      os.proc(TestUtil.cli, "config", dirOptions, "user.name", name).call(cwd = root)
-      val res = os.proc(TestUtil.cli, "config", dirOptions, "user.name").call(cwd = root)
+      os.proc(TestUtil.cli, "config", dirOptions, "publish.user.name", name).call(cwd = root)
+      val res = os.proc(TestUtil.cli, "config", dirOptions, "publish.user.name").call(cwd = root)
       expect(res.out.trim() == name)
 
-      os.proc(TestUtil.cli, "config", dirOptions, "user.name", "--unset").call(cwd = root)
-      val after = os.proc(TestUtil.cli, "config", dirOptions, "user.name").call(cwd = root)
+      os.proc(TestUtil.cli, "config", dirOptions, "publish.user.name", "--unset").call(cwd = root)
+      val after = os.proc(TestUtil.cli, "config", dirOptions, "publish.user.name").call(cwd = root)
       expect(after.out.trim().isEmpty)
     }
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishSetupTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishSetupTests.scala
@@ -20,11 +20,11 @@ class PublishSetupTests extends ScalaCliSuite {
 
   private def configSetup(homeDir: os.Path, root: os.Path): Unit = {
     val dirOptions = Seq[os.Shellable]("--home-directory", homeDir)
-    os.proc(TestUtil.cli, "config", dirOptions, "user.name", devName)
+    os.proc(TestUtil.cli, "config", dirOptions, "publish.user.name", devName)
       .call(cwd = root, stdout = os.Inherit)
-    os.proc(TestUtil.cli, "config", dirOptions, "user.email", devMail)
+    os.proc(TestUtil.cli, "config", dirOptions, "publish.user.email", devMail)
       .call(cwd = root, stdout = os.Inherit)
-    os.proc(TestUtil.cli, "config", dirOptions, "user.url", devUrl)
+    os.proc(TestUtil.cli, "config", dirOptions, "publish.user.url", devUrl)
       .call(cwd = root, stdout = os.Inherit)
     os.proc(TestUtil.cli, "config", dirOptions, "sonatype.user", "value:uSeR")
       .call(cwd = root, stdout = os.Inherit)

--- a/website/docs/commands/misc/config.md
+++ b/website/docs/commands/misc/config.md
@@ -12,8 +12,8 @@ Examples of use:
 <ChainedSnippets>
 
 ```bash
-scala-cli config user.name "Alex Me"
-scala-cli config user.name
+scala-cli config publish.user.name "Alex Me"
+scala-cli config publish.user.name
 ```
 
 ```text

--- a/website/docs/commands/publishing/publish-setup.md
+++ b/website/docs/commands/publishing/publish-setup.md
@@ -36,14 +36,14 @@ the sections below show how to use it to configure things for `publish setup`.
 
 Set details with
 ```sh
-scala-cli config user.name "Alex Me"
-scala-cli config user.email "alex@alex.me"
-scala-cli config user.url "https://alex.me"
+scala-cli config publish.user.name "Alex Me"
+scala-cli config publish.user.email "alex@alex.me"
+scala-cli config publish.user.url "https://alex.me"
 ```
 
 The email can be left empty if you'd rather not put your email in POM files:
 ```sh
-scala-cli config user.email ""
+scala-cli config publish.user.email ""
 ```
 
 ### PGP key pair


### PR DESCRIPTION
Better "namespace" those, as users might not want those values to be used in other future contexts.