### PR TITLE
Enable by default actionable diagnostic

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -403,7 +403,7 @@ object Build {
     for (testBuild <- builds.get(Scope.Test))
       ResourceMapper.copyResourceToClassesDir(testBuild)
 
-    if (actionableDiagnostics.getOrElse(false)) {
+    if (actionableDiagnostics.getOrElse(true)) {
       val projectOptions = builds.get(Scope.Test).getOrElse(builds.main).options
       projectOptions.logActionableDiagnostics(logger)
     }

--- a/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
@@ -186,7 +186,7 @@ final class BspImpl(
       buildChangedTest
     )
 
-    if (actionableDiagnostics.getOrElse(false)) {
+    if (actionableDiagnostics.getOrElse(true)) {
       val projectOptions = options0Test.orElse(options0Main)
       projectOptions.logActionableDiagnostics(persistentLogger)
     }

--- a/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
@@ -78,9 +78,7 @@ object Bsp extends ScalaCommand[BspOptions] {
     CurrentParams.workspaceOpt = Some(inputs.workspace)
     val configDb = options.shared.configDb.orExit(logger)
     val actionableDiagnostics =
-      options.shared.logging.verbosityOptions.actions.orElse(
-        configDb.get(Keys.actions).getOrElse(None)
-      )
+      options.shared.logging.verbosityOptions.actions
 
     BspThreads.withThreads { threads =>
       val bsp = scala.build.bsp.Bsp.create(


### PR DESCRIPTION
To disable printing actionable diagnostic messages in command line, users have to run:
```
scala-cli config action false 
```

If someone wants to disable actionable diagnostic with Metals should run `setup-ide` with `--action false` flag:

```
scala-cli setup-ide --actions false . 
```
