### PR TITLE
Fix - merge extra repos with resolve.repositories

### DIFF
--- a/modules/options/src/main/scala/scala/build/internal/FetchExternalBinary.scala
+++ b/modules/options/src/main/scala/scala/build/internal/FetchExternalBinary.scala
@@ -45,7 +45,7 @@ object FetchExternalBinary {
               params.forcedVersions.map { case (m, v) => m.toCs -> v }*
             )
           }
-          .withRepositories(params.extraRepos)
+          .addRepositories(params.extraRepos: _*)
           .run()(archiveCache.cache.ec)
           .map(os.Path(_, os.pwd))
         ExternalBinary.ClassPath(javaCommand(), classPath, params.mainClass)


### PR DESCRIPTION
Fix fetching external binary in M1 - [fail](https://github.com/VirtusLab/scala-cli/actions/runs/3619015290/jobs/6099621848#step:6:1675).

`withRepositories` only sets repositories from `params.extraRepos` but we should merge the default repositories from courier with `extraRepos`, so I'll use `addRepositories`.