### PR TITLE
Improve docs coverage with `sclicheck`

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,12 +197,13 @@ To just check the documents, run:
 ./mill -i docs-tests.test 'sclicheck.DocTests.*'
 ```
 
-You can also check all root docs, commands, guides or cookbooks:
+You can also check all root docs, commands, reference docs, guides or cookbooks:
 ```bash
 ./mill -i docs-tests.test 'sclicheck.DocTests.root*'
 ./mill -i docs-tests.test 'sclicheck.DocTests.guide*'
 ./mill -i docs-tests.test 'sclicheck.DocTests.command*'
 ./mill -i docs-tests.test 'sclicheck.DocTests.cookbook*'
+./mill -i docs-tests.test 'sclicheck.DocTests.reference*'
 ```
 
 Similarly, you can check single files:

--- a/README.md
+++ b/README.md
@@ -197,8 +197,9 @@ To just check the documents, run:
 ./mill -i docs-tests.test 'sclicheck.DocTests.*'
 ```
 
-You can also check all commands, guides or cookbooks:
+You can also check all root docs, commands, guides or cookbooks:
 ```bash
+./mill -i docs-tests.test 'sclicheck.DocTests.root*'
 ./mill -i docs-tests.test 'sclicheck.DocTests.guide*'
 ./mill -i docs-tests.test 'sclicheck.DocTests.command*'
 ./mill -i docs-tests.test 'sclicheck.DocTests.cookbook*'

--- a/modules/docs-tests/src/main/scala/sclicheck/sclicheck.scala
+++ b/modules/docs-tests/src/main/scala/sclicheck/sclicheck.scala
@@ -9,16 +9,13 @@ import scala.io.StdIn.readLine
 import scala.util.Random
 import scala.util.matching.Regex
 
-val SnippetBlock = """ *(```[`]*)[^ ]+ title=([\w\d\.\-\/_]+) *""".r
-val CompileBlock = """ *(```[`]*) *(\w+) +(compile|fail) *(?:title=([\w\d\.\-\/_]+))? *""".r
-def compileBlockEnds(backticks: String): Regex = {
-  val regexString = s""" *$backticks *"""
-  regexString.r
-}
-val BashCommand   = """ *```bash *(fail)? *""".r
-val CheckBlock    = """ *\<\!-- Expected(-regex)?: *""".r
-val CheckBlockEnd = """ *\--> *""".r
-val Clear         = """ *<!--+ *clear *-+-> *""".r
+val SnippetBlock = """ *(`{2}`+)[^ ]+ title=([\w\d.\-/_]+) *""".r
+val CompileBlock = """ *(`{2}`+) *(\w+) +(compile|fail) *(?:title=([\w\d.\-/_]+))? *""".r
+def compileBlockEnds(backticks: String) = s""" *$backticks *""".r
+val BashCommand                         = """ *```bash *(fail)? *""".r
+val CheckBlock                          = """ *\<\!-- Expected(-regex)?: *""".r
+val CheckBlockEnd                       = """ *\--> *""".r
+val Clear                               = """ *<!--+ *clear *-+-> *""".r
 
 case class Options(
   scalaCliCommand: Seq[String],

--- a/modules/docs-tests/src/main/scala/sclicheck/sclicheck.scala
+++ b/modules/docs-tests/src/main/scala/sclicheck/sclicheck.scala
@@ -5,6 +5,7 @@ import fansi.Color.{Blue, Green, Red}
 import java.io.File
 import java.security.SecureRandom
 
+import scala.annotation.tailrec
 import scala.io.StdIn.readLine
 import scala.util.Random
 import scala.util.matching.Regex
@@ -28,8 +29,8 @@ case class Options(
 
 enum Commands:
   def context: Context
-  def name = toString.takeWhile(_ != '(')
-  def log = this match {
+  def name: String = toString.takeWhile(_ != '(')
+  def log: Any = this match {
     case _: Clear => ""
     case Check(patterns, regex, _) =>
       val kind = if regex then "regexes" else "patterns"
@@ -51,13 +52,13 @@ enum Commands:
   case Clear(context: Context)
 
 case class Context(file: os.RelPath, line: Int):
-  def proceed(linesToSkip: Int = 1) = copy(line = line + linesToSkip)
-  override def toString             = s"$file:$line"
+  def proceed(linesToSkip: Int = 1): Context = copy(line = line + linesToSkip)
+  override def toString                      = s"$file:$line"
 
 case class FailedCheck(line: Int, file: os.RelPath, txt: String)
     extends RuntimeException(s"[$file:$line] $txt")
 
-def check(cond: Boolean, msg: => String)(using c: Context) =
+def check(cond: Boolean, msg: => String)(using c: Context): Unit =
   if !cond then throw FailedCheck(c.line, c.file, msg)
 
 @annotation.tailrec
@@ -197,10 +198,10 @@ def checkFile(file: os.Path, options: Options): Unit =
   var lastOutput: String = null
   val allSources         = Set.newBuilder[os.Path]
 
-  def runCommand(cmd: Commands, log: String => Unit) =
+  def runCommand(cmd: Commands, log: String => Unit): Unit =
     given Context = cmd.context
 
-    def writeFile(file: os.Path, code: Seq[String], c: Context) =
+    def writeFile(file: os.Path, code: Seq[String], c: Context): Unit =
       val (prefixLines, codeLines) =
         code match
           case shbang :: tail if shbang.startsWith("#!") =>
@@ -254,7 +255,7 @@ def checkFile(file: os.Path, options: Options): Unit =
         else
           check(exitCode == 0, s"Compilation failed.")
 
-      case Commands.Check(patterns, regex, line) =>
+      case Commands.Check(patterns, regex, _) =>
         check(lastOutput != null, "No output stored from previous commands")
         val lines = lastOutput.linesIterator.toList
 
@@ -282,7 +283,7 @@ def checkFile(file: os.Path, options: Options): Unit =
     commands.foreach { cmd =>
       val logs = List.newBuilder[String]
 
-      def printResult(success: Boolean, startTime: Long) =
+      def printResult(success: Boolean, startTime: Long): Unit =
         val duration    = System.currentTimeMillis - startTime
         val commandName = s"[${cmd.name} in $duration ms]"
         val cmdLog =
@@ -341,8 +342,8 @@ def checkFile(file: os.Path, options: Options): Unit =
 
     os.list(out).filter(_.last.endsWith(".scala")).foreach(p => os.copy.into(p, exampleDir))
 
-@main def check(args: String*) =
-  def processFiles(options: Options) =
+@main def check(args: String*): Unit =
+  def processFiles(options: Options): Unit =
     val paths = options.files.map { str =>
       val path = os.Path(str, os.pwd)
       assert(os.exists(path), s"Provided path $str does not exists in ${os.pwd}")
@@ -382,6 +383,7 @@ def checkFile(file: os.Path, options: Options): Unit =
   val Dest       = PathParameter("--dest")
   val StatusFile = PathParameter("--status-file")
 
+  @tailrec
   def parseArgs(args: Seq[String], options: Options): Options = args match
     case Nil => options
     case "--step" :: rest =>

--- a/modules/docs-tests/src/test/scala/sclicheck/DocTests.scala
+++ b/modules/docs-tests/src/test/scala/sclicheck/DocTests.scala
@@ -1,11 +1,15 @@
 package sclicheck
 
 class DocTests extends munit.FunSuite {
+  case class DocTestEntry(name: String, path: os.Path, depth: Int = Int.MaxValue)
+
   val docsRootPath: os.Path = os.pwd / "website" / "docs"
-  val dirs: Seq[(String, os.Path)] = Seq(
-    "cookbook" -> docsRootPath / "cookbooks",
-    "command"  -> docsRootPath / "commands",
-    "guide"    -> docsRootPath / "guides"
+  val entries: Seq[DocTestEntry] = Seq(
+    DocTestEntry("root", docsRootPath, depth = 1),
+    DocTestEntry("cookbook", docsRootPath / "cookbooks"),
+    DocTestEntry("command", docsRootPath / "commands"),
+    DocTestEntry("guide", docsRootPath / "guides"),
+    DocTestEntry("reference", docsRootPath / "reference")
   )
 
   val options: Options = Options(scalaCliCommand = Seq(TestUtil.scalaCliPath))
@@ -19,9 +23,8 @@ class DocTests extends munit.FunSuite {
     os.read.lines(f).exists(lineContainsAnyChecks)
 
   for {
-    (tpe, dir) <- dirs :+ ("root", docsRootPath)
-    maxDepth = if dir == docsRootPath then 1 else Int.MaxValue
-    inputs = os.walk(dir, maxDepth = maxDepth)
+    DocTestEntry(tpe, dir, depth) <- entries
+    inputs = os.walk(dir, maxDepth = depth)
       .filter(_.last.endsWith(".md"))
       .filter(os.isFile(_))
       .filter(fileContainsAnyChecks)

--- a/modules/docs-tests/src/test/scala/sclicheck/DocTests.scala
+++ b/modules/docs-tests/src/test/scala/sclicheck/DocTests.scala
@@ -19,8 +19,9 @@ class DocTests extends munit.FunSuite {
     os.read.lines(f).exists(lineContainsAnyChecks)
 
   for {
-    (tpe, dir) <- dirs
-    inputs = os.walk(dir)
+    (tpe, dir) <- dirs :+ ("root", docsRootPath)
+    maxDepth = if dir == docsRootPath then 1 else Int.MaxValue
+    inputs = os.walk(dir, maxDepth = maxDepth)
       .filter(_.last.endsWith(".md"))
       .filter(os.isFile(_))
       .filter(fileContainsAnyChecks)

--- a/modules/docs-tests/src/test/scala/sclicheck/DocTests.scala
+++ b/modules/docs-tests/src/test/scala/sclicheck/DocTests.scala
@@ -10,16 +10,20 @@ class DocTests extends munit.FunSuite {
 
   val options: Options = Options(scalaCliCommand = Seq(TestUtil.scalaCliPath))
 
-  private def containsCheck(f: os.Path): Boolean =
-    os.read.lines(f)
-      .exists(line => line.startsWith("```md") || line.startsWith("```bash"))
+  private def lineContainsAnyChecks(l: String): Boolean =
+    l.startsWith("```md") || l.startsWith("```bash") ||
+    l.startsWith("```scala compile") || l.startsWith("```scala fail") ||
+    l.startsWith("````markdown compile") || l.startsWith("````markdown fail") ||
+    l.startsWith("```java compile") || l.startsWith("````java fail")
+  private def fileContainsAnyChecks(f: os.Path): Boolean =
+    os.read.lines(f).exists(lineContainsAnyChecks)
 
   for {
     (tpe, dir) <- dirs
     inputs = os.walk(dir)
       .filter(_.last.endsWith(".md"))
       .filter(os.isFile(_))
-      .filter(containsCheck)
+      .filter(fileContainsAnyChecks)
       .map(_.relativeTo(dir))
       .sortBy(_.toString)
     md <- inputs

--- a/modules/docs-tests/src/test/scala/sclicheck/SclicheckTests.scala
+++ b/modules/docs-tests/src/test/scala/sclicheck/SclicheckTests.scala
@@ -2,6 +2,7 @@ package sclicheck
 
 class SclicheckTests extends munit.FunSuite:
   test("Run regex") {
+    assert(None == clue(CompileBlock.unapplySeq("``scala compile")))
     assert(
       Some(Seq("```", "scala", "compile", null)) == clue(
         CompileBlock.unapplySeq("```scala compile")
@@ -13,6 +14,16 @@ class SclicheckTests extends munit.FunSuite:
     assert(
       Some(Seq("````", "markdown", "compile", null)) == clue(
         CompileBlock.unapplySeq("````markdown compile")
+      )
+    )
+    assert(
+      Some(Seq("````", "markdown", "fail", "a.md")) == clue(
+        CompileBlock.unapplySeq("````markdown fail  title=a.md")
+      )
+    )
+    assert(
+      None == clue(
+        CompileBlock.unapplySeq("``scala fail  title=a.sc")
       )
     )
     assert(

--- a/modules/docs-tests/src/test/scala/sclicheck/SclicheckTests.scala
+++ b/modules/docs-tests/src/test/scala/sclicheck/SclicheckTests.scala
@@ -2,33 +2,26 @@ package sclicheck
 
 class SclicheckTests extends munit.FunSuite:
   test("Run regex") {
-    assert(None == clue(CompileBlock.unapplySeq("``scala compile")))
+    assert(clue(CompileBlock.unapplySeq("``scala compile")).isEmpty)
     assert(
-      Some(Seq("```", "scala", "compile", null)) == clue(
-        CompileBlock.unapplySeq("```scala compile")
-      )
+      clue(CompileBlock.unapplySeq("```scala compile"))
+        .contains(Seq("```", "scala", "compile", null))
     )
     assert(
-      Some(Seq("```", "scala", "fail", null)) == clue(CompileBlock.unapplySeq("```scala fail"))
+      clue(CompileBlock.unapplySeq("```scala fail"))
+        .contains(Seq("```", "scala", "fail", null))
     )
     assert(
-      Some(Seq("````", "markdown", "compile", null)) == clue(
-        CompileBlock.unapplySeq("````markdown compile")
-      )
+      clue(CompileBlock.unapplySeq("````markdown compile"))
+        .contains(Seq("````", "markdown", "compile", null))
     )
     assert(
-      Some(Seq("````", "markdown", "fail", "a.md")) == clue(
-        CompileBlock.unapplySeq("````markdown fail  title=a.md")
-      )
+      clue(CompileBlock.unapplySeq("````markdown fail  title=a.md"))
+        .contains(Seq("````", "markdown", "fail", "a.md"))
     )
+    assert(clue(CompileBlock.unapplySeq("``scala fail  title=a.sc")).isEmpty)
     assert(
-      None == clue(
-        CompileBlock.unapplySeq("``scala fail  title=a.sc")
-      )
-    )
-    assert(
-      Some(Seq("```", "scala", "fail", "a.sc")) == clue(
-        CompileBlock.unapplySeq("```scala fail  title=a.sc")
-      )
+      clue(CompileBlock.unapplySeq("```scala fail  title=a.sc"))
+        .contains(Seq("```", "scala", "fail", "a.sc"))
     )
   }

--- a/modules/docs-tests/src/test/scala/sclicheck/SclicheckTests.scala
+++ b/modules/docs-tests/src/test/scala/sclicheck/SclicheckTests.scala
@@ -3,13 +3,20 @@ package sclicheck
 class SclicheckTests extends munit.FunSuite:
   test("Run regex") {
     assert(
-      Some(Seq("scala", "compile", null)) == clue(CompileBlock.unapplySeq("```scala compile"))
+      Some(Seq("```", "scala", "compile", null)) == clue(
+        CompileBlock.unapplySeq("```scala compile")
+      )
     )
     assert(
-      Some(Seq("scala", "fail", null)) == clue(CompileBlock.unapplySeq("```scala fail"))
+      Some(Seq("```", "scala", "fail", null)) == clue(CompileBlock.unapplySeq("```scala fail"))
     )
     assert(
-      Some(Seq("scala", "fail", "a.sc")) == clue(
+      Some(Seq("````", "markdown", "compile", null)) == clue(
+        CompileBlock.unapplySeq("````markdown compile")
+      )
+    )
+    assert(
+      Some(Seq("```", "scala", "fail", "a.sc")) == clue(
         CompileBlock.unapplySeq("```scala fail  title=a.sc")
       )
     )

--- a/website/docs/guides/markdown.md
+++ b/website/docs/guides/markdown.md
@@ -19,14 +19,21 @@ You can enable including non-explicit `.md` inputs by passing the `--enable-mark
 
 You can pass local `.md` inputs by passing their path to Scala CLI (as you would for any other kind of input).
 
-```bash ignore
-scala-cli hello.md
+````markdown title=dir/hello.md
+# Simple snippet
+```scala
+println("Hello")
+```
+````
+
+```bash
+scala-cli dir/hello.md
 ```
 
 `.md` sources inside of directories are ignored by default, unless the `--enable-markdown` option is passed.
 
-```bash ignore
-scala-cli dir-with-markdown --enable-markdown
+```bash
+scala-cli dir --enable-markdown
 ```
 
 ### Zipped archives
@@ -147,7 +154,7 @@ top-level.
 
 <ChainedSnippets>
 
-```bash ignore
+```bash
 scala-cli run Example.md
 ```
 
@@ -160,14 +167,29 @@ Hello from Markdown
 Similarly to `.sc` scripts, when multiple `.md` files with plain `scala` snippets are being run, each of them will have
 its own main class, that can be run.
 
+````markdown title=Main1.md
+# Main class 1
+```scala
+println("1")
+```
+````
+
+
+````markdown title=Main2.md
+# Main class 2
+```scala
+println("2")
+```
+````
+
 <ChainedSnippets>
 
-```bash ignore
-scala-cli Example1.md Example2.md
+```bash fail
+scala-cli Main1.md Main2.md
 ```
 
 ```text
-[error]  Found several main classes: Example1_md, Example2_md
+[error]  Found several main classes: Main1_md, Main2_md
 ```
 
 </ChainedSnippets>
@@ -177,12 +199,12 @@ option.
 
 <ChainedSnippets>
 
-```bash ignore
-scala-cli Example1.md Example2.md --main-class Example1_md
+```bash
+scala-cli Main1.md Main2.md --main-class Main1_md
 ```
 
 ```text
-Hello from Markdown
+1
 ```
 
 </ChainedSnippets>
@@ -191,12 +213,12 @@ You can always check what main classes are available in the context with the `--
 
 <ChainedSnippets>
 
-```bash ignore
-scala-cli Example1.md Example2.md --list-main-classes
+```bash
+scala-cli Main1.md Main2.md --list-main-classes
 ```
 
 ```text
-Example1_md Example2_md
+Main1_md Main2_md
 ```
 
 </ChainedSnippets>
@@ -222,7 +244,7 @@ object Main extends App {
 
 <ChainedSnippets>
 
-```bash ignore
+```bash
 scala-cli RawExample.md
 ```
 
@@ -255,7 +277,7 @@ class Test extends munit.FunSuite {
 
 <ChainedSnippets>
 
-```bash ignore
+```bash
 scala-cli test TestExample.md
 ```
 
@@ -303,8 +325,8 @@ println(message)
 
 <ChainedSnippets>
 
-```bash ignore
-scala-cli test ResetExample.md
+```bash
+scala-cli ResetExample.md
 ```
 
 ```text
@@ -315,12 +337,12 @@ world
 
 </ChainedSnippets>
 
-## `using` directives and markdown code blocks
+## `using` directives and Markdown code blocks
 
 It is possible to define `using` directives at the beginning of a `scala` code block inside a markdown input.
 This is supported for all `scala` code block flavours.
 
-````markdown title=UsingDirectives.md
+````markdown compile title=UsingDirectives.md
 # Using directives in `.md` inputs
 
 ## `scala raw` example
@@ -339,7 +361,7 @@ println(os.pwd)
 
 ## `scala test` example
 ```scala test
-//> using lib "org.scalameta::munit:0.7.29"
+//> using lib "org.scalameta::munit:1.0.0-M7"
 
 class Test extends munit.FunSuite {
   test("foo") {
@@ -362,7 +384,7 @@ pprint.pprintln("world")
 `scala` snippets inside of a Markdown input are not isolated. Each `using` directive applies to the whole project's
 context. A directive defined in a later snippet within the same source may override another defined in an earlier one.
 
-````markdown title="OverriddenDirective.md"
+````markdown title=OverriddenDirective.md
 ## 1
 
 ```scala
@@ -383,7 +405,7 @@ be used for both.
 
 <ChainedSnippets>
 
-```bash ignore
+```bash
 scala-cli OverriddenDirective.md
 ```
 
@@ -411,17 +433,17 @@ snippet): `Scope{scopeNumber}`. The `snippetNumber` is omitted for the first scr
 the first scope is just `Scope`, the second is `Scope1`, then `Scope2` and so on.
 
 ````markdown title=src/markdown/Example.md
-## Scope 1
+## Scope 0
 ```scala
 def hello: String = "Hello"
 ```
 
-## Still scope 1, since `reset` wasn't used yet
+## Still scope 0, since `reset` wasn't used yet
 ```scala
 def space: String = " "
 ```
 
-## Scope 2
+## Scope 1
 ```scala reset
 def world: String = "world"
 ```
@@ -429,17 +451,17 @@ def world: String = "world"
 
 ```scala title=Main.scala
 object Main extends App {
-  val hello = src.markdown.Example_md.Scope.hello
-  val space = src.markdown.Example_md.Scope.space
-  val world = src.markdown.Example_md.Scope.world
-  println(s"$hello$space$world)
+  val hello = markdown.Example_md.Scope.hello
+  val space = markdown.Example_md.Scope.space
+  val world = markdown.Example_md.Scope1.world
+  println(s"$hello$space$world")
 }
 ```
 
 <ChainedSnippets>
 
-```bash ignore
-scala-cli . --enable-markdown --main-class Main
+```bash
+scala-cli src Main.scala --enable-markdown --main-class Main
 ```
 
 ```text
@@ -463,7 +485,7 @@ object Something {
 
 <ChainedSnippets>
 
-```bash ignore
+```bash
 scala-cli RawSnippetToReferTo.md -e 'println(Something.message)'
 ```
 

--- a/website/docs/reference/scala-command/index.md
+++ b/website/docs/reference/scala-command/index.md
@@ -18,13 +18,13 @@ There are two recommended ways to test and use Scala CLI:
 
 - with brew:
 
-```bash
+```bash ignore
 brew install virtuslab/scala-experimental/scala
 ```
 
 - with coursier:
 
-```bash
+```bash ignore
 cs setup
 cs install scala-experimental ← this command will replace the default scala runner
 ```

--- a/website/docs/release_notes.md
+++ b/website/docs/release_notes.md
@@ -172,7 +172,7 @@ Added by [@lwronski](https://github.com/lwronski) in https://github.com/VirtusLa
 ### Fixes in Scala Native binaries caching
 
 When running a sequence of commands such as
-```bash
+```bash ignore
 $ scala-cli run --native .
 $ scala-cli package --native . -o my-app
 ```


### PR DESCRIPTION
This improves the coverage of code included in our docs with the following
- `markdown` code blocks are now handled on par with `scala` and `java` (so that `markdown` examples can be compiled and tested)
- code blocks with >3 backticks are now supported (which also enables nesting code blocks in `markdown` examples)
- some docs have been skipped until now, as they didn't include `md` or `bash` code blocks, but they still did have stuff to be compiled and tested (i.e. `using-directives.md`)
- the docs root folder is now included in `sclicheck.DocTests`
```bash
▶ ./mill -i docs-tests.test 'sclicheck.DocTests.root*'
(...)
sclicheck.DocTests:
  + root getting_started 18.253s
  + root release_notes 0.007s
```
- the reference docs folder is now included in `sclicheck.DocTests`
```bash
▶ ./mill -i docs-tests.test 'sclicheck.DocTests.reference*'
(...)
sclicheck.DocTests:
  + reference scala-command/index 0.129s
sclicheck.SclicheckTests:
sclicheck.GifTests:
```