### PR TITLE
Don't fail in case of connection errors in the version sub-command

### DIFF
--- a/modules/core/src/main/scala/scala/build/errors/CheckScalaCliVersionError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/CheckScalaCliVersionError.scala
@@ -1,0 +1,9 @@
+package scala.build.errors
+
+class CheckScalaCliVersionError(val message: String, val cause: Throwable)
+    extends Exception(message, cause)
+
+object CheckScalaCliVersionError {
+  def apply(message: String, cause: Throwable = null): CheckScalaCliVersionError =
+    new CheckScalaCliVersionError(message, cause)
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -93,7 +93,7 @@ class SipScalaTests extends ScalaCliSuite {
   def testVersionCommand(binaryName: String): Unit =
     TestInputs.empty.fromRoot { root =>
       val binary = binaryName.prepareBinary(root)
-      for { versionOption <- Seq("version", "-version", "--version") } {
+      for { versionOption <- VersionTests.variants } {
         val version = os.proc(binary, versionOption).call(check = false)
         assert(
           version.exitCode == 0,

--- a/modules/integration/src/test/scala/scala/cli/integration/VersionTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/VersionTests.scala
@@ -2,12 +2,14 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
+import scala.cli.integration.VersionTests.variants
+
 class VersionTests extends ScalaCliSuite {
   test("version command") {
     // tests if the format is correct instead of comparing to a version passed via Constants
     // in order to catch errors in Mill configuration, too
     val versionRegex = ".*\\d+[.]\\d+[.]\\d+.*".r
-    for (versionOption <- Seq("version", "--version")) {
+    for (versionOption <- variants) {
       val version = os.proc(TestUtil.cli, versionOption).call(check = false)
       assert(
         versionRegex.findFirstMatchIn(version.out.text()).isDefined,
@@ -17,4 +19,8 @@ class VersionTests extends ScalaCliSuite {
     }
   }
 
+}
+
+object VersionTests {
+  val variants = Seq("version", "-version", "--version")
 }


### PR DESCRIPTION
This should make our integration tests less shaky, especially `VersionTests` and `SipTests`.
Since `version` now checks for the upstream newest version by default, a lot of our tests on CI were failing randomly.

This will debug log any connection errors encountered by the `version` sub-command, instead of failing as it did before.

```bash
scala-cli version -v -v
# Scala CLI version: 0.1.20-SNAPSHOT
# Scala version (default): 3.2.1
# Failed to check for the newest Scala CLI version upstream: Error downloading https://api.github.com/repos/VirtusLab/scala-cli/releases: java.net.UnknownHostException: api.github.com
```