### PR TITLE
Rename using lib directive to using dep

### DIFF
--- a/examples/junit/MyTests.scala
+++ b/examples/junit/MyTests.scala
@@ -1,4 +1,4 @@
-//> using lib "com.github.sbt:junit-interface:0.13.2"
+//> using dep "com.github.sbt:junit-interface:0.13.2"
 import org.junit.Test
 
 class MyTests {

--- a/examples/scala-files/simple.scala
+++ b/examples/scala-files/simple.scala
@@ -1,4 +1,4 @@
-//> using lib "com.lihaoyi::pprint:0.8.1"
+//> using dep "com.lihaoyi::pprint:0.8.1"
 
 object Test {
   def something[F[_]] = ()

--- a/examples/scalatest/Tests.scala
+++ b/examples/scalatest/Tests.scala
@@ -1,4 +1,4 @@
-//> using lib "org.scalatest::scalatest::3.2.9"
+//> using dep "org.scalatest::scalatest::3.2.9"
 
 import org.scalatest._
 import flatspec._

--- a/examples/tests/MyTests.scala
+++ b/examples/tests/MyTests.scala
@@ -1,4 +1,4 @@
-//> using lib "org.scalameta::munit::0.7.29"
+//> using dep "org.scalameta::munit::0.7.29"
 
 class MyTests extends munit.FunSuite {
   test("foo") {

--- a/examples/utest/MyTests.scala
+++ b/examples/utest/MyTests.scala
@@ -1,4 +1,4 @@
-//> using lib "com.lihaoyi::utest::0.7.10"
+//> using dep "com.lihaoyi::utest::0.7.10"
 
 import utest._
 

--- a/gcbenchmark/gcbenchmark.scala
+++ b/gcbenchmark/gcbenchmark.scala
@@ -1,5 +1,5 @@
-//> using lib "com.lihaoyi::os-lib:0.8.0"
-//> using lib "com.lihaoyi::pprint:0.7.1"
+//> using dep "com.lihaoyi::os-lib:0.8.0"
+//> using dep "com.lihaoyi::pprint:0.7.1"
 //> using scala "2.13"
 
 // Usage: scala-cli gcbenchmark.scala -- <path_to_scala_cli_executable>

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -318,7 +318,7 @@ case object ScalaPreprocessor extends Preprocessor {
         (importStart, t) <- dependencyTrees
         pos           = toFilePos(Position.Raw(importStart, t.end))
         dep           = t.prefix.drop(1).mkString(".")
-        newImportText = s"//> using lib \"$dep\""
+        newImportText = s"//> using dep \"$dep\""
       } yield new UnsupportedAmmoniteImportError(Seq(pos), newImportText)
 
       Left(CompositeBuildException(exceptions))

--- a/modules/build/src/test/scala/scala/build/tests/ActionableDiagnosticTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ActionableDiagnosticTests.scala
@@ -27,7 +27,7 @@ class ActionableDiagnosticTests extends munit.FunSuite {
     val dependencyOsLib = "com.lihaoyi::os-lib:0.7.8"
     val testInputs = TestInputs(
       os.rel / "Foo.scala" ->
-        s"""//> using lib "$dependencyOsLib"
+        s"""//> using dep "$dependencyOsLib"
            |
            |object Hello extends App {
            |  println("Hello")
@@ -77,9 +77,9 @@ class ActionableDiagnosticTests extends munit.FunSuite {
         expect(exceptions.length == 2)
         expect(exceptions.forall(_.isInstanceOf[UnsupportedAmmoniteImportError]))
 
-        expect(exceptions.head.textEdit.get.newText == s"//> using lib \"$dependencyOsLib\"")
+        expect(exceptions.head.textEdit.get.newText == s"//> using dep \"$dependencyOsLib\"")
         expect(
-          exceptions.tail.head.textEdit.get.newText == s"//> using lib \"$dependencyUpickleLib\""
+          exceptions.tail.head.textEdit.get.newText == s"//> using dep \"$dependencyUpickleLib\""
         )
 
         val filePositions = exceptions.flatMap(_.positions.collect {
@@ -94,7 +94,7 @@ class ActionableDiagnosticTests extends munit.FunSuite {
   test("actionable actions suggest update only to stable version") {
     val testInputs = TestInputs(
       os.rel / "Foo.scala" ->
-        s"""//> using lib "test-org::test-name-1:1.0.6"
+        s"""//> using dep "test-org::test-name-1:1.0.6"
            |
            |object Hello extends App {
            |  println("Hello")
@@ -157,7 +157,7 @@ class ActionableDiagnosticTests extends munit.FunSuite {
   test("actionable actions should not suggest update to previous version") {
     val testInputs = TestInputs(
       os.rel / "Foo.scala" ->
-        s"""//> using lib "test-org::test-name-1:2.0.0-M1"
+        s"""//> using dep "test-org::test-name-1:2.0.0-M1"
            |
            |object Hello extends App {
            |  println("Hello")

--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -279,7 +279,7 @@ abstract class BuildTests(server: Boolean) extends munit.FunSuite {
   test("dependencies - using") {
     val testInputs = TestInputs(
       os.rel / "simple.sc" ->
-        """//> using lib "com.lihaoyi::geny:0.6.5"
+        """//> using dep "com.lihaoyi::geny:0.6.5"
           |import geny.Generator
           |val g = Generator("Hel", "lo")
           |println(g.mkString)
@@ -299,14 +299,14 @@ abstract class BuildTests(server: Boolean) extends munit.FunSuite {
   test("several dependencies - using") {
     val testInputs = TestInputs(
       os.rel / "simple.sc" ->
-        """//> using lib "com.lihaoyi::geny:0.6.5"
-          |//> using lib "com.lihaoyi::pprint:0.6.6"
+        """//> using dep "com.lihaoyi::geny:0.6.5"
+          |//> using dep "com.lihaoyi::pprint:0.6.6"
           |import geny.Generator
           |val g = Generator("Hel", "lo")
           |pprint.log(g)
           |""".stripMargin,
       os.rel / "simple2.sc" ->
-        """//> using lib "com.lihaoyi::geny:0.6.5", "com.lihaoyi::pprint:0.6.6"
+        """//> using dep "com.lihaoyi::geny:0.6.5", "com.lihaoyi::pprint:0.6.6"
           |import geny.Generator
           |val g = Generator("Hel", "lo")
           |pprint.log(g)
@@ -509,7 +509,7 @@ abstract class BuildTests(server: Boolean) extends munit.FunSuite {
   test("Pass files with only commented directives as is to scalac") {
     val testInputs = TestInputs(
       os.rel / "Simple.scala" ->
-        """//> using lib "com.lihaoyi::pprint:0.6.6"
+        """//> using dep "com.lihaoyi::pprint:0.6.6"
           |object Simple {
           |  def main(args: Array[String]): Unit =
           |    pprint.log("Hello " + "from tests")
@@ -617,7 +617,7 @@ abstract class BuildTests(server: Boolean) extends munit.FunSuite {
 
     val inputs = TestInputs(
       os.rel / "foo.scala" ->
-        s"""//> using lib "$usingDependency"
+        s"""//> using dep "$usingDependency"
            |def foo = "bar"
            |""".stripMargin
     )
@@ -805,7 +805,7 @@ abstract class BuildTests(server: Boolean) extends munit.FunSuite {
   test("Pin Scala 2 artifacts version") {
     val inputs = TestInputs(
       os.rel / "Foo.scala" ->
-        """//> using lib "com.lihaoyi:ammonite_2.13.8:2.5.1-6-5fce97fb"
+        """//> using dep "com.lihaoyi:ammonite_2.13.8:2.5.1-6-5fce97fb"
           |//> using scala "2.13.5"
           |
           |object Foo {
@@ -835,7 +835,7 @@ abstract class BuildTests(server: Boolean) extends munit.FunSuite {
   test("Pin Scala 3 artifacts version") {
     val inputs = TestInputs(
       os.rel / "Foo.scala" ->
-        """//> using lib "com.lihaoyi:ammonite_3.1.1:2.5.1-6-5fce97fb"
+        """//> using dep "com.lihaoyi:ammonite_3.1.1:2.5.1-6-5fce97fb"
           |//> using scala "3.1.0"
           |
           |object Foo {

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveParsingTest.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveParsingTest.scala
@@ -130,7 +130,7 @@ class DirectiveParsingTest extends munit.FunSuite {
 
   test("interpolator in dependency") {
     val diags =
-      testDiagnostics("""//> using lib ivy"org.scala-sbt::io:1.6.0"""")(Error("interpolator"))
+      testDiagnostics("""//> using dep ivy"org.scala-sbt::io:1.6.0"""")(Error("interpolator"))
     println(diags)
   }
 

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
@@ -34,7 +34,7 @@ class DirectiveTests extends munit.FunSuite {
   test("resolving position of lib directive") {
     val testInputs = TestInputs(
       os.rel / "simple.sc" ->
-        """//> using lib "com.lihaoyi::utest:0.7.10"
+        """//> using dep "com.lihaoyi::utest:0.7.10"
           |""".stripMargin
     )
     testInputs.withBuild(baseOptions, buildThreads, bloopConfigOpt) {

--- a/modules/build/src/test/scala/scala/build/tests/ScalaPreprocessorTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ScalaPreprocessorTests.scala
@@ -10,7 +10,7 @@ class ScalaPreprocessorTests extends munit.FunSuite {
   test("should respect using directives in a .scala file with the shebang line") {
     TestInputs(os.rel / "Main.scala" ->
       """#!/usr/bin/env -S scala-cli shebang
-        |//> using lib "com.lihaoyi::os-lib::0.8.1"
+        |//> using dep "com.lihaoyi::os-lib::0.8.1"
         |
         |object Main {
         |  def main(args: Array[String]): Unit = {
@@ -33,7 +33,7 @@ class ScalaPreprocessorTests extends munit.FunSuite {
   test("should respect using directives in a .sc file with the shebang line") {
     TestInputs(os.rel / "sample.sc" ->
       """#!/usr/bin/env -S scala-cli shebang
-        |//> using lib "com.lihaoyi::os-lib::0.8.1"
+        |//> using dep "com.lihaoyi::os-lib::0.8.1"
         |println(os.pwd)
         |""".stripMargin).fromRoot { root =>
       val scalaFile = SourceScalaFile(root, os.sub / "sample.sc")

--- a/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
@@ -36,8 +36,8 @@ class SourcesTests extends munit.FunSuite {
   test("dependencies in .scala - using") {
     val testInputs = TestInputs(
       os.rel / "something.scala" ->
-        """//> using libs "org1:name1:1.1", "org2::name2:2.2"
-          |//> using lib "org3:::name3:3.3"
+        """//> using deps "org1:name1:1.1", "org2::name2:2.2"
+          |//> using dep "org3:::name3:3.3"
           |import scala.collection.mutable
           |
           |object Something {
@@ -46,9 +46,9 @@ class SourcesTests extends munit.FunSuite {
           |""".stripMargin
     )
     val expectedDeps = Seq(
+      dep"org3:::name3:3.3",
       dep"org1:name1:1.1",
-      dep"org2::name2:2.2",
-      dep"org3:::name3:3.3"
+      dep"org2::name2:2.2"
     )
     testInputs.withInputs { (_, inputs) =>
       val (crossSources, _) =
@@ -74,8 +74,8 @@ class SourcesTests extends munit.FunSuite {
     val testInputs = TestInputs(
       os.rel / "something.scala" ->
         """//> using target.scope "test"
-          |//> using libs "org1:name1:1.1", "org2::name2:2.2"
-          |//> using lib "org3:::name3:3.3"
+          |//> using deps "org1:name1:1.1", "org2::name2:2.2"
+          |//> using dep "org3:::name3:3.3"
           |import scala.collection.mutable
           |
           |object Something {
@@ -106,8 +106,8 @@ class SourcesTests extends munit.FunSuite {
   test("dependencies in .test.scala - using") {
     val testInputs = TestInputs(
       os.rel / "something.test.scala" ->
-        """//> using libs "org1:name1:1.1", "org2::name2:2.2"
-          |//> using lib "org3:::name3:3.3"
+        """//> using deps "org1:name1:1.1", "org2::name2:2.2"
+          |//> using dep "org3:::name3:3.3"
           |import scala.collection.mutable
           |
           |object Something {
@@ -138,8 +138,8 @@ class SourcesTests extends munit.FunSuite {
   test("dependencies in test/name.scala") {
     val files = Seq(
       os.rel / "test" / "something.scala" ->
-        """//> using libs "org1:name1:1.1", "org2::name2:2.2"
-          |//> using lib "org3:::name3:3.3"
+        """//> using deps "org1:name1:1.1", "org2::name2:2.2"
+          |//> using dep "org3:::name3:3.3"
           |import scala.collection.mutable
           |
           |object Something {
@@ -168,9 +168,9 @@ class SourcesTests extends munit.FunSuite {
   test("dependencies in .scala - //> using") {
     val testInputs = TestInputs(
       os.rel / "something.scala" ->
-        """//> using lib "org1:name1:1.1"
-          |//> using lib "org2::name2:2.2"
-          |//> using lib "org3:::name3:3.3"
+        """//> using dep "org1:name1:1.1"
+          |//> using dep "org2::name2:2.2"
+          |//> using dep "org3:::name3:3.3"
           |import scala.collection.mutable
           |
           |object Something {
@@ -206,9 +206,9 @@ class SourcesTests extends munit.FunSuite {
   test("dependencies in .java - //> using") {
     val testInputs = TestInputs(
       os.rel / "Something.java" ->
-        """//> using lib "org1:name1:1.1"
-          |//> using lib "org2::name2:2.2"
-          |//> using lib "org3:::name3:3.3"
+        """//> using dep "org1:name1:1.1"
+          |//> using dep "org2::name2:2.2"
+          |//> using dep "org3:::name3:3.3"
           |
           |public class Something {
           |  public Int a = 1;
@@ -243,7 +243,7 @@ class SourcesTests extends munit.FunSuite {
   test("should fail dependencies in .java  with using keyword") {
     val testInputs = TestInputs(
       os.rel / "Something.java" ->
-        """using lib "org3:::name3:3.3"
+        """using dep "org3:::name3:3.3"
           |
           |public class Something {
           |  public Int a = 1;
@@ -350,7 +350,7 @@ class SourcesTests extends munit.FunSuite {
   test("dependencies in .sc - using") {
     val testInputs = TestInputs(
       os.rel / "something.sc" ->
-        """//> using libs "org1:name1:1.1", "org2::name2:2.2", "org3:::name3:3.3"
+        """//> using deps "org1:name1:1.1", "org2::name2:2.2", "org3:::name3:3.3"
           |import scala.collection.mutable
           |
           |def a = 1
@@ -384,9 +384,9 @@ class SourcesTests extends munit.FunSuite {
   test("dependencies in .sc - //> using") {
     val testInputs = TestInputs(
       os.rel / "something.sc" ->
-        """//> using lib "org1:name1:1.1"
-          |//> using lib "org2::name2:2.2"
-          |//> using lib "org3:::name3:3.3"
+        """//> using dep "org1:name1:1.1"
+          |//> using dep "org2::name2:2.2"
+          |//> using dep "org3:::name3:3.3"
           |import scala.collection.mutable
           |
           |def a = 1

--- a/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownCodeBlockTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownCodeBlockTests.scala
@@ -118,7 +118,7 @@ class MarkdownCodeBlockTests extends munit.FunSuite {
 
   test("a test Scala snippet is extracted correctly from markdown") {
     val code =
-      """//> using lib "org.scalameta::munit:0.7.29"
+      """//> using dep "org.scalameta::munit:0.7.29"
         |class Test extends munit.FunSuite {
         |  assert(true)
         |}""".stripMargin

--- a/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownCodeWrapperTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownCodeWrapperTests.scala
@@ -142,7 +142,7 @@ class MarkdownCodeWrapperTests extends munit.FunSuite {
 
   test("a test Scala snippet is wrapped correctly") {
     val snippet =
-      """//> using lib "org.scalameta::munit:0.7.29"
+      """//> using dep "org.scalameta::munit:0.7.29"
         |class Test extends munit.FunSuite {
         |  assert(true)
         |}""".stripMargin
@@ -162,7 +162,7 @@ class MarkdownCodeWrapperTests extends munit.FunSuite {
 
   test("multiple test Scala snippets are glued together correctly") {
     val snippet1 =
-      """//> using lib "org.scalameta::munit:0.7.29"
+      """//> using dep "org.scalameta::munit:0.7.29"
         |class Test1 extends munit.FunSuite {
         |  assert(true)
         |}""".stripMargin

--- a/modules/core/src/main/scala/scala/build/errors/UnsupportedAmmoniteImportError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/UnsupportedAmmoniteImportError.scala
@@ -5,7 +5,7 @@ import scala.build.errors.Diagnostic.TextEdit
 
 final class UnsupportedAmmoniteImportError(positions: Seq[Position], usingDirText: String)
     extends BuildException(
-      "Ammonite imports using \"$ivy\" and \"$dep\" are no longer supported, switch to 'using lib' directive",
+      "Ammonite imports using \"$ivy\" and \"$dep\" are no longer supported, switch to 'using dep' directive",
       positions
     ) {
   override def textEdit = Some(TextEdit(usingDirText))

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Dependency.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Dependency.scala
@@ -11,23 +11,25 @@ import scala.build.preprocessing.ScopePath
 import scala.build.{Logger, Positioned}
 import scala.cli.commands.SpecificationLevel
 
-@DirectiveExamples("//> using lib \"org.scalatest::scalatest:3.2.10\"")
-@DirectiveExamples("//> using lib \"org.scalameta::munit:0.7.29\"")
+@DirectiveExamples("//> using dep \"org.scalatest::scalatest:3.2.10\"")
+@DirectiveExamples("//> using dep \"org.scalameta::munit:0.7.29\"")
 @DirectiveExamples(
-  "//> using lib \"tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar\""
+  "//> using dep \"tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar\""
 )
 @DirectiveUsage(
-  "//> using lib \"org:name:ver\" | //> using libs \"org:name:ver\", \"org2:name2:ver2\"",
-  "`//> using lib \"`_org_`:`name`:`ver\""
+  "//> using dep \"org:name:ver\" | //> using deps \"org:name:ver\", \"org2:name2:ver2\"",
+  "`//> using dep \"`_org_`:`name`:`ver\""
 )
 @DirectiveDescription("Add dependencies")
 @DirectiveLevel(SpecificationLevel.MUST)
 final case class Dependency(
+  @DirectiveName("lib")
   @DirectiveName("libs")
-  lib: List[Positioned[String]] = Nil
+  @DirectiveName("deps")
+  dep: List[Positioned[String]] = Nil
 ) extends HasBuildOptions {
   def buildOptions: Either[BuildException, BuildOptions] = either {
-    val maybeDependencies = lib
+    val maybeDependencies = dep
       .map { posStr =>
         posStr
           .map { str =>

--- a/modules/docs-tests/src/main/scala/sclicheck/sclicheck.scala
+++ b/modules/docs-tests/src/main/scala/sclicheck/sclicheck.scala
@@ -179,7 +179,7 @@ def checkFile(file: os.Path, options: Options): Unit =
   // putting a custom scala-cli binary in the PATH, that in turn calls the Scala CLI launcher
   // build from Mill, so that doc scripts run it rather than any user-installed scala-cli.
   val binDir = {
-    val binDir0 = out / ".scala-build" / "bin"
+    val binDir0 = out / ".scala-cli"
     os.makeDir.all(binDir0)
     val escapedCommand = options.scalaCliCommand
       .map(arg => "\"" + arg.replace("\"", "\\\"") + "\"")
@@ -277,7 +277,7 @@ def checkFile(file: os.Path, options: Options): Unit =
             )
           }
       case Commands.Clear(_) =>
-        os.list(out).foreach(os.remove.all)
+        os.list(out).filterNot(_ == binDir).foreach(os.remove.all)
 
   try
     println(Blue(s"\n[${file.relativeTo(os.pwd)}]  Running checks in $out"))

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -217,13 +217,13 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
     }
 
   val importPprintOnlyProject: TestInputs = TestInputs(
-    os.rel / "simple.sc" -> s"//> using lib \"com.lihaoyi::pprint:${Constants.pprintVersion}\""
+    os.rel / "simple.sc" -> s"//> using dep \"com.lihaoyi::pprint:${Constants.pprintVersion}\""
   )
 
   test("setup-ide should have only absolute paths even if relative ones were specified") {
     val path = os.rel / "directory" / "simple.sc"
     val inputs =
-      TestInputs(path -> s"//> using lib \"com.lihaoyi::pprint:${Constants.pprintVersion}\"")
+      TestInputs(path -> s"//> using dep \"com.lihaoyi::pprint:${Constants.pprintVersion}\"")
     inputs.fromRoot { root =>
       val relativeCliCommand = TestUtil.cliCommand(
         TestUtil.relPathStr(os.Path(TestUtil.cliPath).relativeTo(root))
@@ -555,7 +555,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
   test("directive diagnostics") {
     val inputs = TestInputs(
       os.rel / "Test.scala" ->
-        s"""//> using lib "com.lihaoyi::pprint:0.0.0.0.0.1"
+        s"""//> using dep "com.lihaoyi::pprint:0.0.0.0.0.1"
            |
            |object Test {
            |  val msg = "Hello"
@@ -651,7 +651,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
         val didChangeParamsFuture = localClient.buildTargetDidChange()
         val updatedContent =
-          """//> using lib "com.lihaoyi::pprint:0.6.6"
+          """//> using dep "com.lihaoyi::pprint:0.6.6"
             |val msg = "Hello"
             |pprint.log(msg)
             |""".stripMargin
@@ -799,13 +799,13 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
   test("test workspace update after adding file to main scope") {
     val inputs = TestInputs(
       os.rel / "Messages.scala" ->
-        """//> using lib "com.lihaoyi::os-lib:0.7.8"
+        """//> using dep "com.lihaoyi::os-lib:0.7.8"
           |object Messages {
           |  def msg = "Hello"
           |}
           |""".stripMargin,
       os.rel / "MyTests.test.scala" ->
-        """//> using lib "com.lihaoyi::utest::0.7.10"
+        """//> using dep "com.lihaoyi::utest::0.7.10"
           |import utest._
           |
           |object MyTests extends TestSuite {
@@ -1030,7 +1030,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
             val depName    = "os-lib"
             val depVersion = "0.8.1"
             val updatedSourceFile =
-              s"""//> using lib "com.lihaoyi::$depName:$depVersion"
+              s"""//> using dep "com.lihaoyi::$depName:$depVersion"
                  |
                  |object ReloadTest {
                  |  println(os.pwd)
@@ -1222,7 +1222,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
   test("bloop projects are initialised properly for a directive for an unfetchable dependency") {
     val inputs = TestInputs(
       os.rel / "InvalidUsingDirective.scala" ->
-        s"""//> using lib "no::lib:123"
+        s"""//> using dep "no::lib:123"
            |
            |object InvalidUsingDirective extends App {
            |  println("Hello")
@@ -1257,7 +1257,7 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
     val fileName = "Hello.scala"
     val inputs = TestInputs(
       os.rel / fileName ->
-        s"""//> using lib "com.lihaoyi::os-lib:0.7.8"
+        s"""//> using dep "com.lihaoyi::os-lib:0.7.8"
            |
            |object Hello extends App {
            |  println("Hello")

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -18,7 +18,7 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
 
   val simpleInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
-      """//> using lib "com.lihaoyi::os-lib::0.8.1"
+      """//> using dep "com.lihaoyi::os-lib::0.8.1"
         |
         |object MyTests {
         |  def main(args: Array[String]): Unit = {
@@ -31,7 +31,7 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
 
   val mainAndTestInputs: TestInputs = TestInputs(
     os.rel / "Main.scala" ->
-      """//> using lib "com.lihaoyi::utest:0.7.10"
+      """//> using dep "com.lihaoyi::utest:0.7.10"
         |
         |object Main {
         |  val err = utest.compileError("pprint.log(2)")
@@ -43,7 +43,7 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
         |}
         |""".stripMargin,
     os.rel / "Tests.scala" ->
-      """//> using lib "com.lihaoyi::pprint:0.6.6"
+      """//> using dep "com.lihaoyi::pprint:0.6.6"
         |//> using target.scope "test"
         |
         |import utest._
@@ -113,7 +113,7 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
           |""".stripMargin,
       os.rel / "Foo.scala" ->
         """//> using target.scala.>= "2.13"
-          |//> using lib "com.lihaoyi::os-lib::0.8.1"
+          |//> using dep "com.lihaoyi::os-lib::0.8.1"
           |class Foo {}
           |""".stripMargin
     )
@@ -221,7 +221,7 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
           |}
           |""".stripMargin,
       os.rel / "Tests.scala" ->
-        """//> using lib "com.lihaoyi::utest:0.7.10"
+        """//> using dep "com.lihaoyi::utest:0.7.10"
           |//> using target.scope "test"
           |
           |import utest._
@@ -513,7 +513,7 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
     val sparkVersion = "3.3.0"
     val inputs = TestInputs(
       os.rel / "Hello.scala" ->
-        s"""//> using lib "org.apache.spark::spark-sql:$sparkVersion"
+        s"""//> using dep "org.apache.spark::spark-sql:$sparkVersion"
            |object Hello {
            |  def main(args: Array[String]): Unit =
            |    println("Hello")
@@ -554,7 +554,7 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
           |""".stripMargin,
       os.rel / "TestStuff.test.scala" ->
         """//> using jvm "17"
-          |//> using lib "org.scalameta::munit:0.7.29"
+          |//> using dep "org.scalameta::munit:0.7.29"
           |class TestStuff extends munit.FunSuite {
           |  test("the test") {
           |    val javaVer = MainStuff.javaVer

--- a/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
@@ -222,7 +222,7 @@ class ConfigTests extends ScalaCliSuite {
           |}
           |""".stripMargin,
       os.rel / "hello" / "Hello.scala" ->
-        s"""//> using lib "$testOrg::$testName:$testVersion"
+        s"""//> using dep "$testOrg::$testName:$testVersion"
            |import messages.Messages
            |object Hello {
            |  def main(args: Array[String]): Unit =

--- a/modules/integration/src/test/scala/scala/cli/integration/DependencyUpdateTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DependencyUpdateTests.scala
@@ -9,8 +9,8 @@ class DependencyUpdateTests extends ScalaCliSuite {
     val fileName = "Hello.scala"
     val message  = "Hello World"
     val fileContent =
-      s"""|//> using lib "com.lihaoyi::os-lib:0.7.8"
-          |//> using lib "com.lihaoyi::utest:0.7.10"
+      s"""|//> using dep "com.lihaoyi::os-lib:0.7.8"
+          |//> using dep "com.lihaoyi::utest:0.7.10"
           |
           |object Hello extends App {
           |  println("$message")

--- a/modules/integration/src/test/scala/scala/cli/integration/DocTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DocTestsDefault.scala
@@ -7,7 +7,7 @@ class DocTestsDefault extends DocTestDefinitions(scalaVersionOpt = None) {
   test("javadoc") {
     val inputs = TestInputs(
       os.rel / "Foo.java" ->
-        """//> using lib "org.graalvm.nativeimage:svm:22.0.0.2"
+        """//> using dep "org.graalvm.nativeimage:svm:22.0.0.2"
           |
           |import com.oracle.svm.core.annotate.TargetClass;
           |import org.graalvm.nativeimage.Platform;

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportTestProjects.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportTestProjects.scala
@@ -10,7 +10,7 @@ object ExportTestProjects {
       if (scalaVersion.startsWith("3."))
         s"""//> using scala "$scalaVersion"
            |//> using resourceDir "./input"
-           |//> using lib "org.scala-lang::scala3-compiler:$scalaVersion"
+           |//> using dep "org.scala-lang::scala3-compiler:$scalaVersion"
            |//> using option "-deprecation"
            |
            |import scala.io.Source
@@ -44,8 +44,8 @@ object ExportTestProjects {
     TestInputs(
       os.rel / "Hello.scala" -> mainFile,
       os.rel / "Zio.test.scala" ->
-        """|//> using lib "dev.zio::zio::1.0.8"
-           |//> using lib "dev.zio::zio-test-sbt::1.0.8"
+        """|//> using dep "dev.zio::zio::1.0.8"
+           |//> using dep "dev.zio::zio-test-sbt::1.0.8"
            |
            |import zio._
            |import zio.test._
@@ -136,7 +136,7 @@ object ExportTestProjects {
   def repositoryScala3Test(scalaVersion: String): TestInputs = {
     val testFile =
       s"""//> using scala "$scalaVersion"
-         |//> using lib "com.github.jupyter:jvm-repr:0.4.0"
+         |//> using dep "com.github.jupyter:jvm-repr:0.4.0"
          |//> using repository "jitpack"
          |import jupyter._
          |object Test:
@@ -171,8 +171,8 @@ object ExportTestProjects {
   def scalacOptionsScala2Test(scalaVersion: String): TestInputs = {
     val testFile =
       s"""//> using scala "$scalaVersion"
-         |//> using lib "org.scala-lang.modules::scala-async:0.10.0"
-         |//> using lib "org.scala-lang:scala-reflect:$scalaVersion"
+         |//> using dep "org.scala-lang.modules::scala-async:0.10.0"
+         |//> using dep "org.scala-lang:scala-reflect:$scalaVersion"
          |import scala.async.Async.{async, await}
          |import scala.concurrent.{Await, Future}
          |import scala.concurrent.duration.Duration
@@ -219,7 +219,7 @@ object ExportTestProjects {
   def testFrameworkTest(scalaVersion: String): TestInputs = {
     val testFile =
       s"""//> using scala "$scalaVersion"
-         |//> using lib "com.lihaoyi::utest:0.7.10"
+         |//> using dep "com.lihaoyi::utest:0.7.10"
          |//> using test-framework "utest.runner.Framework"
          |
          |import utest._

--- a/modules/integration/src/test/scala/scala/cli/integration/HadoopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/HadoopTests.scala
@@ -9,7 +9,7 @@ class HadoopTests extends munit.FunSuite {
   test("simple map-reduce") {
     val inputs = TestInputs(
       os.rel / "WordCount.java" ->
-        """//> using lib "org.apache.hadoop:hadoop-client-api:3.3.3"
+        """//> using dep "org.apache.hadoop:hadoop-client-api:3.3.3"
           |
           |// from https://hadoop.apache.org/docs/r3.3.3/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
           |

--- a/modules/integration/src/test/scala/scala/cli/integration/MarkdownTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/MarkdownTests.scala
@@ -145,7 +145,7 @@ class MarkdownTests extends ScalaCliSuite {
         s"""# Sample Markdown file
            |A simple scala script snippet.
            |```scala
-           |//> using lib "com.lihaoyi::os-lib:0.8.1"
+           |//> using dep "com.lihaoyi::os-lib:0.8.1"
            |println(os.pwd)
            |```
            |""".stripMargin
@@ -161,7 +161,7 @@ class MarkdownTests extends ScalaCliSuite {
         s"""# Sample Markdown file
            |A simple scala raw snippet.
            |```scala raw
-           |//> using lib "com.lihaoyi::os-lib:0.8.1"
+           |//> using dep "com.lihaoyi::os-lib:0.8.1"
            |object Hello extends App {
            |  println(os.pwd)
            |}
@@ -184,7 +184,7 @@ class MarkdownTests extends ScalaCliSuite {
            |## Circe
            |Let's depend on `circe-parser` in this one.
            |```scala
-           |//> using lib "io.circe::circe-parser:0.14.3"
+           |//> using dep "io.circe::circe-parser:0.14.3"
            |import io.circe._, io.circe.parser._
            |val json = \"\"\"{ "message": "$msg1"}\"\"\"
            |val parsed = parse(json).getOrElse(Json.Null)
@@ -195,7 +195,7 @@ class MarkdownTests extends ScalaCliSuite {
            |## `pprint`
            |And `pprint`, too.
            |```scala
-           |//> using lib "com.lihaoyi::pprint:0.8.0"
+           |//> using dep "com.lihaoyi::pprint:0.8.0"
            |pprint.PPrinter.BlackWhite.pprintln("$msg2")
            |```
            |
@@ -203,7 +203,7 @@ class MarkdownTests extends ScalaCliSuite {
            |And then on `os-lib`, just because.
            |And let's reset the scope for good measure, too.
            |```scala reset
-           |//> using lib "com.lihaoyi::os-lib:0.8.1"
+           |//> using dep "com.lihaoyi::os-lib:0.8.1"
            |val msg = os.pwd.toString
            |println(msg)
            |```
@@ -229,7 +229,7 @@ class MarkdownTests extends ScalaCliSuite {
            |## Circe
            |Let's depend on `circe-parser` in this one.
            |```scala raw
-           |//> using lib "io.circe::circe-parser:0.14.3"
+           |//> using dep "io.circe::circe-parser:0.14.3"
            |
            |object CirceSnippet {
            |  import io.circe._, io.circe.parser._
@@ -246,7 +246,7 @@ class MarkdownTests extends ScalaCliSuite {
            |## `pprint`
            |And `pprint`, too.
            |```scala raw
-           |//> using lib "com.lihaoyi::pprint:0.8.0"
+           |//> using dep "com.lihaoyi::pprint:0.8.0"
            |object PprintSnippet {
            |  def printStuff(): Unit =
            |    pprint.PPrinter.BlackWhite.pprintln("$msg2")
@@ -257,7 +257,7 @@ class MarkdownTests extends ScalaCliSuite {
            |And then on `os-lib`, just because.
            |And let's reset the scope for good measure, too.
            |```scala raw
-           |//> using lib "com.lihaoyi::os-lib:0.8.1"
+           |//> using dep "com.lihaoyi::os-lib:0.8.1"
            |
            |object OsLibSnippet extends App {
            |  CirceSnippet.printStuff()

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -405,7 +405,7 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
     val message  = "Hello"
     val inputs = TestInputs(
       os.rel / fileName ->
-        s"""//> using lib "org.typelevel::cats-kernel:2.6.1"
+        s"""//> using dep "org.typelevel::cats-kernel:2.6.1"
            |import cats.kernel._
            |val m = Monoid.instance[String]("", (a, b) => a + b)
            |val msgStuff = m.combineAll(List("$message", "", ""))

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestsDefault.scala
@@ -15,7 +15,7 @@ class PublishTestsDefault extends PublishTestDefinitions(scalaVersionOpt = None)
          |//> using publish.version "$testVersion"
          |
          |//> using scala "$sbv"
-         |//> using lib "com.lihaoyi::os-lib:0.8.1"
+         |//> using dep "com.lihaoyi::os-lib:0.8.1"
          |
          |object Project {
          |  def message = "$message"

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
@@ -143,7 +143,7 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
   def jsDomTest(): Unit = {
     val inputs = TestInputs(
       os.rel / "JsDom.scala" ->
-        s"""|//> using lib "org.scala-js::scalajs-dom::2.1.0"
+        s"""|//> using dep "org.scala-js::scalajs-dom::2.1.0"
             |
             |import org.scalajs.dom.document
             |

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -544,7 +544,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   test("test scope") {
     val inputs = TestInputs(
       os.rel / "Main.scala" ->
-        """//> using lib "com.lihaoyi::utest:0.7.10"
+        """//> using dep "com.lihaoyi::utest:0.7.10"
           |
           |object Main {
           |  val err = utest.compileError("pprint.log(2)")
@@ -556,7 +556,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
           |}
           |""".stripMargin,
       os.rel / "Tests.scala" ->
-        """//> using lib "com.lihaoyi::pprint:0.6.6"
+        """//> using dep "com.lihaoyi::pprint:0.6.6"
           |//> using target.scope "test"
           |
           |import utest._
@@ -620,7 +620,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
   test("workspace dir") {
     val inputs = TestInputs(
       os.rel / "Hello.scala" ->
-        """|//> using lib "com.lihaoyi::os-lib:0.7.8"
+        """|//> using dep "com.lihaoyi::os-lib:0.7.8"
            |
            |object Hello extends App {
            |  println(os.pwd)

--- a/modules/integration/src/test/scala/scala/cli/integration/SparkTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SparkTestDefinitions.scala
@@ -62,9 +62,9 @@ abstract class SparkTestDefinitions(val scalaVersionOpt: Option[String]) extends
   protected def defaultMaster = "local[4]"
   protected def simpleJobInputs(spark: Spark) = TestInputs(
     os.rel / "SparkJob.scala" ->
-      s"""//> using lib "org.apache.spark::spark-sql:${spark.sparkVersion}"
-         |//> using lib "com.chuusai::shapeless:2.3.10"
-         |//> using lib "com.lihaoyi::pprint:0.7.3"
+      s"""//> using dep "org.apache.spark::spark-sql:${spark.sparkVersion}"
+         |//> using dep "com.chuusai::shapeless:2.3.10"
+         |//> using dep "com.lihaoyi::pprint:0.7.3"
          |
          |import org.apache.spark._
          |import org.apache.spark.sql._
@@ -154,7 +154,7 @@ abstract class SparkTestDefinitions(val scalaVersionOpt: Option[String]) extends
     val jobName = "the test spark job"
     val inputs = TestInputs(
       os.rel / "SparkJob.scala" ->
-        s"""//> using lib "org.apache.spark::spark-sql:3.3.0"
+        s"""//> using dep "org.apache.spark::spark-sql:3.3.0"
            |
            |import org.apache.spark._
            |import org.apache.spark.sql._

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -16,7 +16,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
 
   val successfulTestInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
-      """//> using lib "org.scalameta::munit::0.7.29"
+      """//> using dep "org.scalameta::munit::0.7.29"
         |
         |class MyTests extends munit.FunSuite {
         |  test("foo") {
@@ -29,7 +29,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
 
   val failingTestInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
-      """//> using lib "org.scalameta::munit::0.7.29"
+      """//> using dep "org.scalameta::munit::0.7.29"
         |
         |class MyTests extends munit.FunSuite {
         |  test("foo") {
@@ -41,7 +41,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
 
   val successfulUtestInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
-      """//> using lib "com.lihaoyi::utest::0.7.10"
+      """//> using dep "com.lihaoyi::utest::0.7.10"
         |import utest._
         |
         |object MyTests extends TestSuite {
@@ -57,7 +57,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
 
   val successfulUtestJsInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
-      """//> using lib "com.lihaoyi::utest::0.7.10"
+      """//> using dep "com.lihaoyi::utest::0.7.10"
         |import utest._
         |import scala.scalajs.js
         |
@@ -75,7 +75,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
 
   val successfulUtestNativeInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
-      """//> using lib "com.lihaoyi::utest::0.7.10"
+      """//> using dep "com.lihaoyi::utest::0.7.10"
         |import utest._
         |import scala.scalanative.libc._
         |import scala.scalanative.unsafe._
@@ -97,7 +97,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
     os.rel / "MyTests.scala" ->
       """//> using scala "2.13.8"
         |//> using platform "native"
-        |//> using lib "org.typelevel::cats-kernel-laws::2.8.0"
+        |//> using dep "org.typelevel::cats-kernel-laws::2.8.0"
         |
         |import org.scalacheck._
         |import Prop.forAll
@@ -112,7 +112,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
 
   val successfulJunitInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
-      """//> using lib "com.novocode:junit-interface:0.11"
+      """//> using dep "com.novocode:junit-interface:0.11"
         |import org.junit.Test
         |
         |class MyTests {
@@ -128,7 +128,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
 
   val severalTestsInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
-      """//> using lib "org.scalameta::munit::0.7.29"
+      """//> using dep "org.scalameta::munit::0.7.29"
         |
         |class MyTests extends munit.FunSuite {
         |  test("foo") {
@@ -138,7 +138,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
         |}
         |""".stripMargin,
     os.rel / "OtherTests.scala" ->
-      """//> using lib "org.scalameta::munit::0.7.29"
+      """//> using dep "org.scalameta::munit::0.7.29"
         |
         |class OtherTests extends munit.FunSuite {
         |  test("bar") {
@@ -151,7 +151,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
 
   val successfulWeaverInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
-      """//> using libs "com.disneystreaming::weaver-cats:0.7.6", "com.eed3si9n.expecty::expecty:0.15.4+5-f1d8927e-SNAPSHOT"
+      """//> using deps "com.disneystreaming::weaver-cats:0.7.6", "com.eed3si9n.expecty::expecty:0.15.4+5-f1d8927e-SNAPSHOT"
         |import weaver._
         |import cats.effect.IO
         |
@@ -165,7 +165,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
 
   val successfulESModuleTestInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
-      """//> using lib "org.scalameta::munit::0.7.29"
+      """//> using dep "org.scalameta::munit::0.7.29"
         |//> using jsModuleKind "esmodule"
         |import scala.scalajs.js
         |import scala.scalajs.js.annotation._
@@ -192,7 +192,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
         |
         |## Example Snippet
         |```scala test
-        |//> using lib "org.scalameta::munit:0.7.29"
+        |//> using dep "org.scalameta::munit:0.7.29"
         |
         |class Test extends munit.FunSuite {
         |  test("foo") {
@@ -212,7 +212,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
         |
         |## Example Snippet
         |```scala test
-        |//> using lib "org.scalameta::munit:0.7.29"
+        |//> using dep "org.scalameta::munit:0.7.29"
         |
         |class Test extends munit.FunSuite {
         |  test("foo") {
@@ -261,7 +261,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
   test("run only one test from munit") {
     val inputs: TestInputs = TestInputs(
       os.rel / "MyTests.scala" ->
-        """//> using lib "org.scalameta::munit::0.7.29"
+        """//> using dep "org.scalameta::munit::0.7.29"
           |package test
           |
           |class MyTests extends munit.FunSuite {
@@ -295,7 +295,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
   test("run only one test from utest") {
     val inputs: TestInputs = TestInputs(
       os.rel / "FooTests.scala" ->
-        """//> using lib "com.lihaoyi::utest::0.7.10"
+        """//> using dep "com.lihaoyi::utest::0.7.10"
           |package tests.foo
           |import utest._
           |
@@ -308,7 +308,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
           |}
           |""".stripMargin,
       os.rel / "BarTests.scala" ->
-        """//> using lib "com.lihaoyi::utest::0.7.10"
+        """//> using dep "com.lihaoyi::utest::0.7.10"
           |package tests.bar
           |import utest._
           |
@@ -396,7 +396,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
   test("failing test return code when compiling error") {
     val inputs = TestInputs(
       os.rel / "MyTests.scala" ->
-        """//> using lib "org.scalameta::munit::0.7.29"
+        """//> using dep "org.scalameta::munit::0.7.29"
           |
           |class SomeTest extends munit.FunSuite {
           |  test("failig") {
@@ -494,7 +494,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
     test(s"test framework arguments $platformName") {
       val inputs = TestInputs(
         os.rel / "MyTests.scala" ->
-          """//> using lib "org.scalatest::scalatest::3.2.9"
+          """//> using dep "org.scalatest::scalatest::3.2.9"
             |import org.scalatest._
             |import org.scalatest.flatspec._
             |import org.scalatest.matchers._
@@ -536,7 +536,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
     test(s"custom test framework $platformName") {
       val inputs = TestInputs(
         os.rel / "MyTests.scala" ->
-          """//> using lib "com.lihaoyi::utest::0.7.10"
+          """//> using dep "com.lihaoyi::utest::0.7.10"
             |
             |package mytests
             |import utest._
@@ -583,7 +583,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
     test(s"Fail if no tests were run $platformName") {
       val inputs = TestInputs(
         os.rel / "MyTests.scala" ->
-          """//> using lib "org.scalameta::munit::0.7.29"
+          """//> using dep "org.scalameta::munit::0.7.29"
             |
             |object MyTests
             |""".stripMargin
@@ -622,7 +622,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
     val inputs = {
       var inputs0 = TestInputs(
         os.rel / "MyTests.scala" ->
-          s"""//> using lib "org.scalameta::munit::0.7.29"
+          s"""//> using dep "org.scalameta::munit::0.7.29"
              |//> using platform $platforms
              |
              |class MyTests extends munit.FunSuite {
@@ -679,8 +679,8 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
   def jsDomTest(): Unit = {
     val inputs = TestInputs(
       os.rel / "JsDom.scala" ->
-        s"""//> using lib "com.lihaoyi::utest::0.7.10"
-           |//> using lib "org.scala-js::scalajs-dom::2.1.0"
+        s"""//> using dep "com.lihaoyi::utest::0.7.10"
+           |//> using dep "org.scala-js::scalajs-dom::2.1.0"
            |
            |import utest._
            |

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
@@ -17,7 +17,7 @@ class TestTestsDefault extends TestTestDefinitions(scalaVersionOpt = None) {
           |""".stripMargin,
       os.rel / "test" / "MessagesTests.scala" ->
         """//> using scala "2.13"
-          |//> using lib "com.lihaoyi::utest::0.7.10"
+          |//> using dep "com.lihaoyi::utest::0.7.10"
           |package messages
           |package tests
           |import utest._

--- a/website/docs/commands/compile.md
+++ b/website/docs/commands/compile.md
@@ -31,7 +31,7 @@ For a full list of options, run `scala-cli compile --help`, or check the options
 `--test` makes `scala-cli` compile main and test scopes:
 
 ```scala title=Sample.test.scala
-//> using lib "org.scalameta::munit:0.7.29"
+//> using dep "org.scalameta::munit:0.7.29"
 class Test extends munit.FunSuite {
   test("sample") {
     assert(2 + 2 == 4)

--- a/website/docs/commands/test.md
+++ b/website/docs/commands/test.md
@@ -73,7 +73,7 @@ Some of the most popular test frameworks in Scala are:
 The following example shows how to run an munit-based test suite:
 
 ```scala title=MyTests.scala
-//> using lib "org.scalameta::munit::0.7.27"
+//> using dep "org.scalameta::munit::0.7.27"
 
 class MyTests extends munit.FunSuite {
   test("foo") {
@@ -107,7 +107,7 @@ foo
 Passing the `--test-only` option to the `test` sub-command filters the test suites to be run:
 
 ```scala title=BarTests.scala
-//> using lib "org.scalameta::munit::0.7.29"
+//> using dep "org.scalameta::munit::0.7.29"
 package tests.only
 
 class BarTests extends munit.FunSuite {
@@ -144,7 +144,7 @@ tests.only.BarTests:
 To run a specific test case inside the unit test suite pass `*exact-test-name*` as an argument to scala-cli:
 
 ```scala title=BarTests.scala
-//> using lib "org.scalameta::munit::0.7.29"
+//> using dep "org.scalameta::munit::0.7.29"
 package tests.only
 
 class Tests extends munit.FunSuite {
@@ -178,7 +178,7 @@ tests.only.Tests:
 You can pass test arguments to your test framework by passing them after `--`:
 
 ```scala title=MyTests.scala
-//> using lib "org.scalatest::scalatest::3.2.9"
+//> using dep "org.scalatest::scalatest::3.2.9"
 
 import org.scalatest._
 import org.scalatest.flatspec._

--- a/website/docs/cookbooks/debugging.md
+++ b/website/docs/cookbooks/debugging.md
@@ -18,7 +18,7 @@ object MyClass extends App  {
 ```
 
 ```scala title=MyTests.test.scala
-//> using lib "org.scalameta::munit::0.7.27"
+//> using dep "org.scalameta::munit::0.7.27"
 
 class MyTests extends munit.FunSuite {
   test("foo") {

--- a/website/docs/cookbooks/gh-action.md
+++ b/website/docs/cookbooks/gh-action.md
@@ -11,7 +11,7 @@ To use Scala CLI features in a simple way you can use the GitHub Actions [scala-
 For example, here's a simple `ls` application printing the files in a given directory:
 ```scala title=Ls.scala
 //> using scala "2.13"
-//> using lib "com.lihaoyi::os-lib:0.7.8"
+//> using dep "com.lihaoyi::os-lib:0.7.8"
 
 @main def hello(args: String*) =
   val path = args.headOption match
@@ -25,7 +25,7 @@ For example, here's a simple `ls` application printing the files in a given dire
 and some tests for `ls` application:
 
 ```scala title=TestsLs.test.scala
-//> using lib "org.scalameta::munit::0.7.27"
+//> using dep "org.scalameta::munit::0.7.27"
 import scala.util.Properties
 
 class TestsLs extends munit.FunSuite {
@@ -107,7 +107,7 @@ Scala CLI allows to build native executable applications using [GraalVM](https:/
 Given this simple Scala Script `package.sc` to package application to every platform:
 ```scala title=package.sc
 //> using scala "3.1.2"
-//> using lib "com.lihaoyi::os-lib:0.8.0"
+//> using dep "com.lihaoyi::os-lib:0.8.0"
 import scala.util.Properties
 
 val platformSuffix: String = {

--- a/website/docs/cookbooks/instant-startup-scala-scripts.md
+++ b/website/docs/cookbooks/instant-startup-scala-scripts.md
@@ -18,7 +18,7 @@ a directory with sizes bigger than a passed value.
 
 ```scala title=size-higher-than.scala
 //> using scala "3.1.1"
-//> using lib "com.lihaoyi::os-lib::0.8.1"
+//> using dep "com.lihaoyi::os-lib::0.8.1"
  
 @main
 def sizeHigherThan(dir: String, minSizeMB: Int) =
@@ -56,7 +56,7 @@ in this case, by including an additional using directive:
 
 ```scala compile title=size-higher-than.scala
 //> using scala "3.1.1"
-//> using lib "com.lihaoyi::os-lib::0.8.1"
+//> using dep "com.lihaoyi::os-lib::0.8.1"
 //> using platform "scala-native"
  
 @main
@@ -82,7 +82,7 @@ We pass these using a `-–native-mode` scala-cli option or, like previously, by
 
 ```scala compile title=size-higher-than.scala
 //> using scala "3.1.1"
-//> using lib "com.lihaoyi::os-lib::0.8.1"
+//> using dep "com.lihaoyi::os-lib::0.8.1"
 //> using platform "scala-native"
 //> using nativeMode "release-full"
  

--- a/website/docs/cookbooks/intellij-multi-bsp.md
+++ b/website/docs/cookbooks/intellij-multi-bsp.md
@@ -45,7 +45,7 @@ tree -a
 ```
 
 ```scala title=app1/test/MyTests1.scala
-//> using lib "org.scalameta::munit:1.0.0-M7"
+//> using dep "org.scalameta::munit:1.0.0-M7"
 class MyTests1 extends munit.FunSuite {
   test("my test 1") {
     assert(2 + 2 == 4)
@@ -58,7 +58,7 @@ class MyTests1 extends munit.FunSuite {
 ```
 
 ```scala title=app2/test/MyTests2.scala
-//> using lib "com.lihaoyi::utest::0.8.1"
+//> using dep "com.lihaoyi::utest::0.8.1"
 
 import utest.*
 

--- a/website/docs/cookbooks/intellij.md
+++ b/website/docs/cookbooks/intellij.md
@@ -17,7 +17,7 @@ def hello() = println("Hello, world")
 ```
 
 ```scala title=test/MyTests.test.scala
-//> using lib "org.scalameta::munit::1.0.0-M1"
+//> using dep "org.scalameta::munit::1.0.0-M1"
 
 class MyTests extends munit.FunSuite {
   test("test") {

--- a/website/docs/cookbooks/test-only.md
+++ b/website/docs/cookbooks/test-only.md
@@ -26,7 +26,7 @@ The `--test-only` option is supported for every test framework running with Scal
 For example, passing `tests.only*` to the `--test-only` option runs only the test suites which start with `tests.only`:
 
 ```scala title=BarTests.scala
-//> using lib "org.scalameta::munit::0.7.29"
+//> using dep "org.scalameta::munit::0.7.29"
 package tests.only
 
 class BarTests extends munit.FunSuite {
@@ -70,7 +70,7 @@ To run a specific test case inside a test suite pass `*test-name*` as an argumen
 <!-- clear -->
 
 ```scala title=MunitTests.scala
-//> using lib "org.scalameta::munit::0.7.29"
+//> using dep "org.scalameta::munit::0.7.29"
 package tests.only
 
 class Tests extends munit.FunSuite {
@@ -109,7 +109,7 @@ order to run a specific test case you will need to specify the exact name of the
 <!-- clear -->
 
 ```scala title=MyTests.scala
-//> using lib "com.lihaoyi::utest::0.7.10"
+//> using dep "com.lihaoyi::utest::0.7.10"
 
 import utest._
 

--- a/website/docs/cookbooks/vscode.md
+++ b/website/docs/cookbooks/vscode.md
@@ -13,7 +13,7 @@ def hello() = println("Hello, world")
 ```
 
 ```scala title=MyTests.test.scala
-//> using lib "org.scalameta::munit::1.0.0-M1"
+//> using dep "org.scalameta::munit::1.0.0-M1"
 
 class MyTests extends munit.FunSuite {
   test("test") {

--- a/website/docs/getting_started.md
+++ b/website/docs/getting_started.md
@@ -119,7 +119,7 @@ cd scala-cli-getting-started
 Now we can write our logic in a file named `files.scala`:
 
 ```scala title=files.scala
-//> using lib "com.lihaoyi::os-lib:0.9.0"
+//> using dep "com.lihaoyi::os-lib:0.9.0"
 
 def filesByExtension(
   extension: String,
@@ -129,7 +129,7 @@ def filesByExtension(
     }
 ```
 
-As you may have noticed, we specified a dependency within `files.scala` using the `//> using lib com.lihaoyi::os-lib:0.9.0` syntax. With Scala CLI, you can provide configuration information with `using` directives — a dedicated syntax that can be embedded in any `.scala` file. For more details, see our dedicated [guide for `using` directives](./guides/using-directives.md).
+As you may have noticed, we specified a dependency within `files.scala` using the `//> using dep com.lihaoyi::os-lib:0.9.0` syntax. With Scala CLI, you can provide configuration information with `using` directives — a dedicated syntax that can be embedded in any `.scala` file. For more details, see our dedicated [guide for `using` directives](./guides/using-directives.md).
 
 Now let's check if our code compiles. We do that by running:
 
@@ -156,7 +156,7 @@ With our IDE in place, how can we test if our code works correctly? The best way
 We also need to add a test framework. Scala CLI support most popular test frameworks, and for this guide we will stick with [munit](https://scalameta.org/munit/). To add a test framework, we just need an ordinary dependency, and once again we'll add that with the `using` directive:
 
 ```scala title=files.test.scala
-//> using lib "org.scalameta::munit:1.0.0-M1"
+//> using dep "org.scalameta::munit:1.0.0-M1"
 
 class TestSuite extends munit.FunSuite {
   test("hello") {

--- a/website/docs/guides/configuration.md
+++ b/website/docs/guides/configuration.md
@@ -82,8 +82,8 @@ The reference documentation lists [all available using directives](/docs/referen
 Dependencies can be added right from `.scala` and `.sc` files with [`using` directives](#using-directives):
 
 ```scala compile
-//> using lib "com.lihaoyi::upickle:1.4.0"
-//> using lib "com.lihaoyi::pprint:0.6.6"
+//> using dep "com.lihaoyi::upickle:1.4.0"
+//> using dep "com.lihaoyi::pprint:0.6.6"
 import ujson._
 ```
 

--- a/website/docs/guides/dependencies.md
+++ b/website/docs/guides/dependencies.md
@@ -79,8 +79,8 @@ scala-cli compile Sample.sc --jar /path/to/library.jar
 To check if dependencies in using directives are up-to-date, use `dependency-update` command:
 
 ```scala title=Hello.scala
-//> using lib "com.lihaoyi::os-lib:0.7.8"
-//> using lib "com.lihaoyi::utest:0.7.10"
+//> using dep "com.lihaoyi::os-lib:0.7.8"
+//> using dep "com.lihaoyi::utest:0.7.10"
 
 object Hello extends App {
   println("Hello World")

--- a/website/docs/guides/markdown.md
+++ b/website/docs/guides/markdown.md
@@ -266,7 +266,7 @@ You can run `scala test` code blocks with the `test` sub-command.
 This is a simple example of an `.md` file with a test Scala snippet.
 
 ```scala test
-//> using lib "org.scalameta::munit:0.7.29"
+//> using dep "org.scalameta::munit:0.7.29"
 class Test extends munit.FunSuite {
   test("example test") {
     assert(true)
@@ -359,7 +359,7 @@ This is supported for all `scala` code block flavours.
 
 ## `scala raw` example
 ```scala raw
-//> using lib "com.lihaoyi::pprint:0.8.0"
+//> using dep "com.lihaoyi::pprint:0.8.0"
 object Printer {
   def printHello(): Unit = pprint.pprintln("Hello")
 }
@@ -367,13 +367,13 @@ object Printer {
 
 ## Plain `scala` example
 ```scala
-//> using lib "com.lihaoyi::os-lib:0.8.1"
+//> using dep "com.lihaoyi::os-lib:0.8.1"
 println(os.pwd)
 ```
 
 ## `scala test` example
 ```scala test
-//> using lib "org.scalameta::munit:1.0.0-M7"
+//> using dep "org.scalameta::munit:1.0.0-M7"
 
 class Test extends munit.FunSuite {
   test("foo") {

--- a/website/docs/guides/scala-js.md
+++ b/website/docs/guides/scala-js.md
@@ -143,7 +143,7 @@ npm install jsdom
 :::
 
 ```scala title=Hello.scala
-//> using lib "org.scala-js::scalajs-dom::2.1.0"
+//> using dep "org.scala-js::scalajs-dom::2.1.0"
 //> using platform scala-js
 
 object Hello {

--- a/website/docs/guides/using-directives.md
+++ b/website/docs/guides/using-directives.md
@@ -109,9 +109,9 @@ The only exceptions are `using target` directives, which only apply to the given
 Below is a list of the most important `using` directives that Scala CLI supports. The full list can be found in the [Reference section of this documentation](/docs/reference/directives.md).
 
 - `//> using scala "<scala-version>"` - defines version of Scala used
-- `//> using lib "org::name:version"` - defines dependency to a given library [more in dedicated guide](/docs/guides/dependencies.md)
-- `//> using lib "org:name:version"`  - defines dependency to a given **java** library, note the `:` instead of `::`
-- `//> using lib "org::name:version,url=url"` - defines dependency to a given library with a fallback to its jar url
+- `//> using dep "org::name:version"` - defines dependency to a given library [more in dedicated guide](/docs/guides/dependencies.md)
+- `//> using dep "org:name:version"`  - defines dependency to a given **java** library, note the `:` instead of `::`
+- `//> using dep "org::name:version,url=url"` - defines dependency to a given library with a fallback to its jar url
 - `//> using resourceDir "<dir>"` - marks directory as source of resources. Resources accessible at runtime and packaged together with compiled code.
 - ``//> using `java-opt` "<opt>"`` - use given java options when running application or tests
 - `//> using target ["test"|"main"]` used to marked or unmarked given source as test
@@ -141,25 +141,25 @@ Using directives are part of the code so similarly, developers should be able to
 Paradoxically, commenting out comment-based directives does not cause any problems. Below, some examples how to do it:
 
 ```scala compile
-// //> using lib "no::lib:123"
+// //> using dep "no::lib:123"
 ```
 
 ```scala compile
-// // using lib "no::lib:123"
+// // using dep "no::lib:123"
 ```
 
 Until plain using directives in plain comments are supported, commenting keyword base syntax require some attention. Let' assume that we have a following code:
 
 ```scala fail
 using scala "3.1.1"
-using lib "no::lib:123"
+using dep "no::lib:123"
 ```
 
 and we want to comment out broken using directive: `lib "no::lib:123"` when we simply comment it out we will actually turn it into a using directive that is using a plain comment syntax!
 
 ```scala compile
 using scala "3.1.1"
-// using lib "no::lib:123"
+// using dep "no::lib:123"
 ```
 
 In cases where there are other uncommented directives, scala-cli will ignore that directives, producing a warning. In cases that this is the only directive in the file, the commented directive will be still used to configure build.
@@ -167,9 +167,9 @@ In cases where there are other uncommented directives, scala-cli will ignore tha
 In such cases we suggest to use triple `/` for single line comments, or use `//` withing multiline comments:
 
 ```scala compile
-/// using lib "in::single-line-comments:123"
+/// using dep "in::single-line-comments:123"
 /*
-// using lib "in::multiline-line-comments:123"
+// using dep "in::multiline-line-comments:123"
 */
 ```
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -53,14 +53,14 @@ Manually add sources to the project
 
 Add dependencies
 
-`//> using lib "`_org_`:`name`:`ver"
+`//> using dep "`_org_`:`name`:`ver"
 
 #### Examples
-`//> using lib "org.scalatest::scalatest:3.2.10"`
+`//> using dep "org.scalatest::scalatest:3.2.10"`
 
-`//> using lib "org.scalameta::munit:0.7.29"`
+`//> using dep "org.scalameta::munit:0.7.29"`
 
-`//> using lib "tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar"`
+`//> using dep "tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar"`
 
 ### JVM version
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -37,14 +37,14 @@ Adds compiler plugins
 
 Add dependencies
 
-`//> using lib "`_org_`:`name`:`ver"
+`//> using dep "`_org_`:`name`:`ver"
 
 #### Examples
-`//> using lib "org.scalatest::scalatest:3.2.10"`
+`//> using dep "org.scalatest::scalatest:3.2.10"`
 
-`//> using lib "org.scalameta::munit:0.7.29"`
+`//> using dep "org.scalameta::munit:0.7.29"`
 
-`//> using lib "tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar"`
+`//> using dep "tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar"`
 
 ### Java options
 

--- a/website/docs/release_notes.md
+++ b/website/docs/release_notes.md
@@ -262,7 +262,7 @@ Added by [@carlosedp](https://github.com/carlosedp) in [#1626](https://github.co
 It is now possible to filter test suites with the `--test-only` option.
 
 ```scala title=BarTests.scala
-//> using lib "org.scalameta::munit::1.0.0-M7"
+//> using dep "org.scalameta::munit::1.0.0-M7"
 package tests.only
 class Tests extends munit.FunSuite {
   test("bar") {

--- a/website/src/pages/spark.md
+++ b/website/src/pages/spark.md
@@ -10,7 +10,7 @@ to `spark-submit`, and optimized for it.
 <ChainedSnippets>
 
 ```scala title=SparkJob.scala
-//> using lib "org.apache.spark::spark-sql:3.0.3"
+//> using dep "org.apache.spark::spark-sql:3.0.3"
 //> using scala "2.12.15"
 
 import org.apache.spark._
@@ -81,7 +81,7 @@ The `run` sub-command can run Hadoop jobs, by calling the `hadoop jar` command u
 <ChainedSnippets>
 
 ```java title=WordCount.java
-//> using lib "org.apache.hadoop:hadoop-client-api:3.3.3"
+//> using dep "org.apache.hadoop:hadoop-client-api:3.3.3"
 
 // from https://hadoop.apache.org/docs/r3.3.3/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
 


### PR DESCRIPTION
To be more consistent with command line options where dependency is passed by `--dep`.

I still keep the alias of this using directive (`lib`, `libs`) for backwards compatibility