### PR TITLE
Include launcher options in the help for the default and `help` sub-commands

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/ScalaCliCommands.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCliCommands.scala
@@ -79,7 +79,10 @@ class ScalaCliCommands(
 
   override def summaryDesc =
     s"""|See '$baseRunnerName <command> --help' to read about a specific subcommand. To see full help run '$baseRunnerName <command> --help-full'.
-        |To run another $fullRunnerName version, specify it with '--cli-version' before any other argument, like '$baseRunnerName --cli-version <version> args'.""".stripMargin
+        |
+        |To use launcher options, specify them before any other argument.
+        |For example, to run another $fullRunnerName version, specify it with the '--cli-version' launcher option:
+        |  ${Console.BOLD}$baseRunnerName --cli-version <version> args${Console.RESET}""".stripMargin
   final override def defaultCommand = Some(actualDefaultCommand)
 
   // FIXME Report this in case-app default NameFormatter

--- a/modules/cli/src/main/scala/scala/cli/commands/HelpCmd.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/HelpCmd.scala
@@ -6,10 +6,11 @@ import caseapp.core.help.RuntimeCommandsHelp
 import scala.build.Logger
 import scala.cli.commands.shared.{HelpOptions, ScalaCliHelp}
 
-class HelpCmd(actualHelp: => RuntimeCommandsHelp) extends ScalaCommand[HelpOptions] {
+class HelpCmd(actualHelp: => RuntimeCommandsHelp)
+    extends ScalaCommandWithCustomHelp[HelpOptions](actualHelp) {
   override def names                   = List(List("help"))
   override def scalaSpecificationLevel = SpecificationLevel.IMPLEMENTATION
 
   override def runCommand(options: HelpOptions, args: RemainingArgs, logger: Logger): Unit =
-    println(actualHelp.help(ScalaCliHelp.helpFormat))
+    customHelpAsked(showHidden = false)
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommandWithCustomHelp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommandWithCustomHelp.scala
@@ -1,0 +1,36 @@
+package scala.cli.commands
+
+import caseapp.core.Error
+import caseapp.core.help.{Help, HelpCompanion, RuntimeCommandsHelp}
+import caseapp.core.parser.Parser
+
+import scala.cli.commands.default.DefaultOptions
+import scala.cli.commands.shared.{HasLoggingOptions, ScalaCliHelp}
+import scala.cli.commands.util.HelpUtils.*
+import scala.cli.launcher.LauncherOptions
+
+abstract class ScalaCommandWithCustomHelp[T <: HasLoggingOptions](
+  actualHelp: => RuntimeCommandsHelp
+)(
+  implicit
+  myParser: Parser[T],
+  help: Help[T]
+) extends ScalaCommand[T] {
+  private def launcherHelp: Help[LauncherOptions] = HelpCompanion.deriveHelp[LauncherOptions]
+
+  protected def customHelp(showHidden: Boolean): String = {
+    val helpString         = actualHelp.help(helpFormat, showHidden)
+    val launcherHelpString = launcherHelp.optionsHelp(helpFormat, showHidden)
+    s"""$helpString
+       |
+       |$launcherHelpString""".stripMargin
+  }
+
+  protected def customHelpAsked(showHidden: Boolean): Nothing = {
+    println(customHelp(showHidden))
+    sys.exit(0)
+  }
+  override def helpAsked(progName: String, maybeOptions: Either[Error, T]): Nothing =
+    customHelpAsked(showHidden = false)
+  override def fullHelpAsked(progName: String): Nothing = customHelpAsked(showHidden = true)
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/default/Default.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/Default.scala
@@ -1,22 +1,24 @@
 package scala.cli.commands.default
 
-import caseapp.core.help.RuntimeCommandsHelp
+import caseapp.core.help.{Help, HelpCompanion, RuntimeCommandsHelp}
 import caseapp.core.{Error, RemainingArgs}
 
 import scala.build.Logger
 import scala.build.internal.Constants
 import scala.build.options.BuildOptions
 import scala.cli.CurrentParams
-import scala.cli.commands.ScalaCommand
 import scala.cli.commands.repl.{Repl, ReplOptions}
 import scala.cli.commands.run.{Run, RunOptions}
-import scala.cli.commands.shared.{ScalaCliHelp, SharedOptions}
+import scala.cli.commands.shared.ScalaCliHelp.helpFormat
+import scala.cli.commands.shared.SharedOptions
 import scala.cli.commands.version.Version
+import scala.cli.commands.{ScalaCommand, ScalaCommandWithCustomHelp}
+import scala.cli.launcher.LauncherOptions
 
 class Default(
   actualHelp: => RuntimeCommandsHelp,
   isSipScala: Boolean
-) extends ScalaCommand[DefaultOptions] {
+) extends ScalaCommandWithCustomHelp[DefaultOptions](actualHelp) {
 
   private lazy val defaultCommandHelp: String =
     s"""
@@ -29,10 +31,8 @@ class Default(
        |    - if a main class was passed with the '--main-class' option alongside an extra '--classpath'
        |  - otherwise, if no inputs were passed, it defaults to the 'repl' subcommand""".stripMargin
 
-  private def defaultHelp: String = actualHelp.help(ScalaCliHelp.helpFormat) + defaultCommandHelp
-
-  private def defaultFullHelp: String =
-    actualHelp.help(ScalaCliHelp.helpFormat, showHidden = true) + defaultCommandHelp
+  override def customHelp(showHidden: Boolean): String =
+    super.customHelp(showHidden) + defaultCommandHelp
 
   override def scalaSpecificationLevel = SpecificationLevel.MUST
 
@@ -41,16 +41,6 @@ class Default(
   override def sharedOptions(options: DefaultOptions): Option[SharedOptions] = Some(options.shared)
 
   private[cli] var rawArgs = Array.empty[String]
-
-  override def helpAsked(progName: String, maybeOptions: Either[Error, DefaultOptions]): Nothing = {
-    println(defaultHelp)
-    sys.exit(0)
-  }
-
-  override def fullHelpAsked(progName: String): Nothing = {
-    println(defaultFullHelp)
-    sys.exit(0)
-  }
 
   override def runCommand(options: DefaultOptions, args: RemainingArgs, logger: Logger): Unit =
     if options.version then println(Version.versionInfo)

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
@@ -16,7 +16,8 @@ object ScalaCliHelp {
           "Package",
           "Metabrowse server",
           "Logging",
-          "Runner"
+          "Runner",
+          "Launcher"
         )
       ),
       sortedCommandGroups = Some(

--- a/modules/cli/src/main/scala/scala/cli/commands/util/HelpUtils.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/HelpUtils.scala
@@ -1,0 +1,19 @@
+package scala.cli.commands.util
+
+import caseapp.core.help.{Help, HelpFormat}
+
+object HelpUtils {
+  extension (help: Help[_]) {
+    private def abstractHelp(
+      format: HelpFormat,
+      showHidden: Boolean
+    )(f: (StringBuilder, HelpFormat, Boolean) => Unit): String = {
+      val b = new StringBuilder
+      f(b, format, showHidden)
+      b.result()
+    }
+
+    def optionsHelp(format: HelpFormat, showHidden: Boolean = false): String =
+      abstractHelp(format, showHidden)(help.printOptions)
+  }
+}

--- a/modules/cli/src/main/scala/scala/cli/launcher/LauncherOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/launcher/LauncherOptions.scala
@@ -6,14 +6,15 @@ import caseapp.*
 final case class LauncherOptions(
   @Group("Launcher")
   @HelpMessage("Set the Scala CLI version")
+  @ValueDescription("nightly|version")
   cliVersion: Option[String] = None,
   @Group("Launcher")
   @HelpMessage("The version of Scala on which Scala CLI was published")
   @ValueDescription("2.12|2.13|3")
+  @Hidden
   cliScalaVersion: Option[String] = None,
   @Group("Launcher")
   @HelpMessage("When called as 'scala', allow to use power commands too")
-  @Hidden
   power: Boolean = false
 )
 

--- a/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
@@ -2,21 +2,36 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
+import scala.cli.integration.HelpTests.HelpVariants
+
 class HelpTests extends ScalaCliSuite {
-  for { helpOption <- Seq("help", "-help", "--help") } {
-    val help       = os.proc(TestUtil.cli, helpOption).call(check = false)
-    val helpOutput = help.out.trim()
-    test(s"$helpOption works correctly") {
-      assert(help.exitCode == 0, clues(helpOption, help.out.text(), help.err.text(), help.exitCode))
+  for { helpOptions <- HelpVariants } {
+    val help              = os.proc(TestUtil.cli, helpOptions).call(check = false)
+    val helpOutput        = help.out.trim()
+    val helpOptionsString = helpOptions.mkString(" ")
+    test(s"$helpOptionsString works correctly") {
+      assert(
+        help.exitCode == 0,
+        clues(helpOptions, help.out.text(), help.err.text(), help.exitCode)
+      )
       expect(helpOutput.contains("Usage:"))
     }
 
-    test(s"$helpOption output command groups are ordered correctly") {
+    test(s"$helpOptionsString output command groups are ordered correctly") {
       val mainCommandsIndex  = helpOutput.indexOf("Main commands:")
       val miscellaneousIndex = helpOutput.indexOf("Miscellaneous commands:")
       expect(mainCommandsIndex < miscellaneousIndex)
       expect(miscellaneousIndex < helpOutput.indexOf("Other commands:"))
     }
+
+    test(s"$helpOptionsString output includes launcher options") {
+      expect(helpOutput.contains("--power"))
+    }
   }
 
+}
+
+object HelpTests {
+  val HelpVariants =
+    Seq(Seq("help"), Seq("help", "-help"), Seq("help", "--help"), Seq("-help"), Seq("--help"))
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -109,9 +109,9 @@ class SipScalaTests extends ScalaCliSuite {
 
   def testHelpOutput(binaryName: String): Unit = TestInputs.empty.fromRoot { root =>
     val binary = binaryName.prepareBinary(root)
-    for { helpOption <- Seq("help", "-help", "--help") } {
-      val res                         = os.proc(binary, helpOption).call(cwd = root)
-      val restrictedFeaturesMentioned = res.out.trim().contains("package")
+    for { helpOptions <- HelpTests.HelpVariants } {
+      val output                      = os.proc(binary, helpOptions).call(cwd = root).out.trim()
+      val restrictedFeaturesMentioned = output.contains("package")
       if (binaryName.isSip) expect(!restrictedFeaturesMentioned)
       else expect(restrictedFeaturesMentioned)
     }


### PR DESCRIPTION
Fixes #1698 

Note: this adds the launcher options help to the default and `help` sub-commands **only**.
They probably should also smh be included in other sub-commands' help as well, but that'll be addressed separately.

```bash
▶ scala-cli --help
Usage: /Users/pchabelski/IdeaProjects/scala-cli/out/cli/base-image/nativeImage.dest/scala-cli <COMMAND>
Scala CLI is a command-line tool to interact with the Scala language. It lets you compile, run, test and package your Scala code.

Main commands:
  clean                  Clean the workspace
  compile                Compile Scala code
  dependency-update      Update dependencies in project
  doc                    Generate Scaladoc documentation
  fmt, format, scalafmt  Format Scala code
  repl, console          Fire-up a Scala REPL
  package                Compile and package Scala code
  publish
  publish local
  publish setup
  run                    Compile and run Scala code.
  test                   Compile and test Scala code

Miscellaneous commands:
  about    Print details about this application
  version  Print version

Other commands:
  export                                        Export current project to sbt or Mill
  help                                          Print help message
  install completions, install-completions      Installs completions into your shell
  github secret create, gh secret create
  github secret list, gh secret list
  setup-ide                                     Generate a BSP file that you can import into your IDE
  shebang                                       Like `run`, but more handy from shebang scripts
  uninstall                                     Uninstall scala-cli - only works when installed by the installation script
  uninstall completions, uninstall-completions  Uninstalls completions from your shell
  update                                        Update scala-cli - only works when installed by the installation script

Doctor commands:
  doctor  Print details about this application

See 'scala-cli <command> --help' to read about a specific subcommand. To see full help run 'scala-cli <command> --help-full'.

To use launcher options, specify them before any other argument.
For example, to run another Scala CLI version, specify it with the '--cli-version' launcher option:
  scala-cli --cli-version <version> args

Launcher options:
  --cli-version nightly|version  Set the Scala CLI version
  --power                        When called as 'scala', allow to use power commands too

When no subcommand is passed explicitly, an implicit subcommand is used based on context:
  - if the '--version' option is passed, it prints the 'version' subcommand output, unmodified by any other options
  - if any inputs were passed, it defaults to the 'run' subcommand
  - additionally, when no inputs were passed, it defaults to the 'run' subcommand in the following scenarios:
    - if a snippet was passed with any of the '--execute*' options
    - if a main class was passed with the '--main-class' option alongside an extra '--classpath'
  - otherwise, if no inputs were passed, it defaults to the 'repl' subcommand
```