### PR TITLE
Switch to Scala 3-based case-app

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -509,7 +509,7 @@ trait Options extends ScalaCliSbtModule with ScalaCliPublishModule with HasTests
 
   def ivyDeps = super.ivyDeps() ++ Agg(
     Deps.bloopConfig,
-    Deps.signingCliShared.exclude(("com.github.alexarchambault", "*"))
+    Deps.signingCliShared
   )
   def compileIvyDeps = super.compileIvyDeps() ++ Seq(
     Deps.jsoniterMacros
@@ -639,14 +639,12 @@ trait CliOptions extends SbtModule with ScalaCliPublishModule {
     super.scalacOptions() ++ extraOptions
   }
   def ivyDeps = super.ivyDeps() ++ Agg(
+    Deps.caseApp,
     Deps.jsoniterCore213,
     Deps.osLib,
-    Deps.signingCli
-      .exclude((organization, "config_2.13"))
-      .exclude(("com.github.alexarchambault", "*"))
+    Deps.signingCli.exclude((organization, "config_2.13"))
   )
   def compileIvyDeps = super.compileIvyDeps() ++ Seq(
-    Deps.caseApp,
     Deps.jsoniterMacros
   )
   def scalaVersion = Scala.defaultInternal
@@ -762,9 +760,7 @@ trait Cli extends SbtModule with ProtoBuildModule with CliLaunchers
     Deps.metaconfigTypesafe,
     Deps.pythonNativeLibs,
     Deps.scalaPackager,
-    Deps.signingCli
-      .exclude((organization, "config_2.13"))
-      .exclude(("com.github.alexarchambault", "*")),
+    Deps.signingCli.exclude((organization, "config_2.13")),
     Deps.slf4jNop, // to silence jgit
     Deps.sttp
   )

--- a/build.sc
+++ b/build.sc
@@ -509,7 +509,7 @@ trait Options extends ScalaCliSbtModule with ScalaCliPublishModule with HasTests
 
   def ivyDeps = super.ivyDeps() ++ Agg(
     Deps.bloopConfig,
-    Deps.signingCliShared
+    Deps.signingCliShared.exclude(("com.github.alexarchambault", "*"))
   )
   def compileIvyDeps = super.compileIvyDeps() ++ Seq(
     Deps.jsoniterMacros
@@ -639,12 +639,14 @@ trait CliOptions extends SbtModule with ScalaCliPublishModule {
     super.scalacOptions() ++ extraOptions
   }
   def ivyDeps = super.ivyDeps() ++ Agg(
-    Deps.caseApp,
     Deps.jsoniterCore213,
     Deps.osLib,
-    Deps.signingCli.exclude((organization, "config_2.13"))
+    Deps.signingCli
+      .exclude((organization, "config_2.13"))
+      .exclude(("com.github.alexarchambault", "*"))
   )
   def compileIvyDeps = super.compileIvyDeps() ++ Seq(
+    Deps.caseApp213,
     Deps.jsoniterMacros
   )
   private def scalaVer = Scala.scala213
@@ -750,6 +752,7 @@ trait Cli extends SbtModule with ProtoBuildModule with CliLaunchers
   def repositories = super.repositories ++ customRepositories
 
   def ivyDeps = super.ivyDeps() ++ Agg(
+    Deps.caseApp,
     Deps.coursierLauncher,
     Deps.coursierProxySetup,
     Deps.coursierPublish.exclude((organization, "config_2.13")),
@@ -760,7 +763,9 @@ trait Cli extends SbtModule with ProtoBuildModule with CliLaunchers
     Deps.metaconfigTypesafe,
     Deps.pythonNativeLibs,
     Deps.scalaPackager,
-    Deps.signingCli.exclude((organization, "config_2.13")),
+    Deps.signingCli
+      .exclude((organization, "config_2.13"))
+      .exclude(("com.github.alexarchambault", "*")),
     Deps.slf4jNop, // to silence jgit
     Deps.sttp
   )

--- a/build.sc
+++ b/build.sc
@@ -646,12 +646,11 @@ trait CliOptions extends SbtModule with ScalaCliPublishModule {
       .exclude(("com.github.alexarchambault", "*"))
   )
   def compileIvyDeps = super.compileIvyDeps() ++ Seq(
-    Deps.caseApp213,
+    Deps.caseApp,
     Deps.jsoniterMacros
   )
-  private def scalaVer = Scala.scala213
-  def scalaVersion     = scalaVer
-  def repositories     = super.repositories ++ customRepositories
+  def scalaVersion = Scala.defaultInternal
+  def repositories = super.repositories ++ customRepositories
 
   def constantsFile = T.persistent {
     val dir  = T.dest / "constants"

--- a/modules/cli-options/src/main/scala/scala/cli/commands/BenchmarkingOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/BenchmarkingOptions.scala
@@ -15,7 +15,6 @@ final case class BenchmarkingOptions(
 // format: on
 
 object BenchmarkingOptions {
-  lazy val parser: Parser[BenchmarkingOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[BenchmarkingOptions, parser.D] = parser
-  implicit lazy val help: Help[BenchmarkingOptions]                      = Help.derive
+  implicit lazy val parser: Parser[BenchmarkingOptions] = Parser.derive
+  implicit lazy val help: Help[BenchmarkingOptions]     = Help.derive
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/BloopExitOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/BloopExitOptions.scala
@@ -21,6 +21,4 @@ final case class BloopExitOptions(
 object BloopExitOptions {
   implicit lazy val parser: Parser[BloopExitOptions] = Parser.derive
   implicit lazy val help: Help[BloopExitOptions]     = Help.derive
-  // Parser.Aux for using BloopExitOptions with @Recurse in other options
-  implicit lazy val parserAux: Parser.Aux[BloopExitOptions, parser.D] = parser
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/CoursierOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/CoursierOptions.scala
@@ -24,8 +24,7 @@ final case class CoursierOptions(
 // format: on
 
 object CoursierOptions {
-  lazy val parser: Parser[CoursierOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[CoursierOptions, parser.D] = parser
-  implicit lazy val help: Help[CoursierOptions]                      = Help.derive
-  implicit lazy val jsonCodec: JsonValueCodec[CoursierOptions]       = JsonCodecMaker.make
+  implicit lazy val parser: Parser[CoursierOptions]            = Parser.derive
+  implicit lazy val help: Help[CoursierOptions]                = Help.derive
+  implicit lazy val jsonCodec: JsonValueCodec[CoursierOptions] = JsonCodecMaker.make
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/CrossOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/CrossOptions.scala
@@ -10,7 +10,6 @@ final case class CrossOptions(
 // format: on
 
 object CrossOptions {
-  lazy val parser: Parser[CrossOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[CrossOptions, parser.D] = parser
-  implicit lazy val help: Help[CrossOptions]                      = Help.derive
+  implicit lazy val parser: Parser[CrossOptions] = Parser.derive
+  implicit lazy val help: Help[CrossOptions]     = Help.derive
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/DirectoriesOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/DirectoriesOptions.scala
@@ -15,7 +15,6 @@ final case class DirectoriesOptions(
 // format: on
 
 object DirectoriesOptions {
-  lazy val parser: Parser[DirectoriesOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[DirectoriesOptions, parser.D] = parser
-  implicit lazy val help: Help[DirectoriesOptions]                      = Help.derive
+  implicit lazy val parser: Parser[DirectoriesOptions] = Parser.derive
+  implicit lazy val help: Help[DirectoriesOptions]     = Help.derive
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/HelpGroupOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/HelpGroupOptions.scala
@@ -2,6 +2,7 @@ package scala.cli.commands
 
 import caseapp.*
 import caseapp.core.help.{Help, HelpFormat}
+import caseapp.core.Scala3Helpers.*
 import com.github.plokhotnyuk.jsoniter_scala.core.*
 import com.github.plokhotnyuk.jsoniter_scala.macros.*
 
@@ -40,8 +41,7 @@ case class HelpGroupOptions(
 }
 
 object HelpGroupOptions {
-  lazy val parser: Parser[HelpGroupOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[HelpGroupOptions, parser.D] = parser
-  implicit lazy val help: Help[HelpGroupOptions]                      = Help.derive
-  implicit lazy val jsonCodec: JsonValueCodec[HelpGroupOptions]       = JsonCodecMaker.make
+  implicit lazy val parser: Parser[HelpGroupOptions]            = Parser.derive
+  implicit lazy val help: Help[HelpGroupOptions]                = Help.derive
+  implicit lazy val jsonCodec: JsonValueCodec[HelpGroupOptions] = JsonCodecMaker.make
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/LoggingOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/LoggingOptions.scala
@@ -22,8 +22,7 @@ final case class LoggingOptions(
 }
 
 object LoggingOptions {
-  lazy val parser: Parser[LoggingOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[LoggingOptions, parser.D] = parser
-  implicit lazy val help: Help[LoggingOptions]                      = Help.derive
-  implicit lazy val jsonCodec: JsonValueCodec[LoggingOptions]       = JsonCodecMaker.make
+  implicit lazy val parser: Parser[LoggingOptions]            = Parser.derive
+  implicit lazy val help: Help[LoggingOptions]                = Help.derive
+  implicit lazy val jsonCodec: JsonValueCodec[LoggingOptions] = JsonCodecMaker.make
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/MainClassOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/MainClassOptions.scala
@@ -9,7 +9,7 @@ final case class MainClassOptions(
   @ValueDescription("main-class")
   @Name("M")
     mainClass: Option[String] = None,
-  
+
   @Group("Entrypoint")
   @HelpMessage("List main classes available in the current context")
   @Name("mainClassList")
@@ -20,7 +20,6 @@ final case class MainClassOptions(
 // format: on
 
 object MainClassOptions {
-  lazy val parser: Parser[MainClassOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[MainClassOptions, parser.D] = parser
-  implicit lazy val help: Help[MainClassOptions]                      = Help.derive
+  implicit lazy val parser: Parser[MainClassOptions] = Parser.derive
+  implicit lazy val help: Help[MainClassOptions]     = Help.derive
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/MarkdownOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/MarkdownOptions.scala
@@ -13,7 +13,6 @@ final case class MarkdownOptions(
 // format: on
 
 object MarkdownOptions {
-  lazy val parser: Parser[MarkdownOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[MarkdownOptions, parser.D] = parser
-  implicit lazy val help: Help[MarkdownOptions]                      = Help.derive
+  implicit lazy val parser: Parser[MarkdownOptions] = Parser.derive
+  implicit lazy val help: Help[MarkdownOptions]     = Help.derive
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/PackagerOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/PackagerOptions.scala
@@ -124,7 +124,6 @@ final case class PackagerOptions(
 // format: on
 
 object PackagerOptions {
-  lazy val parser: Parser[PackagerOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[PackagerOptions, parser.D] = parser
-  implicit lazy val help: Help[PackagerOptions]                      = Help.derive
+  implicit lazy val parser: Parser[PackagerOptions] = Parser.derive
+  implicit lazy val help: Help[PackagerOptions]     = Help.derive
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/ScalaJsOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/ScalaJsOptions.scala
@@ -80,8 +80,7 @@ final case class ScalaJsOptions(
 // format: on
 
 object ScalaJsOptions {
-  lazy val parser: Parser[ScalaJsOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[ScalaJsOptions, parser.D] = parser
-  implicit lazy val help: Help[ScalaJsOptions]                      = Help.derive
-  implicit lazy val jsonCodec: JsonValueCodec[ScalaJsOptions]       = JsonCodecMaker.make
+  implicit lazy val parser: Parser[ScalaJsOptions]            = Parser.derive
+  implicit lazy val help: Help[ScalaJsOptions]                = Help.derive
+  implicit lazy val jsonCodec: JsonValueCodec[ScalaJsOptions] = JsonCodecMaker.make
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/ScalaNativeOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/ScalaNativeOptions.scala
@@ -55,8 +55,7 @@ final case class ScalaNativeOptions(
 // format: on
 
 object ScalaNativeOptions {
-  lazy val parser: Parser[ScalaNativeOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[ScalaNativeOptions, parser.D] = parser
-  implicit lazy val help: Help[ScalaNativeOptions]                      = Help.derive
-  implicit lazy val jsonCodec: JsonValueCodec[ScalaNativeOptions]       = JsonCodecMaker.make
+  implicit lazy val parser: Parser[ScalaNativeOptions]            = Parser.derive
+  implicit lazy val help: Help[ScalaNativeOptions]                = Help.derive
+  implicit lazy val jsonCodec: JsonValueCodec[ScalaNativeOptions] = JsonCodecMaker.make
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/ScalacExtraOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/ScalacExtraOptions.scala
@@ -22,8 +22,7 @@ final case class ScalacExtraOptions(
 // format: on
 
 object ScalacExtraOptions {
-  lazy val parser: Parser[ScalacExtraOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[ScalacExtraOptions, parser.D] = parser
-  implicit lazy val help: Help[ScalacExtraOptions]                      = Help.derive
-  implicit lazy val jsonCodec: JsonValueCodec[ScalacExtraOptions]       = JsonCodecMaker.make
+  implicit lazy val parser: Parser[ScalacExtraOptions]            = Parser.derive
+  implicit lazy val help: Help[ScalacExtraOptions]                = Help.derive
+  implicit lazy val jsonCodec: JsonValueCodec[ScalacExtraOptions] = JsonCodecMaker.make
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/ScalacOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/ScalacOptions.scala
@@ -4,6 +4,7 @@ import caseapp.*
 import caseapp.core.{Arg, Error}
 import caseapp.core.parser.{Argument, NilParser, StandardArgument}
 import caseapp.core.util.Formatter
+import caseapp.core.Scala3Helpers.*
 import com.github.plokhotnyuk.jsoniter_scala.core.*
 import com.github.plokhotnyuk.jsoniter_scala.macros.*
 
@@ -21,14 +22,15 @@ final case class ScalacOptions(
 
 object ScalacOptions {
 
-  private val scalacOptionsArg = Arg("scalacOption")
-    .withExtraNames(Seq(Name("scala-opt"), Name("O"), Name("scala-option")))
-    .withValueDescription(Some(ValueDescription("option")))
-    .withHelpMessage(Some(HelpMessage(
+  private val scalacOptionsArg = Arg("scalacOption").copy(
+    extraNames = Seq(Name("scala-opt"), Name("O"), Name("scala-option")),
+    valueDescription = Some(ValueDescription("option")),
+    helpMessage = Some(HelpMessage(
       "Add a `scalac` option. Note that options starting with `-g`, `-language`, `-opt`, `-P`, `-target`, `-V`, `-W`, `-X`, and `-Y` are assumed to be Scala compiler options and don't require to be passed after `-O` or `--scalac-option`."
-    )))
-    .withGroup(Some(Group("Scala")))
-    .withOrigin(Some("ScalacOptions"))
+    )),
+    group = Some(Group("Scala")),
+    origin = Some("ScalacOptions")
+  )
   // .withIsFlag(true) // The scalac options we handle accept no value after the -… argument
   private val scalacOptionsPurePrefixes =
     Set("-V", "-W", "-X", "-Y")
@@ -93,7 +95,7 @@ object ScalacOptions {
         Right(acc.getOrElse(Nil))
     }
 
-  implicit lazy val parser = {
+  implicit lazy val parser: Parser[ScalacOptions] = {
     val baseParser =
       scalacOptionsArgument ::
         NilParser

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedBspFileOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedBspFileOptions.scala
@@ -16,7 +16,6 @@ final case class SharedBspFileOptions(
 // format: on
 
 object SharedBspFileOptions {
-  lazy val parser: Parser[SharedBspFileOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[SharedBspFileOptions, parser.D] = parser
-  implicit lazy val help: Help[SharedBspFileOptions]                      = Help.derive
+  implicit lazy val parser: Parser[SharedBspFileOptions] = Parser.derive
+  implicit lazy val help: Help[SharedBspFileOptions]     = Help.derive
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedCompilationServerOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedCompilationServerOptions.scala
@@ -86,8 +86,7 @@ final case class SharedCompilationServerOptions(
 // format: on
 
 object SharedCompilationServerOptions {
-  lazy val parser: Parser[SharedCompilationServerOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[SharedCompilationServerOptions, parser.D] = parser
-  implicit lazy val help: Help[SharedCompilationServerOptions]                      = Help.derive
+  implicit lazy val parser: Parser[SharedCompilationServerOptions]            = Parser.derive
+  implicit lazy val help: Help[SharedCompilationServerOptions]                = Help.derive
   implicit lazy val jsonCodec: JsonValueCodec[SharedCompilationServerOptions] = JsonCodecMaker.make
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedDebugOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedDebugOptions.scala
@@ -23,6 +23,4 @@ final case class SharedDebugOptions(
 object SharedDebugOptions {
   implicit lazy val parser: Parser[SharedDebugOptions] = Parser.derive
   implicit lazy val help: Help[SharedDebugOptions]     = Help.derive
-  // Parser.Aux for using SharedDebugOptions with @Recurse in other options
-  implicit lazy val parserAux: Parser.Aux[SharedDebugOptions, parser.D] = parser
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedDependencyOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedDependencyOptions.scala
@@ -25,8 +25,7 @@ final case class SharedDependencyOptions(
 // format: on
 
 object SharedDependencyOptions {
-  lazy val parser: Parser[SharedDependencyOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[SharedDependencyOptions, parser.D] = parser
-  implicit lazy val help: Help[SharedDependencyOptions]                      = Help.derive
-  implicit lazy val jsonCodec: JsonValueCodec[SharedDependencyOptions]       = JsonCodecMaker.make
+  implicit lazy val parser: Parser[SharedDependencyOptions]            = Parser.derive
+  implicit lazy val help: Help[SharedDependencyOptions]                = Help.derive
+  implicit lazy val jsonCodec: JsonValueCodec[SharedDependencyOptions] = JsonCodecMaker.make
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedDirectoriesOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedDirectoriesOptions.scala
@@ -12,8 +12,7 @@ final case class SharedDirectoriesOptions(
 // format: on
 
 object SharedDirectoriesOptions {
-  lazy val parser: Parser[SharedDirectoriesOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[SharedDirectoriesOptions, parser.D] = parser
-  implicit lazy val help: Help[SharedDirectoriesOptions]                      = Help.derive
-  implicit lazy val jsonCodec: JsonValueCodec[SharedDirectoriesOptions]       = JsonCodecMaker.make
+  implicit lazy val parser: Parser[SharedDirectoriesOptions]            = Parser.derive
+  implicit lazy val help: Help[SharedDirectoriesOptions]                = Help.derive
+  implicit lazy val jsonCodec: JsonValueCodec[SharedDirectoriesOptions] = JsonCodecMaker.make
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedInputOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedInputOptions.scala
@@ -12,7 +12,6 @@ final case class SharedInputOptions(
 // format: on
 
 object SharedInputOptions {
-  lazy val parser: Parser[SharedInputOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[SharedInputOptions, parser.D] = parser
-  implicit lazy val help: Help[SharedInputOptions]                      = Help.derive
+  implicit lazy val parser: Parser[SharedInputOptions] = Parser.derive
+  implicit lazy val help: Help[SharedInputOptions]     = Help.derive
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedJavaOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedJavaOptions.scala
@@ -23,7 +23,6 @@ final case class SharedJavaOptions(
 }
 
 object SharedJavaOptions {
-  lazy val parser: Parser[SharedJavaOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[SharedJavaOptions, parser.D] = parser
-  implicit lazy val help: Help[SharedJavaOptions]                      = Help.derive
+  implicit lazy val parser: Parser[SharedJavaOptions] = Parser.derive
+  implicit lazy val help: Help[SharedJavaOptions]     = Help.derive
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedJvmOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedJvmOptions.scala
@@ -54,8 +54,7 @@ final case class SharedJvmOptions(
 // format: on
 
 object SharedJvmOptions {
-  lazy val parser: Parser[SharedJvmOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[SharedJvmOptions, parser.D] = parser
-  implicit lazy val help: Help[SharedJvmOptions]                      = Help.derive
-  implicit lazy val jsonCodec: JsonValueCodec[SharedJvmOptions]       = JsonCodecMaker.make
+  implicit lazy val parser: Parser[SharedJvmOptions]            = Parser.derive
+  implicit lazy val help: Help[SharedJvmOptions]                = Help.derive
+  implicit lazy val jsonCodec: JsonValueCodec[SharedJvmOptions] = JsonCodecMaker.make
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedPythonOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedPythonOptions.scala
@@ -18,7 +18,6 @@ final case class SharedPythonOptions(
 // format: on
 
 object SharedPythonOptions {
-  lazy val parser: Parser[SharedPythonOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[SharedPythonOptions, parser.D] = parser
-  implicit lazy val help: Help[SharedPythonOptions]                      = Help.derive
+  implicit lazy val parser: Parser[SharedPythonOptions] = Parser.derive
+  implicit lazy val help: Help[SharedPythonOptions]     = Help.derive
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedReplOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedReplOptions.scala
@@ -15,7 +15,7 @@ final case class SharedReplOptions(
     compileCross: CrossOptions = CrossOptions(),
   @Recurse
     sharedPython: SharedPythonOptions = SharedPythonOptions(),
-  
+
   @Group("Repl")
   @HelpMessage("[restricted] Use Ammonite (instead of the default Scala REPL)")
   @Name("A")
@@ -43,6 +43,4 @@ final case class SharedReplOptions(
 object SharedReplOptions {
   implicit lazy val parser: Parser[SharedReplOptions] = Parser.derive
   implicit lazy val help: Help[SharedReplOptions]     = Help.derive
-  // Parser.Aux for using SharedReplOptions with @Recurse in other options
-  implicit lazy val parserAux: Parser.Aux[SharedReplOptions, parser.D] = parser
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedRunOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedRunOptions.scala
@@ -53,6 +53,4 @@ final case class SharedRunOptions(
 object SharedRunOptions {
   implicit lazy val parser: Parser[SharedRunOptions] = Parser.derive
   implicit lazy val help: Help[SharedRunOptions]     = Help.derive
-  // Parser.Aux for using SharedRunOptions with @Recurse in other options
-  implicit lazy val parserAux: Parser.Aux[SharedRunOptions, parser.D] = parser
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedUninstallCompletionsOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedUninstallCompletionsOptions.scala
@@ -18,6 +18,4 @@ final case class SharedUninstallCompletionsOptions(
 object SharedUninstallCompletionsOptions {
   implicit lazy val parser: Parser[SharedUninstallCompletionsOptions] = Parser.derive
   implicit lazy val help: Help[SharedUninstallCompletionsOptions]     = Help.derive
-  // Parser.Aux for using SharedUninstallCompletionsOptions with @Recurse in other options
-  implicit lazy val parserAux: Parser.Aux[SharedUninstallCompletionsOptions, parser.D] = parser
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedWatchOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedWatchOptions.scala
@@ -17,7 +17,6 @@ final case class SharedWatchOptions(
 }
 
 object SharedWatchOptions {
-  lazy val parser: Parser[SharedWatchOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[SharedWatchOptions, parser.D] = parser
-  implicit lazy val help: Help[SharedWatchOptions]                      = Help.derive
+  implicit lazy val parser: Parser[SharedWatchOptions] = Parser.derive
+  implicit lazy val help: Help[SharedWatchOptions]     = Help.derive
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SharedWorkspaceOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SharedWorkspaceOptions.scala
@@ -14,8 +14,7 @@ final case class SharedWorkspaceOptions(
 // format: on
 
 object SharedWorkspaceOptions {
-  lazy val parser: Parser[SharedWorkspaceOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[SharedWorkspaceOptions, parser.D] = parser
-  implicit lazy val help: Help[SharedWorkspaceOptions]                      = Help.derive
-  implicit lazy val jsonCodec: JsonValueCodec[SharedWorkspaceOptions]       = JsonCodecMaker.make
+  implicit lazy val parser: Parser[SharedWorkspaceOptions]            = Parser.derive
+  implicit lazy val help: Help[SharedWorkspaceOptions]                = Help.derive
+  implicit lazy val jsonCodec: JsonValueCodec[SharedWorkspaceOptions] = JsonCodecMaker.make
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/SnippetOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/SnippetOptions.scala
@@ -49,7 +49,5 @@ final case class SnippetOptions(
 object SnippetOptions {
   implicit lazy val parser: Parser[SnippetOptions] = Parser.derive
   implicit lazy val help: Help[SnippetOptions]     = Help.derive
-  // Parser.Aux for using SnippetOptions with @Recurse in other options
-  implicit lazy val parserAux: Parser.Aux[SnippetOptions, parser.D] = parser
 
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/VerbosityOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/VerbosityOptions.scala
@@ -23,9 +23,8 @@ final case class VerbosityOptions(
 }
 
 object VerbosityOptions {
-  lazy val parser: Parser[VerbosityOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[VerbosityOptions, parser.D] = parser
-  implicit lazy val help: Help[VerbosityOptions]                      = Help.derive
+  implicit lazy val parser: Parser[VerbosityOptions] = Parser.derive
+  implicit lazy val help: Help[VerbosityOptions]     = Help.derive
   implicit val rwCounter: JsonValueCodec[Int @@ Counter] =
     new JsonValueCodec[Int @@ Counter] {
       private val intCodec: JsonValueCodec[Int] = JsonCodecMaker.make

--- a/modules/cli-options/src/main/scala/scala/cli/commands/github/SharedSecretOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/github/SharedSecretOptions.scala
@@ -27,7 +27,6 @@ final case class SharedSecretOptions(
 }
 
 object SharedSecretOptions {
-  lazy val parser: Parser[SharedSecretOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[SharedSecretOptions, parser.D] = parser
-  implicit lazy val help: Help[SharedSecretOptions]                      = Help.derive
+  implicit lazy val parser: Parser[SharedSecretOptions] = Parser.derive
+  implicit lazy val help: Help[SharedSecretOptions]     = Help.derive
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/pgp/SharedPgpPushPullOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/pgp/SharedPgpPushPullOptions.scala
@@ -14,7 +14,6 @@ final case class SharedPgpPushPullOptions(
 // format: on
 
 object SharedPgpPushPullOptions {
-  lazy val parser: Parser[SharedPgpPushPullOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[SharedPgpPushPullOptions, parser.D] = parser
-  implicit lazy val help: Help[SharedPgpPushPullOptions]                      = Help.derive
+  implicit lazy val parser: Parser[SharedPgpPushPullOptions] = Parser.derive
+  implicit lazy val help: Help[SharedPgpPushPullOptions]     = Help.derive
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/publish/PublishParamsOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/publish/PublishParamsOptions.scala
@@ -65,7 +65,6 @@ final case class PublishParamsOptions(
 }
 
 object PublishParamsOptions {
-  lazy val parser: Parser[PublishParamsOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[PublishParamsOptions, parser.D] = parser
-  implicit lazy val help: Help[PublishParamsOptions]                      = Help.derive
+  implicit lazy val parser: Parser[PublishParamsOptions] = Parser.derive
+  implicit lazy val help: Help[PublishParamsOptions]     = Help.derive
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/publish/PublishRepositoryOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/publish/PublishRepositoryOptions.scala
@@ -34,7 +34,6 @@ final case class PublishRepositoryOptions(
 // format: on
 
 object PublishRepositoryOptions {
-  lazy val parser: Parser[PublishRepositoryOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[PublishRepositoryOptions, parser.D] = parser
-  implicit lazy val help: Help[PublishRepositoryOptions]                      = Help.derive
+  implicit lazy val parser: Parser[PublishRepositoryOptions] = Parser.derive
+  implicit lazy val help: Help[PublishRepositoryOptions]     = Help.derive
 }

--- a/modules/cli-options/src/main/scala/scala/cli/commands/publish/SharedPublishOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/commands/publish/SharedPublishOptions.scala
@@ -69,7 +69,6 @@ final case class SharedPublishOptions(
 // format: on
 
 object SharedPublishOptions {
-  lazy val parser: Parser[SharedPublishOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[SharedPublishOptions, parser.D] = parser
-  implicit lazy val help: Help[SharedPublishOptions]                      = Help.derive
+  implicit lazy val parser: Parser[SharedPublishOptions] = Parser.derive
+  implicit lazy val help: Help[SharedPublishOptions]     = Help.derive
 }

--- a/modules/cli-options/src/main/scala/scala/cli/lanuncher/LauncherOptions.scala
+++ b/modules/cli-options/src/main/scala/scala/cli/lanuncher/LauncherOptions.scala
@@ -18,7 +18,6 @@ final case class LauncherOptions(
 )
 
 object LauncherOptions {
-  lazy val parser: Parser[LauncherOptions]                           = Parser.derive
-  implicit lazy val parserAux: Parser.Aux[LauncherOptions, parser.D] = parser
-  implicit lazy val help: Help[LauncherOptions]                      = Help.derive
+  implicit lazy val parser: Parser[LauncherOptions] = Parser.derive
+  implicit lazy val help: Help[LauncherOptions]     = Help.derive
 }

--- a/modules/cli/src/main/scala/scala/cli/ScalaCliCommands.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCliCommands.scala
@@ -79,7 +79,7 @@ class ScalaCliCommands(
   // FIXME Report this in case-app default NameFormatter
   override lazy val help: RuntimeCommandsHelp = {
     val parent = super.help
-    parent.withDefaultHelp(Help[Unit]())
+    parent.copy(defaultHelp = Help[Unit]())
   }
 
   override def enableCompleteCommand    = true

--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
@@ -12,9 +12,9 @@ object RestrictedCommandsParser {
       m.message.contains("[experimental]") || m.message.contains("[restricted]")
     )
 
-  def apply[T, TD](parser: Parser.Aux[T, TD]): Parser.Aux[T, TD] = new Parser[T] {
+  def apply[T](parser: Parser[T]): Parser[T] = new Parser[T] {
 
-    type D = TD
+    type D = parser.D
 
     private def isArgSupported(a: Arg): Boolean =
       scala.cli.ScalaCli.allowRestrictedFeatures || !isExperimentalOrRestricted(a)
@@ -29,7 +29,7 @@ object RestrictedCommandsParser {
 
     def init: D = parser.init
 
-    def withDefaultOrigin(origin: String): caseapp.core.parser.Parser.Aux[T, D] =
+    def withDefaultOrigin(origin: String): caseapp.core.parser.Parser[T] =
       RestrictedCommandsParser(parser.withDefaultOrigin(origin))
 
     override def step(

--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
@@ -6,49 +6,50 @@ import caseapp.core.parser.Parser
 import caseapp.core.util.Formatter
 import caseapp.core.{Arg, Error}
 
+final case class RestrictedCommandsParser[T](underlying: Parser[T]) extends Parser[T] {
+
+  type D = underlying.D
+
+  private def isArgSupported(a: Arg): Boolean =
+    scala.cli.ScalaCli.allowRestrictedFeatures ||
+    !RestrictedCommandsParser.isExperimentalOrRestricted(a)
+
+  def args: Seq[Arg] = underlying.args.filter(isArgSupported)
+
+  def get(
+    d: D,
+    nameFormatter: Formatter[Name]
+  ): Either[Error, T] =
+    underlying.get(d, nameFormatter)
+
+  def init: D = underlying.init
+
+  def withDefaultOrigin(origin: String): Parser[T] =
+    copy(underlying = underlying.withDefaultOrigin(origin))
+
+  override def step(
+    args: List[String],
+    index: Int,
+    d: D,
+    nameFormatter: Formatter[Name]
+  ): Either[(Error, Arg, List[String]), Option[(D, Arg, List[String])]] =
+    underlying.step(args, index, d, nameFormatter) match {
+      case Right(Some(_, arg, _)) if !isArgSupported(arg) =>
+        Left((
+          Error.UnrecognizedArgument(
+            s"`${args(index)}` option is not supported in `scala` command.\n  Please run it with `scala-cli` command or with `--power` flag."
+          ),
+          arg,
+          Nil
+        ))
+      case other =>
+        other
+    }
+}
+
 object RestrictedCommandsParser {
   def isExperimentalOrRestricted(a: Arg) =
     a.helpMessage.exists(m =>
       m.message.contains("[experimental]") || m.message.contains("[restricted]")
     )
-
-  def apply[T](parser: Parser[T]): Parser[T] = new Parser[T] {
-
-    type D = parser.D
-
-    private def isArgSupported(a: Arg): Boolean =
-      scala.cli.ScalaCli.allowRestrictedFeatures || !isExperimentalOrRestricted(a)
-
-    def args: Seq[caseapp.core.Arg] = parser.args.filter(isArgSupported)
-
-    def get(
-      d: D,
-      nameFormatter: caseapp.core.util.Formatter[caseapp.Name]
-    ): Either[caseapp.core.Error, T] =
-      parser.get(d, nameFormatter)
-
-    def init: D = parser.init
-
-    def withDefaultOrigin(origin: String): caseapp.core.parser.Parser[T] =
-      RestrictedCommandsParser(parser.withDefaultOrigin(origin))
-
-    override def step(
-      args: List[String],
-      index: Int,
-      d: D,
-      nameFormatter: Formatter[Name]
-    ): Either[(Error, Arg, List[String]), Option[(D, Arg, List[String])]] =
-      parser.step(args, index, d, nameFormatter) match {
-        case Right(Some(_, arg, _)) if !isArgSupported(arg) =>
-          Left((
-            Error.UnrecognizedArgument(
-              s"`${args(index)}` option is not supported in `scala` command.\n  Please run it with `scala-cli` command or with `--power` flag."
-            ),
-            arg,
-            Nil
-          ))
-        case other =>
-          other
-      }
-  }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -236,8 +236,8 @@ abstract class ScalaCommand[T <: HasLoggingOptions](implicit myParser: Parser[T]
     }
 
   override def helpFormat: HelpFormat =
-    HelpFormat.default()
-      .withSortedGroups(Some(Seq(
+    HelpFormat.default().copy(
+      sortedGroups = Some(Seq(
         "Help",
         "Scala",
         "Java",
@@ -246,17 +246,17 @@ abstract class ScalaCommand[T <: HasLoggingOptions](implicit myParser: Parser[T]
         "Metabrowse server",
         "Logging",
         "Runner"
-      )))
-      .withSortedCommandGroups(Some(Seq(
+      )),
+      sortedCommandGroups = Some(Seq(
         "Main",
         "Miscellaneous",
         ""
-      )))
-      .withHiddenGroups(Some(Seq(
+      )),
+      hiddenGroups = Some(Seq(
         "Scala.js",
         "Scala Native"
-      )))
-      .withTerminalWidthOpt {
+      )),
+      terminalWidthOpt =
         if (Properties.isWin)
           if (coursier.paths.Util.useJni())
             Try(coursier.jniutils.WindowsAnsiTerminal.terminalSize()).toOption.map(
@@ -277,7 +277,7 @@ abstract class ScalaCommand[T <: HasLoggingOptions](implicit myParser: Parser[T]
           //   https://github.com/fusesource/jansi/blob/09722b7cccc8a99f14ac1656db3072dbeef34478/src/main/java/org/fusesource/jansi/AnsiConsole.java#L344
           // This requires writing our own minimal JNI library, that publishes '.a' files too for static linking in the executable of Scala CLI.
           None
-      }
+    )
 
   /** @param options
     *   command-specific [[T]] options

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
@@ -2,6 +2,7 @@ package scala.cli.doc
 
 import caseapp.*
 import caseapp.core.Arg
+import caseapp.core.Scala3Helpers.*
 import caseapp.core.util.Formatter
 import munit.internal.difflib.Diff
 
@@ -155,7 +156,13 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
           val names = (arg.name +: arg.extraNames).map(_.option(nameFormatter))
           b.append(s"### `${names.head}`\n\n")
           if (names.tail.nonEmpty)
-            b.append(names.tail.map(n => s"`$n`").mkString("Aliases: ", ", ", "\n\n"))
+            b.append(
+              names
+                .tail
+                .sortBy(_.dropWhile(_ == '-'))
+                .map(n => s"`$n`")
+                .mkString("Aliases: ", ", ", "\n\n")
+            )
 
           if (isInternal || arg.noHelp) b.append("[Internal]\n")
 
@@ -204,7 +211,7 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
       val names        = c.names.map(_.mkString(" "))
 
       b.append(s"$headerPrefix## ${names.head}\n\n")
-      if (names.tail.nonEmpty) b.append(names.tail.mkString("Aliases: `", "`, `", "`\n\n"))
+      if (names.tail.nonEmpty) b.append(names.tail.sorted.mkString("Aliases: `", "`, `", "`\n\n"))
 
       for (desc <- c.messages.helpMessage.map(_.message))
         b.append(

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -99,7 +99,6 @@ object Deps {
   // Force using of 2.13 - is there a better way?
   def bloopConfig      = ivy"io.github.alexarchambault.bleep:bloop-config_2.13:1.5.4-sc-3"
   def bsp4j            = ivy"ch.epfl.scala:bsp4j:2.1.0-M3"
-  def caseApp213       = ivy"com.github.alexarchambault:case-app_2.13:2.1.0-M21"
   def caseApp          = ivy"com.github.alexarchambault::case-app:2.1.0-M21"
   def collectionCompat = ivy"org.scala-lang.modules::scala-collection-compat:2.8.1"
   // Force using of 2.13 - is there a better way?

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -164,8 +164,8 @@ object Deps {
   def semanticDbScalac         = ivy"org.scalameta:::semanticdb-scalac:${Versions.scalaMeta}"
   def shapeless                = ivy"com.chuusai::shapeless:2.3.9"
   def signingCliShared =
-    ivy"io.github.alexarchambault.scala-cli.signing:shared_2.13:${Versions.signingCli}"
-  def signingCli = ivy"io.github.alexarchambault.scala-cli.signing:cli_2.13:${Versions.signingCli}"
+    ivy"io.github.alexarchambault.scala-cli.signing::shared:${Versions.signingCli}"
+  def signingCli = ivy"io.github.alexarchambault.scala-cli.signing::cli:${Versions.signingCli}"
   def slf4jNop   = ivy"org.slf4j:slf4j-nop:2.0.3"
   // Force using of 2.13 - is there a better way?
   def snailgun(force213: Boolean = false) =

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -99,7 +99,8 @@ object Deps {
   // Force using of 2.13 - is there a better way?
   def bloopConfig      = ivy"io.github.alexarchambault.bleep:bloop-config_2.13:1.5.4-sc-3"
   def bsp4j            = ivy"ch.epfl.scala:bsp4j:2.1.0-M3"
-  def caseApp          = ivy"com.github.alexarchambault:case-app_2.13:2.1.0-M21"
+  def caseApp213       = ivy"com.github.alexarchambault:case-app_2.13:2.1.0-M21"
+  def caseApp          = ivy"com.github.alexarchambault::case-app:2.1.0-M21"
   def collectionCompat = ivy"org.scala-lang.modules::scala-collection-compat:2.8.1"
   // Force using of 2.13 - is there a better way?
   def coursier           = ivy"io.get-coursier:coursier_2.13:${Versions.coursier}"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -171,7 +171,7 @@ Add dependencies
 
 ### `--repository`
 
-Aliases: `--repo`, `-r`
+Aliases: `-r`, `--repo`
 
 Add repositories
 
@@ -308,7 +308,7 @@ Custom path to the scalafmt configuration file.
 
 ### `--scalafmt-conf-str`
 
-Aliases: `--scalafmt-config-str`, `--scalafmt-conf-snippet`
+Aliases: `--scalafmt-conf-snippet`, `--scalafmt-config-str`
 
 Pass configuration as a string.
 
@@ -344,7 +344,7 @@ Print help message and exit
 
 ### `--help-full`
 
-Aliases: `--full-help`, `-help-full`, `-full-help`
+Aliases: `--full-help`, `-full-help`, `-help-full`
 
 Print help message, including hidden options, and exit
 
@@ -366,7 +366,7 @@ Show options for ScalaNative
 
 ### `--help-scaladoc`
 
-Aliases: `--scaladoc-help`, `--doc-help`, `--help-doc`
+Aliases: `--doc-help`, `--help-doc`, `--scaladoc-help`
 
 Show options for Scaladoc
 
@@ -378,7 +378,7 @@ Show options for Scala REPL
 
 ### `--help-scalafmt`
 
-Aliases: `--scalafmt-help`, `--fmt-help`, `--help-fmt`
+Aliases: `--fmt-help`, `--help-fmt`, `--scalafmt-help`
 
 Show options for Scalafmt
 
@@ -522,7 +522,7 @@ Specify which main class to run
 
 ### `--main-class-ls`
 
-Aliases: `--main-class-list`, `--list-main-class`, `--list-main-classes`
+Aliases: `--list-main-class`, `--list-main-classes`, `--main-class-list`
 
 List main classes available in the current context
 
@@ -536,7 +536,7 @@ Available in commands:
 
 ### `--enable-markdown`
 
-Aliases: `--md`, `--markdown`
+Aliases: `--markdown`, `--md`
 
 [experimental] Enable markdown support.
 
@@ -570,7 +570,7 @@ Generate a source JAR rather than an executable JAR
 
 ### `--doc`
 
-Aliases: `--scaladoc`, `--javadoc`
+Aliases: `--javadoc`, `--scaladoc`
 
 Generate a scaladoc JAR rather than an executable JAR
 
@@ -804,7 +804,7 @@ Whether to build and publish source JARs
 
 ### `--doc`
 
-Aliases: `--scaladoc`, `--javadoc`
+Aliases: `--javadoc`, `--scaladoc`
 
 Whether to build and publish doc JARs
 
@@ -1225,7 +1225,7 @@ Available in commands:
 
 ### `--scalac-option`
 
-Aliases: `--scala-opt`, `-O`, `--scala-option`
+Aliases: `-O`, `--scala-opt`, `--scala-option`
 
 Add a `scalac` option. Note that options starting with `-g`, `-language`, `-opt`, `-P`, `-target`, `-V`, `-W`, `-X`, and `-Y` are assumed to be Scala compiler options and don't require to be passed after `-O` or `--scalac-option`.
 
@@ -1292,20 +1292,20 @@ Available in commands:
 
 ### `--scala-version`
 
-Aliases: `--scala`, `-S`
+Aliases: `-S`, `--scala`
 
 Set the Scala version (3.2.1 by default)
 
 ### `--scala-binary-version`
 
-Aliases: `--scala-binary`, `--scala-bin`, `-B`
+Aliases: `-B`, `--scala-bin`, `--scala-binary`
 
 [Internal]
 Set the Scala binary version
 
 ### `--extra-jars`
 
-Aliases: `--jar`, `--jars`, `--extra-jar`, `--class`, `--extra-class`, `--classes`, `--extra-classes`, `-classpath`, `-cp`, `--classpath`, `--class-path`, `--extra-class-path`
+Aliases: `--class`, `--class-path`, `--classes`, `--classpath`, `-classpath`, `-cp`, `--extra-class`, `--extra-class-path`, `--extra-classes`, `--extra-jar`, `--jar`, `--jars`
 
 Add extra JARs and compiled classes to the class path
 
@@ -1317,7 +1317,7 @@ Add extra JARs in the compilaion class path. Mainly using to run code in managed
 
 ### `--extra-source-jars`
 
-Aliases: `--source-jar`, `--source-jars`, `--extra-source-jar`
+Aliases: `--extra-source-jar`, `--source-jar`, `--source-jars`
 
 Add extra source JARs
 
@@ -1359,7 +1359,7 @@ Add dependency for stubs needed to make $ivy and $dep imports to work.
 [Internal]
 ### `--compilation-output`
 
-Aliases: `--output-directory`, `-d`, `--destination`, `--compile-output`, `--compile-out`
+Aliases: `--compile-out`, `--compile-output`, `-d`, `--destination`, `--output-directory`
 
 Copy compilation results to output directory using either relative or absolute path
 
@@ -1377,7 +1377,7 @@ Allows to execute a passed string as a Scala script
 
 ### `--execute-script`
 
-Aliases: `--execute-scala-script`, `--execute-sc`, `-e`
+Aliases: `-e`, `--execute-sc`, `--execute-scala-script`
 
 [Internal]
 A synonym to --script-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
@@ -1610,7 +1610,7 @@ Available in commands:
 
 ### `--working-directory`
 
-Aliases: `--working-dir`, `--dir`
+Aliases: `--dir`, `--working-dir`
 
 [Internal]
 ### Bloop start options

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -143,7 +143,7 @@ Add dependencies
 
 ### `--repository`
 
-Aliases: `--repo`, `-r`
+Aliases: `-r`, `--repo`
 
 Add repositories
 
@@ -252,7 +252,7 @@ Custom path to the scalafmt configuration file.
 
 ### `--scalafmt-conf-str`
 
-Aliases: `--scalafmt-config-str`, `--scalafmt-conf-snippet`
+Aliases: `--scalafmt-conf-snippet`, `--scalafmt-config-str`
 
 Pass configuration as a string.
 
@@ -288,7 +288,7 @@ Print help message and exit
 
 ### `--help-full`
 
-Aliases: `--full-help`, `-help-full`, `-full-help`
+Aliases: `--full-help`, `-full-help`, `-help-full`
 
 Print help message, including hidden options, and exit
 
@@ -310,7 +310,7 @@ Show options for ScalaNative
 
 ### `--help-scaladoc`
 
-Aliases: `--scaladoc-help`, `--doc-help`, `--help-doc`
+Aliases: `--doc-help`, `--help-doc`, `--scaladoc-help`
 
 Show options for Scaladoc
 
@@ -322,7 +322,7 @@ Show options for Scala REPL
 
 ### `--help-scalafmt`
 
-Aliases: `--scalafmt-help`, `--fmt-help`, `--help-fmt`
+Aliases: `--fmt-help`, `--help-fmt`, `--scalafmt-help`
 
 Show options for Scalafmt
 
@@ -466,7 +466,7 @@ Specify which main class to run
 
 ### `--main-class-ls`
 
-Aliases: `--main-class-list`, `--list-main-class`, `--list-main-classes`
+Aliases: `--list-main-class`, `--list-main-classes`, `--main-class-list`
 
 List main classes available in the current context
 
@@ -641,7 +641,7 @@ Available in commands:
 
 ### `--scalac-option`
 
-Aliases: `--scala-opt`, `-O`, `--scala-option`
+Aliases: `-O`, `--scala-opt`, `--scala-option`
 
 Add a `scalac` option. Note that options starting with `-g`, `-language`, `-opt`, `-P`, `-target`, `-V`, `-W`, `-X`, and `-Y` are assumed to be Scala compiler options and don't require to be passed after `-O` or `--scalac-option`.
 
@@ -675,20 +675,20 @@ Available in commands:
 
 ### `--scala-version`
 
-Aliases: `--scala`, `-S`
+Aliases: `-S`, `--scala`
 
 Set the Scala version (3.2.1 by default)
 
 ### `--scala-binary-version`
 
-Aliases: `--scala-binary`, `--scala-bin`, `-B`
+Aliases: `-B`, `--scala-bin`, `--scala-binary`
 
 [Internal]
 Set the Scala binary version
 
 ### `--extra-jars`
 
-Aliases: `--jar`, `--jars`, `--extra-jar`, `--class`, `--extra-class`, `--classes`, `--extra-classes`, `-classpath`, `-cp`, `--classpath`, `--class-path`, `--extra-class-path`
+Aliases: `--class`, `--class-path`, `--classes`, `--classpath`, `-classpath`, `-cp`, `--extra-class`, `--extra-class-path`, `--extra-classes`, `--extra-jar`, `--jar`, `--jars`
 
 Add extra JARs and compiled classes to the class path
 
@@ -700,7 +700,7 @@ Add extra JARs in the compilaion class path. Mainly using to run code in managed
 
 ### `--extra-source-jars`
 
-Aliases: `--source-jar`, `--source-jars`, `--extra-source-jar`
+Aliases: `--extra-source-jar`, `--source-jar`, `--source-jars`
 
 Add extra source JARs
 
@@ -742,7 +742,7 @@ Add dependency for stubs needed to make $ivy and $dep imports to work.
 [Internal]
 ### `--compilation-output`
 
-Aliases: `--output-directory`, `-d`, `--destination`, `--compile-output`, `--compile-out`
+Aliases: `--compile-out`, `--compile-output`, `-d`, `--destination`, `--output-directory`
 
 Copy compilation results to output directory using either relative or absolute path
 
@@ -760,7 +760,7 @@ Allows to execute a passed string as a Scala script
 
 ### `--execute-script`
 
-Aliases: `--execute-scala-script`, `--execute-sc`, `-e`
+Aliases: `-e`, `--execute-sc`, `--execute-scala-script`
 
 [Internal]
 A synonym to --script-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly


### PR DESCRIPTION
This makes us use the Scala 3 artifacts of case-app (including the macros deriving CLI options parsers).

This is handled in 3 steps here:
- first we use the Scala 3 artifacts from the `cli` module only (not from `cli-options` that derives parsers), and adjust some API calls - this breaks things at runtime (because of case-app Scala 2 and Scala 3 artifacts compatibility issues)
- then we use them from `cli-options` too
- lastly, we update to a version of scala-cli-signing relying on a Scala 3 case-app, so that there's no runtime issues with the scala-cli-signing stuff either.

The changes of the first two points mainly revolve around dropping the uses of `Parser.Aux` stuff (required to make the Scala 2 typer happy, and not necessary anymore in Scala 3).