### PR TITLE
Fix BSP `workspace/reload` to always pick up dependencies from `using` directives

### DIFF
--- a/modules/build/src/main/scala/scala/build/bsp/BloopSession.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BloopSession.scala
@@ -10,6 +10,7 @@ import scala.build.input.{Inputs, OnDisk, SingleFile, Virtual}
 
 final class BloopSession(
   val inputs: Inputs,
+  val inputsHash: String,
   val remoteServer: BloopCompiler,
   val bspServer: BspServer,
   val watcher: Build.Watcher
@@ -53,6 +54,13 @@ final class BloopSession(
 }
 
 object BloopSession {
+
+  def apply(
+    inputs: Inputs,
+    remoteServer: BloopCompiler,
+    bspServer: BspServer,
+    watcher: Build.Watcher
+  ): BloopSession = new BloopSession(inputs, inputs.sourceHash(), remoteServer, bspServer, watcher)
 
   final class Reference {
     private val ref = new AtomicReference[BloopSession](null)

--- a/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
@@ -390,12 +390,7 @@ final class BspImpl(
       build(bloopSession0, actualLocalClient, notifyChanges = true, reloadableOptions),
       ()
     )
-    lazy val bloopSession0: BloopSession = new BloopSession(
-      inputs,
-      remoteServer,
-      bspServer,
-      watcher
-    )
+    lazy val bloopSession0: BloopSession = BloopSession(inputs, remoteServer, bspServer, watcher)
 
     bloopSession0.registerWatchInputs()
     bspServer.newInputs(inputs)
@@ -578,8 +573,11 @@ final class BspImpl(
           }
         }
         val newInputs      = value(argsToInputs(ideInputs.args))
+        val newHash        = newInputs.sourceHash()
         val previousInputs = currentBloopSession.inputs
-        if (newInputs == previousInputs) CompletableFuture.completedFuture(new Object)
+        val previousHash   = currentBloopSession.inputsHash
+        if newInputs == previousInputs && newHash == previousHash then
+          CompletableFuture.completedFuture(new Object)
         else reloadBsp(currentBloopSession, previousInputs, newInputs, reloadableOptions)
       }
       maybeResponse match {

--- a/modules/build/src/main/scala/scala/build/bsp/BuildServerForwardStubs.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BuildServerForwardStubs.scala
@@ -79,11 +79,12 @@ trait BuildServerForwardStubs extends b.BuildServer {
     forwardTo.workspaceBuildTargets()
       .handle(fatalExceptionHandler("workspaceBuildTargets"))
 
+  /** This implementation should never be called and is merely a placeholder. As Bloop doesn't
+    * support reloading its workspace, Scala CLI has to reload Bloop instead. And so,
+    * [[BuildServerProxy]].workspaceReload() is responsible for the actual reload.
+    */
   override def workspaceReload(): CompletableFuture[Object] =
-    CompletableFuture.completedFuture(new Object)
-  // Bloop does not support workspaceReload and Intellij calls it at the start
-  // forwardTo.workspaceReload()
-  //   .handle(fatalExceptionHandler("workspaceReload"))
+    CompletableFuture.completedFuture(new Object) // should never be called, as per scaladoc
 
   override def buildTargetDependencyModules(params: DependencyModulesParams)
     : CompletableFuture[DependencyModulesResult] =

--- a/modules/build/src/main/scala/scala/build/bsp/BuildServerProxy.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BuildServerProxy.scala
@@ -8,6 +8,12 @@ import scala.build.GeneratedSource
 import scala.build.input.Inputs
 import scala.build.options.Scope
 
+/** A wrapper for [[BspServer]], allowing to reload the workspace on the fly.
+  * @param bspServer
+  *   the underlying BSP server relying on Bloop
+  * @param onReload
+  *   the actual `workspace/reload` function
+  */
 class BuildServerProxy(
   bspServer: () => BspServer,
   onReload: () => CompletableFuture[Object]
@@ -77,6 +83,10 @@ class BuildServerProxy(
   override def buildTargetOutputPaths(params: b.OutputPathsParams)
     : CompletableFuture[b.OutputPathsResult] =
     bspServer().buildTargetOutputPaths(params)
+
+  /** As Bloop doesn't support `workspace/reload` requests and we have to reload it on Scala CLI's
+    * end, this is used instead of [[BspServer]]'s [[BspServerForwardStubs]].workspaceReload().
+    */
   override def workspaceReload(): CompletableFuture[AnyRef] =
     onReload()
 


### PR DESCRIPTION
Fixes #1673 

https://user-images.githubusercontent.com/18601388/207319736-534f2d8a-862d-4c0a-8c8a-e52d95ac03e6.mov

