### PR TITLE
Download `aarch64` artifact in launcher script

### DIFF
--- a/scala-cli.sh
+++ b/scala-cli.sh
@@ -19,7 +19,13 @@ else
 fi
 
 if [ "$(expr substr $(uname -s) 1 5 2>/dev/null)" == "Linux" ]; then
-  SCALA_CLI_URL="https://github.com/$GH_ORG/$GH_NAME/releases/download/$TAG/scala-cli-x86_64-pc-linux.gz"
+  arch=$(uname -m)
+  if [[ "$arch" == "aarch64" ]] || [[ "$arch" == "x86_64" ]]; then
+    SCALA_CLI_URL="https://github.com/$GH_ORG/$GH_NAME/releases/download/$TAG/scala-cli-${arch}-pc-linux.gz"
+  else
+    echoerr "scala-cli is not supported on $arch"
+    exit 2
+  fi
   CACHE_BASE="$HOME/.cache/coursier/v1"
 elif [ "$(uname)" == "Darwin" ]; then
   SCALA_CLI_URL="https://github.com/$GH_ORG/$GH_NAME/releases/download/$TAG/scala-cli-x86_64-apple-darwin.gz"


### PR DESCRIPTION
Follow-up to #1726 / #1714.
Now that scala-ci has `aarch64` support since [v0.1.19](https://github.com/VirtusLab/scala-cli/releases/tag/v0.1.19) the launcher script should also download the correct artifact.

This pull request does more or less the same we do in the sbt script [here](https://github.com/sbt/sbt/blob/31c09c114e7a180f09f534557bb267d6dfee3285/sbt#L176-L183), just since a couple of hours actually :wink: (https://github.com/sbt/sbt/pull/7110)

Currently on my Linux `aarch64` machine:
```sh
$ ./scala-cli.sh 
Downloading https://github.com/VirtusLab/scala-cli/releases/download/v0.1.19/scala-cli-x86_64-pc-linux.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 30.6M  100 30.6M    0     0  6166k      0  0:00:05  0:00:05 --:--:-- 8667k
```

With this pull request:
```sh
$ ./scala-cli.sh 
Downloading https://github.com/VirtusLab/scala-cli/releases/download/v0.1.19/scala-cli-aarch64-pc-linux.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 30.3M  100 30.3M    0     0  8329k      0  0:00:03  0:00:03 --:--:-- 10.0M
```