### PR TITLE
Fix reading passwords from commands

### DIFF
--- a/modules/config/src/main/scala/scala/cli/config/PasswordOption.scala
+++ b/modules/config/src/main/scala/scala/cli/config/PasswordOption.scala
@@ -3,6 +3,7 @@ package scala.cli.config
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.github.plokhotnyuk.jsoniter_scala.macros._
 
+import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
 
@@ -74,9 +75,39 @@ object PasswordOption extends LowPriorityPasswordOption {
     def get(): Secret[String] = {
       // should we add a timeout?
 
-      import sys.process._
-      val res = command.!!<
-      Secret(res.trim)
+      // Better use ProcessBuilder than sys.process here, as the latter
+      // adds superfluous new line characters when reading the command output.
+      // That way, we know we are reading the actual output of the command, and we
+      // don't have to speculatively trim the result (which would work if the new
+      // line is added by sys.process, but wouldn't if the new line is legit and is in
+      // the original output).
+
+      val b = new ProcessBuilder(command: _*)
+      b.redirectInput(ProcessBuilder.Redirect.INHERIT)
+      b.redirectError(ProcessBuilder.Redirect.INHERIT)
+      b.redirectOutput(ProcessBuilder.Redirect.PIPE)
+
+      val p = b.start()
+
+      val is   = p.getInputStream()
+      var read = -1
+      val buf  = Array.ofDim[Byte](2048)
+      val baos = new ByteArrayOutputStream
+      while ({
+        read = is.read(buf)
+        read >= 0
+      })
+        if (read > 0)
+          baos.write(buf, 0, read)
+
+      val exitCode = p.waitFor()
+      if (exitCode != 0)
+        throw new RuntimeException(
+          s"Error running command ${command.mkString(" ")} (exit code: $exitCode)"
+        )
+
+      val res = new String(baos.toByteArray()) // Using default codec here
+      Secret(res)
     }
     def asString: Secret[String] = {
       val json = writeToString(command.toList)(commandCodec)


### PR DESCRIPTION
It seems using `sys.process` adds superfluous new line characters when reading the command output. Better use `ProcessBuilder` / `Process` directly.