### PR TITLE
Update Bloop to 1.5.4-sc-4

### DIFF
--- a/modules/build/src/main/scala/scala/build/ConsoleBloopBuildClient.scala
+++ b/modules/build/src/main/scala/scala/build/ConsoleBloopBuildClient.scala
@@ -186,7 +186,7 @@ object ConsoleBloopBuildClient {
       logger.message(s"$prefix$path0:$line$col" + (if (msgIt.hasNext) " " + msgIt.next() else ""))
       for (line <- msgIt)
         logger.message(prefix + line)
-      val codeOpt = Option(diag.getCode).orElse {
+      val codeOpt = {
         val lineOpt =
           if (diag.getRange.getStart.getLine == diag.getRange.getEnd.getLine)
             Option(diag.getRange.getStart.getLine)

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -97,7 +97,7 @@ object Deps {
   def ammonite = ivy"com.lihaoyi:::ammonite:2.5.5-17-df243e14"
   def asm      = ivy"org.ow2.asm:asm:9.4"
   // Force using of 2.13 - is there a better way?
-  def bloopConfig      = ivy"io.github.alexarchambault.bleep:bloop-config_2.13:1.5.4-sc-3"
+  def bloopConfig      = ivy"io.github.alexarchambault.bleep:bloop-config_2.13:1.5.4-sc-4"
   def bsp4j            = ivy"ch.epfl.scala:bsp4j:2.1.0-M3"
   def caseApp          = ivy"com.github.alexarchambault::case-app:2.1.0-M21"
   def collectionCompat = ivy"org.scala-lang.modules::scala-collection-compat:2.8.1"


### PR DESCRIPTION
This should (at last) make most things Bloop write to stderr be actually written to the output file, that users can print with `scala-cli bloop output`, thanks to https://github.com/scala-cli/bloop-core/pull/124. Before that, nailgun was messing with stdout / stderr, which was discarding stdout / stderr during most nailgun requests.