### PR TITLE
Add warnings for `-save` & `-nosave` legacy `scala` runner options instead of failing

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/default/Default.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/Default.scala
@@ -52,7 +52,7 @@ class Default(
     sys.exit(0)
   }
 
-  override def runCommand(options: DefaultOptions, args: RemainingArgs, logger: Logger): Unit = {
+  override def runCommand(options: DefaultOptions, args: RemainingArgs, logger: Logger): Unit =
     if options.version then println(Version.versionInfo)
     else
       {
@@ -62,9 +62,8 @@ class Default(
           options.shared.snippet.executeMarkdown.nonEmpty ||
           (options.shared.extraJarsAndClassPath.nonEmpty && options.sharedRun.mainClass.mainClass.nonEmpty)
         if shouldDefaultToRun then RunOptions.parser else ReplOptions.parser
-      }.parse(rawArgs) match
+      }.parse(options.legacyScala.filterNonDeprecatedArgs(rawArgs, progName, logger)) match
         case Left(e)                              => error(e)
         case Right((replOptions: ReplOptions, _)) => Repl.runCommand(replOptions, args, logger)
         case Right((runOptions: RunOptions, _))   => Run.runCommand(runOptions, args, logger)
-  }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/default/DefaultOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/DefaultOptions.scala
@@ -14,6 +14,8 @@ case class DefaultOptions(
     sharedRun: SharedRunOptions = SharedRunOptions(),
   @Recurse
     sharedRepl: SharedReplOptions = SharedReplOptions(),
+  @Recurse
+    legacyScala: LegacyScalaOptions = LegacyScalaOptions(),
   @Name("-version")
     version: Boolean = false
 ) extends HasSharedOptions

--- a/modules/cli/src/main/scala/scala/cli/commands/default/LegacyScalaOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/LegacyScalaOptions.scala
@@ -1,0 +1,67 @@
+package scala.cli.commands.default
+
+import caseapp.*
+import caseapp.core.Indexed
+
+import scala.build.Logger
+import scala.cli.ScalaCli
+import scala.cli.commands.default.LegacyScalaOptions.*
+import scala.cli.commands.package0.Package
+import scala.cli.commands.tags
+
+/** Options covering backwards compatibility with the old scala runner.
+  */
+// format: off
+case class LegacyScalaOptions(
+  @Group("Scala")
+  @HelpMessage(s"Ignored legacy option. Deprecated equivalent of running a subsequent `$PowerString${Package.name}` command.")
+  @Tag(tags.must)
+  @Name("-save")
+    save: Option[Indexed[Boolean]] = None,
+  @Group("Scala")
+  @HelpMessage("Ignored legacy option. Deprecated override canceling the `-nosave` option.")
+  @Tag(tags.must)
+  @Name("-nosave")
+    nosave: Option[Indexed[Boolean]] = None,
+) {
+// format: on
+
+  extension [T](indexedOption: Option[Indexed[T]]) {
+    private def findArg(args: Array[String]): Option[String] =
+      indexedOption.flatMap(io => args.lift(io.index))
+  }
+
+  def filterNonDeprecatedArgs(
+    args: Array[String],
+    progName: String,
+    logger: Logger
+  ): Array[String] = {
+    val saveOptionString   = save.findArg(args)
+    val noSaveOptionString = nosave.findArg(args)
+    val deprecatedArgs     = Seq(saveOptionString, noSaveOptionString).flatten
+    val filteredArgs       = args.filterNot(deprecatedArgs.contains)
+    val filteredArgsString = filteredArgs.mkString(" ")
+    saveOptionString.foreach { s =>
+      logger.message(
+        s"""Deprecated option '$s' is ignored.
+           |The compiled project files will be saved in the '.scala-build' directory in the project root folder.
+           |If you need to produce an actual jar file, run the '$PowerString${Package.name}' sub-command as follows:
+           |  ${Console.BOLD}$progName $PowerString${Package.name} --library $filteredArgsString${Console.RESET}""".stripMargin
+      )
+    }
+    noSaveOptionString.foreach { ns =>
+      logger.message(
+        s"""Deprecated option '$ns' is ignored.
+           |A jar file is not saved unless the '$PowerString${Package.name}' sub-command is called.""".stripMargin
+      )
+    }
+    filteredArgs
+  }
+}
+object LegacyScalaOptions {
+  implicit lazy val parser: Parser[LegacyScalaOptions] = Parser.derive
+  implicit lazy val help: Help[LegacyScalaOptions]     = Help.derive
+
+  private[default] lazy val PowerString =
+    if ScalaCli.allowRestrictedFeatures then "" else "--power "
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/DefaultTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DefaultTests.scala
@@ -183,6 +183,42 @@ class DefaultTests extends WithWarmUpScalaCliSuite {
     }
   }
 
+  test("ensure -save/--save works with the default command") {
+    val msg = "Hello world"
+    TestInputs(os.rel / "s.sc" -> s"""println("$msg")""").fromRoot { root =>
+      val legacySaveOption = "-save"
+      val res1 =
+        os.proc(TestUtil.cli, ".", legacySaveOption, TestUtil.extraOptions)
+          .call(cwd = root, stderr = os.Pipe)
+      expect(res1.out.trim() == msg)
+      expect(res1.err.trim().contains(s"Deprecated option '$legacySaveOption' is ignored"))
+      val doubleDashSaveOption = "--save"
+      val res2 =
+        os.proc(TestUtil.cli, ".", doubleDashSaveOption, TestUtil.extraOptions)
+          .call(cwd = root, stderr = os.Pipe)
+      expect(res2.out.trim() == msg)
+      expect(res2.err.trim().contains(s"Deprecated option '$doubleDashSaveOption' is ignored"))
+    }
+  }
+
+  test("ensure -nosave/--nosave works with the default command") {
+    val msg = "Hello world"
+    TestInputs(os.rel / "s.sc" -> s"""println("$msg")""").fromRoot { root =>
+      val legacyNoSaveOption = "-nosave"
+      val res1 =
+        os.proc(TestUtil.cli, ".", legacyNoSaveOption, TestUtil.extraOptions)
+          .call(cwd = root, stderr = os.Pipe)
+      expect(res1.out.trim() == msg)
+      expect(res1.err.trim().contains(s"Deprecated option '$legacyNoSaveOption' is ignored"))
+      val doubleDashNoSaveOption = "--nosave"
+      val res2 =
+        os.proc(TestUtil.cli, ".", doubleDashNoSaveOption, TestUtil.extraOptions)
+          .call(cwd = root, stderr = os.Pipe)
+      expect(res2.out.trim() == msg)
+      expect(res2.err.trim().contains(s"Deprecated option '$doubleDashNoSaveOption' is ignored"))
+    }
+  }
+
   private def unrecognizedArgMessage(argName: String) =
     s"""
        |Unrecognized argument: $argName


### PR DESCRIPTION
Fixes #1670 

for `scala-cli`:
```bash
▶ scala-cli -e 'println("Hello")' -save -nosave
Deprecated option '-save' is ignored.
The compiled project files will be saved in the '.scala-build' directory in the project root folder.
If an actual jar file is necessary to be saved, run the 'package' sub-command after this one:
  scala-cli package --library -e println("Hello")
Deprecated option '-nosave' is ignored.
A jar file is not saved unless the 'package' sub-command is called.
Compiling project (Scala 3.2.1, JVM)
Compiled project (Scala 3.2.1, JVM)
Hello
```
for `scala` (SIP mode):
```bash
▶ scala -e 'println("Hello")' -save -nosave
Deprecated option '-save' is ignored.
The compiled project files will be saved in the '.scala-build' directory in the project root folder.
If an actual jar file is necessary to be saved, run the '--power package' sub-command after this one:
  scala --power package --library -e println("Hello")
Deprecated option '-nosave' is ignored.
A jar file is not saved unless the '--power package' sub-command is called.
Compiling project (Scala 3.2.1, JVM)
Compiled project (Scala 3.2.1, JVM)
Hello
```