### PR TITLE
Make `PackageTestsDefault.reuse run native binary` more robust

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestsDefault.scala
@@ -24,7 +24,7 @@ class PackageTestsDefault extends PackageTestDefinitions(scalaVersionOpt = None)
       val packageOutput    = packageRes.out.trim()
       val topPackageOutput = packageOutput.linesIterator.takeWhile(!_.startsWith("Wrote ")).toVector
       // no compilation or Scala Native pipeline output, as this should just re-use what the run command wrote
-      expect(topPackageOutput.isEmpty)
+      expect(topPackageOutput.forall(!_.startsWith("[info] ")))
     }
   }
 


### PR DESCRIPTION
It should fix M1 [fail](https://github.com/VirtusLab/scala-cli/actions/runs/3572441393/jobs/6007109792#step:6:4982).