### PR TITLE
Fix - clean up only homebrew-scala-experimental directory

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1474,8 +1474,8 @@ object ci extends Module {
     val targetDir          = os.pwd / "target"
     val homebrewFormulaDir = targetDir / "homebrew-scala-experimental"
 
-    // clean target directory
-    if (os.exists(targetDir)) os.remove.all(targetDir)
+    // clean homebrew-scala-experimental directory
+    if (os.exists(homebrewFormulaDir)) os.remove.all(homebrewFormulaDir)
 
     os.makeDir.all(targetDir)
 


### PR DESCRIPTION
To prevent [error](https://github.com/VirtusLab/scala-cli/actions/runs/3436583499/jobs/5731648466#step:21:14) with removing files without access permission, we clean only  ` homebrew-scala-experimental` directory.