### PR TITLE
Fix overriding settings from tests

### DIFF
--- a/modules/build/src/main/scala/scala/build/ScopedSources.scala
+++ b/modules/build/src/main/scala/scala/build/ScopedSources.scala
@@ -17,6 +17,6 @@ final case class ScopedSources(
       resourceDirs.flatMap(_.valueFor(scope).toSeq),
       buildOptions
         .flatMap(_.valueFor(scope).toSeq)
-        .foldLeft(baseOptions)(_ orElse _)
+        .foldRight(baseOptions)(_ orElse _)
     )
 }


### PR DESCRIPTION
Seems overriding main settings from tests wasn't working well, as options were not "summed-up" correctly.