### PR TITLE
Fix the order of help command groups for the default help

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -17,7 +17,7 @@ import scala.build.errors.BuildException
 import scala.build.internal.{Constants, Runner}
 import scala.build.options.{BuildOptions, Scope}
 import scala.build.{Artifacts, Logger, Positioned, ReplArtifacts}
-import scala.cli.commands.shared.{HasLoggingOptions, ScalacOptions, SharedOptions}
+import scala.cli.commands.shared.{HasLoggingOptions, ScalaCliHelp, ScalacOptions, SharedOptions}
 import scala.cli.commands.util.CommandHelpers
 import scala.cli.commands.util.ScalacOptionsUtil.*
 import scala.cli.{CurrentParams, ScalaCli}
@@ -234,49 +234,7 @@ abstract class ScalaCommand[T <: HasLoggingOptions](implicit myParser: Parser[T]
       sys.exit(exitCode.orExit(logger))
     }
 
-  override def helpFormat: HelpFormat =
-    HelpFormat.default().copy(
-      sortedGroups = Some(Seq(
-        "Help",
-        "Scala",
-        "Java",
-        "Repl",
-        "Package",
-        "Metabrowse server",
-        "Logging",
-        "Runner"
-      )),
-      sortedCommandGroups = Some(Seq(
-        "Main",
-        "Miscellaneous",
-        ""
-      )),
-      hiddenGroups = Some(Seq(
-        "Scala.js",
-        "Scala Native"
-      )),
-      terminalWidthOpt =
-        if (Properties.isWin)
-          if (coursier.paths.Util.useJni())
-            Try(coursier.jniutils.WindowsAnsiTerminal.terminalSize()).toOption.map(
-              _.getWidth
-            ).orElse {
-              val fallback = 120
-              if (java.lang.Boolean.getBoolean("scala.cli.windows-terminal.verbose"))
-                System.err.println(s"Could not get terminal width, falling back to $fallback")
-              Some(fallback)
-            }
-          else None
-        else
-          // That's how Ammonite gets the terminal width, but I'd rather not spawn a sub-process upfront in Scala CLI…
-          //   val pathedTput = if (os.isFile(os.Path("/usr/bin/tput"))) "/usr/bin/tput" else "tput"
-          //   val width = os.proc("sh", "-c", s"$pathedTput cols 2>/dev/tty").call(stderr = os.Pipe).out.trim().toInt
-          //   Some(width)
-          // Ideally, we should do an ioctl, like jansi does here:
-          //   https://github.com/fusesource/jansi/blob/09722b7cccc8a99f14ac1656db3072dbeef34478/src/main/java/org/fusesource/jansi/AnsiConsole.java#L344
-          // This requires writing our own minimal JNI library, that publishes '.a' files too for static linking in the executable of Scala CLI.
-          None
-    )
+  override def helpFormat: HelpFormat = ScalaCliHelp.helpFormat
 
   /** @param options
     *   command-specific [[T]] options

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
@@ -2,6 +2,56 @@ package scala.cli.commands.shared
 
 import caseapp.core.help.HelpFormat
 
+import scala.util.{Properties, Try}
+
 object ScalaCliHelp {
-  val helpFormat = HelpFormat.default()
+  val helpFormat: HelpFormat = HelpFormat.default()
+    .copy(
+      sortedGroups = Some(
+        Seq(
+          "Help",
+          "Scala",
+          "Java",
+          "Repl",
+          "Package",
+          "Metabrowse server",
+          "Logging",
+          "Runner"
+        )
+      ),
+      sortedCommandGroups = Some(
+        Seq(
+          "Main",
+          "Miscellaneous",
+          ""
+        )
+      ),
+      hiddenGroups = Some(
+        Seq(
+          "Scala.js",
+          "Scala Native"
+        )
+      ),
+      terminalWidthOpt =
+        if (Properties.isWin)
+          if (coursier.paths.Util.useJni())
+            Try(coursier.jniutils.WindowsAnsiTerminal.terminalSize()).toOption.map(
+              _.getWidth
+            ).orElse {
+              val fallback = 120
+              if (java.lang.Boolean.getBoolean("scala.cli.windows-terminal.verbose"))
+                System.err.println(s"Could not get terminal width, falling back to $fallback")
+              Some(fallback)
+            }
+          else None
+        else
+          // That's how Ammonite gets the terminal width, but I'd rather not spawn a sub-process upfront in Scala CLI…
+          //   val pathedTput = if (os.isFile(os.Path("/usr/bin/tput"))) "/usr/bin/tput" else "tput"
+          //   val width = os.proc("sh", "-c", s"$pathedTput cols 2>/dev/tty").call(stderr = os.Pipe).out.trim().toInt
+          //   Some(width)
+          // Ideally, we should do an ioctl, like jansi does here:
+          //   https://github.com/fusesource/jansi/blob/09722b7cccc8a99f14ac1656db3072dbeef34478/src/main/java/org/fusesource/jansi/AnsiConsole.java#L344
+          // This requires writing our own minimal JNI library, that publishes '.a' files too for static linking in the executable of Scala CLI.
+          None
+    )
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
@@ -3,11 +3,20 @@ package scala.cli.integration
 import com.eed3si9n.expecty.Expecty.expect
 
 class HelpTests extends ScalaCliSuite {
-  test("help command") {
-    for { helpOption <- Seq("help", "-help", "--help") } {
-      val help = os.proc(TestUtil.cli, helpOption).call(check = false)
+  for { helpOption <- Seq("help", "-help", "--help") } {
+    val help       = os.proc(TestUtil.cli, helpOption).call(check = false)
+    val helpOutput = help.out.trim()
+    test(s"$helpOption works correctly") {
       assert(help.exitCode == 0, clues(helpOption, help.out.text(), help.err.text(), help.exitCode))
-      expect(help.out.text().contains("Usage:"))
+      expect(helpOutput.contains("Usage:"))
+    }
+
+    test(s"$helpOption output command groups are ordered correctly") {
+      val mainCommandsIndex  = helpOutput.indexOf("Main commands:")
+      val miscellaneousIndex = helpOutput.indexOf("Miscellaneous commands:")
+      expect(mainCommandsIndex < miscellaneousIndex)
+      expect(miscellaneousIndex < helpOutput.indexOf("Other commands:"))
     }
   }
+
 }


### PR DESCRIPTION
Fixes #1663 

```bash
▶ scala-cli --help
Usage: scala-cli <COMMAND>
Scala CLI is a command-line tool to interact with the Scala language. It lets you compile, run, test, and package your Scala code.

Main commands:
  clean                  Clean the workspace
  compile                Compile Scala code
  dependency-update      Update dependencies in project
  doc                    Generate Scaladoc documentation
  fmt, format, scalafmt  Format Scala code
  repl, console          Fire-up a Scala REPL
  package                Compile and package Scala code
  publish
  publish local
  publish setup
  run                    Compile and run Scala code.
  test                   Compile and test Scala code

Miscellaneous commands:
  about    Print details about this application
  version  Print version

Other commands:
  export                                        Export current project to sbt or Mill
  help                                          Print help message
  install completions, install-completions      Installs completions into your shell
  github secret create, gh secret create
  github secret list, gh secret list
  setup-ide                                     Generate a BSP file that you can import into your IDE
  shebang                                       Like `run`, but more handy from shebang scripts
  uninstall                                     Uninstall scala-cli - only works when installed by the installation script
  uninstall completions, uninstall-completions  Uninstalls completions from your shell
  update                                        Update scala-cli - only works when installed by the installation script

Doctor commands:
  doctor  Print details about this application

See 'scala-cli <command> --help' to read about a specific subcommand. To see full help run 'scala-cli <command> --help-full'.
To run another Scala CLI version, specify it with '--cli-version' before any other argument, like 'scala-cli --cli-version <version> args'.

When no subcommand is passed explicitly, an implicit subcommand is used based on context:
  - if the '--version' option is passed, it prints the 'version' subcommand output, unmodified by any other options
  - if any inputs were passed, it defaults to the 'run' subcommand
  - additionally, when no inputs were passed, it defaults to the 'run' subcommand in the following scenarios:
    - if a snippet was passed with any of the '--execute*' options
    - if a main class was passed with the '--main-class' option alongside an extra '--classpath'
  - otherwise, if no inputs were passed, it defaults to the 'repl' subcommand
```