### PR TITLE
Put workspace and / or current directory in PYTHONPATH in the run and repl commands

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -194,6 +194,13 @@ object dummy extends Module {
       Deps.pythonInterface
     )
   }
+  object scalaPy extends ScalaModule with Bloop.Module {
+    def skipBloop    = true
+    def scalaVersion = Scala.defaultInternal
+    def ivyDeps = Agg(
+      Deps.scalaPy
+    )
+  }
 }
 
 trait BuildMacros extends ScalaCliSbtModule

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -160,7 +160,7 @@ object Deps {
   def scalaPackagerCli = ivy"org.virtuslab:scala-packager-cli_2.13:${Versions.scalaPackager}"
   // Force using of 2.13 - is there a better way?
   def scalaparse               = ivy"com.lihaoyi:scalaparse_2.13:2.3.3"
-  def scalaPy                  = ivy"me.shadaj::scalapy-core::0.5.2+5-83f1eb68"
+  def scalaPy                  = ivy"dev.scalapy::scalapy-core::0.5.3"
   def scalaReflect(sv: String) = ivy"org.scala-lang:scala-reflect:$sv"
   def semanticDbJavac          = ivy"com.sourcegraph:semanticdb-javac:0.7.4"
   def semanticDbScalac         = ivy"org.scalameta:::semanticdb-scalac:${Versions.scalaMeta}"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1039,7 +1039,7 @@ Enable Python support via ScalaPy
 
 Aliases: `--scalapy-version`
 
-[experimental] Set ScalaPy version (0.5.2+5-83f1eb68 by default)
+[experimental] Set ScalaPy version (0.5.3 by default)
 
 ## Repl options
 


### PR DESCRIPTION
I guess it's something that ScalaPy ought to do on its own (going to open an issue for it…). In the mean time, this PR makes things work for the `run` command at least.