### PR TITLE
Filter out `restricted` & `experimental` options from `SIP` mode help

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
@@ -6,65 +6,14 @@ import caseapp.core.parser.Parser
 import caseapp.core.util.Formatter
 import caseapp.core.{Arg, Error}
 
-final case class RestrictedCommandsParser[T](underlying: Parser[T]) extends Parser[T] {
-
-  type D = underlying.D
-
-  private def isArgSupported(a: Arg): Boolean =
-    scala.cli.ScalaCli.allowRestrictedFeatures ||
-    !RestrictedCommandsParser.isExperimentalOrRestricted(a)
-
-  def args: Seq[Arg] = underlying.args.filter(isArgSupported)
-
-  def get(
-    d: D,
-    nameFormatter: Formatter[Name]
-  ): Either[Error, T] =
-    underlying.get(d, nameFormatter)
-
-  def init: D = underlying.init
-
-  def withDefaultOrigin(origin: String): Parser[T] =
-    copy(underlying = underlying.withDefaultOrigin(origin))
-
-  override def step(
-    args: List[String],
-    index: Int,
-    d: D,
-    nameFormatter: Formatter[Name]
-  ): Either[(Error, Arg, List[String]), Option[(D, Arg, List[String])]] =
-    underlying.step(args, index, d, nameFormatter) match {
-      case Right(Some(_, arg, _)) if !isArgSupported(arg) =>
-        Left((
-          Error.UnrecognizedArgument(
-            s"`${args(index)}` option is not supported in `scala` command.\n  Please run it with `scala-cli` command or with `--power` flag."
-          ),
-          arg,
-          Nil
-        ))
-      case other =>
-        other
-    }
-}
+import scala.cli.util.ArgHelpers.*
 
 object RestrictedCommandsParser {
-  def isExperimentalOrRestricted(a: Arg) =
-    a.tags.exists(_.name == tags.restricted) || a.tags.exists(_.name == tags.experimental)
-
-  def level(a: Arg): SpecificationLevel = a.tags.flatMap(t =>
-    tags.levelFor(t.name)
-  ).headOption.getOrElse { // TODO why do I need to add it here/
-    SpecificationLevel.IMPLEMENTATION
-  }
-
   def apply[T](parser: Parser[T]): Parser[T] = new Parser[T] {
 
     type D = parser.D
 
-    private def isArgSupported(a: Arg): Boolean =
-      scala.cli.ScalaCli.allowRestrictedFeatures || !isExperimentalOrRestricted(a)
-
-    def args: Seq[caseapp.core.Arg] = parser.args.filter(isArgSupported)
+    def args: Seq[caseapp.core.Arg] = parser.args.filter(_.isSupported)
 
     def get(
       d: D,
@@ -84,7 +33,7 @@ object RestrictedCommandsParser {
       nameFormatter: Formatter[Name]
     ): Either[(Error, Arg, List[String]), Option[(D, Arg, List[String])]] =
       parser.step(args, index, d, nameFormatter) match {
-        case Right(Some(_, arg, _)) if !isArgSupported(arg) =>
+        case Right(Some(_, arg, _)) if !arg.isSupported =>
           Left((
             Error.UnrecognizedArgument(
               s"`${args(index)}` option is not supported in `scala` command.\n  Please run it with `scala-cli` command or with `--power` flag."

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
@@ -4,13 +4,13 @@ import caseapp.core.Arg
 import caseapp.core.help.HelpFormat
 
 import scala.cli.ScalaCli.allowRestrictedFeatures
-import scala.cli.commands.RestrictedCommandsParser.isExperimentalOrRestricted
+import scala.cli.util.ArgHelpers.*
 import scala.util.{Properties, Try}
 
 object ScalaCliHelp {
   val helpFormat: HelpFormat = HelpFormat.default()
     .copy(
-      filterArgs = Some(allowRestrictedFeatures || !isExperimentalOrRestricted(_)),
+      filterArgs = Some(_.isSupported),
       sortedGroups = Some(
         Seq(
           "Help",

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
@@ -1,12 +1,16 @@
 package scala.cli.commands.shared
 
+import caseapp.core.Arg
 import caseapp.core.help.HelpFormat
 
+import scala.cli.ScalaCli.allowRestrictedFeatures
+import scala.cli.commands.RestrictedCommandsParser.isExperimentalOrRestricted
 import scala.util.{Properties, Try}
 
 object ScalaCliHelp {
   val helpFormat: HelpFormat = HelpFormat.default()
     .copy(
+      filterArgs = Some(allowRestrictedFeatures || !isExperimentalOrRestricted(_)),
       sortedGroups = Some(
         Seq(
           "Help",

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedPythonOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedPythonOptions.scala
@@ -14,7 +14,7 @@ final case class SharedPythonOptions(
   @ExtraName("py")
     python: Option[Boolean] = None,
   @Tag(tags.experimental)
-  @HelpMessage(s"[experimental] Set ScalaPy version (${Constants.scalaPyVersion} by default)")
+  @HelpMessage(s"Set ScalaPy version (${Constants.scalaPyVersion} by default)")
   @ExtraName("scalapyVersion")
     scalaPyVersion: Option[String] = None
 )

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SnippetOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SnippetOptions.scala
@@ -42,13 +42,15 @@ final case class SnippetOptions(
     executeJava: List[String] = List.empty,
 
   @Group("Markdown")
-  @HelpMessage("[experimental] Allows to execute a passed string as Markdown code")
+  @HelpMessage("Allows to execute a passed string as Markdown code")
   @Name("mdSnippet")
+  @Tag(tags.experimental)
     markdownSnippet: List[String] = List.empty,
 
   @Group("Markdown")
-  @HelpMessage("[experimental] A synonym to --markdown-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly")
+  @HelpMessage("A synonym to --markdown-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly")
   @Name("executeMd")
+  @Tag(tags.experimental)
   @Hidden
     executeMarkdown: List[String] = List.empty,
 )

--- a/modules/cli/src/main/scala/scala/cli/util/ArgHelpers.scala
+++ b/modules/cli/src/main/scala/scala/cli/util/ArgHelpers.scala
@@ -1,0 +1,20 @@
+package scala.cli.util
+
+import caseapp.core.Arg
+
+import scala.cli.ScalaCli.allowRestrictedFeatures
+import scala.cli.commands.{SpecificationLevel, tags}
+
+object ArgHelpers {
+  extension (arg: Arg) {
+    def isExperimentalOrRestricted: Boolean =
+      arg.tags.exists(_.name == tags.restricted) || arg.tags.exists(_.name == tags.experimental)
+
+    def isSupported: Boolean = allowRestrictedFeatures || !arg.isExperimentalOrRestricted
+
+    def level: SpecificationLevel = arg.tags
+      .flatMap(t => tags.levelFor(t.name))
+      .headOption
+      .getOrElse(SpecificationLevel.IMPLEMENTATION)
+  }
+}

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
@@ -14,7 +14,8 @@ import java.util.{Arrays, Locale}
 import scala.build.options.{BuildOptions, BuildRequirements}
 import scala.build.preprocessing.ScalaPreprocessor
 import scala.build.preprocessing.directives.DirectiveHandler
-import scala.cli.commands.{RestrictedCommandsParser, ScalaCommand, SpecificationLevel, tags}
+import scala.cli.commands.{ScalaCommand, SpecificationLevel, tags}
+import scala.cli.util.ArgHelpers.*
 import scala.cli.{ScalaCli, ScalaCliCommands}
 
 object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
@@ -122,7 +123,7 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
   ): String = {
     val argsToShow = if (!onlyRestricted) allArgs
     else
-      allArgs.filterNot(RestrictedCommandsParser.isExperimentalOrRestricted)
+      allArgs.filterNot(_.isExperimentalOrRestricted)
 
     val argsByOrigin = argsToShow.groupBy(arg => cleanUpOrigin(arg.origin.getOrElse("")))
 
@@ -201,7 +202,7 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
             )
 
           if (onlyRestricted)
-            b.section(s"`${RestrictedCommandsParser.level(arg).md}` per Scala Runner specification")
+            b.section(s"`${arg.level.md}` per Scala Runner specification")
           else if (isInternal || arg.noHelp) b.append("[Internal]\n")
 
           for (desc <- arg.helpMessage.map(_.message))
@@ -224,7 +225,7 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
     allArgs: Seq[Arg],
     nameFormatter: Formatter[Name]
   ): String = {
-    val argsToShow = allArgs.filterNot(RestrictedCommandsParser.isExperimentalOrRestricted)
+    val argsToShow = allArgs.filterNot(_.isExperimentalOrRestricted)
 
     val b = new StringBuilder
 
@@ -254,7 +255,7 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
 
     def optionsForCommand(command: Command[_]) = {
       val supportedArgs = actualHelp(command).args
-      val argsByLevel   = supportedArgs.groupBy(RestrictedCommandsParser.level)
+      val argsByLevel   = supportedArgs.groupBy(_.level)
 
       import caseapp.core.util.NameOps._
 

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -120,7 +120,7 @@ class SipScalaTests extends ScalaCliSuite {
       }
     }
 
-  def testHelpOutput(binaryName: String): Unit = TestInputs.empty.fromRoot { root =>
+  def testDefaultHelpOutput(binaryName: String): Unit = TestInputs.empty.fromRoot { root =>
     val binary = binaryName.prepareBinary(root)
     for (helpOptions <- HelpTests.variants) {
       val output                      = os.proc(binary, helpOptions).call(cwd = root).out.trim()
@@ -128,6 +128,15 @@ class SipScalaTests extends ScalaCliSuite {
       if (binaryName.isSip) expect(!restrictedFeaturesMentioned)
       else expect(restrictedFeaturesMentioned)
     }
+  }
+
+  def testReplHelpOutput(binaryName: String): Unit = TestInputs.empty.fromRoot { root =>
+    val binary                        = binaryName.prepareBinary(root)
+    val output                        = os.proc(binary, "repl", "-help").call(cwd = root).out.trim()
+    val restrictedFeaturesMentioned   = output.contains("--amm")
+    val experimentalFeaturesMentioned = output.contains("--python")
+    if (binaryName.isSip) expect(!restrictedFeaturesMentioned && !experimentalFeaturesMentioned)
+    else expect(restrictedFeaturesMentioned && experimentalFeaturesMentioned)
   }
 
   if (TestUtil.isNativeCli)
@@ -144,8 +153,11 @@ class SipScalaTests extends ScalaCliSuite {
       test(s"test version command when run as $binaryName") {
         testVersionCommand(binaryName)
       }
-      test(s"test help when run as $binaryName") {
-        testHelpOutput(binaryName)
+      test(s"test default help when run as $binaryName") {
+        testDefaultHelpOutput(binaryName)
+      }
+      test(s"test repl help when run as $binaryName") {
+        testReplHelpOutput(binaryName)
       }
     }
 }

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -100,7 +100,7 @@ object Deps {
   // Force using of 2.13 - is there a better way?
   def bloopConfig      = ivy"ch.epfl.scala:bloop-config_2.13:1.5.5"
   def bsp4j            = ivy"ch.epfl.scala:bsp4j:2.1.0-M3"
-  def caseApp          = ivy"com.github.alexarchambault::case-app:2.1.0-M21"
+  def caseApp          = ivy"com.github.alexarchambault::case-app:2.1.0-M22"
   def collectionCompat = ivy"org.scala-lang.modules::scala-collection-compat:2.9.0"
   // Force using of 2.13 - is there a better way?
   def coursier           = ivy"io.get-coursier:coursier_2.13:${Versions.coursier}"
@@ -167,8 +167,13 @@ object Deps {
   def shapeless                = ivy"com.chuusai::shapeless:2.3.9"
   def signingCliShared =
     ivy"io.github.alexarchambault.scala-cli.signing::shared:${Versions.signingCli}"
-  def signingCli = ivy"io.github.alexarchambault.scala-cli.signing::cli:${Versions.signingCli}"
-  def slf4jNop   = ivy"org.slf4j:slf4j-nop:2.0.6"
+      // to prevent collisions with scala-cli's case-app version
+      .exclude(("com.github.alexarchambault", "case-app_3"))
+  def signingCli =
+    ivy"io.github.alexarchambault.scala-cli.signing::cli:${Versions.signingCli}"
+      // to prevent collisions with scala-cli's case-app version
+      .exclude(("com.github.alexarchambault", "case-app_3"))
+  def slf4jNop = ivy"org.slf4j:slf4j-nop:2.0.6"
   // Force using of 2.13 - is there a better way?
   def snailgun(force213: Boolean = false) =
     if (force213) ivy"io.github.alexarchambault.scala-cli.snailgun:snailgun-core_2.13:0.4.1-sc2"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1039,7 +1039,7 @@ Enable Python support via ScalaPy
 
 Aliases: `--scalapy-version`
 
-[experimental] Set ScalaPy version (0.5.3 by default)
+Set ScalaPy version (0.5.3 by default)
 
 ## Repl options
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1460,14 +1460,14 @@ A synonym to --scala-snippet, which defaults the sub-command to `run` when no su
 
 Aliases: `--md-snippet`
 
-[experimental] Allows to execute a passed string as Markdown code
+Allows to execute a passed string as Markdown code
 
 ### `--execute-markdown`
 
 Aliases: `--execute-md`
 
 [Internal]
-[experimental] A synonym to --markdown-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
+A synonym to --markdown-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
 ## Suppress warning options
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -1024,22 +1024,6 @@ Allows to execute a passed string as Java code
 
 A synonym to --scala-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
-### `--markdown-snippet`
-
-Aliases: `--md-snippet`
-
-`IMPLEMENTATION specific` per Scala Runner specification
-
-[experimental] Allows to execute a passed string as Markdown code
-
-### `--execute-markdown`
-
-Aliases: `--execute-md`
-
-`IMPLEMENTATION specific` per Scala Runner specification
-
-[experimental] A synonym to --markdown-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
-
 ## Suppress warning options
 
 Available in commands:

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -490,18 +490,6 @@ Allows to execute a passed string as Java code
 
 A synonym to --scala-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
-**--markdown-snippet**
-
-[experimental] Allows to execute a passed string as Markdown code
-
-Aliases: `--md-snippet`
-
-**--execute-markdown**
-
-[experimental] A synonym to --markdown-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
-
-Aliases: `--execute-md`
-
 **--scala-library**
 
 
@@ -1014,18 +1002,6 @@ Allows to execute a passed string as Java code
 **--execute-java**
 
 A synonym to --scala-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
-
-**--markdown-snippet**
-
-[experimental] Allows to execute a passed string as Markdown code
-
-Aliases: `--md-snippet`
-
-**--execute-markdown**
-
-[experimental] A synonym to --markdown-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
-
-Aliases: `--execute-md`
 
 **--scala-library**
 
@@ -1541,18 +1517,6 @@ Allows to execute a passed string as Java code
 **--execute-java**
 
 A synonym to --scala-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
-
-**--markdown-snippet**
-
-[experimental] Allows to execute a passed string as Markdown code
-
-Aliases: `--md-snippet`
-
-**--execute-markdown**
-
-[experimental] A synonym to --markdown-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
-
-Aliases: `--execute-md`
 
 **--scala-library**
 
@@ -2098,18 +2062,6 @@ Allows to execute a passed string as Java code
 **--execute-java**
 
 A synonym to --scala-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
-
-**--markdown-snippet**
-
-[experimental] Allows to execute a passed string as Markdown code
-
-Aliases: `--md-snippet`
-
-**--execute-markdown**
-
-[experimental] A synonym to --markdown-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
-
-Aliases: `--execute-md`
 
 **--scala-library**
 
@@ -2678,18 +2630,6 @@ Allows to execute a passed string as Java code
 
 A synonym to --scala-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
-**--markdown-snippet**
-
-[experimental] Allows to execute a passed string as Markdown code
-
-Aliases: `--md-snippet`
-
-**--execute-markdown**
-
-[experimental] A synonym to --markdown-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
-
-Aliases: `--execute-md`
-
 **--scala-library**
 
 
@@ -3206,18 +3146,6 @@ Allows to execute a passed string as Java code
 **--execute-java**
 
 A synonym to --scala-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
-
-**--markdown-snippet**
-
-[experimental] Allows to execute a passed string as Markdown code
-
-Aliases: `--md-snippet`
-
-**--execute-markdown**
-
-[experimental] A synonym to --markdown-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
-
-Aliases: `--execute-md`
 
 **--scala-library**
 
@@ -3802,18 +3730,6 @@ Allows to execute a passed string as Java code
 
 A synonym to --scala-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
-**--markdown-snippet**
-
-[experimental] Allows to execute a passed string as Markdown code
-
-Aliases: `--md-snippet`
-
-**--execute-markdown**
-
-[experimental] A synonym to --markdown-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
-
-Aliases: `--execute-md`
-
 **--scala-library**
 
 
@@ -4393,18 +4309,6 @@ Allows to execute a passed string as Java code
 **--execute-java**
 
 A synonym to --scala-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
-
-**--markdown-snippet**
-
-[experimental] Allows to execute a passed string as Markdown code
-
-Aliases: `--md-snippet`
-
-**--execute-markdown**
-
-[experimental] A synonym to --markdown-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
-
-Aliases: `--execute-md`
 
 **--scala-library**
 
@@ -5212,18 +5116,6 @@ Allows to execute a passed string as Java code
 **--execute-java**
 
 A synonym to --scala-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
-
-**--markdown-snippet**
-
-[experimental] Allows to execute a passed string as Markdown code
-
-Aliases: `--md-snippet`
-
-**--execute-markdown**
-
-[experimental] A synonym to --markdown-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
-
-Aliases: `--execute-md`
 
 **--scala-library**
 


### PR DESCRIPTION
context: #1669 
- bumps `case-app` to [`2.1.0-M22`](https://github.com/alexarchambault/case-app/releases/tag/v2.1.0-M22)
- ensures `experimental` and `restricted` options are not included in help outputs in `SIP` mode
- fixes a bunch of options' help descriptions
- refactors `case-app` args handling a bit