### PR TITLE
Remove irrelevant options from `version` help message

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/shared/VerbosityOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/VerbosityOptions.scala
@@ -14,10 +14,12 @@ final case class VerbosityOptions(
   @Tag(tags.implementation)
   @Name("v")
     verbose: Int @@ Counter = Tag.of(0),
+  @Group("Logging")
   @HelpMessage("Interactive mode")
   @Name("i")
   @Tag(tags.implementation)
     interactive: Option[Boolean] = None,
+  @Group("Logging")
   @HelpMessage("Enable actionable diagnostics")
   @Tag(tags.implementation)
     actions: Option[Boolean] = None

--- a/modules/cli/src/main/scala/scala/cli/commands/version/Version.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/version/Version.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.version
 
 import caseapp.*
+import caseapp.core.help.HelpFormat
 
 import scala.build.Logger
 import scala.build.internal.Constants
@@ -11,6 +12,16 @@ object Version extends ScalaCommand[VersionOptions] {
   override def group = "Miscellaneous"
 
   override def scalaSpecificationLevel = SpecificationLevel.SHOULD
+  override def hasFullHelp: Boolean    = false
+  override def helpFormat: HelpFormat = super.helpFormat.copy(
+    hiddenGroups = Some(Seq("Logging")),
+    sortedGroups = Some(
+      Seq(
+        "Version",
+        "Help"
+      )
+    )
+  )
 
   override def runCommand(options: VersionOptions, args: RemainingArgs, logger: Logger): Unit = {
     if (options.cliVersion)

--- a/modules/cli/src/main/scala/scala/cli/commands/version/VersionOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/version/VersionOptions.scala
@@ -6,15 +6,25 @@ import scala.cli.commands.shared.{HasLoggingOptions, LoggingOptions}
 import scala.cli.commands.tags
 
 // format: off
-@HelpMessage("Print version")
+@HelpMessage(
+  """|Print the version of the scala runner and the default version of Scala (unless specified in the project).
+     |
+     |The version of the scala runner is the version of the command-line tool that runs Scala programs, which
+     |is distinct from the Scala version of a program. We recommend you specify the version of Scala of a
+     |program in the program itself (via a configuration directive). Otherwise, the runner falls back to the default
+     |Scala version defined by the runner.
+     |""".stripMargin
+)
 final case class VersionOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
   @Tag(tags.implementation)
+  @Group("Version")
   @HelpMessage("Show only plain version")
   @Name("cli")
     cliVersion: Boolean = false,
   @HelpMessage("Show only plain scala version")
+  @Group("Version")
   @Tag(tags.implementation)
   @Name("scala")
     scalaVersion: Boolean = false

--- a/modules/cli/src/test/scala/cli/tests/HelpCheck.scala
+++ b/modules/cli/src/test/scala/cli/tests/HelpCheck.scala
@@ -1,6 +1,9 @@
 package cli.tests
 
-import scala.cli.ScalaCliCommands
+import com.eed3si9n.expecty.Expecty.expect
+
+import scala.cli.commands.version.Version
+import scala.cli.{ScalaCli, ScalaCliCommands}
 
 class HelpCheck extends munit.FunSuite {
 
@@ -10,5 +13,15 @@ class HelpCheck extends munit.FunSuite {
 
     val lines = helpMessage.split("\r\n|\r|\n").length
     assert(lines <= 80)
+  }
+
+  test("version help message should only contain relevant options") { // regression test - https://github.com/VirtusLab/scala-cli/issues/1666
+    val helpMessage = Version.finalHelp.help(Version.helpFormat)
+
+    expect(helpMessage.contains("Version options:"))
+
+    expect(!helpMessage.contains("-help-full"))
+    expect(!helpMessage.contains("Logging options:"))
+    expect(!helpMessage.contains("Other options:"))
   }
 }

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -184,7 +184,13 @@ Accepts option groups: [logging](./cli-options.md#logging-options), [update](./c
 
 ## version
 
-Print version
+Print the version of the scala runner and the default version of Scala (unless specified in the project).
+
+The version of the scala runner is the version of the command-line tool that runs Scala programs, which
+is distinct from the Scala version of a program. We recommend you specify the version of Scala of a
+program in the program itself (via a configuration directive). Otherwise, the runner falls back to the default
+Scala version defined by the runner.
+
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [version](./cli-options.md#version-options)
 

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -95,7 +95,13 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 ### version
 
-Print version
+Print the version of the scala runner and the default version of Scala (unless specified in the project).
+
+The version of the scala runner is the version of the command-line tool that runs Scala programs, which
+is distinct from the Scala version of a program. We recommend you specify the version of Scala of a
+program in the program itself (via a configuration directive). Otherwise, the runner falls back to the default
+Scala version defined by the runner.
+
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [version](./cli-options.md#version-options)
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -3753,7 +3753,13 @@ Aliases: `--help-fmt` ,`--fmt-help` ,`--scalafmt-help`
 ## `version` command
 **SHOULD have for Scala Runner specification.**
 
-Print version
+Print the version of the scala runner and the default version of Scala (unless specified in the project).
+
+The version of the scala runner is the version of the command-line tool that runs Scala programs, which
+is distinct from the Scala version of a program. We recommend you specify the version of Scala of a
+program in the program itself (via a configuration directive). Otherwise, the runner falls back to the default
+Scala version defined by the runner.
+
 
 <details><summary>
 
@@ -3770,12 +3776,6 @@ Print usage and exit
 Print help message and exit
 
 Aliases: `-h` ,`-help`
-
-**--help-full**
-
-Print help message, including hidden options, and exit
-
-Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 **--verbose**
 


### PR DESCRIPTION
It change the output of `version` help message  to:
```
Usage: scala-cli version [options]
Print the version of the scala runner and the default version of Scala (unless specified in the project).

The version of the scala runner is the version of the command-line tool that runs Scala programs, which
is distinct from the Scala version of a program. We recommend you specify the version of Scala of a
program in the program itself (via a configuration directive). Otherwise, the runner falls back to the default
Scala version defined by the runner.

Version options:
  --cli, --cli-version      Show only plain version
  --scala, --scala-version  Show only plain scala version

Help options:
  --usage            Print usage and exit
  -h, -help, --help  Print help message and exit

```

I added @julienrf as co-authored commit who created the help message content. Help message was copied from https://github.com/VirtusLab/scala-cli/issues/1666#issue-1484074598.

Fixes #1666.