### PR TITLE
Add option to customize Mill exported project name

### DIFF
--- a/modules/cli-options/src/main/scala/scala/cli/commands/ExportOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/ExportOptions.scala
@@ -21,6 +21,10 @@ final case class ExportOptions(
   @Name("setting")
   @Group("Build Tool export options")
     sbtSetting: List[String] = Nil,
+  @Name("p")
+  @Group("Build Tool export options")
+  @HelpMessage("Project name to be used on Mill build file")
+  project: Option[String] = None,
   @Group("Build Tool export options")
   sbtVersion: Option[String] = None,
   @Name("o")

--- a/modules/cli/src/main/scala/scala/cli/commands/export/Export.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/export/Export.scala
@@ -53,7 +53,7 @@ object Export extends ScalaCommand[ExportOptions] {
   // FIXME Auto-update those
   def sbtBuildTool(extraSettings: Seq[String], sbtVersion: String, logger: Logger): Sbt =
     Sbt(sbtVersion, extraSettings, logger)
-  def millBuildTool(cache: FileCache[Task], logger: Logger): Mill = {
+  def millBuildTool(cache: FileCache[Task], projectName: Option[String], logger: Logger): Mill = {
     val launcherArtifacts = Seq(
       os.rel / "mill" -> s"https://github.com/lefou/millw/raw/${Constants.lefouMillwRef}/millw",
       os.rel / "mill.bat" -> s"https://github.com/lefou/millw/raw/${Constants.lefouMillwRef}/millw.bat"
@@ -71,7 +71,7 @@ object Export extends ScalaCommand[ExportOptions] {
     }
     val launchersTask = cache.logger.using(Task.gather.gather(launcherTasks))
     val launchers     = launchersTask.unsafeRun()(cache.ec)
-    Mill(Constants.millVersion, launchers, logger)
+    Mill(Constants.millVersion, projectName, launchers, logger)
   }
 
   override def sharedOptions(opts: ExportOptions): Option[SharedOptions] = Some(opts.shared)
@@ -140,7 +140,7 @@ object Export extends ScalaCommand[ExportOptions] {
 
     val buildTool =
       if (shouldExportToMill)
-        millBuildTool(options.shared.coursierCache, logger)
+        millBuildTool(options.shared.coursierCache, options.project, logger)
       else // shouldExportToSbt isn't checked, as it's treated as default
         sbtBuildTool0
 

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/Mill.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/Mill.scala
@@ -15,6 +15,7 @@ import scala.build.{Logger, Sources}
 
 final case class Mill(
   millVersion: String,
+  projectName: Option[String] = None,
   launchers: Seq[(os.RelPath, Array[Byte])],
   logger: Logger
 ) extends BuildTool {
@@ -173,6 +174,7 @@ final case class Mill(
 
     val baseSettings = MillProject(
       millVersion = Some(millVersion),
+      nameOpt = projectName,
       launchers = launchers,
       mainClass = optionsMain.mainClass
     )

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
@@ -49,11 +49,11 @@ abstract class ExportMillTestDefinitions(val scalaVersionOpt: Option[String])
       expect(output.contains("Hello from exported Scala CLI project"))
     }
 
-  def jvmTest(): Unit = {
+  def jvmTest(projectName: String = "project"): Unit = {
     val inputs = addMillJvmOpts(ExportTestProjects.jvmTest(actualScalaVersion))
     inputs.fromRoot { root =>
-      val projectName = "project"
-      os.proc(TestUtil.cli, "export", extraOptions, "--mill", "-o", "mill-proj", ".")
+      val setProject = if (projectName != "project") Seq("-p", projectName) else Seq.empty
+      os.proc(TestUtil.cli, "export", extraOptions, "--mill", setProject, "-o", "mill-proj", ".")
         .call(cwd = root, stdout = os.Inherit)
       // main
       val res =
@@ -72,6 +72,11 @@ abstract class ExportMillTestDefinitions(val scalaVersionOpt: Option[String])
   if (runExportTests)
     test("JVM") {
       jvmTest()
+    }
+
+  if (runExportTests)
+    test("JVM custom project name") {
+      jvmTest("newproject")
     }
 
   if (runExportTests)

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -247,6 +247,12 @@ Available in commands:
 
 Aliases: `--setting`
 
+### `--project`
+
+Aliases: `-p`
+
+Project name to be used on Mill build file
+
 ### `--sbt-version`
 
 ### `--output`


### PR DESCRIPTION
This PR adds an option to export command allowing customization of Mill project name (currently assumed as "project").

This changes:
- Mill project name on `build.sc` (`object myprojectname extends ScalaModule {`)
- Mill project directory is named to the flag (`./dest/myprojname/src/...`)