### PR TITLE
Add support for deprecated Scala `2.13.x`-specific `scala` runner options

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommandWithCustomHelp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommandWithCustomHelp.scala
@@ -4,7 +4,7 @@ import caseapp.core.Error
 import caseapp.core.help.{Help, HelpCompanion, RuntimeCommandsHelp}
 import caseapp.core.parser.Parser
 
-import scala.cli.commands.default.DefaultOptions
+import scala.cli.commands.default.{DefaultOptions, LegacyScalaOptions}
 import scala.cli.commands.shared.{HasLoggingOptions, ScalaCliHelp}
 import scala.cli.commands.util.HelpUtils.*
 import scala.cli.launcher.LauncherOptions
@@ -18,12 +18,23 @@ abstract class ScalaCommandWithCustomHelp[T <: HasLoggingOptions](
 ) extends ScalaCommand[T] {
   private def launcherHelp: Help[LauncherOptions] = HelpCompanion.deriveHelp[LauncherOptions]
 
+  private def legacyScalaHelp: Help[LegacyScalaOptions] =
+    HelpCompanion.deriveHelp[LegacyScalaOptions]
+
   protected def customHelp(showHidden: Boolean): String = {
-    val helpString         = actualHelp.help(helpFormat, showHidden)
-    val launcherHelpString = launcherHelp.optionsHelp(helpFormat, showHidden)
+    val helpString            = actualHelp.help(helpFormat, showHidden)
+    val launcherHelpString    = launcherHelp.optionsHelp(helpFormat, showHidden)
+    val legacyScalaHelpString = legacyScalaHelp.optionsHelp(helpFormat, showHidden)
+    val legacyScalaHelpStringWithPadding =
+      if legacyScalaHelpString.nonEmpty then
+        s"""
+           |$legacyScalaHelpString
+           |""".stripMargin
+      else ""
     s"""$helpString
        |
-       |$launcherHelpString""".stripMargin
+       |$launcherHelpString
+       |$legacyScalaHelpStringWithPadding""".stripMargin
   }
 
   protected def customHelpAsked(showHidden: Boolean): Nothing = {

--- a/modules/cli/src/main/scala/scala/cli/commands/default/Default.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/Default.scala
@@ -22,7 +22,6 @@ class Default(
 
   private lazy val defaultCommandHelp: String =
     s"""
-       |
        |When no subcommand is passed explicitly, an implicit subcommand is used based on context:
        |  - if the '--version' option is passed, it prints the 'version' subcommand output, unmodified by any other options
        |  - if any inputs were passed, it defaults to the 'run' subcommand

--- a/modules/cli/src/main/scala/scala/cli/commands/default/LegacyScalaOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/LegacyScalaOptions.scala
@@ -35,6 +35,12 @@ case class LegacyScalaOptions(
   @Tag(tags.must)
   @ValueDescription("file")
     I: Option[Indexed[List[String]]] = None,
+  @Group("Scala")
+  @HelpMessage("Ignored legacy option. Deprecated option allowing to prevent the use of the legacy fsc compilation daemon.")
+  @Tag(tags.must)
+  @Name("-nc")
+  @Name("-nocompdaemon")
+    noCompilationDaemon: Option[Indexed[Boolean]] = None,
 ) {
 // format: on
 
@@ -48,11 +54,14 @@ case class LegacyScalaOptions(
     progName: String,
     logger: Logger
   ): Array[String] = {
-    val saveOptionString   = save.findArg(args)
-    val noSaveOptionString = nosave.findArg(args)
-    val howToRunString     = howToRun.findArg(args)
-    val iString            = I.findArg(args)
-    val deprecatedArgs     = Seq(saveOptionString, noSaveOptionString, howToRunString, iString).flatten
+    val saveOptionString          = save.findArg(args)
+    val noSaveOptionString        = nosave.findArg(args)
+    val howToRunString            = howToRun.findArg(args)
+    val iString                   = I.findArg(args)
+    val noCompilationDaemonString = noCompilationDaemon.findArg(args)
+    val deprecatedArgs =
+      Seq(saveOptionString, noSaveOptionString, howToRunString, iString, noCompilationDaemonString)
+        .flatten
     val filteredArgs       = args.filterNot(deprecatedArgs.contains)
     val filteredArgsString = filteredArgs.mkString(" ")
     saveOptionString.foreach { s =>
@@ -97,7 +106,7 @@ case class LegacyScalaOptions(
       )
     }
     for {
-      optionName <- iString
+      optionName   <- iString
       optionValues <- I.map(_.value)
       exampleReplInputs = optionValues.mkString(" ")
     } {
@@ -105,7 +114,12 @@ case class LegacyScalaOptions(
       logger.message(
         s"""To preload the extra files for the repl, try passing them as inputs for the repl sub-command.
            |  ${Console.BOLD}$progName repl $exampleReplInputs${Console.RESET}
-           |""".stripMargin)
+           |""".stripMargin
+      )
+    }
+    noCompilationDaemonString.foreach { nc =>
+      logger.message(s"Deprecated option '$nc' is ignored.")
+      logger.message("The script runner can no longer be picked as before.")
     }
     filteredArgs
   }

--- a/modules/cli/src/main/scala/scala/cli/commands/default/LegacyScalaOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/LegacyScalaOptions.scala
@@ -14,30 +14,35 @@ import scala.cli.commands.tags
   */
 // format: off
 case class LegacyScalaOptions(
-  @Group("Scala")
+  @Group("Legacy Scala runner")
   @HelpMessage(s"Ignored legacy option. Deprecated equivalent of running a subsequent `$PowerString${Package.name}` command.")
   @Tag(tags.must)
+  @Hidden
   @Name("-save")
     save: Option[Indexed[Boolean]] = None,
-  @Group("Scala")
+  @Group("Legacy Scala runner")
   @HelpMessage("Ignored legacy option. Deprecated override canceling the `-nosave` option.")
   @Tag(tags.must)
+  @Hidden
   @Name("-nosave")
     nosave: Option[Indexed[Boolean]] = None,
-  @Group("Scala")
+  @Group("Legacy Scala runner")
   @HelpMessage("Ignored legacy option. Deprecated override defining how the runner should treat the input. Use the appropriate sub-command instead.")
   @Tag(tags.must)
+  @Hidden
   @ValueDescription("object|script|jar|repl|guess")
   @Name("-howtorun")
     howToRun: Option[Indexed[String]] = None,
-  @Group("Scala")
+  @Group("Legacy Scala runner")
   @HelpMessage("Ignored legacy option. Deprecated option allowing to preload inputs for the repl or command execution.")
   @Tag(tags.must)
+  @Hidden
   @ValueDescription("file")
     I: Option[Indexed[List[String]]] = None,
-  @Group("Scala")
+  @Group("Legacy Scala runner")
   @HelpMessage("Ignored legacy option. Deprecated option allowing to prevent the use of the legacy fsc compilation daemon.")
   @Tag(tags.must)
+  @Hidden
   @Name("-nc")
   @Name("-nocompdaemon")
     noCompilationDaemon: Option[Indexed[Boolean]] = None,

--- a/modules/cli/src/main/scala/scala/cli/commands/default/LegacyScalaOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/LegacyScalaOptions.scala
@@ -5,6 +5,7 @@ import caseapp.core.Indexed
 
 import scala.build.Logger
 import scala.cli.ScalaCli
+import scala.cli.ScalaCli.fullRunnerName
 import scala.cli.commands.default.LegacyScalaOptions.*
 import scala.cli.commands.package0.Package
 import scala.cli.commands.tags
@@ -23,6 +24,12 @@ case class LegacyScalaOptions(
   @Tag(tags.must)
   @Name("-nosave")
     nosave: Option[Indexed[Boolean]] = None,
+  @Group("Scala")
+  @HelpMessage("Ignored legacy option. Deprecated override defining how the runner should treat the input. Use the appropriate sub-command instead.")
+  @Tag(tags.must)
+  @ValueDescription("object|script|jar|repl|guess")
+  @Name("-howtorun")
+    howToRun: Option[Indexed[String]] = None,
 ) {
 // format: on
 
@@ -38,7 +45,8 @@ case class LegacyScalaOptions(
   ): Array[String] = {
     val saveOptionString   = save.findArg(args)
     val noSaveOptionString = nosave.findArg(args)
-    val deprecatedArgs     = Seq(saveOptionString, noSaveOptionString).flatten
+    val howToRunString     = howToRun.findArg(args)
+    val deprecatedArgs     = Seq(saveOptionString, noSaveOptionString, howToRunString).flatten
     val filteredArgs       = args.filterNot(deprecatedArgs.contains)
     val filteredArgsString = filteredArgs.mkString(" ")
     saveOptionString.foreach { s =>
@@ -53,6 +61,33 @@ case class LegacyScalaOptions(
       logger.message(
         s"""Deprecated option '$ns' is ignored.
            |A jar file is not saved unless the '$PowerString${Package.name}' sub-command is called.""".stripMargin
+      )
+    }
+    for {
+      htrString <- howToRunString
+      htrValue  <- howToRun.map(_.value)
+    } {
+      logger.message(s"Deprecated option '$htrString' is ignored.".stripMargin)
+      val passedValueExplanation = htrValue match {
+        case v @ ("object" | "script" | "jar") =>
+          s"""$fullRunnerName does not support explicitly forcing an input to be run as '$v'.
+             |Just make sure your inputs have the correct format and extension.""".stripMargin
+        case "guess" =>
+          s"""$fullRunnerName does not support `guess` mode.
+             |Just make sure your inputs have the correct format and extension.""".stripMargin
+        case "repl" =>
+          s"""In order to explicitly run the repl, use the 'repl' sub-command.
+             |  ${Console.BOLD}$progName repl $filteredArgsString${Console.RESET}
+             |""".stripMargin
+        case invalid @ _ =>
+          s"""'$invalid' is not an accepted value for the '$htrString' option.
+             |$fullRunnerName uses an equivalent of the old 'guess' mode by default at all times.""".stripMargin
+      }
+      logger.message(passedValueExplanation)
+      logger.message(
+        s"""Instead of the deprecated '$htrString' option, $fullRunnerName now uses a sub-command system.
+           |To learn more, try viewing the help.
+           |  ${Console.BOLD}$progName -help${Console.RESET}""".stripMargin
       )
     }
     filteredArgs

--- a/modules/cli/src/main/scala/scala/cli/commands/default/LegacyScalaOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/LegacyScalaOptions.scala
@@ -30,6 +30,11 @@ case class LegacyScalaOptions(
   @ValueDescription("object|script|jar|repl|guess")
   @Name("-howtorun")
     howToRun: Option[Indexed[String]] = None,
+  @Group("Scala")
+  @HelpMessage("Ignored legacy option. Deprecated option allowing to preload inputs for the repl or command execution.")
+  @Tag(tags.must)
+  @ValueDescription("file")
+    I: Option[Indexed[List[String]]] = None,
 ) {
 // format: on
 
@@ -46,7 +51,8 @@ case class LegacyScalaOptions(
     val saveOptionString   = save.findArg(args)
     val noSaveOptionString = nosave.findArg(args)
     val howToRunString     = howToRun.findArg(args)
-    val deprecatedArgs     = Seq(saveOptionString, noSaveOptionString, howToRunString).flatten
+    val iString            = I.findArg(args)
+    val deprecatedArgs     = Seq(saveOptionString, noSaveOptionString, howToRunString, iString).flatten
     val filteredArgs       = args.filterNot(deprecatedArgs.contains)
     val filteredArgsString = filteredArgs.mkString(" ")
     saveOptionString.foreach { s =>
@@ -89,6 +95,17 @@ case class LegacyScalaOptions(
            |To learn more, try viewing the help.
            |  ${Console.BOLD}$progName -help${Console.RESET}""".stripMargin
       )
+    }
+    for {
+      optionName <- iString
+      optionValues <- I.map(_.value)
+      exampleReplInputs = optionValues.mkString(" ")
+    } {
+      logger.message(s"Deprecated option '$optionName' is ignored.".stripMargin)
+      logger.message(
+        s"""To preload the extra files for the repl, try passing them as inputs for the repl sub-command.
+           |  ${Console.BOLD}$progName repl $exampleReplInputs${Console.RESET}
+           |""".stripMargin)
     }
     filteredArgs
   }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/VerbosityOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/VerbosityOptions.scala
@@ -13,6 +13,7 @@ final case class VerbosityOptions(
   @HelpMessage("Increase verbosity (can be specified multiple times)")
   @Tag(tags.implementation)
   @Name("v")
+  @Name("-verbose")
     verbose: Int @@ Counter = Tag.of(0),
   @Group("Logging")
   @HelpMessage("Interactive mode")

--- a/modules/integration/src/test/scala/scala/cli/integration/DefaultTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DefaultTests.scala
@@ -2,7 +2,7 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-class DefaultTests extends WithWarmUpScalaCliSuite {
+class DefaultTests extends WithWarmUpScalaCliSuite with LegacyScalaRunnerTestDefinitions {
   override def warmUpExtraTestOptions: Seq[String] = TestUtil.extraOptions
 
   test("running scala-cli with no args should default to repl") {
@@ -33,17 +33,6 @@ class DefaultTests extends WithWarmUpScalaCliSuite {
       )
       expect(res.exitCode == 1)
       expect(res.out.lines().endsWith(unrecognizedArgMessage(replSpecificOption)))
-    }
-  }
-
-  test("default to the run sub-command when a script snippet is passed with -e") {
-    TestInputs.empty.fromRoot { root =>
-      val msg       = "Hello world"
-      val quotation = TestUtil.argQuotationMark
-      val res =
-        os.proc(TestUtil.cli, "-e", s"println($quotation$msg$quotation)", TestUtil.extraOptions)
-          .call(cwd = root)
-      expect(res.out.trim() == msg)
     }
   }
 
@@ -96,23 +85,6 @@ class DefaultTests extends WithWarmUpScalaCliSuite {
         )
           .call(cwd = root)
       expect(res.out.trim() == msg)
-    }
-  }
-
-  test("running scala-cli with a script snippet passed with -e shouldn't allow repl-only options") {
-    TestInputs.empty.fromRoot { root =>
-      val replSpecificOption = "--repl-dry-run"
-      val res =
-        os.proc(
-          TestUtil.cli,
-          "-e",
-          "println()",
-          replSpecificOption,
-          TestUtil.extraOptions
-        )
-          .call(cwd = root, mergeErrIntoOut = true, check = false)
-      expect(res.exitCode == 1)
-      expect(res.out.lines().endsWith(unrecognizedArgMessage(replSpecificOption)))
     }
   }
 
@@ -183,65 +155,7 @@ class DefaultTests extends WithWarmUpScalaCliSuite {
     }
   }
 
-  test("ensure -save/--save works with the default command") {
-    val msg = "Hello world"
-    TestInputs(os.rel / "s.sc" -> s"""println("$msg")""").fromRoot { root =>
-      val legacySaveOption = "-save"
-      val res1 =
-        os.proc(TestUtil.cli, ".", legacySaveOption, TestUtil.extraOptions)
-          .call(cwd = root, stderr = os.Pipe)
-      expect(res1.out.trim() == msg)
-      expect(res1.err.trim().contains(s"Deprecated option '$legacySaveOption' is ignored"))
-      val doubleDashSaveOption = "--save"
-      val res2 =
-        os.proc(TestUtil.cli, ".", doubleDashSaveOption, TestUtil.extraOptions)
-          .call(cwd = root, stderr = os.Pipe)
-      expect(res2.out.trim() == msg)
-      expect(res2.err.trim().contains(s"Deprecated option '$doubleDashSaveOption' is ignored"))
-    }
-  }
-
-  test("ensure -nosave/--nosave works with the default command") {
-    val msg = "Hello world"
-    TestInputs(os.rel / "s.sc" -> s"""println("$msg")""").fromRoot { root =>
-      val legacyNoSaveOption = "-nosave"
-      val res1 =
-        os.proc(TestUtil.cli, ".", legacyNoSaveOption, TestUtil.extraOptions)
-          .call(cwd = root, stderr = os.Pipe)
-      expect(res1.out.trim() == msg)
-      expect(res1.err.trim().contains(s"Deprecated option '$legacyNoSaveOption' is ignored"))
-      val doubleDashNoSaveOption = "--nosave"
-      val res2 =
-        os.proc(TestUtil.cli, ".", doubleDashNoSaveOption, TestUtil.extraOptions)
-          .call(cwd = root, stderr = os.Pipe)
-      expect(res2.out.trim() == msg)
-      expect(res2.err.trim().contains(s"Deprecated option '$doubleDashNoSaveOption' is ignored"))
-    }
-  }
-
-  test("ensure -howtorun/--how-to-run works with the default command") {
-    val msg = "Hello world"
-    TestInputs(os.rel / "s.sc" -> s"""println("$msg")""").fromRoot { root =>
-      Seq("object", "script", "jar", "repl", "guess", "invalid").foreach { htrValue =>
-        val legacyHtrOption = "-howtorun"
-        val res1 =
-          os.proc(TestUtil.cli, ".", legacyHtrOption, htrValue, TestUtil.extraOptions)
-            .call(cwd = root, stderr = os.Pipe)
-        expect(res1.out.trim() == msg)
-        expect(res1.err.trim().contains(s"Deprecated option '$legacyHtrOption' is ignored"))
-        expect(res1.err.trim().contains(htrValue))
-        val doubleDashHtrOption = "--how-to-run"
-        val res2 =
-          os.proc(TestUtil.cli, ".", doubleDashHtrOption, htrValue, TestUtil.extraOptions)
-            .call(cwd = root, stderr = os.Pipe)
-        expect(res2.out.trim() == msg)
-        expect(res2.err.trim().contains(s"Deprecated option '$doubleDashHtrOption' is ignored"))
-        expect(res2.err.trim().contains(htrValue))
-      }
-    }
-  }
-
-  private def unrecognizedArgMessage(argName: String) =
+  protected def unrecognizedArgMessage(argName: String): Vector[String] =
     s"""
        |Unrecognized argument: $argName
        |
@@ -249,5 +163,5 @@ class DefaultTests extends WithWarmUpScalaCliSuite {
        |  ${Console.BOLD}${TestUtil.detectCliPath} --help${Console.RESET}
        |""".stripMargin.trim.linesIterator.toVector
 
-  private lazy val replDryRunOutput = "Dry run, not running REPL."
+  protected lazy val replDryRunOutput = "Dry run, not running REPL."
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/DefaultTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DefaultTests.scala
@@ -219,6 +219,28 @@ class DefaultTests extends WithWarmUpScalaCliSuite {
     }
   }
 
+  test("ensure -howtorun/--how-to-run works with the default command") {
+    val msg = "Hello world"
+    TestInputs(os.rel / "s.sc" -> s"""println("$msg")""").fromRoot { root =>
+      Seq("object", "script", "jar", "repl", "guess", "invalid").foreach { htrValue =>
+        val legacyHtrOption = "-howtorun"
+        val res1 =
+          os.proc(TestUtil.cli, ".", legacyHtrOption, htrValue, TestUtil.extraOptions)
+            .call(cwd = root, stderr = os.Pipe)
+        expect(res1.out.trim() == msg)
+        expect(res1.err.trim().contains(s"Deprecated option '$legacyHtrOption' is ignored"))
+        expect(res1.err.trim().contains(htrValue))
+        val doubleDashHtrOption = "--how-to-run"
+        val res2 =
+          os.proc(TestUtil.cli, ".", doubleDashHtrOption, htrValue, TestUtil.extraOptions)
+            .call(cwd = root, stderr = os.Pipe)
+        expect(res2.out.trim() == msg)
+        expect(res2.err.trim().contains(s"Deprecated option '$doubleDashHtrOption' is ignored"))
+        expect(res2.err.trim().contains(htrValue))
+      }
+    }
+  }
+
   private def unrecognizedArgMessage(argName: String) =
     s"""
        |Unrecognized argument: $argName

--- a/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
@@ -25,11 +25,46 @@ class HelpTests extends ScalaCliSuite {
     test(s"$helpOptionsString output includes launcher options") {
       expect(helpOutput.contains("--power"))
     }
+
+    test(s"$helpOptionsString output does not include legacy scala runner options") {
+      expect(!helpOutput.contains("Legacy Scala runner options"))
+    }
   }
 
+  for (fullHelpOptions <- HelpTests.fullHelpVariants) {
+    lazy val fullHelp         = os.proc(TestUtil.cli, fullHelpOptions).call(check = false)
+    lazy val fullHelpOutput   = fullHelp.out.trim()
+    val fullHelpOptionsString = fullHelpOptions.mkString(" ")
+    test(s"$fullHelpOptionsString works correctly") {
+      assert(
+        fullHelp.exitCode == 0,
+        clues(fullHelpOptions, fullHelp.out.text(), fullHelp.err.text(), fullHelp.exitCode)
+      )
+      expect(fullHelpOutput.contains("Usage:"))
+    }
+    test(s"$fullHelpOptionsString output includes legacy scala runner options") {
+      expect(fullHelpOutput.contains("Legacy Scala runner options"))
+    }
+  }
 }
 
 object HelpTests {
   val variants =
-    Seq(Seq("help"), Seq("help", "-help"), Seq("help", "--help"), Seq("-help"), Seq("--help"))
+    Seq(
+      Seq("help"),
+      Seq("help", "-help"),
+      Seq("help", "--help"),
+      Seq("-help"),
+      Seq("--help")
+    )
+  val fullHelpVariants =
+    Seq(
+      Seq("help", "--full-help"),
+      Seq("help", "-full-help"),
+      Seq("help", "--help-full"),
+      Seq("help", "-help-full"),
+      Seq("--full-help"),
+      Seq("-full-help"),
+      Seq("-help-full")
+    )
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/LegacyScalaRunnerTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/LegacyScalaRunnerTestDefinitions.scala
@@ -1,0 +1,90 @@
+package scala.cli.integration
+
+import com.eed3si9n.expecty.Expecty.expect
+trait LegacyScalaRunnerTestDefinitions { _: DefaultTests =>
+  test("default to the run sub-command when a script snippet is passed with -e") {
+    TestInputs.empty.fromRoot { root =>
+      val msg       = "Hello world"
+      val quotation = TestUtil.argQuotationMark
+      val res =
+        os.proc(TestUtil.cli, "-e", s"println($quotation$msg$quotation)", TestUtil.extraOptions)
+          .call(cwd = root)
+      expect(res.out.trim() == msg)
+    }
+  }
+
+  test("running scala-cli with a script snippet passed with -e shouldn't allow repl-only options") {
+    TestInputs.empty.fromRoot { root =>
+      val replSpecificOption = "--repl-dry-run"
+      val res =
+        os.proc(
+          TestUtil.cli,
+          "-e",
+          "println()",
+          replSpecificOption,
+          TestUtil.extraOptions
+        )
+          .call(cwd = root, mergeErrIntoOut = true, check = false)
+      expect(res.exitCode == 1)
+      expect(res.out.lines().endsWith(unrecognizedArgMessage(replSpecificOption)))
+    }
+  }
+
+  test("ensure -save/--save works with the default command") {
+    val msg = "Hello world"
+    TestInputs(os.rel / "s.sc" -> s"""println("$msg")""").fromRoot { root =>
+      val legacySaveOption = "-save"
+      val res1 =
+        os.proc(TestUtil.cli, ".", legacySaveOption, TestUtil.extraOptions)
+          .call(cwd = root, stderr = os.Pipe)
+      expect(res1.out.trim() == msg)
+      expect(res1.err.trim().contains(s"Deprecated option '$legacySaveOption' is ignored"))
+      val doubleDashSaveOption = "--save"
+      val res2 =
+        os.proc(TestUtil.cli, ".", doubleDashSaveOption, TestUtil.extraOptions)
+          .call(cwd = root, stderr = os.Pipe)
+      expect(res2.out.trim() == msg)
+      expect(res2.err.trim().contains(s"Deprecated option '$doubleDashSaveOption' is ignored"))
+    }
+  }
+
+  test("ensure -nosave/--nosave works with the default command") {
+    val msg = "Hello world"
+    TestInputs(os.rel / "s.sc" -> s"""println("$msg")""").fromRoot { root =>
+      val legacyNoSaveOption = "-nosave"
+      val res1 =
+        os.proc(TestUtil.cli, ".", legacyNoSaveOption, TestUtil.extraOptions)
+          .call(cwd = root, stderr = os.Pipe)
+      expect(res1.out.trim() == msg)
+      expect(res1.err.trim().contains(s"Deprecated option '$legacyNoSaveOption' is ignored"))
+      val doubleDashNoSaveOption = "--nosave"
+      val res2 =
+        os.proc(TestUtil.cli, ".", doubleDashNoSaveOption, TestUtil.extraOptions)
+          .call(cwd = root, stderr = os.Pipe)
+      expect(res2.out.trim() == msg)
+      expect(res2.err.trim().contains(s"Deprecated option '$doubleDashNoSaveOption' is ignored"))
+    }
+  }
+
+  test("ensure -howtorun/--how-to-run works with the default command") {
+    val msg = "Hello world"
+    TestInputs(os.rel / "s.sc" -> s"""println("$msg")""").fromRoot { root =>
+      Seq("object", "script", "jar", "repl", "guess", "invalid").foreach { htrValue =>
+        val legacyHtrOption = "-howtorun"
+        val res1 =
+          os.proc(TestUtil.cli, ".", legacyHtrOption, htrValue, TestUtil.extraOptions)
+            .call(cwd = root, stderr = os.Pipe)
+        expect(res1.out.trim() == msg)
+        expect(res1.err.trim().contains(s"Deprecated option '$legacyHtrOption' is ignored"))
+        expect(res1.err.trim().contains(htrValue))
+        val doubleDashHtrOption = "--how-to-run"
+        val res2 =
+          os.proc(TestUtil.cli, ".", doubleDashHtrOption, htrValue, TestUtil.extraOptions)
+            .call(cwd = root, stderr = os.Pipe)
+        expect(res2.out.trim() == msg)
+        expect(res2.err.trim().contains(s"Deprecated option '$doubleDashHtrOption' is ignored"))
+        expect(res2.err.trim().contains(htrValue))
+      }
+    }
+  }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/LegacyScalaRunnerTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/LegacyScalaRunnerTestDefinitions.scala
@@ -98,4 +98,25 @@ trait LegacyScalaRunnerTestDefinitions { _: DefaultTests =>
       expect(res.err.trim().contains(s"Deprecated option '$legacyIOption' is ignored"))
     }
   }
+
+  test("ensure -nc/-nocompdaemon/--no-compilation-daemon works with the default command") {
+    val msg = "Hello world"
+    TestInputs(os.rel / "s.sc" -> s"""println("$msg")""").fromRoot { root =>
+      val legacyOption = "-nc"
+      val res =
+        os.proc(TestUtil.cli, legacyOption, "s.sc", TestUtil.extraOptions)
+          .call(cwd = root, stderr = os.Pipe)
+      expect(res.err.trim().contains(s"Deprecated option '$legacyOption' is ignored"))
+      val legacyOption2 = "-nocompdaemon"
+      val res2 =
+        os.proc(TestUtil.cli, legacyOption2, "s.sc", TestUtil.extraOptions)
+          .call(cwd = root, stderr = os.Pipe)
+      expect(res2.err.trim().contains(s"Deprecated option '$legacyOption2' is ignored"))
+      val legacyOption3 = "--no-compilation-daemon"
+      val res3 =
+        os.proc(TestUtil.cli, legacyOption3, "s.sc", TestUtil.extraOptions)
+          .call(cwd = root, stderr = os.Pipe)
+      expect(res3.err.trim().contains(s"Deprecated option '$legacyOption3' is ignored"))
+    }
+  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/LegacyScalaRunnerTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/LegacyScalaRunnerTestDefinitions.scala
@@ -87,4 +87,15 @@ trait LegacyScalaRunnerTestDefinitions { _: DefaultTests =>
       }
     }
   }
+
+  test("ensure -I works with the default command") {
+    val msg = "Hello world"
+    TestInputs(os.rel / "s.sc" -> s"""println("$msg")""").fromRoot { root =>
+      val legacyIOption = "-I"
+      val res =
+        os.proc(TestUtil.cli, legacyIOption, "s.sc", "--repl-dry-run", TestUtil.extraOptions)
+          .call(cwd = root, stderr = os.Pipe)
+      expect(res.err.trim().contains(s"Deprecated option '$legacyIOption' is ignored"))
+    }
+  }
 }

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1570,7 +1570,7 @@ Available in commands:
 
 ### `--verbose`
 
-Aliases: `-v`
+Aliases: `-v`, `-verbose`
 
 Increase verbosity (can be specified multiple times)
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -1158,7 +1158,7 @@ Available in commands:
 
 ### `--verbose`
 
-Aliases: `-v`
+Aliases: `-v`, `-verbose`
 
 `IMPLEMENTATION specific` per Scala Runner specification
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -276,7 +276,7 @@ Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 
@@ -783,7 +783,7 @@ Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 
@@ -1292,7 +1292,7 @@ Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 
@@ -1831,7 +1831,7 @@ Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 
@@ -2392,7 +2392,7 @@ Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 
@@ -2903,7 +2903,7 @@ Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 
@@ -3480,7 +3480,7 @@ Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 
@@ -3789,7 +3789,7 @@ Aliases: `-h` ,`-help`
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 
@@ -4054,7 +4054,7 @@ Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 
@@ -4361,7 +4361,7 @@ Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 
@@ -4440,7 +4440,7 @@ Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 
@@ -4499,7 +4499,7 @@ Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 
@@ -4590,7 +4590,7 @@ Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 
@@ -4855,7 +4855,7 @@ Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 
@@ -5174,7 +5174,7 @@ Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 
@@ -5353,7 +5353,7 @@ Custom completions name
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 
@@ -5410,7 +5410,7 @@ Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 Increase verbosity (can be specified multiple times)
 
-Aliases: `-v`
+Aliases: `-verbose` ,`-v`
 
 **--interactive**
 


### PR DESCRIPTION
Context: #1721 

Added the following deprecated options from the Scala 2 runner, along with appropriate warnings:
- `-howtorun`
- `-I`
- `-nc`

All of them are ignored, with deprecation warnings explaining how Scala CLI does things.

I deliberately skipped over `-i`, which will stay as an abbrevation for Scala CLI's `--interactive` mode. It will be documented in #1749.

Did some relevant fixes as well, like adding the missing `-verbose` alias for `-v`.
The legacy `scala` runner options will now also be included in the `--full-help` (they're all `@Hidden`, so not in regular `-help`).

```
Legacy Scala runner options:
  -save, --save                                  (hidden) Ignored legacy option. Deprecated equivalent of running a subsequent `package` command.
  -nosave, --nosave                              (hidden) Ignored legacy option. Deprecated override canceling the `-nosave` option.
  -howtorun, --how-to-run object|script|jar|repl|guess  (hidden) Ignored legacy option. Deprecated override defining how the runner should treat the input. Use the appropriate sub-command instead.
  -I file                                        (hidden) Ignored legacy option. Deprecated option allowing to preload inputs for the repl or command execution.
  -nc, -nocompdaemon, --no-compilation-daemon    (hidden) Ignored legacy option. Deprecated option allowing to prevent the use of the legacy fsc compilation daemon.
```