### PR TITLE
Add a warning for the `-run` option of the legacy `scala` runner, instead of failing

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/default/LegacyScalaOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/LegacyScalaOptions.scala
@@ -46,6 +46,13 @@ case class LegacyScalaOptions(
   @Name("-nc")
   @Name("-nocompdaemon")
     noCompilationDaemon: Option[Indexed[Boolean]] = None,
+  @Group("Legacy Scala runner")
+  @HelpMessage("Ignored legacy option. Deprecated option allowing to force the `run` mode on an input.")
+  @Tag(tags.must)
+  @Hidden
+  @ValueDescription("file")
+  @Name("-run")
+    run: Option[Indexed[String]] = None,
 ) {
 // format: on
 
@@ -64,8 +71,16 @@ case class LegacyScalaOptions(
     val howToRunString            = howToRun.findArg(args)
     val iString                   = I.findArg(args)
     val noCompilationDaemonString = noCompilationDaemon.findArg(args)
+    val runString                 = run.findArg(args)
     val deprecatedArgs =
-      Seq(saveOptionString, noSaveOptionString, howToRunString, iString, noCompilationDaemonString)
+      Seq(
+        saveOptionString,
+        noSaveOptionString,
+        howToRunString,
+        iString,
+        noCompilationDaemonString,
+        runString
+      )
         .flatten
     val filteredArgs       = args.filterNot(deprecatedArgs.contains)
     val filteredArgsString = filteredArgs.mkString(" ")
@@ -125,6 +140,20 @@ case class LegacyScalaOptions(
     noCompilationDaemonString.foreach { nc =>
       logger.message(s"Deprecated option '$nc' is ignored.")
       logger.message("The script runner can no longer be picked as before.")
+    }
+    for {
+      rString <- runString
+      rValue  <- run.map(_.value)
+    } {
+      logger.message(s"Deprecated option '$rString' is ignored.")
+      logger.message(
+        s"""$fullRunnerName does not support explicitly forcing the old `run` mode.
+           |Just pass $rValue as input and make sure it has the correct format and extension.
+           |i.e. to run a JAR, pass it as an input, just make sure it has the `.jar` extension and a main class.
+           |For details on how inputs can be run with $fullRunnerName, check the `run` sub-command.
+           |  ${Console.BOLD}$progName run --help${Console.RESET}
+           |""".stripMargin
+      )
     }
     filteredArgs
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/LegacyScalaRunnerTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/LegacyScalaRunnerTestDefinitions.scala
@@ -63,6 +63,17 @@ trait LegacyScalaRunnerTestDefinitions { _: DefaultTests =>
     simpleLegacyOptionBackwardsCompatTest("-nc", "-nocompdaemon", "--no-compilation-daemon")
   }
 
+  test("ensure -run works with the default command") {
+    legacyOptionBackwardsCompatTest("-run") {
+      (legacyOption, root) =>
+        val legacyOptionParam = "s.sc"
+        val res = os.proc(TestUtil.cli, legacyOption, legacyOptionParam, ".", TestUtil.extraOptions)
+          .call(cwd = root, stderr = os.Pipe)
+        expect(res.err.trim().contains(deprecatedOptionWarning(legacyOption)))
+        expect(res.err.trim().contains(legacyOptionParam))
+    }
+  }
+
   private def simpleLegacyOptionBackwardsCompatTest(optionAliases: String*): Unit =
     abstractLegacyOptionBackwardsCompatTest(optionAliases) {
       (legacyOption, expectedMsg, root) =>


### PR DESCRIPTION
context: #1721 