### PR TITLE
Prevent NPE from being thrown by the `export` sub-command if `testFramework` isn't defined

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/ExportCommonTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportCommonTestDefinitions.scala
@@ -1,0 +1,78 @@
+package scala.cli.integration
+
+import com.eed3si9n.expecty.Expecty.expect
+
+import java.nio.charset.Charset
+
+import scala.util.Properties
+
+trait ExportCommonTestDefinitions { _: ScalaCliSuite & TestScalaVersionArgs =>
+  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
+
+  protected def runExportTests: Boolean = Properties.isLinux
+
+  protected def exportCommand(args: String*): os.proc
+
+  protected def buildToolCommand(root: os.Path, args: String*): os.proc
+
+  protected def runMainArgs: Seq[String]
+  protected def runTestsArgs: Seq[String]
+
+  protected val prepareTestInputs: TestInputs => TestInputs = identity
+
+  protected val outputDir: os.RelPath = os.rel / "output-project"
+
+  protected def simpleTest(inputs: TestInputs, extraExportArgs: Seq[String] = Nil): Unit =
+    prepareTestInputs(inputs).fromRoot { root =>
+      val exportArgs = "." +: extraExportArgs
+      exportCommand(exportArgs*).call(cwd = root, stdout = os.Inherit)
+      val res =
+        buildToolCommand(root, runMainArgs*).call(cwd = root / outputDir)
+      val output = res.out.text(Charset.defaultCharset())
+      expect(output.contains("Hello from exported Scala CLI project"))
+    }
+
+  protected def jvmTest(
+    mainArgs: Seq[String] = runMainArgs,
+    testArgs: Seq[String] = runTestsArgs,
+    extraExportArgs: Seq[String] = Nil
+  ): Unit =
+    prepareTestInputs(ExportTestProjects.jvmTest(actualScalaVersion)).fromRoot { root =>
+      val exportArgs = "." +: extraExportArgs
+      exportCommand(exportArgs*).call(cwd = root, stdout = os.Inherit)
+      // main
+      val res    = buildToolCommand(root, mainArgs*).call(cwd = root / outputDir)
+      val output = res.out.text(Charset.defaultCharset())
+      expect(output.contains("Hello from " + actualScalaVersion))
+      // resource
+      expect(output.contains("resource:1,2"))
+      // test
+      val testRes    = buildToolCommand(root, testArgs*).call(cwd = root / outputDir)
+      val testOutput = testRes.out.text(Charset.defaultCharset())
+      expect(testOutput.contains("1 succeeded"))
+    }
+
+  protected def logbackBugCase(): Unit =
+    prepareTestInputs(ExportTestProjects.logbackBugCase(actualScalaVersion)).fromRoot { root =>
+      exportCommand(".").call(cwd = root, stdout = os.Inherit)
+      val res = buildToolCommand(root, runMainArgs*)
+        .call(cwd = root / outputDir)
+      val output = res.out.text(Charset.defaultCharset())
+      expect(output.contains("Hello"))
+    }
+
+  if (runExportTests) {
+    test("JVM") {
+      jvmTest()
+    }
+    test("Scala.js") {
+      simpleTest(ExportTestProjects.jsTest(actualScalaVersion))
+    }
+    test("Scala Native") {
+      simpleTest(ExportTestProjects.nativeTest(actualScalaVersion))
+    }
+    test("Ensure test framework NPE is not thrown when depending on logback") {
+      logbackBugCase()
+    }
+  }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
@@ -6,166 +6,93 @@ import java.nio.charset.Charset
 
 import scala.util.Properties
 
-abstract class ExportMillTestDefinitions(val scalaVersionOpt: Option[String])
-    extends ScalaCliSuite with TestScalaVersionArgs {
-
-  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
-
-  protected def runExportTests: Boolean =
-    Properties.isLinux
+abstract class ExportMillTestDefinitions(override val scalaVersionOpt: Option[String])
+    extends ScalaCliSuite with TestScalaVersionArgs with ExportCommonTestDefinitions {
 
   protected def launcher: os.RelPath =
     if (Properties.isWin) os.rel / "mill.bat"
     else os.rel / "mill"
 
-  private def addMillJvmOpts(inputs: TestInputs): TestInputs =
-    inputs.add(
+  implicit class MillTestInputs(inputs: TestInputs) {
+    def withMillJvmOpts: TestInputs = inputs.add(
       os.rel / ".mill-jvm-opts" ->
         """-Xmx512m
           |-Xms128m
           |""".stripMargin
     )
-
-  protected def simpleTest(
-    inputs: TestInputs,
-    extraExportArgs: Seq[String] = Nil,
-    millArgs: Seq[String] = Seq("project.run")
-  ): Unit =
-    addMillJvmOpts(inputs).fromRoot { root =>
-      os.proc(
-        TestUtil.cli,
-        "export",
-        extraOptions,
-        "--mill",
-        "-o",
-        "mill-proj",
-        ".",
-        extraExportArgs
-      )
-        .call(cwd = root, stdout = os.Inherit)
-      val res = os.proc(root / "mill-proj" / launcher, "-i", millArgs)
-        .call(cwd = root / "mill-proj")
-      val output = res.out.text(Charset.defaultCharset())
-      expect(output.contains("Hello from exported Scala CLI project"))
-    }
-
-  def jvmTest(projectName: String = "project"): Unit = {
-    val inputs = addMillJvmOpts(ExportTestProjects.jvmTest(actualScalaVersion))
-    inputs.fromRoot { root =>
-      val setProject = if (projectName != "project") Seq("-p", projectName) else Seq.empty
-      os.proc(TestUtil.cli, "export", extraOptions, "--mill", setProject, "-o", "mill-proj", ".")
-        .call(cwd = root, stdout = os.Inherit)
-      locally {
-        // main
-        val res =
-          os.proc(root / "mill-proj" / launcher, s"$projectName.run").call(cwd = root / "mill-proj")
-        val output = res.out.text(Charset.defaultCharset())
-        expect(output.contains("Hello from " + actualScalaVersion))
-        // resource
-        expect(output.contains("resource:1,2"))
-      }
-      locally {
-        // scalacOptions
-        val res =
-          os.proc(
-            root / "mill-proj" / launcher,
-            "--disable-ticker",
-            "show",
-            s"$projectName.scalacOptions"
-          ).call(cwd = root / "mill-proj")
-        val output = res.out.text(Charset.defaultCharset())
-        expect(output.filterNot(_.isWhitespace) == "[\"-deprecation\"]")
-      }
-      locally {
-        // test
-        val res =
-          os.proc(root / "mill-proj" / launcher, s"$projectName.test").call(cwd =
-            root / "mill-proj"
-          )
-        val output = res.out.text(Charset.defaultCharset())
-        expect(output.contains("1 succeeded"))
-      }
-    }
   }
 
-  def jvmTestCompilerPlugin(projectName: String = "project"): Unit = {
-    val inputs = addMillJvmOpts(ExportTestProjects.jvmTest(actualScalaVersion))
-    inputs.fromRoot { root =>
-      val setProject = if (projectName != "project") Seq("-p", projectName) else Seq.empty
-      os.proc(
-        TestUtil.cli,
-        "export",
-        extraOptions,
-        "--mill",
-        setProject,
-        "-o",
-        "mill-proj",
-        "."
-      )
-        .call(cwd = root, stdout = os.Inherit)
+  override val prepareTestInputs: TestInputs => TestInputs = _.withMillJvmOpts
+
+  override def exportCommand(args: String*): os.proc =
+    os.proc(
+      TestUtil.cli,
+      "export",
+      extraOptions,
+      "--mill",
+      "-o",
+      outputDir.toString,
+      args
+    )
+
+  override def buildToolCommand(root: os.Path, args: String*): os.proc =
+    os.proc(root / outputDir / launcher, args)
+
+  protected val defaultProjectName      = "project"
+  override val runMainArgs: Seq[String] = Seq(s"$defaultProjectName.run")
+
+  override val runTestsArgs: Seq[String] = Seq(s"$defaultProjectName.test")
+
+  def jvmTestScalacOptions(): Unit =
+    ExportTestProjects.jvmTest(actualScalaVersion).withMillJvmOpts.fromRoot { root =>
+      exportCommand(".").call(cwd = root, stdout = os.Inherit)
+      val res =
+        buildToolCommand(root, "--disable-ticker", "show", s"$defaultProjectName.scalacOptions")
+          .call(cwd = root / outputDir)
+      val output = res.out.text(Charset.defaultCharset())
+      expect(output.filterNot(_.isWhitespace) == "[\"-deprecation\"]")
+    }
+
+  def jvmTestCompilerPlugin(): Unit =
+    ExportTestProjects.jvmTest(actualScalaVersion).withMillJvmOpts.fromRoot { root =>
+      exportCommand(".").call(cwd = root, stdout = os.Inherit)
       locally {
         // scalacPluginIvyDeps
         val res =
-          os.proc(
-            root / "mill-proj" / launcher,
+          buildToolCommand(
+            root,
             "--disable-ticker",
             "show",
-            s"$projectName.scalacPluginIvyDeps"
-          ).call(cwd = root / "mill-proj")
+            s"$defaultProjectName.scalacPluginIvyDeps"
+          )
+            .call(cwd = root / outputDir)
         val output = res.out.text(Charset.defaultCharset())
         expect(output.contains("com.olegpy"))
         expect(output.contains("better-monadic-for"))
       }
       locally {
         // test
-        val res =
-          os.proc(root / "mill-proj" / launcher, s"$projectName.test").call(cwd =
-            root / "mill-proj"
-          )
+        val res = buildToolCommand(root, s"$defaultProjectName.test").call(cwd = root / outputDir)
         val output = res.out.text(Charset.defaultCharset())
         expect(output.contains("1 succeeded"))
       }
     }
-  }
 
-  def logbackBugCase(): Unit =
-    ExportTestProjects.logbackBugCase(actualScalaVersion).fromRoot { root =>
-      os.proc(TestUtil.cli, "export", extraOptions, "--mill", "-o", "mill-proj", ".")
-        .call(cwd = root, stdout = os.Inherit)
-      val res = os.proc(root / "mill-proj" / launcher, "-i", "project.run")
-        .call(cwd = root / "mill-proj")
-      val output = res.out.text(Charset.defaultCharset())
-      expect(output.contains("Hello"))
-    }
-
-  if (runExportTests)
-    test("JVM") {
-      jvmTest()
-    }
-
-  if (runExportTests)
+  if (runExportTests) {
     test("JVM custom project name") {
-      jvmTest("newproject")
+      val customProjectName = "newproject"
+      jvmTest(
+        mainArgs = Seq(s"$customProjectName.run"),
+        testArgs = Seq(s"$customProjectName.test"),
+        extraExportArgs = Seq("-p", customProjectName)
+      )
     }
-
+    test("JVM scalac options") {
+      jvmTestScalacOptions()
+    }
+  }
   if (runExportTests && !actualScalaVersion.startsWith("3."))
     test("JVM with compiler plugin") {
       jvmTestCompilerPlugin()
     }
-
-  if (runExportTests)
-    test("Scala.js") {
-      simpleTest(ExportTestProjects.jsTest(actualScalaVersion))
-    }
-
-  if (runExportTests && !actualScalaVersion.startsWith("3."))
-    test("Scala Native") {
-      simpleTest(ExportTestProjects.nativeTest(actualScalaVersion))
-    }
-
-  if (runExportTests)
-    test("Ensure test framework NPE is not thrown when depending on logback") {
-      logbackBugCase()
-    }
-
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
@@ -128,6 +128,16 @@ abstract class ExportMillTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
 
+  def logbackBugCase(): Unit =
+    ExportTestProjects.logbackBugCase(actualScalaVersion).fromRoot { root =>
+      os.proc(TestUtil.cli, "export", extraOptions, "--mill", "-o", "mill-proj", ".")
+        .call(cwd = root, stdout = os.Inherit)
+      val res = os.proc(root / "mill-proj" / launcher, "-i", "project.run")
+        .call(cwd = root / "mill-proj")
+      val output = res.out.text(Charset.defaultCharset())
+      expect(output.contains("Hello"))
+    }
+
   if (runExportTests)
     test("JVM") {
       jvmTest()
@@ -151,6 +161,11 @@ abstract class ExportMillTestDefinitions(val scalaVersionOpt: Option[String])
   if (runExportTests && !actualScalaVersion.startsWith("3."))
     test("Scala Native") {
       simpleTest(ExportTestProjects.nativeTest(actualScalaVersion))
+    }
+
+  if (runExportTests)
+    test("Ensure test framework NPE is not thrown when depending on logback") {
+      logbackBugCase()
     }
 
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMillTests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMillTests212.scala
@@ -1,7 +1,4 @@
 package scala.cli.integration
 
-// format: off
-class ExportMillTests212 extends ExportMillTestDefinitions(
-  scalaVersionOpt = Some(Constants.scala212)
-)
-// format: on
+class ExportMillTests212
+    extends ExportMillTestDefinitions(scalaVersionOpt = Some(Constants.scala212))

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMillTests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMillTests213.scala
@@ -1,24 +1,16 @@
 package scala.cli.integration
 
-// format: off
-class ExportMillTests213 extends ExportMillTestDefinitions(
-  scalaVersionOpt = Some(Constants.scala213)
-) {
-  // format: on
-
-  if (runExportTests)
+class ExportMillTests213
+    extends ExportMillTestDefinitions(scalaVersionOpt = Some(Constants.scala213)) {
+  if (runExportTests) {
     test("scalac options") {
       simpleTest(ExportTestProjects.scalacOptionsScala2Test(actualScalaVersion))
     }
-
-  if (runExportTests)
     test("pure java") {
       simpleTest(ExportTestProjects.pureJavaTest)
     }
-
-  if (runExportTests)
     test("custom JAR") {
       simpleTest(ExportTestProjects.customJarTest(actualScalaVersion))
     }
-
+  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestDefinitions.scala
@@ -64,6 +64,16 @@ abstract class ExportSbtTestDefinitions(val scalaVersionOpt: Option[String])
       expect(testOutput.contains("1 succeeded"))
     }
   }
+
+  def logbackBugCase(): Unit =
+    ExportTestProjects.logbackBugCase(actualScalaVersion).fromRoot { root =>
+      os.proc(TestUtil.cli, "export", extraOptions, "--sbt", "-o", "sbt-proj", ".")
+        .call(cwd = root, stdout = os.Inherit)
+      val res    = os.proc(sbt, "run").call(cwd = root / "sbt-proj")
+      val output = res.out.text(Charset.defaultCharset())
+      expect(output.contains("Hello"))
+    }
+
   if (runExportTests)
     test("JVM") {
       jvmTest()
@@ -77,6 +87,11 @@ abstract class ExportSbtTestDefinitions(val scalaVersionOpt: Option[String])
   if (runExportTests && !actualScalaVersion.startsWith("3."))
     test("Scala Native") {
       simpleTest(ExportTestProjects.nativeTest(actualScalaVersion))
+    }
+
+  if (runExportTests)
+    test("Ensure test framework NPE is not thrown when depending on logback") {
+      logbackBugCase()
     }
 
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTests212.scala
@@ -1,7 +1,3 @@
 package scala.cli.integration
 
-// format: off
-class ExportSbtTests212 extends ExportSbtTestDefinitions(
-  scalaVersionOpt = Some(Constants.scala212)
-)
-// format: on
+class ExportSbtTests212 extends ExportSbtTestDefinitions(scalaVersionOpt = Some(Constants.scala212))

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTests213.scala
@@ -1,27 +1,19 @@
 package scala.cli.integration
 
-// format: off
-class ExportSbtTests213 extends ExportSbtTestDefinitions(
-  scalaVersionOpt = Some(Constants.scala213)
-) {
-  // format: on
-
-  if (runExportTests)
+class ExportSbtTests213
+    extends ExportSbtTestDefinitions(scalaVersionOpt = Some(Constants.scala213)) {
+  if (runExportTests) {
     test("scalac options") {
       simpleTest(ExportTestProjects.scalacOptionsScala2Test(actualScalaVersion))
     }
-
-  if (runExportTests)
     test("pure java") {
       simpleTest(
         ExportTestProjects.pureJavaTest,
         extraExportArgs = Seq("--sbt-setting=fork := true")
       )
     }
-
-  if (runExportTests)
     test("custom JAR") {
       simpleTest(ExportTestProjects.customJarTest(actualScalaVersion))
     }
-
+  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportTestProjects.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportTestProjects.scala
@@ -270,4 +270,11 @@ object ExportTestProjects {
          |""".stripMargin
     TestInputs(os.rel / "Test.scala" -> testFile)
   }
+
+  def logbackBugCase(scalaVersion: String): TestInputs =
+    TestInputs(os.rel / "script.sc" ->
+      s"""//> using scala "$scalaVersion"
+         |//> using lib "ch.qos.logback:logback-classic:1.4.5"
+         |println("Hello")
+         |""".stripMargin)
 }

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
@@ -16,7 +16,7 @@ object AsmTestRunner {
 
     private val cache = new ConcurrentHashMap[String, Seq[String]]
 
-    def parents(className: String): Seq[String] =
+    private def parents(className: String): Seq[String] =
       Option(cache.get(className)) match {
         case Some(value) => value
         case None =>
@@ -225,7 +225,7 @@ object AsmTestRunner {
       }
     (preferredClassesByteCode ++ listClassesByteCode(classPath, true))
       .flatMap {
-        case ("module-info", _) => Iterator.empty
+        case (moduleInfo, _) if moduleInfo.contains("module-info") => Iterator.empty
         case (name, is) =>
           val checker          = new TestClassChecker
           var is0: InputStream = null
@@ -275,7 +275,7 @@ object AsmTestRunner {
       isInterfaceOpt = Some((access & asm.Opcodes.ACC_INTERFACE) != 0)
       isAbstractOpt = Some((access & asm.Opcodes.ACC_ABSTRACT) != 0)
       nameOpt = Some(name)
-      implements0 = superName :: implements0
+      implements0 = Option(superName).toList ::: implements0
       if (interfaces.nonEmpty)
         implements0 = interfaces.toList ::: implements0
     }


### PR DESCRIPTION
Fixes #1765 