### PR TITLE
Add scalaCompilerPlugins to Mill project export

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/exportCmd/Mill.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/Mill.scala
@@ -48,7 +48,9 @@ final case class Mill(
 
   private def scalaCompilerPlugins(buildOptions: BuildOptions): MillProject =
     MillProject(scalaCompilerPlugins =
-      buildOptions.scalaOptions.compilerPlugins.toSeq.map(_.value.render)
+      buildOptions.scalaOptions.compilerPlugins.toSeq.map { p =>
+        s"${p.value.organization}:::${p.value.name}:${p.value.version}"
+      }
     )
 
   private def scalacOptionsSettings(buildOptions: BuildOptions): MillProject =

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/Mill.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/Mill.scala
@@ -48,9 +48,7 @@ final case class Mill(
 
   private def scalaCompilerPlugins(buildOptions: BuildOptions): MillProject =
     MillProject(scalaCompilerPlugins =
-      buildOptions.scalaOptions.compilerPlugins.toSeq.map { p =>
-        s"${p.value.organization}:::${p.value.name}:${p.value.version}"
-      }
+      buildOptions.scalaOptions.compilerPlugins.toSeq.map(_.value.render)
     )
 
   private def scalacOptionsSettings(buildOptions: BuildOptions): MillProject =

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/Mill.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/Mill.scala
@@ -46,6 +46,11 @@ final case class Mill(
       MillProject(scalaVersion = Some(sv))
   }
 
+  private def scalaCompilerPlugins(buildOptions: BuildOptions): MillProject =
+    MillProject(scalaCompilerPlugins =
+      buildOptions.scalaOptions.compilerPlugins.toSeq.map(_.value.render)
+    )
+
   private def scalacOptionsSettings(buildOptions: BuildOptions): MillProject =
     MillProject(scalacOptions = buildOptions.scalaOptions.scalacOptions.toSeq.map(_.value.value))
 
@@ -187,6 +192,7 @@ final case class Mill(
       sourcesSettings(sourcesMain, sourcesTest),
       scalaVersionSettings(optionsMain, sourcesMain),
       scalacOptionsSettings(optionsMain),
+      scalaCompilerPlugins(optionsMain),
       dependencySettings(optionsMain, optionsTest),
       repositorySettings(optionsMain),
       if (optionsMain.platform.value == Platform.JS) scalaJsSettings(optionsMain.scalaJsOptions)

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/MillProject.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/MillProject.scala
@@ -12,6 +12,7 @@ final case class MillProject(
   testDeps: Seq[String] = Nil,
   scalaVersion: Option[String] = None,
   scalacOptions: Seq[String] = Nil,
+  scalaCompilerPlugins: Seq[String] = Nil,
   scalaJsVersion: Option[String] = None,
   scalaNativeVersion: Option[String] = None,
   nameOpt: Option[String] = None,
@@ -87,6 +88,23 @@ final case class MillProject(
           ")" + nl
       }
 
+    val maybeScalaCompilerPlugins =
+      if (scalaCompilerPlugins.isEmpty) ""
+      else {
+        val depLen = scalaCompilerPlugins.length
+        "def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++ Seq(" + nl +
+          scalaCompilerPlugins
+            .iterator
+            .zipWithIndex
+            .map {
+              case (dep, idx) =>
+                val maybeComma = if (idx == depLen - 1) "" else ","
+                """  ivy"""" + dep + "\"" + maybeComma + nl
+            }
+            .mkString + nl +
+          ")" + nl
+      }
+
     val maybeMain = mainClass.fold("") { mc =>
       s"""def mainClass = Some("$mc")""" + nl
     }
@@ -101,6 +119,7 @@ final case class MillProject(
          |  $maybeScalacOptions
          |  $extraDecs
          |  ${maybeDeps(mainDeps)}
+         |  $maybeScalaCompilerPlugins
          |  $maybeMain
          |  ${extraDecls.map("  " + _ + nl).mkString}
          |

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
@@ -77,6 +77,33 @@ abstract class ExportMillTestDefinitions(val scalaVersionOpt: Option[String])
         expect(output.filterNot(_.isWhitespace) == "[\"-deprecation\"]")
       }
       locally {
+        // test
+        val res =
+          os.proc(root / "mill-proj" / launcher, s"$projectName.test").call(cwd =
+            root / "mill-proj"
+          )
+        val output = res.out.text(Charset.defaultCharset())
+        expect(output.contains("1 succeeded"))
+      }
+    }
+  }
+
+  def jvmTestCompilerPlugin(projectName: String = "project"): Unit = {
+    val inputs = addMillJvmOpts(ExportTestProjects.jvmTest(actualScalaVersion))
+    inputs.fromRoot { root =>
+      val setProject = if (projectName != "project") Seq("-p", projectName) else Seq.empty
+      os.proc(
+        TestUtil.cli,
+        "export",
+        extraOptions,
+        "--mill",
+        setProject,
+        "-o",
+        "mill-proj",
+        "."
+      )
+        .call(cwd = root, stdout = os.Inherit)
+      locally {
         // scalacPluginIvyDeps
         val res =
           os.proc(
@@ -100,6 +127,7 @@ abstract class ExportMillTestDefinitions(val scalaVersionOpt: Option[String])
       }
     }
   }
+
   if (runExportTests)
     test("JVM") {
       jvmTest()
@@ -108,6 +136,11 @@ abstract class ExportMillTestDefinitions(val scalaVersionOpt: Option[String])
   if (runExportTests)
     test("JVM custom project name") {
       jvmTest("newproject")
+    }
+
+  if (runExportTests && !actualScalaVersion.startsWith("3."))
+    test("JVM with compiler plugin") {
+      jvmTestCompilerPlugin()
     }
 
   if (runExportTests)

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
@@ -75,8 +75,19 @@ abstract class ExportMillTestDefinitions(val scalaVersionOpt: Option[String])
           ).call(cwd = root / "mill-proj")
         val output = res.out.text(Charset.defaultCharset())
         expect(output.filterNot(_.isWhitespace) == "[\"-deprecation\"]")
-        expect(output.contains("def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++ Seq("))
-        expect(output.contains("ivy\"com.olegpy::better-monadic-for:0.3.1\""))
+      }
+      locally {
+        // scalacPluginIvyDeps
+        val res =
+          os.proc(
+            root / "mill-proj" / launcher,
+            "--disable-ticker",
+            "show",
+            s"$projectName.scalacPluginIvyDeps"
+          ).call(cwd = root / "mill-proj")
+        val output = res.out.text(Charset.defaultCharset())
+        expect(output.contains("com.olegpy"))
+        expect(output.contains("better-monadic-for"))
       }
       locally {
         // test

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
@@ -75,6 +75,8 @@ abstract class ExportMillTestDefinitions(val scalaVersionOpt: Option[String])
           ).call(cwd = root / "mill-proj")
         val output = res.out.text(Charset.defaultCharset())
         expect(output.filterNot(_.isWhitespace) == "[\"-deprecation\"]")
+        expect(output.contains("def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++ Seq("))
+        expect(output.contains("ivy\"com.olegpy::better-monadic-for:0.3.1\""))
       }
       locally {
         // test

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportTestProjects.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportTestProjects.scala
@@ -12,7 +12,6 @@ object ExportTestProjects {
            |//> using resourceDir "./input"
            |//> using lib "org.scala-lang::scala3-compiler:$scalaVersion"
            |//> using option "-deprecation"
-           |//> using plugins "com.olegpy::better-monadic-for:0.3.1"
            |
            |import scala.io.Source
            |

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportTestProjects.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportTestProjects.scala
@@ -12,6 +12,7 @@ object ExportTestProjects {
            |//> using resourceDir "./input"
            |//> using lib "org.scala-lang::scala3-compiler:$scalaVersion"
            |//> using option "-deprecation"
+           |//> using plugins "com.olegpy::better-monadic-for:0.3.1"
            |
            |import scala.io.Source
            |
@@ -28,6 +29,7 @@ object ExportTestProjects {
         s"""//> using scala "$scalaVersion"
            |//> using resourceDir "./input"
            |//> using option "-deprecation"
+           |//> using plugins "com.olegpy::better-monadic-for:0.3.1"
            |
            |import scala.io.Source
            |


### PR DESCRIPTION
This PR adds the export of scala compiler plugins to Mill projects.

A file like:

```scala
//> using scala "2.13.10"
//> using lib "edu.berkeley.cs::chisel3::3.5.5"
//> using plugin "edu.berkeley.cs:::chisel3-plugin::3.5.5"

import chisel3._
import circt.stage.ChiselStage
...
```

Generates a `build.sc`:

```scala
import mill._
import mill.scalalib._

object memmask extends ScalaModule {
  def scalaVersion = "2.13.10"
  
  def ivyDeps = super.ivyDeps() ++ Seq(
  ivy"edu.berkeley.cs::chisel3::3.5.5",
)

  def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++ Seq(
  ivy"edu.berkeley.cs:::chisel3-plugin::3.5.5"
)
...
```