### PR TITLE
Don't run commands upon HelpTests instantiation

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
@@ -2,12 +2,10 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-import scala.cli.integration.HelpTests.HelpVariants
-
 class HelpTests extends ScalaCliSuite {
-  for { helpOptions <- HelpVariants } {
-    val help              = os.proc(TestUtil.cli, helpOptions).call(check = false)
-    val helpOutput        = help.out.trim()
+  for (helpOptions <- HelpTests.variants) {
+    lazy val help         = os.proc(TestUtil.cli, helpOptions).call(check = false)
+    lazy val helpOutput   = help.out.trim()
     val helpOptionsString = helpOptions.mkString(" ")
     test(s"$helpOptionsString works correctly") {
       assert(
@@ -32,6 +30,6 @@ class HelpTests extends ScalaCliSuite {
 }
 
 object HelpTests {
-  val HelpVariants =
+  val variants =
     Seq(Seq("help"), Seq("help", "-help"), Seq("help", "--help"), Seq("-help"), Seq("--help"))
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -122,7 +122,7 @@ class SipScalaTests extends ScalaCliSuite {
 
   def testHelpOutput(binaryName: String): Unit = TestInputs.empty.fromRoot { root =>
     val binary = binaryName.prepareBinary(root)
-    for { helpOptions <- HelpTests.HelpVariants } {
+    for (helpOptions <- HelpTests.variants) {
       val output                      = os.proc(binary, helpOptions).call(cwd = root).out.trim()
       val restrictedFeaturesMentioned = output.contains("package")
       if (binaryName.isSip) expect(!restrictedFeaturesMentioned)


### PR DESCRIPTION
That slows down running tests with './mill integration.test "…"', even when no HelpTests are run.