### PR TITLE
Add cross-platform toolkit dependency

### DIFF
--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Toolkit.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Toolkit.scala
@@ -41,7 +41,7 @@ final case class Toolkit(
 object Toolkit {
   def resolveDependency(toolkitVersion: Positioned[String]) = toolkitVersion.map(version =>
     val v = if version == "latest" then "latest.release" else version
-    dep"${Constants.toolkitOrganization}::${Constants.toolkitName}:$v,toolkit"
+    dep"${Constants.toolkitOrganization}::${Constants.toolkitName}::$v,toolkit"
   )
   val handler: DirectiveHandler[Toolkit] = DirectiveHandler.derive
 }


### PR DESCRIPTION
this should select the toolkit dependency that matches the current platform.