### PR TITLE
Remove superfluous annotation

### DIFF
--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedDependencyOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedDependencyOptions.scala
@@ -13,7 +13,6 @@ final case class SharedDependencyOptions(
 
   @Group("Dependency")
   @HelpMessage("Add repositories")
-  @HelpMessage("")
   @Name("repo")
   @Name("r")
     repository: List[String] = Nil,


### PR DESCRIPTION
Seems it doesn't matter when using case-app from Scala 2, but it does when using from Scala 3 apparently (subsequent PRs handle that).