### PR TITLE
Make the default sub-command default to `shebang` instead of `run` when inputs are provided

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/default/Default.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/Default.scala
@@ -8,9 +8,9 @@ import scala.build.internal.Constants
 import scala.build.options.BuildOptions
 import scala.cli.CurrentParams
 import scala.cli.commands.repl.{Repl, ReplOptions}
-import scala.cli.commands.run.{Run, RunOptions}
 import scala.cli.commands.shared.ScalaCliHelp.helpFormat
 import scala.cli.commands.shared.SharedOptions
+import scala.cli.commands.shebang.{Shebang, ShebangOptions}
 import scala.cli.commands.version.Version
 import scala.cli.commands.{ScalaCommand, ScalaCommandWithCustomHelp}
 import scala.cli.launcher.LauncherOptions
@@ -25,8 +25,8 @@ class Default(
        |
        |When no subcommand is passed explicitly, an implicit subcommand is used based on context:
        |  - if the '--version' option is passed, it prints the 'version' subcommand output, unmodified by any other options
-       |  - if any inputs were passed, it defaults to the 'run' subcommand
-       |  - additionally, when no inputs were passed, it defaults to the 'run' subcommand in the following scenarios:
+       |  - if any inputs were passed, it defaults to the 'shebang' subcommand
+       |  - additionally, when no inputs were passed, it defaults to the 'shebang' subcommand in the following scenarios:
        |    - if a snippet was passed with any of the '--execute*' options
        |    - if a main class was passed with the '--main-class' option alongside an extra '--classpath'
        |  - otherwise, if no inputs were passed, it defaults to the 'repl' subcommand""".stripMargin
@@ -46,14 +46,14 @@ class Default(
     if options.version then println(Version.versionInfo)
     else
       {
-        val shouldDefaultToRun =
+        val shouldDefaultToShebang =
           args.remaining.nonEmpty || options.shared.snippet.executeScript.nonEmpty ||
           options.shared.snippet.executeScala.nonEmpty || options.shared.snippet.executeJava.nonEmpty ||
           options.shared.snippet.executeMarkdown.nonEmpty ||
           (options.shared.extraJarsAndClassPath.nonEmpty && options.sharedRun.mainClass.mainClass.nonEmpty)
-        if shouldDefaultToRun then RunOptions.parser else ReplOptions.parser
+        if shouldDefaultToShebang then ShebangOptions.parser else ReplOptions.parser
       }.parse(options.legacyScala.filterNonDeprecatedArgs(rawArgs, progName, logger)) match
-        case Left(e)                              => error(e)
-        case Right((replOptions: ReplOptions, _)) => Repl.runCommand(replOptions, args, logger)
-        case Right((runOptions: RunOptions, _))   => Run.runCommand(runOptions, args, logger)
+        case Left(e)                               => error(e)
+        case Right((replOptions: ReplOptions, _))  => Repl.runCommand(replOptions, args, logger)
+        case Right((sbOptions: ShebangOptions, _)) => Shebang.runCommand(sbOptions, args, logger)
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/shebang/Shebang.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shebang/Shebang.scala
@@ -14,8 +14,7 @@ object Shebang extends ScalaCommand[ShebangOptions] {
 
   override def scalaSpecificationLevel = SpecificationLevel.MUST
 
-  override def sharedOptions(options: ShebangOptions): Option[SharedOptions] =
-    Run.sharedOptions(options.runOptions)
+  override def sharedOptions(options: ShebangOptions): Option[SharedOptions] = Some(options.shared)
 
   override def runCommand(options: ShebangOptions, args: RemainingArgs, logger: Logger): Unit =
     Run.runCommand(

--- a/modules/cli/src/main/scala/scala/cli/commands/shebang/ShebangOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shebang/ShebangOptions.scala
@@ -2,7 +2,7 @@ package scala.cli.commands.shebang
 
 import caseapp.*
 
-import scala.cli.commands.run.RunOptions
+import scala.cli.commands.run.{RunOptions, SharedRunOptions}
 import scala.cli.commands.shared.{HasSharedOptions, SharedOptions}
 
 @HelpMessage(
@@ -34,9 +34,11 @@ import scala.cli.commands.shared.{HasSharedOptions, SharedOptions}
 )
 final case class ShebangOptions(
   @Recurse
-  runOptions: RunOptions = RunOptions()
+  shared: SharedOptions = SharedOptions(),
+  @Recurse
+  sharedRun: SharedRunOptions = SharedRunOptions()
 ) extends HasSharedOptions {
-  override def shared: SharedOptions = runOptions.shared
+  def runOptions: RunOptions = RunOptions(shared, sharedRun)
 }
 
 object ShebangOptions {

--- a/modules/integration/src/test/scala/scala/cli/integration/DefaultTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DefaultTests.scala
@@ -116,7 +116,7 @@ class DefaultTests extends WithWarmUpScalaCliSuite {
     }
   }
 
-  test("default to the run sub-command if -classpath and --main-class are passed") {
+  test("default to the shebang sub-command if -classpath and --main-class are passed") {
     val expectedOutput = "Hello"
     val mainClassName  = "Main"
     TestInputs(
@@ -131,15 +131,15 @@ class DefaultTests extends WithWarmUpScalaCliSuite {
         compilationOutputDir
       ).call(cwd = root)
 
-      // next, run while relying on the pre-compiled class instead of passing inputs
-      val runRes = os.proc(
+      // next, run shebang while relying on the pre-compiled class instead of passing inputs
+      val shebangRes = os.proc(
         TestUtil.cli,
         "--main-class",
         mainClassName,
         "-classpath",
         (os.rel / compilationOutputDir).toString
       ).call(cwd = root)
-      expect(runRes.out.trim() == expectedOutput)
+      expect(shebangRes.out.trim() == expectedOutput)
     }
   }
 
@@ -216,6 +216,15 @@ class DefaultTests extends WithWarmUpScalaCliSuite {
           .call(cwd = root, stderr = os.Pipe)
       expect(res2.out.trim() == msg)
       expect(res2.err.trim().contains(s"Deprecated option '$doubleDashNoSaveOption' is ignored"))
+    }
+  }
+
+  test("ensure natural arguments handling is supported by default") {
+    TestInputs(os.rel / "s.sc" -> s"""println(args.mkString)""").fromRoot { root =>
+      val msg = "Hello"
+      val res = os.proc(TestUtil.cli, ".", msg, TestUtil.extraOptions)
+        .call(cwd = root, stderr = os.Pipe)
+      expect(res.out.trim() == msg)
     }
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/RunGistTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunGistTestDefinitions.scala
@@ -14,7 +14,7 @@ trait RunGistTestDefinitions { _: RunTestDefinitions =>
       "https://gist.github.com/alexarchambault/f972d941bc4a502d70267cfbbc4d6343/raw/b0285fa0305f76856897517b06251970578565af/test.sc"
     val message = "Hello from GitHub Gist"
     emptyInputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, escapedUrls(url))
+      val output = os.proc(TestUtil.cli, "run", extraOptions, escapedUrls(url))
         .call(cwd = root)
         .out.trim()
       expect(output == message)
@@ -26,7 +26,7 @@ trait RunGistTestDefinitions { _: RunTestDefinitions =>
       "https://gist.github.com/alexarchambault/f972d941bc4a502d70267cfbbc4d6343/raw/2691c01984c9249936a625a42e29a822a357b0f6/Test.scala"
     val message = "Hello from Scala GitHub Gist"
     emptyInputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, escapedUrls(url))
+      val output = os.proc(TestUtil.cli, "run", extraOptions, escapedUrls(url))
         .call(cwd = root)
         .out.trim()
       expect(output == message)
@@ -38,7 +38,7 @@ trait RunGistTestDefinitions { _: RunTestDefinitions =>
       "https://gist.github.com/alexarchambault/f972d941bc4a502d70267cfbbc4d6343/raw/2691c01984c9249936a625a42e29a822a357b0f6/Test.java"
     val message = "Hello from Java GitHub Gist"
     emptyInputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, escapedUrls(url))
+      val output = os.proc(TestUtil.cli, "run", extraOptions, escapedUrls(url))
         .call(cwd = root)
         .out.trim()
       expect(output == message)
@@ -50,7 +50,7 @@ trait RunGistTestDefinitions { _: RunTestDefinitions =>
       "https://gist.github.com/alexarchambault/7b4ec20c4033690dd750ffd601e540ec"
     val message = "Hello"
     emptyInputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, escapedUrls(url))
+      val output = os.proc(TestUtil.cli, "run", extraOptions, escapedUrls(url))
         .call(cwd = root)
         .out.trim()
       expect(output == message)

--- a/modules/integration/src/test/scala/scala/cli/integration/RunPipedSourcesTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunPipedSourcesTestDefinitions.scala
@@ -23,7 +23,7 @@ trait RunPipedSourcesTestDefinitions { _: RunTestDefinitions =>
       val message = "Hello"
       val input   = s"println(\"$message\")"
       emptyInputs.fromRoot { root =>
-        val output = os.proc(TestUtil.cli, "-", extraOptions)
+        val output = os.proc(TestUtil.cli, "run", "-", extraOptions)
           .call(cwd = root, stdin = input)
           .out.trim()
         expect(output == message)
@@ -33,7 +33,7 @@ trait RunPipedSourcesTestDefinitions { _: RunTestDefinitions =>
       val expectedOutput = "Hello"
       val pipedInput     = s"object Test extends App { println(\"$expectedOutput\") }"
       emptyInputs.fromRoot { root =>
-        val output = os.proc(TestUtil.cli, "_.scala", extraOptions)
+        val output = os.proc(TestUtil.cli, "run", "_.scala", extraOptions)
           .call(cwd = root, stdin = pipedInput)
           .out.trim()
         expect(output == expectedOutput)
@@ -48,7 +48,7 @@ trait RunPipedSourcesTestDefinitions { _: RunTestDefinitions =>
            |}""".stripMargin
       val inputs = TestInputs(os.rel / "SomeData.scala" -> "case class SomeData(value: String)")
       inputs.fromRoot { root =>
-        val output = os.proc(TestUtil.cli, ".", "_.scala", extraOptions)
+        val output = os.proc(TestUtil.cli, "run", ".", "_.scala", extraOptions)
           .call(cwd = root, stdin = pipedInput)
           .out.trim()
         expect(output == expectedOutput)
@@ -64,7 +64,7 @@ trait RunPipedSourcesTestDefinitions { _: RunTestDefinitions =>
            |}
            |""".stripMargin
       emptyInputs.fromRoot { root =>
-        val output = os.proc(TestUtil.cli, "_.java", extraOptions)
+        val output = os.proc(TestUtil.cli, "run", "_.java", extraOptions)
           .call(cwd = root, stdin = pipedInput)
           .out.trim()
         expect(output == expectedOutput)
@@ -88,7 +88,7 @@ trait RunPipedSourcesTestDefinitions { _: RunTestDefinitions =>
            |}
            |""".stripMargin
       emptyInputs.fromRoot { root =>
-        val output = os.proc(TestUtil.cli, "_.java", extraOptions)
+        val output = os.proc(TestUtil.cli, "run", "_.java", extraOptions)
           .call(cwd = root, stdin = pipedInput)
           .out.trim()
         expect(output == expectedOutput)
@@ -121,6 +121,7 @@ trait RunPipedSourcesTestDefinitions { _: RunTestDefinitions =>
         val output =
           os.proc(
             TestUtil.cli,
+            "run",
             ".",
             "_.sc",
             "--script-snippet",
@@ -196,7 +197,7 @@ trait RunPipedSourcesTestDefinitions { _: RunTestDefinitions =>
          |```
          |""".stripMargin
     emptyInputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, "_.md", extraOptions)
+      val output = os.proc(TestUtil.cli, "run", "_.md", extraOptions)
         .call(cwd = root, stdin = pipedInput)
         .out.trim()
       expect(output == expectedOutput)

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
@@ -17,9 +17,10 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, fileName, "--js", extraArgs).call(cwd =
-        root
-      ).out.trim()
+      val output =
+        os.proc(TestUtil.cli, "run", extraOptions, fileName, "--js", extraArgs).call(cwd =
+          root
+        ).out.trim()
       expect(output.linesIterator.toSeq.last == message)
     }
   }
@@ -45,6 +46,7 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
     inputs.fromRoot { root =>
       val output = os.proc(
         TestUtil.cli,
+        "run",
         extraOptions,
         fileName,
         "--js",
@@ -79,7 +81,7 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, fileName, "--js")
+      val output = os.proc(TestUtil.cli, "run", extraOptions, fileName, "--js")
         .call(cwd = root).out.trim()
       expect(output == message)
     }
@@ -97,7 +99,7 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, ".").call(cwd = root).out.trim()
+      val output = os.proc(TestUtil.cli, "run", extraOptions, ".").call(cwd = root).out.trim()
       expect(output == message)
     }
   }
@@ -115,7 +117,9 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
     )
     inputs.fromRoot { root =>
       val output =
-        os.proc(TestUtil.cli, extraOptions, ".", "--platform", "js").call(cwd = root).out.trim()
+        os.proc(TestUtil.cli, "run", extraOptions, ".", "--platform", "js").call(cwd =
+          root
+        ).out.trim()
       expect(output == message)
     }
   }
@@ -133,9 +137,10 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, "print.sc", "messages.sc", "--js").call(cwd =
-        root
-      ).out.trim()
+      val output =
+        os.proc(TestUtil.cli, "run", extraOptions, "print.sc", "messages.sc", "--js").call(cwd =
+          root
+        ).out.trim()
       expect(output == message)
     }
   }
@@ -159,7 +164,7 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
       os.proc(npmPath, "init", "private").call(cwd = root)
       os.proc(npmPath, "install", "jsdom").call(cwd = root)
 
-      val output = os.proc(TestUtil.cli, extraOptions, ".", "--js", "--js-dom")
+      val output = os.proc(TestUtil.cli, "run", extraOptions, ".", "--js", "--js-dom")
         .call(cwd = root)
         .out.text()
       expect(output.contains("Hello from js dom"))
@@ -194,9 +199,10 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, "dir", "--js", "--main-class", "print_sc")
-        .call(cwd = root)
-        .out.trim()
+      val output =
+        os.proc(TestUtil.cli, "run", extraOptions, "dir", "--js", "--main-class", "print_sc")
+          .call(cwd = root)
+          .out.trim()
       expect(output == message)
     }
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
@@ -21,7 +21,7 @@ trait RunScalaNativeTestDefinitions { _: RunTestDefinitions =>
     )
     inputs.fromRoot { root =>
       val output =
-        os.proc(TestUtil.cli, extraOptions, fileName, "--native", "-q")
+        os.proc(TestUtil.cli, "run", extraOptions, fileName, "--native", "-q")
           .call(cwd = root)
           .out.trim()
       expect(output == message)
@@ -47,7 +47,7 @@ trait RunScalaNativeTestDefinitions { _: RunTestDefinitions =>
     )
     inputs.fromRoot { root =>
       val output =
-        os.proc(TestUtil.cli, extraOptions, fileName, "--native", "--command")
+        os.proc(TestUtil.cli, "run", extraOptions, fileName, "--native", "--command")
           .call(cwd = root)
           .out.trim()
       val command      = output.linesIterator.toVector.filter(!_.startsWith("["))
@@ -82,7 +82,7 @@ trait RunScalaNativeTestDefinitions { _: RunTestDefinitions =>
     )
     inputs.fromRoot { root =>
       val output =
-        os.proc(TestUtil.cli, extraOptions, projectDir, "-q")
+        os.proc(TestUtil.cli, "run", extraOptions, projectDir, "-q")
           .call(cwd = root)
           .out.trim()
       println(output)
@@ -122,7 +122,7 @@ trait RunScalaNativeTestDefinitions { _: RunTestDefinitions =>
     )
     inputs.fromRoot { root =>
       val output =
-        os.proc(TestUtil.cli, extraOptions, projectDir, "-q")
+        os.proc(TestUtil.cli, "run", extraOptions, projectDir, "-q")
           .call(cwd = root)
           .out.trim()
       expect(output == interopMsg)
@@ -185,7 +185,7 @@ trait RunScalaNativeTestDefinitions { _: RunTestDefinitions =>
     )
     inputs.fromRoot { root =>
       val output =
-        os.proc(TestUtil.cli, extraOptions, "print.sc", "messages.sc", "--native", "-q")
+        os.proc(TestUtil.cli, "run", extraOptions, "print.sc", "messages.sc", "--native", "-q")
           .call(cwd = root)
           .out.trim()
       expect(output == message)
@@ -213,7 +213,16 @@ trait RunScalaNativeTestDefinitions { _: RunTestDefinitions =>
     )
     inputs.fromRoot { root =>
       val output =
-        os.proc(TestUtil.cli, extraOptions, "dir", "--native", "--main-class", "print_sc", "-q")
+        os.proc(
+          TestUtil.cli,
+          "run",
+          extraOptions,
+          "dir",
+          "--native",
+          "--main-class",
+          "print_sc",
+          "-q"
+        )
           .call(cwd = root)
           .out.trim()
       expect(output == message)

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalacCompatTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalacCompatTestDefinitions.scala
@@ -24,7 +24,7 @@ trait RunScalacCompatTestDefinitions { _: RunTestDefinitions =>
       def run(warnAny: Boolean) = {
         // format: off
         val cmd = Seq[os.Shellable](
-          TestUtil.cli, extraOptions, ".",
+          TestUtil.cli, "run", extraOptions, ".",
           if (warnAny) Seq("-Xlint:infer-any") else Nil
         )
         // format: on
@@ -111,7 +111,7 @@ trait RunScalacCompatTestDefinitions { _: RunTestDefinitions =>
       // to the application's main method. This test ensures it is not
       // cut. "--java-opt" option requires a value, so it would fail
       // if -Xmx1g is cut
-      val res = os.proc(TestUtil.cli, "Hello.scala", "--java-opt", "-Xmx1g").call(
+      val res = os.proc(TestUtil.cli, "run", "Hello.scala", "--java-opt", "-Xmx1g").call(
         cwd = root,
         check = false
       )
@@ -389,7 +389,7 @@ trait RunScalacCompatTestDefinitions { _: RunTestDefinitions =>
     val inputRelPath   = os.rel / s"$mainClass.scala"
     TestInputs(inputRelPath -> s"""object $mainClass extends App { println("$expectedOutput") }""")
       .fromRoot { root =>
-        val res = os.proc(TestUtil.cli, ".", "--scalac-verbose", extraOptions)
+        val res = os.proc(TestUtil.cli, "run", ".", "--scalac-verbose", extraOptions)
           .call(cwd = root, stderr = os.Pipe)
         val errLines = res.err.trim().lines.toList.asScala
         // there should be a lot of logs, but different stuff is logged depending on the Scala version
@@ -409,6 +409,7 @@ trait RunScalacCompatTestDefinitions { _: RunTestDefinitions =>
         .fromRoot { root =>
           val res = os.proc(
             TestUtil.cli,
+            "run",
             "s.scala",
             "-encoding",
             "cp1252",
@@ -437,6 +438,7 @@ trait RunScalacCompatTestDefinitions { _: RunTestDefinitions =>
         .fromRoot { root =>
           val res = os.proc(
             TestUtil.cli,
+            "run",
             fileName,
             "-new-syntax",
             "-rewrite",
@@ -454,6 +456,7 @@ trait RunScalacCompatTestDefinitions { _: RunTestDefinitions =>
         .fromRoot { root =>
           val res = os.proc(
             TestUtil.cli,
+            "run",
             fileName,
             "-old-syntax",
             "-rewrite",

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
@@ -16,7 +16,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
     )
     inputs.fromRoot { root =>
       val output =
-        os.proc(TestUtil.cli, extraOptions, extraArgs, fileName).call(cwd = root).out.trim()
+        os.proc(TestUtil.cli, "run", extraOptions, extraArgs, fileName).call(cwd = root).out.trim()
       if (!ignoreErrors)
         expect(output == message)
     }
@@ -41,7 +41,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, "print.sc", "messages.sc").call(cwd =
+      val output = os.proc(TestUtil.cli, "run", extraOptions, "print.sc", "messages.sc").call(cwd =
         root
       ).out.trim()
       expect(output == message)
@@ -56,7 +56,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, "main.sc").call(cwd =
+      val output = os.proc(TestUtil.cli, "run", extraOptions, "main.sc").call(cwd =
         root
       ).out.trim()
       expect(output == message)
@@ -74,7 +74,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, "message.sc", "main.sc").call(cwd =
+      val output = os.proc(TestUtil.cli, "run", extraOptions, "message.sc", "main.sc").call(cwd =
         root
       ).out.trim()
       expect(output == message)
@@ -92,9 +92,10 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, "dir", "--main-class", "print_sc").call(cwd =
-        root
-      ).out.trim()
+      val output =
+        os.proc(TestUtil.cli, "run", extraOptions, "dir", "--main-class", "print_sc").call(cwd =
+          root
+        ).out.trim()
       expect(output == message)
     }
   }
@@ -109,7 +110,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, scriptPath.toString)
+      val output = os.proc(TestUtil.cli, "run", extraOptions, scriptPath.toString)
         .call(cwd = root)
         .out.text()
         .trim
@@ -138,7 +139,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, "dir", scriptPath.toString)
+      val output = os.proc(TestUtil.cli, "run", extraOptions, "dir", scriptPath.toString)
         .call(cwd = root)
         .out.text()
         .trim
@@ -299,7 +300,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
     )
     inputs.fromRoot { root =>
       val p =
-        os.proc(TestUtil.cli, "main0.sc", "f.sc", "--", "20").call(cwd = root)
+        os.proc(TestUtil.cli, "run", "main0.sc", "f.sc", "--", "20").call(cwd = root)
       val res = p.out.trim()
       expect(res == "202020")
     }
@@ -307,7 +308,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
   test("CLI args passed to script") {
     val inputs = TestInputs(os.rel / "f.sc" -> "println(args(0))")
     inputs.fromRoot { root =>
-      val p = os.proc(TestUtil.cli, "f.sc", "--", "16").call(cwd = root)
+      val p = os.proc(TestUtil.cli, "run", "f.sc", "--", "16").call(cwd = root)
       expect(p.out.trim() == "16")
     }
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunZipTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunZipTestDefinitions.scala
@@ -18,7 +18,7 @@ trait RunZipTestDefinitions { _: RunTestDefinitions =>
     )
     inputs.asZip { (root, zipPath) =>
       val message = "Hello"
-      val output = os.proc(TestUtil.cli, extraOptions, zipPath.toString)
+      val output = os.proc(TestUtil.cli, "run", extraOptions, zipPath.toString)
         .call(cwd = root)
         .out.trim()
       expect(output == message)
@@ -44,7 +44,7 @@ trait RunZipTestDefinitions { _: RunTestDefinitions =>
     inputs.asZip { (root, zipPath) =>
       val message = "1,2"
 
-      val output = os.proc(TestUtil.cli, extraOptions, zipPath.toString)
+      val output = os.proc(TestUtil.cli, "run", extraOptions, zipPath.toString)
         .call(cwd = root)
         .out.trim()
       expect(output == message)
@@ -68,7 +68,7 @@ trait RunZipTestDefinitions { _: RunTestDefinitions =>
     inputs.asZip { (root, zipPath) =>
       val message = "1,2"
 
-      val output = os.proc(TestUtil.cli, extraOptions, zipPath.toString)
+      val output = os.proc(TestUtil.cli, "run", extraOptions, zipPath.toString)
         .call(cwd = root)
         .out.trim()
       expect(output == message)
@@ -97,7 +97,7 @@ trait RunZipTestDefinitions { _: RunTestDefinitions =>
            |""".stripMargin
     )
     inputs.asZip { (root, zipPath) =>
-      val result = os.proc(TestUtil.cli, extraOptions, zipPath, "--md").call(cwd = root)
+      val result = os.proc(TestUtil.cli, "run", extraOptions, zipPath, "--md").call(cwd = root)
       expect(result.out.trim() == expectedMessage)
     }
   }

--- a/website/docs/commands/basics.md
+++ b/website/docs/commands/basics.md
@@ -11,7 +11,9 @@ given [configuration](../guides/configuration.md) to produce a result.
 The most important sub-commands are:
 
 - [compile](./compile.md) compiles your code (excluding tests)
-- [run](./run.md) runs your code using the provided arguments (it’s also used when no other command is provided)
+- [run](./run.md) runs your code using the provided arguments (it’s also used when no other command is provided))
+- `shebang` is a variant of the `run` sub-command, which is meant for a more natural way of handling arguments when
+  working with scripts. (see more in [the scripts guide](../guides/scripts.md))
 - [test](./test.md) compiles and runs the tests defined in your code
 - [package](./package.md) packages your code into a jar or other format
 - [repl](./repl.md) / [console](./repl.md) runs the interactive Scala shell
@@ -21,9 +23,9 @@ Scala CLI can also be run without passing any explicit sub-command,
 in which case it defaults to one of the sub-commands based on context:
 
 - if the `--version` option is passed, it prints the `version` command output (unmodified by any other options)
-- if any inputs were passed, it defaults to the `run` sub-command
+- if any inputs were passed, it defaults to the `shebang` sub-command
     - and so, `scala-cli a.scala` runs your `a.scala` file
-- additionally, when no inputs were passed, it defaults to the `run` sub-command in the following scenarios:
+- additionally, when no inputs were passed, it defaults to the `shebang` sub-command in the following scenarios:
     - if a snippet was passed with `-e`, `--execute-script`, `--execute-scala`, `--execute-java` or `--execute-markdown`
     - if a main class was passed with the `--main-class` option alongside an extra `--classpath`
 - otherwise if no inputs were passed, it defaults to the `repl` sub-command
@@ -95,7 +97,7 @@ and the run them with `scala-cli`:
 <ChainedSnippets>
 
 ```bash
-scala-cli Hello.scala Messages.scala
+scala-cli run Hello.scala Messages.scala
 ```
 
 ```text
@@ -252,7 +254,7 @@ You can also pipe code to `scala-cli` for execution:
   ```bash
   echo 'println("Hello")' | scala-cli _.sc
   ```
-  
+
   ```text
   Hello
   ```
@@ -266,7 +268,7 @@ You can also pipe code to `scala-cli` for execution:
   ```bash
   echo '@main def hello() = println("Hello")' | scala-cli _.scala
   ```
-  
+
   ```text
   Hello
   ```
@@ -280,7 +282,7 @@ You can also pipe code to `scala-cli` for execution:
   ```bash
   echo 'class Hello { public static void main(String args[]) { System.out.println("Hello"); } }' | scala-cli _.java
   ```
-  
+
   ```text
   Hello
   ```
@@ -297,7 +299,7 @@ You can also pipe code to `scala-cli` for execution:
   println("Hello")
   ```' | scala-cli _.md
   ```
-  
+
   ```text
   Hello
   ```

--- a/website/docs/commands/run.md
+++ b/website/docs/commands/run.md
@@ -51,7 +51,7 @@ println(args.mkString("App called with arguments: ", ", ", ""))
 <ChainedSnippets>
 
 ```bash
-scala-cli app.sc -- first-arg second-arg
+scala-cli run app.sc -- first-arg second-arg
 ```
 
 ```text
@@ -73,7 +73,7 @@ println("Hi")
 ```
 
 ```bash
-scala-cli Hello.scala hi.sc --main-class hi_sc
+scala-cli run Hello.scala hi.sc --main-class hi_sc
 ```
 
 ## Custom JVM
@@ -81,7 +81,7 @@ scala-cli Hello.scala hi.sc --main-class hi_sc
 `--jvm` lets you run your application with a custom JVM:
 
 ```bash
-scala-cli Hello.scala --jvm adopt:14
+scala-cli run Hello.scala --jvm adopt:14
 ```
 
 You can also specify custom JVM with the using directive `//> using jvm`:
@@ -98,7 +98,7 @@ swiftly.)
 `--java-opt` lets you add `java` options which will be passed when running an application:
 
 ```bash
-scala-cli Hello.scala --java-opt -Xmx1g --java-opt -Dfoo=bar
+scala-cli run Hello.scala --java-opt -Xmx1g --java-opt -Dfoo=bar
 ```
 
 You can also add java options with the using directive `//> using javaOpt`:
@@ -142,7 +142,7 @@ object Utils {
 <ChainedSnippets>
 
 ```bash
-scala-cli Main.scala
+scala-cli run Main.scala
 ```
 
 ```text
@@ -214,13 +214,13 @@ Scala.js applications can also be compiled and run with the `--js` option.
 Note that this requires `node` to be [installed](/install#scala-js) on your system:
 
 ```bash
-scala-cli Hello.scala --js
+scala-cli run Hello.scala --js
 ```
 
 It is also possible to achieve it using `--platform` option:
 
 ```bash
-scala-cli Hello.scala --platform js
+scala-cli run Hello.scala --platform js
 ```
 
 See our dedicated [Scala.js guide](../guides/scala-js.md) for more information.
@@ -231,13 +231,13 @@ Scala Native applications can be compiled and run with the `--native` option.
 Note that the [Scala Native requirements](https://scala-native.readthedocs.io/en/latest/user/setup.html#installing-clang-and-runtime-dependencies) need to be [installed](/install#scala-native) for this to work:
 
 ```bash
-scala-cli Hello.scala --native -S 2.13.6
+scala-cli run Hello.scala --native -S 2.13.6
 ```
 
 It is also possible to achieve it using `--platform` option:
 
 ```bash
-scala-cli Hello.scala --platform native
+scala-cli run Hello.scala --platform native
 ```
 
 We have a dedicated [Scala Native guide](../guides/scala-native.md) as well.

--- a/website/docs/cookbooks/scala-versions.md
+++ b/website/docs/cookbooks/scala-versions.md
@@ -99,7 +99,7 @@ object OldCode
 Now when you compile that code along with the previous `ScalaVersion.scala` file:
 
 ```bash
-scala-cli ScalaVersion.scala version.scala
+scala-cli run ScalaVersion.scala version.scala
 ```
 
 <!-- Expected-regex:

--- a/website/docs/guides/markdown.md
+++ b/website/docs/guides/markdown.md
@@ -473,7 +473,7 @@ object Main extends App {
 <ChainedSnippets>
 
 ```bash
-scala-cli src Main.scala --enable-markdown --main-class Main
+scala-cli run src Main.scala --enable-markdown --main-class Main
 ```
 
 ```text
@@ -498,7 +498,7 @@ object Something {
 <ChainedSnippets>
 
 ```bash
-scala-cli RawSnippetToReferTo.md -e 'println(Something.message)'
+scala-cli run RawSnippetToReferTo.md -e 'println(Something.message)'
 ```
 
 ```text

--- a/website/docs/guides/piping.md
+++ b/website/docs/guides/piping.md
@@ -101,7 +101,7 @@ It is also possible to pipe some code via standard input, while the rest of your
 
 ```bash
 echo 'case class HelloMessage(msg: String)' > HelloMessage.scala
-echo '@main def hello() = println(HelloMessage(msg = "Hello").msg)' | scala-cli _ HelloMessage.scala
+echo '@main def hello() = println(HelloMessage(msg = "Hello").msg)' | scala-cli run _ HelloMessage.scala
 ```
 
 ```text
@@ -117,7 +117,7 @@ name `stdin`, as in the example below.
 
 ```bash
 echo '@main def main() = println(stdin.message)' > PrintMessage.scala
-echo 'def message: String = "Hello"' | scala-cli PrintMessage.scala _.sc
+echo 'def message: String = "Hello"' | scala-cli run PrintMessage.scala _.sc
 ```
 
 ```text

--- a/website/docs/guides/scripts.md
+++ b/website/docs/guides/scripts.md
@@ -65,7 +65,7 @@ When referring to code from a piped script, just use its wrapper name: `stdin`.
 
 ```bash
 echo '@main def main() = println(stdin.message)' > PrintMessage.scala
-echo 'def message: String = "Hello"' | scala-cli PrintMessage.scala _.sc
+echo 'def message: String = "Hello"' | scala-cli run PrintMessage.scala _.sc
 ```
 
 ```text
@@ -79,7 +79,7 @@ To specify a main class when running a script, use this command:
 <ChainedSnippets>
 
 ```bash
-scala-cli my-app --main-class main_sc
+scala-cli run my-app --main-class main_sc
 ```
 
 ```text

--- a/website/docs/guides/snippets.md
+++ b/website/docs/guides/snippets.md
@@ -169,7 +169,7 @@ def script = "on-disk-script"
 ```
 
 ```bash
-echo 'def piped = "piped-script"'|scala-cli . _.sc --scala-snippet 'case class ScalaSnippet(value: String = "scala-snippet")' --java-snippet 'public class JavaSnippet { public static String data = "java-snippet"; }' --script-snippet 'def script = "script-snippet"'
+echo 'def piped = "piped-script"'|scala-cli run . _.sc --scala-snippet 'case class ScalaSnippet(value: String = "scala-snippet")' --java-snippet 'public class JavaSnippet { public static String data = "java-snippet"; }' --script-snippet 'def script = "script-snippet"'
 ```
 
 ```text
@@ -226,7 +226,7 @@ println(s"${stdin.hello} ${snippet.world}${snippet1.exclamation}")
 ```
 
 ```bash
-echo 'def hello = "Hello"' | scala-cli _.sc ondisk.sc -e 'def world = "world"' -e 'def exclamation = "!"' --main-class ondisk_sc
+echo 'def hello = "Hello"' | scala-cli run _.sc ondisk.sc -e 'def world = "world"' -e 'def exclamation = "!"' --main-class ondisk_sc
 ```
 
 ```text
@@ -241,7 +241,7 @@ of `--list-main-classes`
 <ChainedSnippets>
 
 ```bash
-echo 'def hello = "Hello"' | scala-cli _.sc ondisk.sc -e 'def world = "world"' -e 'def exclamation = "!"' --list-main-classes
+echo 'def hello = "Hello"' | scala-cli run _.sc ondisk.sc -e 'def world = "world"' -e 'def exclamation = "!"' --list-main-classes
 ```
 
 ```text


### PR DESCRIPTION
Fixes #603 

This switches out the default sub-command (when no sub-command is specified explicitly) from `run` to `shebang`.
What it effectively does is that the command-line arguments handling is switched to the natural style of other scripts` engines.

```bash
▶ cat Main.scala 
object Main {
  def main(args: Array[String]): Unit = println(args.mkString)
}                                                                                                                                                                                                                                                                   
▶ scala-cli Main.scala Hello ' ' world
Hello world
```

Please note that the `run` sub-command's behaviour remains unchanged.
```bash
▶ scala-cli run Main.scala Hello ' ' world
[error]  Hello: not found
 : not found
world: not found
```