### PR TITLE
Run warm up test before running default tests

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/DefaultTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DefaultTests.scala
@@ -2,7 +2,9 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-class DefaultTests extends ScalaCliSuite {
+class DefaultTests extends WithWarmUpScalaCliSuite {
+  override def warmUpExtraTestOptions: Seq[String] = TestUtil.extraOptions
+
   test("running scala-cli with no args should default to repl") {
     TestInputs.empty.fromRoot { root =>
       val res = os.proc(TestUtil.cli, "--repl-dry-run").call(cwd = root, mergeErrIntoOut = true)

--- a/modules/integration/src/test/scala/scala/cli/integration/WithWarmUpScalaCliSuite.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/WithWarmUpScalaCliSuite.scala
@@ -1,0 +1,39 @@
+package scala.cli.integration
+
+import com.eed3si9n.expecty.Expecty.expect
+
+abstract class WithWarmUpScalaCliSuite extends ScalaCliSuite {
+
+  def warmUpExtraTestOptions: Seq[String]
+
+  // warm-up run that downloads compiler bridges
+  // The "Downloading compiler-bridge (from bloop?) pollute the output, and would make the first test fail.
+  lazy val warmupTest: Unit = {
+    System.err.println("Running warmup test…")
+    warmUpTests(ignoreErrors = true)
+    System.err.println("Done running warmup test.")
+  }
+
+  def warmUpTests(ignoreErrors: Boolean): Unit = {
+    val fileName = "simple.sc"
+    val message  = "Hello"
+    val inputs = TestInputs(
+      os.rel / fileName ->
+        s"""val msg = "$message"
+           |println(msg)
+           |""".stripMargin
+    )
+    inputs.fromRoot { root =>
+      val output =
+        os.proc(TestUtil.cli, warmUpExtraTestOptions, fileName).call(cwd = root).out.trim()
+      if (!ignoreErrors)
+        expect(output == message)
+    }
+  }
+
+  override def test(name: String)(body: => Any)(implicit loc: munit.Location): Unit =
+    super.test(name) { warmupTest; body }(loc)
+
+  override def test(name: munit.TestOptions)(body: => Any)(implicit loc: munit.Location): Unit =
+    super.test(name) { warmupTest; body }(loc)
+}


### PR DESCRIPTION
In the first run of the test, the output may be polluted by staff downloading, like this:
```
Downloading https://repo1.maven.org/maven2/org/scala-lang/scala-library/maven-metadata.xml
[4410](https://github.com/VirtusLab/scala-cli/actions/runs/3523852928/jobs/5908513925#step:4:4411)
Downloaded https://repo1.maven.org/maven2/org/scala-lang/scala-library/maven-metadata.xml
[4411](https://github.com/VirtusLab/scala-cli/actions/runs/3523852928/jobs/5908513925#step:4:4412)
Downloading https://repo1.maven.org/maven2/org/scala-lang/scala3-library_3/maven-metadata.xml
[4412](https://github.com/VirtusLab/scala-cli/actions/runs/3523852928/jobs/5908513925#step:4:4413)
Downloaded https://repo1.maven.org/maven2/org/scala-lang/scala3-library_3/maven-metadata.xml
[4413](https://github.com/VirtusLab/scala-cli/actions/runs/3523852928/jobs/5908513925#step:4:4414)
Downloading https://github.com/VirtusLab/scala-cli-scala-versions/raw/main/scala-versions-v1.json
[4414](https://github.com/VirtusLab/scala-cli/actions/runs/3523852928/jobs/5908513925#step:4:4415)
Downloaded https://github.com/VirtusLab/scala-cli-scala-versions/raw/main/scala-versions-v1.json
```
to clean this up, I added a warm-up test to `DefaultTests`.

To prevent CI fail such as this [error](https://github.com/VirtusLab/scala-cli/actions/runs/3523852928/jobs/5908513925#step:4:4389). 