### PR TITLE
Clean up references to scala-cli in SIP mode

### DIFF
--- a/modules/cli-options/src/main/scala/scala/cli/commands/DirectoriesOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/DirectoriesOptions.scala
@@ -5,7 +5,7 @@ import caseapp.*
 import scala.cli.commands.common.HasLoggingOptions
 
 // format: off
-@HelpMessage("Prints directories used by `scala-cli`")
+@HelpMessage("Prints directories used by Scala CLI")
 final case class DirectoriesOptions(
   @Recurse
     directories: SharedDirectoriesOptions = SharedDirectoriesOptions(),

--- a/modules/cli-options/src/main/scala/scala/cli/commands/DocOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/DocOptions.scala
@@ -19,7 +19,7 @@ final case class DocOptions(
   @Name("f")
     force: Boolean = false,
   @Group("Doc")
-  @HelpMessage("Control if scala CLI should use default options for scaladoc, true by default. Use `--default-scaladoc-opts:false` to not include default options.")
+  @HelpMessage("Control if Scala CLI should use default options for scaladoc, true by default. Use `--default-scaladoc-opts:false` to not include default options.")
   @ExtraName("defaultScaladocOpts")
     defaultScaladocOptions: Option[Boolean] = None,
 ) extends HasSharedOptions

--- a/modules/cli-options/src/main/scala/scala/cli/commands/InstallHomeOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/InstallHomeOptions.scala
@@ -5,7 +5,7 @@ import caseapp.*
 import scala.cli.commands.common.HasLoggingOptions
 
 // format: off
-@HelpMessage("Install `scala-cli` in a sub-directory of the home directory")
+@HelpMessage("Install Scala CLI in a sub-directory of the home directory")
 final case class InstallHomeOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
@@ -13,7 +13,7 @@ final case class InstallHomeOptions(
     scalaCliBinaryPath: String,
   @Group("InstallHome")
   @Name("f")
-  @HelpMessage("Overwrite `scala-cli`, if it exists")
+  @HelpMessage("Overwrite if it exists")
     force: Boolean = false,
   @Hidden
   @HelpMessage("Binary name")

--- a/modules/cli-options/src/main/scala/scala/cli/commands/ShebangOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/ShebangOptions.scala
@@ -8,7 +8,7 @@ import scala.cli.commands.common.HasSharedOptions
   """|Like `run`, but more handy from shebang scripts
      |
      |This command is equivalent to `run`, but it changes the way
-     |`scala-cli` parses its command-line arguments in order to be compatible
+     |Scala CLI parses its command-line arguments in order to be compatible
      |with shebang scripts.
      |
      |Normally, inputs and scala-cli options can be mixed. Program have to be specified after `--`

--- a/modules/cli-options/src/main/scala/scala/cli/commands/VersionOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/VersionOptions.scala
@@ -5,11 +5,11 @@ import caseapp.*
 import scala.cli.commands.common.HasLoggingOptions
 
 // format: off
-@HelpMessage("Print `scala-cli` version")
+@HelpMessage("Print version")
 final case class VersionOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
-  @HelpMessage("Show only plain scala-cli version")
+  @HelpMessage("Show only plain version")
   @Name("cli")
     cliVersion: Boolean = false,
   @HelpMessage("Show only plain scala version") 

--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -34,7 +34,8 @@ object ScalaCli {
 
   private var isSipScala      = checkName("scala") || checkName("scala-cli-sip")
   def allowRestrictedFeatures = !isSipScala
-
+  def fullRunnerName          = if (isSipScala) "Scala code runner" else "Scala CLI"
+  def baseRunnerName          = if (isSipScala) "scala" else "scala-cli"
   private def isGraalvmNativeImage: Boolean =
     sys.props.contains("org.graalvm.nativeimage.imagecode")
 
@@ -131,10 +132,10 @@ object ScalaCli {
             // Suggest workaround of https://github.com/VirtusLab/scala-cli/pull/865
             // for https://github.com/VirtusLab/scala-cli/issues/828
             System.err.println(
-              """Running
-                |  export SCALA_CLI_VENDORED_ZIS=true
-                |before running Scala CLI might fix the issue.
-                |""".stripMargin
+              s"""Running
+                 |  export SCALA_CLI_VENDORED_ZIS=true
+                 |before running $fullRunnerName might fix the issue.
+                 |""".stripMargin
             )
           case _ =>
         }
@@ -145,7 +146,7 @@ object ScalaCli {
 
   private def warnRequiresJava17(): Unit =
     System.err.println(
-      s"Java >= 17 is required to run Scala CLI (found Java $javaMajorVersion)"
+      s"Java >= 17 is required to run $fullRunnerName (found Java $javaMajorVersion)"
     )
 
   private def main0(args: Array[String]): Unit = {
@@ -185,7 +186,7 @@ object ScalaCli {
       // Enable ANSI output in Windows terminal
       coursier.jniutils.WindowsAnsiTerminal.enableAnsiOutput()
 
-    new ScalaCliCommands(progName, isSipScala)
+    new ScalaCliCommands(progName, baseRunnerName, fullRunnerName, isSipScala)
       .main(scalaCliArgs)
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/ScalaCliCommands.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCliCommands.scala
@@ -15,6 +15,8 @@ import scala.cli.commands.publish.{Publish, PublishLocal, PublishSetup}
 
 class ScalaCliCommands(
   val progName: String,
+  baseRunnerName: String,
+  fullRunnerName: String,
   isSipScala: Boolean
 ) extends CommandsEntryPoint {
 
@@ -27,7 +29,7 @@ class ScalaCliCommands(
   private def pgpBinaryCommands = new PgpCommandsSubst
 
   private def allCommands = Seq[ScalaCommand[_]](
-    new About(isSipScala = isSipScala),
+    About,
     AddPath,
     Bloop,
     BloopExit,
@@ -64,7 +66,7 @@ class ScalaCliCommands(
     Uninstall,
     UninstallCompletions,
     Update,
-    new Version(isSipScala = isSipScala)
+    Version
   ) ++ (if (pgpUseBinaryCommands) Nil else pgpCommands.allScalaCommands.toSeq) ++
     (if (pgpUseBinaryCommands) pgpBinaryCommands.allScalaCommands.toSeq else Nil)
 
@@ -74,10 +76,10 @@ class ScalaCliCommands(
       (if (pgpUseBinaryCommands) pgpBinaryCommands.allExternalCommands.toSeq else Nil)
 
   override def description =
-    "Scala CLI is a command-line tool to interact with the Scala language. It lets you compile, run, test, and package your Scala code."
+    s"$fullRunnerName is a command-line tool to interact with the Scala language. It lets you compile, run, test, and package your Scala code."
   override def summaryDesc =
-    """|See 'scala-cli <command> --help' to read about a specific subcommand. To see full help run 'scala-cli <command> --help-full'.
-       |To run another Scala CLI version, specify it with '--cli-version' before any other argument, like 'scala-cli --cli-version <version> args'.""".stripMargin
+    s"""|See '$baseRunnerName <command> --help' to read about a specific subcommand. To see full help run '$baseRunnerName <command> --help-full'.
+        |To run another $fullRunnerName version, specify it with '--cli-version' before any other argument, like '$baseRunnerName --cli-version <version> args'.""".stripMargin
   final override def defaultCommand = Some(actualDefaultCommand)
 
   // FIXME Report this in case-app default NameFormatter

--- a/modules/cli/src/main/scala/scala/cli/commands/About.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/About.scala
@@ -7,17 +7,17 @@ import scala.build.internal.Constants
 import scala.cli.CurrentParams
 import scala.cli.commands.util.CommonOps.*
 
-class About(isSipScala: Boolean) extends ScalaCommand[AboutOptions] {
+object About extends ScalaCommand[AboutOptions] {
 
   override def group                                                         = "Miscellaneous"
   override def runCommand(options: AboutOptions, args: RemainingArgs, logger: Logger): Unit = {
-    println(Version.versionInfo(isSipScala))
+    println(Version.versionInfo)
     val newestScalaCliVersion = Update.newestScalaCliVersion(options.ghToken.map(_.get()))
     val isOutdated = CommandUtils.isOutOfDateVersion(newestScalaCliVersion, Constants.version)
     if (isOutdated)
       logger.message(
-        s"""Your Scala CLI version is outdated. The newest version is $newestScalaCliVersion
-           |It is recommended that you update Scala CLI through the same tool or method you used for its initial installation for avoiding the creation of outdated duplicates.""".stripMargin
+        s"""Your $fullRunnerName. version is outdated. The newest version is $newestScalaCliVersion
+           |It is recommended that you update $fullRunnerName through the same tool or method you used for its initial installation for avoiding the creation of outdated duplicates.""".stripMargin
       )
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/Default.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Default.scala
@@ -30,7 +30,7 @@ class Default(
   }
 
   override def runCommand(options: DefaultOptions, args: RemainingArgs, logger: Logger): Unit = {
-    if options.version then println(Version.versionInfo(isSipScala))
+    if options.version then println(Version.versionInfo)
     else
       {
         val shouldDefaultToRun =

--- a/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/DependencyUpdate.scala
@@ -62,8 +62,8 @@ object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
       actionableUpdateDiagnostics.foreach(update =>
         println(s"   * ${update.oldDependency.render} -> ${update.newVersion}")
       )
-      println("""|To update all dependencies run:
-                 |    scala-cli dependency-update --all""".stripMargin)
+      println(s"""|To update all dependencies run:
+                  |    $baseRunnerName dependency-update --all""".stripMargin)
     }
   }
 
@@ -91,7 +91,9 @@ object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
       case (Left(file), diagnostics) =>
         diagnostics.foreach {
           diagnostic =>
-            logger.message(s"Warning: Scala CLI can't update ${diagnostic._2.suggestion} in $file")
+            logger.message(
+              s"Warning: $fullRunnerName can't update ${diagnostic._2.suggestion} in $file"
+            )
         }
     }
   }

--- a/modules/cli/src/main/scala/scala/cli/commands/Doctor.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Doctor.scala
@@ -4,9 +4,9 @@ import caseapp.core.RemainingArgs
 
 import scala.build.Logger
 import scala.build.internal.Constants
-import scala.cli.ScalaCli
 import scala.cli.internal.ProcUtil
 import scala.cli.signing.shared.Secret
+import scala.cli.{CurrentParams, ScalaCli}
 
 // current version / latest version + potentially information that
 // scala-cli should be updated (and that should take SNAPSHOT version
@@ -49,10 +49,10 @@ object Doctor extends ScalaCommand[DoctorOptions] {
     val isOutdated = CommandUtils.isOutOfDateVersion(newestScalaCliVersion, currentVersion)
     if (isOutdated)
       println(
-        s"Your scala-cli version is out of date. your version: $currentVersion. please update to: $newestScalaCliVersion"
+        s"Your $baseRunnerName version is out of date. your version: $currentVersion. please update to: $newestScalaCliVersion"
       )
     else
-      println(s"Your scala-cli version ($currentVersion) is current.")
+      println(s"Your $baseRunnerName version ($currentVersion) is current.")
   }
 
   private def checkBloopStatus(): Unit = {
@@ -66,15 +66,15 @@ object Doctor extends ScalaCommand[DoctorOptions] {
 
     if (scalaCliPaths.size > 1)
       println(
-        s"scala-cli would not be able to update itself since it is installed in multiple directories: ${scalaCliPaths.mkString(", ")}."
+        s"$baseRunnerName would not be able to update itself since it is installed in multiple directories: ${scalaCliPaths.mkString(", ")}."
       )
     else if (Update.isScalaCLIInstalledByInstallationScript)
       println(
-        s"scala-cli could update itself since it is correctly installed in only one location: ${scalaCliPaths.mkString}."
+        s"$baseRunnerName could update itself since it is correctly installed in only one location: ${scalaCliPaths.mkString}."
       )
     else
       println(
-        s"scala-cli can be updated by your package manager since it is correctly installed in only one location: ${scalaCliPaths.mkString}."
+        s"$baseRunnerName can be updated by your package manager since it is correctly installed in only one location: ${scalaCliPaths.mkString}."
       )
 
   }
@@ -95,12 +95,12 @@ object Doctor extends ScalaCommand[DoctorOptions] {
 
   private def checkIsNativeOrJvm(): Unit = {
     if (System.getProperty("org.graalvm.nativeimage.kind") == "executable")
-      println("Your scala-cli is a native application.")
+      println(s"Your $baseRunnerName is a native application.")
     else {
       val jvmVersion        = System.getProperty("java.vm.name")
       val javaVendorVersion = System.getProperty("java.vendor.version")
       println(
-        s"Your scala-cli is using the java launcher with JVM: $jvmVersion ($javaVendorVersion)."
+        s"Your $baseRunnerName is using the java launcher with JVM: $jvmVersion ($javaVendorVersion)."
       )
     }
   }

--- a/modules/cli/src/main/scala/scala/cli/commands/InstallCompletions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/InstallCompletions.scala
@@ -99,7 +99,7 @@ object InstallCompletions extends ScalaCommand[InstallCompletionsOptions] {
 
   def getName(name: Option[String]): String =
     name.getOrElse {
-      val baseName = (new Argv0).get("scala-cli")
+      val baseName = (new Argv0).get(baseRunnerName)
       val idx      = baseName.lastIndexOf(File.separator)
       if (idx < 0) baseName
       else baseName.drop(idx + 1)

--- a/modules/cli/src/main/scala/scala/cli/commands/InstallHome.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/InstallHome.scala
@@ -14,7 +14,7 @@ object InstallHome extends ScalaCommand[InstallHomeOptions] {
   override def isRestricted    = true
 
   private def logEqual(version: String, logger: Logger) = {
-    logger.message(s"Scala CLI $version is already installed and up-to-date.")
+    logger.message(s"$fullRunnerName $version is already installed and up-to-date.")
     sys.exit(0)
   }
 
@@ -25,8 +25,8 @@ object InstallHome extends ScalaCommand[InstallHomeOptions] {
     logger: Logger
   ): Unit =
     if (!env) logger.message(
-      s"""scala-cli $oldVersion is already installed and out-of-date.
-         |scala-cli will be updated to version $newVersion
+      s"""$baseRunnerName $oldVersion is already installed and out-of-date.
+         |$baseRunnerName will be updated to version $newVersion
          |""".stripMargin
     )
 
@@ -37,8 +37,12 @@ object InstallHome extends ScalaCommand[InstallHomeOptions] {
     logger: Logger
   ): Unit =
     if (!env && coursier.paths.Util.useAnsiOutput()) {
-      logger.message(s"scala-cli $oldVersion is already installed and up-to-date.")
-      logger.error(s"Do you want to downgrade scala-cli to version $newVersion [Y/n]")
+      logger.message(
+        s"$baseRunnerName $oldVersion is already installed and up-to-date."
+      )
+      logger.error(
+        s"Do you want to downgrade $baseRunnerName to version $newVersion [Y/n]"
+      )
       val response = readLine()
       if (response != "Y") {
         logger.message("Abort")
@@ -47,7 +51,7 @@ object InstallHome extends ScalaCommand[InstallHomeOptions] {
     }
     else {
       logger.error(
-        s"Error: scala-cli is already installed $oldVersion and up-to-date. Downgrade to $newVersion pass -f or --force."
+        s"Error: $baseRunnerName is already installed $oldVersion and up-to-date. Downgrade to $newVersion pass -f or --force."
       )
       sys.exit(1)
     }
@@ -58,7 +62,9 @@ object InstallHome extends ScalaCommand[InstallHomeOptions] {
     logger: Logger
   ): Unit = {
     val binDirPath =
-      options.binDirPath.getOrElse(scala.build.Directories.default().binRepoDir / "scala-cli")
+      options.binDirPath.getOrElse(
+        scala.build.Directories.default().binRepoDir / baseRunnerName
+      )
     val destBinPath = binDirPath / options.binaryName
 
     val newScalaCliBinPath = os.Path(options.scalaCliBinaryPath, os.pwd)
@@ -111,16 +117,18 @@ object InstallHome extends ScalaCommand[InstallHomeOptions] {
           updater.applyUpdate(update)
         }
 
-      println(s"Successfully installed scala-cli $newVersion")
+      println(s"Successfully installed $baseRunnerName $newVersion")
 
       if (didUpdate) {
         if (Properties.isLinux)
           println(
             s"""|Profile file(s) updated.
-                |To run scala-cli, log out and log back in, or run 'source ~/.profile'""".stripMargin
+                |To run $baseRunnerName, log out and log back in, or run 'source ~/.profile'""".stripMargin
           )
         if (Properties.isMac)
-          println("To run scala-cli, open new terminal or run 'source ~/.profile'")
+          println(
+            s"To run $baseRunnerName, open new terminal or run 'source ~/.profile'"
+          )
       }
 
     }

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -40,6 +40,12 @@ abstract class ScalaCommand[T <: HasLoggingOptions](implicit myParser: Parser[T]
   /** @return the actual Scala CLI program name which was run */
   protected def progName: String = ScalaCli.progName
 
+  /** @return the actual Scala CLI runner name which was run */
+  protected def fullRunnerName = ScalaCli.fullRunnerName
+
+  /** @return the actual Scala CLI base runner name, for SIP it is scala otherwise scala-cli */
+  protected def baseRunnerName = ScalaCli.baseRunnerName
+
   // TODO Manage to have case-app give use the exact command name that was used instead
   /** The actual sub-command name that was used. If the sub-command name is a list of strings, space
     * is used as the separator. If [[argvOpt]] hasn't been defined, it defaults to [[name]].

--- a/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/SetupIde.scala
@@ -159,9 +159,9 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
 
     if (inputs.workspaceOrigin.contains(WorkspaceOrigin.HomeDir))
       value(Left(new WorkspaceError(
-        """scala-cli can not determine where to write its BSP configuration.
-          |Set an explicit BSP directory path via `--bsp-directory`.
-          |""".stripMargin
+        s"""$baseRunnerName can not determine where to write its BSP configuration.
+           |Set an explicit BSP directory path via `--bsp-directory`.
+           |""".stripMargin
       )))
 
     if (previousCommandName.isEmpty || !bspJsonDestination.toIO.exists()) {
@@ -189,7 +189,7 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
       .filter(_.nonEmpty)
       .map(os.Path(_, Os.pwd))
       .getOrElse(workspace / ".bsp")
-    val bspName0 = bspName.map(_.trim).filter(_.nonEmpty).getOrElse("scala-cli")
+    val bspName0 = bspName.map(_.trim).filter(_.nonEmpty).getOrElse(baseRunnerName)
 
     (bspName0, dir / s"$bspName0.json")
   }

--- a/modules/cli/src/main/scala/scala/cli/commands/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Test.scala
@@ -253,7 +253,7 @@ object Test extends ScalaCommand[TestOptions] {
         case Right(f) => Some(f)
         case Left(_) =>
           logger.message(
-            "zio-test found in the class path, zio-test-sbt should be added to run zio tests with Scala CLI."
+            s"zio-test found in the class path, zio-test-sbt should be added to run zio tests with $fullRunnerName."
           )
           None
       }

--- a/modules/cli/src/main/scala/scala/cli/commands/Uninstall.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Uninstall.scala
@@ -13,7 +13,9 @@ object Uninstall extends ScalaCommand[UninstallOptions] {
       options.bloopExit.logging.verbosityOptions.interactiveInstance(forceEnable = true)
 
     val binDirPath =
-      options.binDirPath.getOrElse(scala.build.Directories.default().binRepoDir / "scala-cli")
+      options.binDirPath.getOrElse(
+        scala.build.Directories.default().binRepoDir / baseRunnerName
+      )
     val destBinPath = binDirPath / options.binaryName
     val cacheDir    = scala.build.Directories.default().cacheDir
 
@@ -21,16 +23,16 @@ object Uninstall extends ScalaCommand[UninstallOptions] {
       !Update.isScalaCLIInstalledByInstallationScript && (options.binDir.isEmpty || !options.force)
     ) {
       logger.error(
-        "Scala CLI was not installed by the installation script, please use your package manager to uninstall scala-cli."
+        s"$fullRunnerName was not installed by the installation script, please use your package manager to uninstall $baseRunnerName."
       )
       sys.exit(1)
     }
     if (!options.force) {
       val fallbackAction = () => {
-        logger.error(s"To uninstall scala-cli pass -f or --force")
+        logger.error(s"To uninstall $baseRunnerName pass -f or --force")
         sys.exit(1)
       }
-      val msg = s"Do you want to uninstall scala-cli?"
+      val msg = s"Do you want to uninstall $baseRunnerName?"
       interactive.confirmOperation(msg).getOrElse(fallbackAction())
     }
     if (os.exists(destBinPath)) {
@@ -44,15 +46,15 @@ object Uninstall extends ScalaCommand[UninstallOptions] {
       logger.debug("Stopping Bloop server...")
       BloopExit.run(options.bloopExit, args)
       // remove scala-cli launcher
-      logger.debug("Removing scala-cli binary...")
+      logger.debug(s"Removing $baseRunnerName binary...")
       os.remove.all(binDirPath)
       // remove scala-cli caches
-      logger.debug("Removing scala-cli cache directory...")
+      logger.debug(s"Removing $baseRunnerName cache directory...")
       if (!options.skipCache) os.remove.all(cacheDir)
       logger.message("Uninstalled successfully.")
     }
     else {
-      logger.error(s"Could't find scala-cli binary at $destBinPath.")
+      logger.error(s"Could't find $baseRunnerName binary at $destBinPath.")
       sys.exit(1)
     }
   }

--- a/modules/cli/src/main/scala/scala/cli/commands/UninstallCompletions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/UninstallCompletions.scala
@@ -41,10 +41,12 @@ object UninstallCompletions extends ScalaCommand[UninstallCompletionsOptions] {
       if (options.logging.verbosity >= 0)
         if (updated) {
           logger.message(s"Updated $rcFile")
-          logger.message("scala-cli completions uninstalled successfully")
+          logger.message(s"$baseRunnerName completions uninstalled successfully")
         }
         else
-          logger.error("Problem occurred while uninstalling scala-cli completions")
+          logger.error(
+            s"Problem occurred while uninstalling $baseRunnerName completions"
+          )
     }
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/Update.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Update.scala
@@ -51,7 +51,7 @@ object Update extends ScalaCommand[UpdateOptions] {
       .maxByOption(_.version)
       .map(_.version.repr)
       .getOrElse {
-        sys.error(s"No Scala CLI versions found in $url")
+        sys.error(s"No $fullRunnerName versions found in $url")
       }
   }
 
@@ -64,10 +64,10 @@ object Update extends ScalaCommand[UpdateOptions] {
     val interactive = options.logging.verbosityOptions.interactiveInstance(forceEnable = true)
     if (!options.force) {
       val fallbackAction = () => {
-        logger.error(s"To update scala-cli to $newVersion pass -f or --force")
+        logger.error(s"To update $baseRunnerName to $newVersion pass -f or --force")
         sys.exit(1)
       }
-      val msg = s"Do you want to update scala-cli to version $newVersion?"
+      val msg = s"Do you want to update $baseRunnerName to version $newVersion?"
       interactive.confirmOperation(msg).getOrElse(fallbackAction())
     }
 
@@ -91,7 +91,7 @@ object Update extends ScalaCommand[UpdateOptions] {
     // format: on
     val output = res.out.trim()
     if (res.exitCode != 0) {
-      logger.error(s"Error during updating scala-cli: $output")
+      logger.error(s"Error during updating $baseRunnerName: $output")
       sys.exit(1)
     }
   }
@@ -112,11 +112,11 @@ object Update extends ScalaCommand[UpdateOptions] {
     if (!options.isInternalRun)
       if (isOutdated)
         updateScalaCli(options, newestScalaCliVersion0, logger)
-      else println("Scala CLI is up-to-date")
+      else println(s"$fullRunnerName is up-to-date")
     else if (isOutdated)
       println(
-        s"""Your Scala CLI $currentVersion is outdated, please update Scala CLI to $newestScalaCliVersion0
-           |Run 'curl -sSLf https://virtuslab.github.io/scala-cli-packages/scala-setup.sh | sh' to update Scala CLI.""".stripMargin
+        s"""Your $fullRunnerName $currentVersion is outdated, please update $fullRunnerName to $newestScalaCliVersion0
+           |Run 'curl -sSLf https://virtuslab.github.io/scala-cli-packages/scala-setup.sh | sh' to update $fullRunnerName.""".stripMargin
       )
   }
 
@@ -142,18 +142,19 @@ object Update extends ScalaCommand[UpdateOptions] {
     if (!os.exists(scalaCliBinPath) || !isScalaCliInPath) {
       if (!options.isInternalRun) {
         logger.error(
-          "Scala CLI was not installed by the installation script, please use your package manager to update scala-cli."
+          s"$fullRunnerName was not installed by the installation script, please use your package manager to update $baseRunnerName."
         )
         sys.exit(1)
       }
     }
     else if (Properties.isWin) {
       if (!options.isInternalRun) {
-        logger.error("Scala CLI update is not supported on Windows.")
+        logger.error(s"$fullRunnerName update is not supported on Windows.")
         sys.exit(1)
       }
     }
-    else if (options.binaryName == "scala-cli") update(options, scalaCliVersion, logger)
+    else if (options.binaryName == baseRunnerName)
+      update(options, scalaCliVersion, logger)
     else
       update(options, getCurrentVersion(scalaCliBinPath), logger)
   }

--- a/modules/cli/src/main/scala/scala/cli/commands/Version.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/Version.scala
@@ -6,7 +6,7 @@ import scala.build.Logger
 import scala.build.internal.Constants
 import scala.cli.CurrentParams
 
-class Version(isSipScala: Boolean) extends ScalaCommand[VersionOptions] {
+object Version extends ScalaCommand[VersionOptions] {
   override def group = "Miscellaneous"
   override def runCommand(options: VersionOptions, args: RemainingArgs, logger: Logger): Unit = {
     if (options.cliVersion)
@@ -14,17 +14,12 @@ class Version(isSipScala: Boolean) extends ScalaCommand[VersionOptions] {
     else if (options.scalaVersion)
       println(Constants.defaultScalaVersion)
     else
-      println(Version.versionInfo(isSipScala))
+      println(versionInfo)
   }
-}
 
-object Version {
-  def versionInfo(isSipScala: Boolean): String =
+  def versionInfo: String =
     val version            = Constants.version
     val detailedVersionOpt = Constants.detailedVersion.filter(_ != version).fold("")(" (" + _ + ")")
-    val appName =
-      if (isSipScala) "Scala code runner"
-      else "Scala CLI"
-    s"""$appName version: $version$detailedVersionOpt
+    s"""$fullRunnerName version: $version$detailedVersionOpt
        |Scala version (default): ${Constants.defaultScalaVersion}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/util/SharedOptionsUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/SharedOptionsUtil.scala
@@ -22,13 +22,13 @@ import scala.build.internal.{Constants, FetchExternalBinary, OsLibc, Util}
 import scala.build.options.ScalaVersionUtil.fileWithTtl0
 import scala.build.options.{Platform, ScalacOpt, ShadowingSeq}
 import scala.build.options as bo
-import scala.cli.ScalaCli
 import scala.cli.commands.ScalaJsOptions
 import scala.cli.commands.publish.ConfigUtil._
 import scala.cli.commands.util.CommonOps.*
 import scala.cli.commands.util.ScalacOptionsUtil.*
 import scala.cli.commands.util.SharedCompilationServerOptionsUtil.*
 import scala.cli.config.{ConfigDb, ConfigDbException, Keys}
+import scala.cli.{CurrentParams, ScalaCli}
 import scala.concurrent.ExecutionContextExecutorService
 import scala.concurrent.duration.*
 import scala.util.Properties
@@ -293,8 +293,8 @@ object SharedOptionsUtil extends CommandHelpers {
         case (Some(true), _, _) =>
           val answers @ List(yesAnswer, _) = List("Yes", "No")
           InteractiveAsk.chooseOne(
-            """You have run the current scala-cli command with the --interactive mode turned on.
-              |Would you like to leave it on permanently?""".stripMargin,
+            s"""You have run the current ${ScalaCli.baseRunnerName} command with the --interactive mode turned on.
+               |Would you like to leave it on permanently?""".stripMargin,
             answers
           ) match {
             case Some(answer) if answer == yesAnswer =>
@@ -305,10 +305,10 @@ object SharedOptionsUtil extends CommandHelpers {
                 .wrapConfigException
                 .orExit(logger)
               logger.message(
-                "--interactive is now set permanently. All future scala-cli commands will run with the flag set to true."
+                s"--interactive is now set permanently. All future ${ScalaCli.baseRunnerName} commands will run with the flag set to true."
               )
               logger.message(
-                "If you want to turn this setting off at any point, just run `scala-cli config interactive false`."
+                s"If you want to turn this setting off at any point, just run `${ScalaCli.baseRunnerName} config interactive false`."
               )
             case _ =>
               configDb
@@ -317,7 +317,7 @@ object SharedOptionsUtil extends CommandHelpers {
                 .wrapConfigException
                 .orExit(logger)
               logger.message(
-                "If you want to turn this setting permanently on at any point, just run `scala-cli config interactive true`."
+                s"If you want to turn this setting permanently on at any point, just run `${ScalaCli.baseRunnerName} config interactive true`."
               )
           }
           InteractiveAsk

--- a/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
@@ -4,16 +4,17 @@ import coursier.Repositories
 import coursier.cache.FileCache
 import coursier.core.Version
 import coursier.util.{Artifact, Task}
-import dependency._
+import dependency.*
 
 import scala.build.internal.CsLoggerUtil.CsCacheExtensions
 import scala.build.internal.{Constants, OsLibc, Runner}
 import scala.build.options.ScalaVersionUtil.fileWithTtl0
 import scala.build.options.{BuildOptions, JavaOptions}
 import scala.build.{Artifacts, Os, Positioned}
-import scala.cli.commands.util.CommonOps._
+import scala.cli.commands.util.CommonOps.*
 import scala.cli.commands.{CoursierOptions, LoggingOptions}
-import scala.concurrent.duration._
+import scala.cli.{CurrentParams, ScalaCli}
+import scala.concurrent.duration.*
 import scala.util.control.NonFatal
 
 object LauncherCli {
@@ -36,7 +37,7 @@ object LauncherCli {
         snapshotsRepo,
         Some(scalaParameters),
         logger,
-        cache.withMessage(s"Fetching Scala CLI $cliVersion"),
+        cache.withMessage(s"Fetching ${ScalaCli.fullRunnerName} $cliVersion"),
         None
       ) match {
         case Right(value) => value
@@ -86,7 +87,7 @@ object LauncherCli {
     val artifact = Artifact(snapshotRepoUrl).withChanging(true)
     cache.fileWithTtl0(artifact) match {
       case Left(_) =>
-        System.err.println("Unable to find nightly Scala CLI version")
+        System.err.println(s"Unable to find nightly ${ScalaCli.fullRunnerName} version")
         sys.exit(1)
       case Right(f) =>
         val snapshotRepoPage = os.read(os.Path(f, Os.pwd))

--- a/modules/cli/src/test/scala/cli/tests/HelpCheck.scala
+++ b/modules/cli/src/test/scala/cli/tests/HelpCheck.scala
@@ -5,7 +5,7 @@ import scala.cli.ScalaCliCommands
 class HelpCheck extends munit.FunSuite {
 
   test("help message should be shorter then 80 lines") {
-    val scalaCli    = new ScalaCliCommands("scala-cli", isSipScala = false)
+    val scalaCli = new ScalaCliCommands("scala-cli", "scala-cli", "Scala CLI", isSipScala = false)
     val helpMessage = scalaCli.help.help(scalaCli.helpFormat)
 
     val lines = helpMessage.split("\r\n|\r|\n").length

--- a/modules/cli/src/test/scala/cli/tests/OptionsCheck.scala
+++ b/modules/cli/src/test/scala/cli/tests/OptionsCheck.scala
@@ -4,7 +4,10 @@ import scala.cli.ScalaCliCommands
 
 class OptionsCheck extends munit.FunSuite {
 
-  for (command <- (new ScalaCliCommands("scala-cli", isSipScala = false)).commands)
+  for (
+    command <-
+      (new ScalaCliCommands("scala-cli", "scala-cli", "Scala CLI", isSipScala = false)).commands
+  )
     test(s"No duplicated options in ${command.names.head.mkString(" ")}") {
       command.ensureNoDuplicates()
     }

--- a/modules/core/src/main/scala/scala/build/errors/Diagnostic.scala
+++ b/modules/core/src/main/scala/scala/build/errors/Diagnostic.scala
@@ -14,7 +14,7 @@ object Diagnostic {
   case class TextEdit(newText: String)
   object Messages {
     val bloopTooOld =
-      "JVM that is hosting bloop is older than the requested runtime. Please run `scala-cli bloop exit`, and then use `--jvm` flag to restart Bloop"
+      "JVM that is hosting bloop is older than the requested runtime. Please run command `bloop exit`, and then use `--jvm` flag to restart Bloop"
   }
 
   private case class ADiagnostic(

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/UsingSourceDirectiveHandler.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/UsingSourceDirectiveHandler.scala
@@ -9,7 +9,7 @@ import scala.util.Try
 
 case object UsingSourceDirectiveHandler extends UsingDirectiveHandler {
   def name        = "Custom sources"
-  def description = "Manually add sources to the Scala CLI project"
+  def description = "Manually add sources to the project"
   def usage       = "`//> using file `_path_ | `//> using files `_path1_, _path2_ …"
   override def usageMd =
     """//> using file hello.sc

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
@@ -14,8 +14,8 @@ import scala.build.preprocessing.directives.{
   RequireDirectiveHandler,
   UsingDirectiveHandler
 }
-import scala.cli.ScalaCliCommands
 import scala.cli.commands.{RestrictedCommandsParser, ScalaCommand}
+import scala.cli.{CurrentParams, ScalaCli, ScalaCliCommands}
 
 object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
 
@@ -117,7 +117,7 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
           else ""
         }
          |
-         |This is a summary of options that are available for each subcommand of the `scala-cli` command.
+         |This is a summary of options that are available for each subcommand of the `${ScalaCli.baseRunnerName}` command.
          |
          |""".stripMargin
     )
@@ -309,7 +309,12 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
 
   def run(options: InternalDocOptions, args: RemainingArgs): Unit = {
 
-    val scalaCli = new ScalaCliCommands("scala-cli", isSipScala = false)
+    val scalaCli = new ScalaCliCommands(
+      "scala-cli",
+      ScalaCli.baseRunnerName,
+      ScalaCli.fullRunnerName,
+      isSipScala = false
+    )
     val commands = scalaCli.commands
     val restrictedCommands =
       commands.iterator.collect { case s: ScalaCommand[_] if !s.isRestricted => s }.toSeq

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -192,7 +192,7 @@ final case class BuildOptions(
 
     val msg =
       if (internal.verbosityOrDefault > 0)
-        "Getting list of Scala CLI-supported Scala versions"
+        "Getting list of Scala CLI supported Scala versions"
       else ""
     val cache                     = finalCache.withMessage(msg)
     val supportedScalaVersionsUrl = scalaOptions.scalaVersionsUrl

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -229,7 +229,7 @@ Overwrite the destination directory, if it exists
 
 Aliases: `--default-scaladoc-opts`
 
-Control if scala CLI should use default options for scaladoc, true by default. Use `--default-scaladoc-opts:false` to not include default options.
+Control if Scala CLI should use default options for scaladoc, true by default. Use `--default-scaladoc-opts:false` to not include default options.
 
 ## Export options
 
@@ -1524,7 +1524,7 @@ Available in commands:
 
 Aliases: `--cli`
 
-Show only plain scala-cli version
+Show only plain version
 
 ### `--scala-version`
 
@@ -1794,7 +1794,7 @@ Available in commands:
 Aliases: `-f`
 
 [Internal]
-Overwrite `scala-cli`, if it exists
+Overwrite if it exists
 
 ### `--binary-name`
 

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -131,7 +131,7 @@ Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [compilati
 Like `run`, but more handy from shebang scripts
 
 This command is equivalent to `run`, but it changes the way
-`scala-cli` parses its command-line arguments in order to be compatible
+Scala CLI parses its command-line arguments in order to be compatible
 with shebang scripts.
 
 Normally, inputs and scala-cli options can be mixed. Program have to be specified after `--`
@@ -184,7 +184,7 @@ Accepts option groups: [logging](./cli-options.md#logging-options), [update](./c
 
 ## version
 
-Print `scala-cli` version
+Print version
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [version](./cli-options.md#version-options)
 
@@ -226,13 +226,13 @@ Accepts option groups: [default file](./cli-options.md#default-file-options), [l
 
 ### directories
 
-Prints directories used by `scala-cli`
+Prints directories used by Scala CLI
 
 Accepts option groups: [directories](./cli-options.md#directories-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### install-home
 
-Install `scala-cli` in a sub-directory of the home directory
+Install Scala CLI in a sub-directory of the home directory
 
 Accepts option groups: [install home](./cli-options.md#install-home-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -42,7 +42,7 @@ Manually add JAR(s) to the class path
 
 ### Custom sources
 
-Manually add sources to the Scala CLI project
+Manually add sources to the project
 
 //> using file hello.sc
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -201,7 +201,7 @@ Overwrite the destination directory, if it exists
 
 Aliases: `--default-scaladoc-opts`
 
-Control if scala CLI should use default options for scaladoc, true by default. Use `--default-scaladoc-opts:false` to not include default options.
+Control if Scala CLI should use default options for scaladoc, true by default. Use `--default-scaladoc-opts:false` to not include default options.
 
 ## Fmt options
 
@@ -917,7 +917,7 @@ Available in commands:
 
 Aliases: `--cli`
 
-Show only plain scala-cli version
+Show only plain version
 
 ### `--scala-version`
 

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -95,7 +95,7 @@ Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [compilati
 Like `run`, but more handy from shebang scripts
 
 This command is equivalent to `run`, but it changes the way
-`scala-cli` parses its command-line arguments in order to be compatible
+Scala CLI parses its command-line arguments in order to be compatible
 with shebang scripts.
 
 Normally, inputs and scala-cli options can be mixed. Program have to be specified after `--`
@@ -148,7 +148,7 @@ Accepts option groups: [logging](./cli-options.md#logging-options), [update](./c
 
 ## version
 
-Print `scala-cli` version
+Print version
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [version](./cli-options.md#version-options)
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -42,7 +42,7 @@ Manually add JAR(s) to the class path
 
 ### Custom sources
 
-Manually add sources to the Scala CLI project
+Manually add sources to the project
 
 //> using file hello.sc
 


### PR DESCRIPTION
~~I skipped runner name Scala CLI replacement for case-app options, e.g. `DocOptions`,` SharedOptions`. I don't have any idea, how to detect there if is `SIP` or not. Therefore I added there a more general name `Runner`.~~

Instead of adding support to use `ScalaCli.progName` in options, I replaced keyword `scala-cli` into `Scala CLI`.

Fixes #1528 