### PR TITLE
Remove latest supported scala version mechanism

### DIFF
--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -272,64 +272,6 @@ class BuildOptionsTests extends munit.FunSuite {
       expect(scalaParams == expectedScalaParams)
     }
 
-  val expectedScalaConfVersions = Seq(
-    Some("3")      -> "3.0.1",
-    Some("3.0")    -> "3.0.1",
-    None           -> "3.0.1",
-    Some("2.13")   -> "2.13.4",
-    Some("2.12")   -> "2.12.13",
-    Some("2")      -> "2.13.4",
-    Some("2.13.2") -> "2.13.2"
-  )
-
-  val testVersion           = "1.11.3"
-  val testRightAfterVersion = "1.11.4"
-  val testPrevVersion       = "1.11.1"
-  val testNextVersion       = "1.11.5"
-  val confFile =
-    s"""[
-       | {
-       |  "scalaCliVersion": "$testPrevVersion",
-       |  "supportedScalaVersions": ["3.0.0", "2.13.3", "2.12.11"]
-       | },
-       | {
-       |  "scalaCliVersion": "$testVersion",
-       |  "supportedScalaVersions": ["3.0.1", "2.13.4", "2.12.13"]
-       | },
-       | {
-       |  "scalaCliVersion": "$testNextVersion",
-       |  "supportedScalaVersions": ["3.1.0", "2.13.8", "2.12.15]"]
-       | }
-       |]""".stripMargin
-
-  for {
-    (testVer, testNameSuffix) <-
-      Seq((testVersion, "exact version"), (testRightAfterVersion, "next version"))
-    (prefix, expectedScalaVersion) <- expectedScalaConfVersions
-  }
-    test(
-      s"use expected scala version from conf file, prefix: ${prefix.getOrElse("empty")}, $testNameSuffix"
-    ) {
-      TestInputs.withTmpDir("conf-scala-versions") { dirPath =>
-
-        val confFilePath = dirPath / "conf-file.json"
-        os.write(confFilePath, confFile)
-
-        val options = BuildOptions(
-          scalaOptions = ScalaOptions(
-            scalaVersion = prefix.map(MaybeScalaVersion(_)),
-            supportedScalaVersionsUrl = Some(confFilePath.toNIO.toUri.toASCIIString)
-          )
-        )
-
-        val scalaParams         = options.computeScalaParams(testVer).orThrow.getOrElse(???)
-        val expectedScalaParams = ScalaParameters(expectedScalaVersion)
-
-        expect(scalaParams == expectedScalaParams)
-      }
-
-    }
-
   val extraRepoTmpDir = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
   val directories     = Directories.under(extraRepoTmpDir)
   val buildThreads    = BuildThreads.create()

--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -599,8 +599,7 @@ abstract class BuildTests(server: Boolean) extends munit.FunSuite {
     val buildOptions = baseOptions.copy(
       scalaOptions = baseOptions.scalaOptions.copy(
         scalaVersion = Some(MaybeScalaVersion(s"3.${Int.MaxValue}.3")),
-        scalaBinaryVersion = None,
-        supportedScalaVersionsUrl = None
+        scalaBinaryVersion = None
       )
     )
     testInputs.withBuild(buildOptions, buildThreads, bloopConfigOpt) { (_, _, maybeBuild) =>
@@ -871,30 +870,7 @@ abstract class BuildTests(server: Boolean) extends munit.FunSuite {
           |}
           |""".stripMargin
     )
-    val options = baseOptions.copy(
-      scalaOptions = baseOptions.scalaOptions.copy(
-        supportedScalaVersionsUrl =
-          Some("abcd://nope"), // should not be checked, as we're a pure Java project
-        ignoreSupportedScalaVersionsErrors = Some(false)
-      )
-    )
-
-    // Checking that this effectively throws if it tries to download the supported Scala version
-    // listing.
-    // The test right after checks that things _don't_ throw, meaning it doesn't try to download
-    // the listing (which would have thrown).
-    val gotExpectedError =
-      try {
-        options.scalaParams
-        false
-      }
-      catch {
-        case e if e.getCause.isInstanceOf[ArtifactError.DownloadError] =>
-          true
-      }
-    expect(gotExpectedError)
-
-    inputs.withBuild(options, buildThreads, bloopConfigOpt, buildTests = false) {
+    inputs.withBuild(baseOptions, buildThreads, bloopConfigOpt, buildTests = false) {
       (_, _, maybeBuild) =>
         expect(maybeBuild.exists(_.success))
         val build = maybeBuild

--- a/modules/core/src/main/scala/scala/build/errors/InvalidBinaryScalaVersionError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/InvalidBinaryScalaVersionError.scala
@@ -2,8 +2,5 @@ package scala.build.errors
 
 import scala.build.errors.ScalaVersionError.getTheGeneralErrorInfo
 
-final class InvalidBinaryScalaVersionError(
-  val invalidBinaryVersion: String,
-  val latestSupportedStableVersions: Seq[String]
-) extends ScalaVersionError(s"Cannot find matching Scala version for '$invalidBinaryVersion'\n" +
-      getTheGeneralErrorInfo(latestSupportedStableVersions))
+final class InvalidBinaryScalaVersionError(val invalidBinaryVersion: String)
+    extends ScalaVersionError(s"Cannot find matching Scala version for '$invalidBinaryVersion")

--- a/modules/core/src/main/scala/scala/build/errors/NoValidScalaVersionFoundError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/NoValidScalaVersionFoundError.scala
@@ -2,10 +2,6 @@ package scala.build.errors
 
 import scala.build.errors.ScalaVersionError.getTheGeneralErrorInfo
 
-final class NoValidScalaVersionFoundError(
-  val foundVersions: Seq[String],
-  val latestSupportedStableVersions: Seq[String]
-) extends ScalaVersionError(
-      s"Cannot find a valid matching Scala version among ${foundVersions.mkString(", ")}\n" +
-        getTheGeneralErrorInfo(latestSupportedStableVersions)
+final class NoValidScalaVersionFoundError(val foundVersions: Seq[String]) extends ScalaVersionError(
+      s"Cannot find a valid matching Scala version among ${foundVersions.mkString(", ")}"
     )

--- a/modules/core/src/main/scala/scala/build/errors/ScalaVersionError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/ScalaVersionError.scala
@@ -1,14 +1,22 @@
 package scala.build.errors
 
 import scala.build.Position
+import scala.build.internal.Constants.*
 
 class ScalaVersionError(message: String, positions: Seq[Position] = Nil, cause: Throwable = null)
-    extends BuildException(message, positions = positions, cause)
+    extends BuildException(
+      s"$message${ScalaVersionError.getTheGeneralErrorInfo}",
+      positions = positions,
+      cause
+    ) {}
 
 object ScalaVersionError {
-  def getTheGeneralErrorInfo(latestSupportedStableVersions: Seq[String]): String =
-    s"""You can only choose one of the 3.x, 2.13.x, and 2.12.x. versions.
-       |The latest supported stable versions are ${latestSupportedStableVersions.mkString(", ")}.
+  private lazy val defaultScalaVersions =
+    Seq(defaultScala212Version, defaultScala213Version, defaultScalaVersion)
+  lazy val getTheGeneralErrorInfo: String =
+    s"""
+       |You can only choose one of the 3.x, 2.13.x, and 2.12.x. versions.
+       |The latest supported stable versions are ${defaultScalaVersions.mkString(", ")}.
        |In addition, you can request compilation with the last nightly versions of Scala,
        |by passing the 2.nightly, 2.12.nightly, 2.13.nightly, or 3.nightly arguments.
        |Specific Scala 2 or Scala 3 nightly versions are also accepted.

--- a/modules/core/src/main/scala/scala/build/errors/UnsupportedScalaVersionError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/UnsupportedScalaVersionError.scala
@@ -2,11 +2,5 @@ package scala.build.errors
 
 import scala.build.errors.ScalaVersionError.getTheGeneralErrorInfo
 
-final class UnsupportedScalaVersionError(
-  val binaryVersion: String,
-  val latestSupportedStableVersions: Seq[String]
-) extends ScalaVersionError(
-      s"Unsupported Scala version: $binaryVersion" + "\n" + getTheGeneralErrorInfo(
-        latestSupportedStableVersions
-      )
-    )
+final class UnsupportedScalaVersionError(val binaryVersion: String)
+    extends ScalaVersionError("Unsupported Scala version: $binaryVersion")

--- a/modules/options/src/main/scala/scala/build/options/ScalaOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaOptions.scala
@@ -14,15 +14,8 @@ final case class ScalaOptions(
   extraScalaVersions: Set[String] = Set.empty,
   compilerPlugins: Seq[Positioned[AnyDependency]] = Nil,
   platform: Option[Positioned[Platform]] = None,
-  extraPlatforms: Map[Platform, Positioned[Unit]] = Map.empty,
-  supportedScalaVersionsUrl: Option[String] = None,
-  ignoreSupportedScalaVersionsErrors: Option[Boolean] = None
+  extraPlatforms: Map[Platform, Positioned[Unit]] = Map.empty
 ) {
-
-  lazy val scalaVersionsUrl = supportedScalaVersionsUrl.getOrElse(
-    "https://github.com/VirtusLab/scala-cli-scala-versions/raw/main/scala-versions-v1.json"
-  )
-
   def normalize: ScalaOptions = {
     var opt = this
     for (sv <- opt.scalaVersion.map(_.asString) if opt.extraScalaVersions.contains(sv))


### PR DESCRIPTION
Since we hardcoded the default versions of Scala and don't change them later. Then we no longer need the `scalaVersion`. mechanism.

Originally, the mechanism was introduced to bump scala versions in previous versions of `scala-cli`, if the tests for this version pass. But this is useless as default scala versions are hardcoded. 