### PR TITLE
Add warnings for the deprecated `-Yscriptrunner` legacy `scala` runner option instead of passing it to `scalac`

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
@@ -35,12 +35,13 @@ object ScalacOptions {
     origin = Some("ScalacOptions")
   )
   // .withIsFlag(true) // The scalac options we handle accept no value after the -… argument
+  val YScriptRunnerOption = "-Yscriptrunner"
   private val scalacOptionsPurePrefixes =
     Set("-V", "-W", "-X", "-Y")
   private val scalacOptionsPrefixes =
     Set("-g", "-language", "-opt", "-P", "-target", "-source") ++ scalacOptionsPurePrefixes
   private val scalacAliasedOptions = // these options don't require being passed after -O and accept an arg
-    Set("-encoding", "-release", "-color")
+    Set("-encoding", "-release", "-color", YScriptRunnerOption)
   private val scalacNoArgAliasedOptions = // these options don't require being passed after -O and don't accept an arg
     Set(
       "-nowarn",
@@ -64,6 +65,9 @@ object ScalacOptions {
     "-classpath", // redirected to --extra-jars
     "-d"          // redirected to --compilation-output
   )
+  val ScalacDeprecatedOptions: Set[String] = Set(
+    YScriptRunnerOption // old 'scala' runner specific, no longer supported
+  )
 
   private val scalacOptionsArgument: Argument[List[String]] =
     new Argument[List[String]] {
@@ -81,7 +85,9 @@ object ScalacOptions {
         formatter: Formatter[Name]
       ): Either[(Error, List[String]), Option[(Option[List[String]], List[String])]] =
         args match {
-          case h :: t if scalacOptionsPrefixes.exists(h.startsWith) =>
+          case h :: t
+              if scalacOptionsPrefixes.exists(h.startsWith) &&
+              !ScalacDeprecatedOptions.contains(h) =>
             Right(Some((Some(h :: acc.getOrElse(Nil)), t)))
           case h :: t if scalacNoArgAliasedOptions.contains(h) =>
             Right(Some((Some(h :: acc.getOrElse(Nil)), t)))

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -300,6 +300,7 @@ final case class SharedOptions(
           .withScalacExtraOptions(scalacExtra)
           .toScalacOptShadowingSeq
           .filterNonRedirected
+          .filterNonDeprecated
           .map(Positioned.commandLine),
         compilerPlugins =
           SharedOptions.parseDependencies(

--- a/modules/cli/src/main/scala/scala/cli/commands/util/ScalacOptionsUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/ScalacOptionsUtil.scala
@@ -1,6 +1,10 @@
 package scala.cli.commands.util
 
+import scala.build.Logger
 import scala.build.options.{ScalacOpt, ShadowingSeq}
+import scala.cli.commands.bloop.BloopExit
+import scala.cli.commands.default.LegacyScalaOptions
+import scala.cli.commands.shared.ScalacOptions.YScriptRunnerOption
 import scala.cli.commands.shared.{ScalacExtraOptions, ScalacOptions}
 
 object ScalacOptionsUtil {
@@ -31,6 +35,8 @@ object ScalacOptionsUtil {
       opts.filterKeys(_.key.exists(f))
     def filterNonRedirected: ShadowingSeq[ScalacOpt] =
       opts.filterScalacOptionKeys(!ScalacOptions.ScalaCliRedirectedOptions.contains(_))
+    def filterNonDeprecated: ShadowingSeq[ScalacOpt] =
+      opts.filterScalacOptionKeys(!ScalacOptions.ScalacDeprecatedOptions.contains(_))
     def getOption(key: String): Option[String] =
       opts.get(ScalacOpt(key)).headOption.map(_.value)
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/LegacyScalaRunnerTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/LegacyScalaRunnerTestDefinitions.scala
@@ -85,6 +85,26 @@ trait LegacyScalaRunnerTestDefinitions { _: DefaultTests =>
     }
   }
 
+  test("ensure -Yscriptrunner works with the default command") {
+    legacyOptionBackwardsCompatTest("-Yscriptrunner") {
+      (legacyOption, inputFile, root) =>
+        Seq("default", "resident", "shutdown", "scala.tools.nsc.fsc.ResidentScriptRunner").foreach {
+          legacyOptionValue =>
+            val res =
+              os.proc(
+                TestUtil.cli,
+                legacyOption,
+                legacyOptionValue,
+                inputFile,
+                TestUtil.extraOptions
+              )
+                .call(cwd = root, stderr = os.Pipe)
+            expect(res.err.trim().contains(deprecatedOptionWarning(legacyOption)))
+            expect(res.err.trim().contains(legacyOptionValue))
+        }
+    }
+  }
+
   private def simpleLegacyOptionBackwardsCompatTest(optionAliases: String*): Unit =
     abstractLegacyOptionBackwardsCompatTest(optionAliases) {
       (legacyOption, expectedMsg, _, root) =>

--- a/modules/options/src/main/scala/scala/build/options/ShadowingSeq.scala
+++ b/modules/options/src/main/scala/scala/build/options/ShadowingSeq.scala
@@ -20,6 +20,7 @@ final case class ShadowingSeq[T] private (values: Seq[Seq[T]]) {
       case Seq(head, _*) => f(head)
       case _             => true
     }
+  def keys: Seq[T] = values.map(_.head)
   def ++(other: Seq[T])(implicit key: ShadowingSeq.KeyOf[T]): ShadowingSeq[T] =
     addGroups(ShadowingSeq.groups(other, key.groups(other)))
   private def addGroups(other: Seq[Seq[T]])(implicit key: ShadowingSeq.KeyOf[T]): ShadowingSeq[T] =


### PR DESCRIPTION
Fixes #1721 
Depends on #1801 (relies on some of the refactors from there)
Despite the `-Y` prefix, `-Yscriptrunner` is actually a `scala` runner option (and not a `scalac` option) and thus will be covered as part of #1721.
Up until now, Scala CLI has been assuming it's a `scalac` option and has been passing it to the compiler.
However, the compiler doesn't know what to do with it.
```
▶ scalac -Yscriptrunner resident
bad option '-Yscriptrunner' was ignored
source file not found: resident
▶ scala-cli -Yscriptrunner -O resident
bad option '-Yscriptrunner' was ignored
Ignoring spurious arguments: resident
```

With these changes, we'll be logging a reasonable warning about the option being deprecated and no longer supported in Scala CLI (it being the new `scala` runner). We'll no longer pass the option to the compiler, either.
```
▶ scala-cli . -Yscriptrunner resident 
Deprecated option '-Yscriptrunner' is ignored.
The script runner can no longer be picked as before.
scala.tools.nsc.fsc.ResidentScriptRunner (the resident script runner) is no longer available.
```