### PR TITLE
Set workspace dir to `os.tmp.dir` for virtual sources

### DIFF
--- a/modules/build/src/main/scala/scala/build/input/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/input/Inputs.scala
@@ -157,6 +157,11 @@ object Inputs {
               )
             (f.path / os.up, true, WorkspaceOrigin.SourcePaths)
         }
+      }.orElse {
+        validElems.collectFirst {
+          case _: Virtual =>
+            (os.temp.dir(), true, WorkspaceOrigin.VirtualForced)
+        }
       }.getOrElse((os.pwd, true, WorkspaceOrigin.Forced))
     }
 

--- a/modules/build/src/main/scala/scala/build/input/WorkspaceOrigin.scala
+++ b/modules/build/src/main/scala/scala/build/input/WorkspaceOrigin.scala
@@ -9,5 +9,6 @@ object WorkspaceOrigin {
 
   case object ResourcePaths extends WorkspaceOrigin
 
-  case object HomeDir extends WorkspaceOrigin
+  case object HomeDir       extends WorkspaceOrigin
+  case object VirtualForced extends WorkspaceOrigin
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunSnippetTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunSnippetTestDefinitions.scala
@@ -144,4 +144,28 @@ trait RunSnippetTestDefinitions { _: RunTestDefinitions =>
       expect(res.out.trim() == expectedOutput)
     }
   }
+  test("running a script snippet should not create the workspace dir in cwd") {
+    emptyInputs.fromRoot { root =>
+      val quotation = TestUtil.argQuotationMark
+      val msg       = "Hello World from snippet"
+      os.proc(TestUtil.cli, "-e", s"println($quotation$msg$quotation)", extraOptions)
+        .call(cwd = root)
+        .out.trim()
+      expect(!os.exists(root / Constants.workspaceDirName))
+    }
+  }
+  test("running a script snippet with one source file should create the workspace dir in cwd") {
+    val inputs = TestInputs(
+      os.rel / "Hello.scala" ->
+        s"""object Hello {
+           | val hello = "Hello World"
+           |}""".stripMargin
+    )
+    inputs.fromRoot { root =>
+      os.proc(TestUtil.cli, "-e", s"println(Hello.hello)", ".", extraOptions)
+        .call(cwd = root)
+        .out.trim()
+      expect(os.exists(root / Constants.workspaceDirName))
+    }
+  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -176,11 +176,13 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
       passArgumentsScala3()
     }
 
-  test("setting root dir with no inputs") {
+  test("setting root dir with virtual input") {
     val url = "https://gist.github.com/alexarchambault/7b4ec20c4033690dd750ffd601e540ec"
     emptyInputs.fromRoot { root =>
       os.proc(TestUtil.cli, extraOptions, escapedUrls(url)).call(cwd = root)
-      expect(os.exists(root / ".scala-build"))
+      expect(
+        !os.exists(root / ".scala-build")
+      ) // virtual source should not create workspace dir in cwd
     }
   }
 


### PR DESCRIPTION
Fixes #1459 