### PR TITLE
Add some explanations on implicit sub-commands in `-help`

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/default/Default.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/Default.scala
@@ -18,8 +18,20 @@ class Default(
   isSipScala: Boolean
 ) extends ScalaCommand[DefaultOptions] {
 
-  private def defaultHelp: String     = actualHelp.help(ScalaCliHelp.helpFormat)
-  private def defaultFullHelp: String = actualHelp.help(ScalaCliHelp.helpFormat, showHidden = true)
+  private lazy val defaultCommandHelp: String =
+    s"""
+       |
+       |When no subcommand is passed explicitly, an implicit subcommand is used based on context:
+       |  - if the '--version' option is passed, it prints the 'version' subcommand output, unmodified by any other options
+       |  - if any inputs were passed, it defaults to the 'run' subcommand
+       |  - additionally, when no inputs were passed, it defaults to the 'run' subcommand in the following scenarios:
+       |    - if a snippet was passed with any of the '--execute*' options
+       |    - if a main class was passed with the '--main-class' option alongside an extra '--classpath'
+       |  - otherwise, if no inputs were passed, it defaults to the 'repl' subcommand""".stripMargin
+
+  private def defaultHelp: String = actualHelp.help(ScalaCliHelp.helpFormat) + defaultCommandHelp
+  private def defaultFullHelp: String =
+    actualHelp.help(ScalaCliHelp.helpFormat, showHidden = true) + defaultCommandHelp
 
   override def group                                                         = "Main"
   override def sharedOptions(options: DefaultOptions): Option[SharedOptions] = Some(options.shared)


### PR DESCRIPTION
Closes #1370 

This is an attempt at explaining the default sub-command behaviour in the CLI `-help` as well (as until now it was only mentioned on the docs website).

```bash
▶ scala-cli -help
Usage: /Users/pchabelski/IdeaProjects/scala-cli/out/cli/base-image/nativeImage.dest/scala-cli <COMMAND>
Scala CLI is a command-line tool to interact with the Scala language. It lets you compile, run, test, and package your Scala code.

Other commands:
  export                                        Export current project to sbt or Mill
  help                                          Print help message
  install completions, install-completions      Installs completions into your shell
  github secret create, gh secret create
  github secret list, gh secret list
  setup-ide                                     Generate a BSP file that you can import into your IDE
  shebang                                       Like `run`, but more handy from shebang scripts
  uninstall                                     Uninstall scala-cli - only works when installed by the installation script
  uninstall completions, uninstall-completions  Uninstalls completions from your shell
  update                                        Update scala-cli - only works when installed by the installation script

Doctor commands:
  doctor  Print details about this application

Main commands:
  clean                  Clean the workspace
  compile                Compile Scala code
  dependency-update      Update dependencies in project
  doc                    Generate Scaladoc documentation
  fmt, format, scalafmt  Format Scala code
  repl, console          Fire-up a Scala REPL
  package                Compile and package Scala code
  publish
  publish local
  publish setup
  run                    Compile and run Scala code.
  test                   Compile and test Scala code

Miscellaneous commands:
  about    Print details about this application
  version  Print version

See 'scala-cli <command> --help' to read about a specific subcommand. To see full help run 'scala-cli <command> --help-full'.
To run another Scala CLI version, specify it with '--cli-version' before any other argument, like 'scala-cli --cli-version <version> args'.

When no subcommand is passed explicitly, an implicit subcommand is used based on context:
  - if the '--version' option is passed, it prints the 'version' subcommand output, unmodified by any other options
  - if any inputs were passed, it defaults to the 'run' subcommand
  - additionally, when no inputs were passed, it defaults to the 'run' subcommand in the following scenarios:
    - if a snippet was passed with any of the '--execute*' options
    - if a main class was passed with the '--main-class' option alongside an extra '--classpath'
  - otherwise, if no inputs were passed, it defaults to the 'repl' subcommand

```