### PR TITLE
Add build/taskStart and taskFinish to the exception reporting BSP mechanism

### DIFF
--- a/modules/core/src/main/scala/scala/build/errors/Diagnostic.scala
+++ b/modules/core/src/main/scala/scala/build/errors/Diagnostic.scala
@@ -20,12 +20,14 @@ object Diagnostic {
   private case class ADiagnostic(
     message: String,
     severity: Severity,
-    positions: Seq[Position]
+    positions: Seq[Position],
+    override val textEdit: Option[TextEdit]
   ) extends Diagnostic
 
   def apply(
     message: String,
     severity: Severity,
-    positions: Seq[Position] = Nil
-  ): Diagnostic = ADiagnostic(message, severity, positions)
+    positions: Seq[Position] = Nil,
+    textEdit: Option[TextEdit] = None
+  ): Diagnostic = ADiagnostic(message, severity, positions, textEdit)
 }


### PR DESCRIPTION
This resolves the issue with only one $ivy or $dep import error being visible at a time. The behaviour has been checked with metals.