### PR TITLE
Add support for running `.md` files inside of zipped archives

### DIFF
--- a/modules/build/src/main/scala/scala/build/input/Element.scala
+++ b/modules/build/src/main/scala/scala/build/input/Element.scala
@@ -27,6 +27,17 @@ sealed abstract class Virtual extends SingleElement {
     ScopePath(Left(source), subPath)
 }
 
+object Virtual {
+  def apply(path: String, content: Array[Byte]): Virtual = {
+    val wrapperPath = os.sub / path.split("/").last
+    if path.endsWith(".scala") then VirtualScalaFile(content, path)
+    else if path.endsWith(".java") then VirtualJavaFile(content, path)
+    else if path.endsWith(".sc") then VirtualScript(content, path, wrapperPath)
+    else if path.endsWith(".md") then VirtualMarkdownFile(content, path, wrapperPath)
+    else VirtualData(content, path)
+  }
+}
+
 sealed abstract class VirtualSourceFile extends Virtual {
   def isStdin: Boolean = source.startsWith("<stdin>")
 
@@ -46,7 +57,9 @@ sealed trait SourceFile extends SingleFile {
 
 sealed trait Compiled extends Element
 
-sealed trait AnyScalaFile extends Compiled
+sealed trait AnyScalaFile    extends Compiled
+sealed trait AnyJavaFile     extends Compiled
+sealed trait AnyMarkdownFile extends Compiled
 
 sealed trait ScalaFile extends AnyScalaFile {
   def base: os.Path
@@ -68,17 +81,17 @@ final case class ProjectScalaFile(base: os.Path, subPath: os.SubPath)
     extends OnDisk with SourceFile with ScalaFile
 
 final case class JavaFile(base: os.Path, subPath: os.SubPath)
-    extends OnDisk with SourceFile with Compiled {
+    extends OnDisk with SourceFile with AnyJavaFile {
   lazy val path: os.Path = base / subPath
 }
 
 final case class CFile(base: os.Path, subPath: os.SubPath)
     extends OnDisk with SourceFile with Compiled {
-  lazy val path = base / subPath
+  lazy val path: os.Path = base / subPath
 }
 
 final case class MarkdownFile(base: os.Path, subPath: os.SubPath)
-    extends OnDisk with SourceFile with Compiled {
+    extends OnDisk with SourceFile with AnyMarkdownFile {
   lazy val path: os.Path = base / subPath
 }
 
@@ -87,7 +100,7 @@ final case class Directory(path: os.Path) extends OnDisk with Compiled
 final case class ResourceDirectory(path: os.Path) extends OnDisk
 
 final case class VirtualScript(content: Array[Byte], source: String, wrapperPath: os.SubPath)
-    extends Virtual with AnyScalaFile with AnyScript
+    extends VirtualSourceFile with AnyScalaFile with AnyScript
 
 object VirtualScript {
   val VirtualScriptNameRegex: Regex = "(^stdin$|^snippet\\d*$)".r
@@ -99,7 +112,7 @@ final case class VirtualScalaFile(content: Array[Byte], source: String)
 }
 
 final case class VirtualJavaFile(content: Array[Byte], source: String)
-    extends VirtualSourceFile with Compiled {
+    extends VirtualSourceFile with AnyJavaFile {
   def generatedSourceFileName: String = generatedSourceFileName(".java")
 }
 
@@ -107,7 +120,7 @@ final case class VirtualMarkdownFile(
   content: Array[Byte],
   override val source: String,
   wrapperPath: os.SubPath
-) extends Virtual with Compiled
+) extends VirtualSourceFile with AnyMarkdownFile
 
 final case class VirtualData(content: Array[Byte], source: String)
     extends Virtual

--- a/modules/build/src/main/scala/scala/build/input/Element.scala
+++ b/modules/build/src/main/scala/scala/build/input/Element.scala
@@ -78,7 +78,7 @@ final case class CFile(base: os.Path, subPath: os.SubPath)
 }
 
 final case class MarkdownFile(base: os.Path, subPath: os.SubPath)
-    extends OnDisk with SourceFile {
+    extends OnDisk with SourceFile with Compiled {
   lazy val path: os.Path = base / subPath
 }
 
@@ -102,6 +102,12 @@ final case class VirtualJavaFile(content: Array[Byte], source: String)
     extends VirtualSourceFile with Compiled {
   def generatedSourceFileName: String = generatedSourceFileName(".java")
 }
+
+final case class VirtualMarkdownFile(
+  content: Array[Byte],
+  override val source: String,
+  wrapperPath: os.SubPath
+) extends Virtual with Compiled
 
 final case class VirtualData(content: Array[Byte], source: String)
     extends Virtual

--- a/modules/build/src/main/scala/scala/build/input/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/input/Inputs.scala
@@ -199,16 +199,23 @@ object Inputs {
       val wrapperPath = os.sub / path.split("/").last
       VirtualScript(content, path, wrapperPath)
     }
+    else if (path.endsWith(".md")) {
+      val wrapperPath = os.sub / path.split("/").last
+      VirtualMarkdownFile(content, path, wrapperPath)
+    }
     else VirtualData(content, path)
 
-  private def resolveZipArchive(content: Array[Byte]): Seq[Element] = {
+  private def resolveZipArchive(content: Array[Byte], enableMarkdown: Boolean): Seq[Element] = {
     val zipInputStream = WrappedZipInputStream.create(new ByteArrayInputStream(content))
     zipInputStream.entries().foldLeft(List.empty[Element]) {
       (acc, ent) =>
         if (ent.isDirectory) acc
         else {
           val content = zipInputStream.readAllBytes()
-          resolve(ent.getName, content) :: acc
+          (resolve(ent.getName, content) match {
+            case _: VirtualMarkdownFile if !enableMarkdown => None
+            case e: Element                                => Some(e)
+          }) map { element => element :: acc } getOrElse acc
         }
     }
   }
@@ -251,7 +258,8 @@ object Inputs {
     cwd: os.Path,
     download: String => Either[String, Array[Byte]],
     stdinOpt: => Option[Array[Byte]],
-    acceptFds: Boolean
+    acceptFds: Boolean,
+    enableMarkdown: Boolean
   ): Seq[Either[String, Seq[Element]]] = args.zipWithIndex.map {
     case (arg, idx) =>
       lazy val path      = os.Path(arg, cwd)
@@ -267,14 +275,14 @@ object Inputs {
         Right(Seq(VirtualScript(stdinOpt0.get, "stdin", os.sub / "stdin.sc")))
       else if (arg.endsWith(".zip") && os.exists(os.Path(arg, cwd))) {
         val content = os.read.bytes(os.Path(arg, cwd))
-        Right(resolveZipArchive(content))
+        Right(resolveZipArchive(content, enableMarkdown))
       }
       else if (arg.contains("://")) {
         val url =
           if githubGistsArchiveRegex.findFirstMatchIn(arg).nonEmpty then s"$arg/download" else arg
         download(url).map { content =>
           if (githubGistsArchiveRegex.findFirstMatchIn(arg).nonEmpty)
-            resolveZipArchive(content)
+            resolveZipArchive(content, enableMarkdown)
           else
             List(resolve(url, content))
         }
@@ -315,7 +323,7 @@ object Inputs {
     extraClasspathWasPassed: Boolean
   ): Either[BuildException, Inputs] = {
     val validatedArgs: Seq[Either[String, Seq[Element]]] =
-      validateArgs(args, cwd, download, stdinOpt, acceptFds)
+      validateArgs(args, cwd, download, stdinOpt, acceptFds, enableMarkdown)
     val validatedSnippets: Seq[Either[String, Seq[Element]]] =
       validateSnippets(scriptSnippetList, scalaSnippetList, javaSnippetList)
     val validatedArgsAndSnippets = validatedArgs ++ validatedSnippets

--- a/modules/build/src/main/scala/scala/build/internal/MainClass.scala
+++ b/modules/build/src/main/scala/scala/build/internal/MainClass.scala
@@ -7,7 +7,6 @@ import java.io.{ByteArrayInputStream, InputStream}
 import java.util.zip.ZipEntry
 
 import scala.build.input.Element
-import scala.build.input.Inputs.resolve
 import scala.build.internal.zip.WrappedZipInputStream
 
 object MainClass {

--- a/modules/build/src/main/scala/scala/build/preprocessing/MarkdownPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/MarkdownPreprocessor.scala
@@ -5,7 +5,7 @@ import java.nio.charset.StandardCharsets
 import scala.build.EitherCps.{either, value}
 import scala.build.Logger
 import scala.build.errors.BuildException
-import scala.build.input.{Inputs, MarkdownFile, SingleElement}
+import scala.build.input.{Inputs, MarkdownFile, SingleElement, VirtualMarkdownFile}
 import scala.build.internal.markdown.MarkdownCodeWrapper
 import scala.build.internal.{AmmUtil, CodeWrapper, CustomCodeWrapper, Name}
 import scala.build.options.{BuildOptions, BuildRequirements}
@@ -36,7 +36,23 @@ case object MarkdownPreprocessor extends Preprocessor {
           preprocessed
         }
         Some(res)
-
+      case markdown: VirtualMarkdownFile =>
+        val content = new String(markdown.content, StandardCharsets.UTF_8)
+        val res = either {
+          val preprocessed = value {
+            MarkdownPreprocessor.preprocess(
+              Left(markdown.source),
+              content,
+              markdown.wrapperPath,
+              markdown.scopePath,
+              logger,
+              maybeRecoverOnError,
+              allowRestrictedFeatures
+            )
+          }
+          preprocessed
+        }
+        Some(res)
       case _ =>
         None
     }

--- a/modules/cli/src/main/scala/scala/cli/commands/util/SharedOptionsUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/SharedOptionsUtil.scala
@@ -421,7 +421,8 @@ object SharedOptionsUtil extends CommandHelpers {
         Os.pwd,
         downloadInputs(coursierCache),
         readStdin(logger = logger),
-        !Properties.isWin
+        !Properties.isWin,
+        enableMarkdown = true
       )
 
     def strictBloopJsonCheckOrDefault: Boolean =


### PR DESCRIPTION
Fixes #1514 

Note that this simultanously adds the support for running markdown from GitHub Gists:
```scala
▶ scala-cli https://gist.github.com/Gedochao/6415211eeb8ca4d8d6db123f83f0f839 --md
Compiling project (Scala 3.2.0, JVM)
Compiled project (Scala 3.2.0, JVM)
Hello
```