### PR TITLE
Upgrade scripts to latest coursier

### DIFF
--- a/.github/scripts/build-linux-aarch64.sh
+++ b/.github/scripts/build-linux-aarch64.sh
@@ -6,7 +6,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
 mkdir -p artifacts
 mkdir -p utils
-cp "$(cs get https://github.com/coursier/coursier/releases/download/v2.0.16/cs-aarch64-pc-linux)" utils/cs
+cp "$(cs get https://github.com/coursier/coursier/releases/download/v2.1.4/cs-aarch64-pc-linux)" utils/cs
 chmod +x utils/cs
 
 cp "$DIR/build-linux-aarch64-from-docker.sh" utils/

--- a/.github/scripts/build-linux-aarch64.sh
+++ b/.github/scripts/build-linux-aarch64.sh
@@ -6,7 +6,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
 mkdir -p artifacts
 mkdir -p utils
-cp "$(cs get https://github.com/coursier/coursier/releases/download/v2.1.4/cs-aarch64-pc-linux)" utils/cs
+cp "$(cs get https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.4/cs-aarch64-pc-linux)" utils/cs
 chmod +x utils/cs
 
 cp "$DIR/build-linux-aarch64-from-docker.sh" utils/

--- a/.github/scripts/get-latest-cs.sh
+++ b/.github/scripts/get-latest-cs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-CS_VERSION="2.1.0-M5-5-g2cb552ea9"
+CS_VERSION="2.1.4"
 
 DIR="$(cs get --archive "https://github.com/coursier/coursier/releases/download/v$CS_VERSION/cs-x86_64-pc-win32.zip")"
 


### PR DESCRIPTION
~This is just a reminder for myself.~
~RC5 is not yet released, but if it is, I hope it contains https://github.com/coursier/coursier/pull/2641 so I am also able to build scala-ci on my Apple Silicon hardware running Linux (I can do that already using locally build cs that works, this just makes it official).~