### PR TITLE
Allow to circumvent Scala version checks

### DIFF
--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -258,6 +258,8 @@ final case class BuildOptions(
     val svOpt: Option[String] = scalaOptions.scalaVersion match {
       case Some(MaybeScalaVersion(None)) =>
         None
+      case Some(MaybeScalaVersion(Some(svInput))) if svInput.endsWith("!") =>
+        Some(svInput.stripSuffix("!"))
       case Some(MaybeScalaVersion(Some(svInput))) =>
         val sv = value {
           svInput match {


### PR DESCRIPTION
Just in case. Having issues with it with locally published Scala versions right now, so I'd rather disable this check if I can.

Needs https://github.com/scalacenter/bloop-config/pull/20, https://github.com/scala-cli/bloop-core/pull/129