### PR TITLE
blooprifle: report exit code in exception

### DIFF
--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/FailedToStartServerException.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/FailedToStartServerException.scala
@@ -2,5 +2,11 @@ package scala.build.blooprifle
 
 import scala.concurrent.duration.Duration
 
-final class FailedToStartServerException(timeoutOpt: Option[Duration] = None)
-  extends Exception("Server didn't start" + timeoutOpt.fold("")(t => s" after $t"))
+abstract class FailedToStartServerException(message: String)
+  extends Exception(message)
+
+final class FailedToStartServerExitCodeException(exitCode: Int)
+  extends FailedToStartServerException(f"Server failed with exit code $exitCode")
+
+final class FailedToStartServerTimeoutException(timeout: Duration)
+  extends FailedToStartServerException(f"Server didn't start after $timeout")

--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Operations.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Operations.scala
@@ -13,7 +13,7 @@ import java.nio.file.{Files, Path, Paths}
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.{ExecutorService, ScheduledExecutorService, ScheduledFuture}
 
-import scala.build.blooprifle.{BloopRifleConfig, BloopRifleLogger, BspConnection, BspConnectionAddress, FailedToStartServerException}
+import scala.build.blooprifle.{BloopRifleConfig, BloopRifleLogger, BspConnection, BspConnectionAddress, FailedToStartServerExitCodeException, FailedToStartServerTimeoutException}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future, Promise}
 import scala.util.control.NonFatal
@@ -247,11 +247,11 @@ object Operations {
           }
           val completionOpt =
             if (!p.isAlive() && exitCode != serverAlreadyRunningExitCode)
-              Some(Failure(new FailedToStartServerException))
+              Some(Failure(new FailedToStartServerExitCodeException(exitCode)))
             else if (check(address, logger))
               Some(Success(()))
             else if (timeout.isFinite && System.currentTimeMillis() - start > timeout.toMillis)
-              Some(Failure(new FailedToStartServerException(Some(timeout))))
+              Some(Failure(new FailedToStartServerTimeoutException(timeout)))
             else
               None
 

--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -66,7 +66,7 @@ class BloopTests extends ScalaCliSuite {
         mergeErrIntoOut = true
       )
       expect(res.exitCode == 1)
-      expect(res.out.text().contains("Server didn't start"))
+      expect(res.out.text().contains("Server failed with exit code 1"))
     }
   }
 
@@ -87,7 +87,7 @@ class BloopTests extends ScalaCliSuite {
         (root / "bloop.json").toString()
       ).call(cwd = root, stderr = os.Pipe, check = false)
       expect(res.exitCode == 1)
-      expect(res.err.text().contains("Server didn't start") || res.err.text().contains(
+      expect(res.err.text().contains("Server failed with exit code 1") || res.err.text().contains(
         "java.lang.OutOfMemoryError: Garbage-collected heap size exceeded"
       ))
     }


### PR DESCRIPTION
To help debugging, the failure code is now part of the exception in case the bloop server failed to start.

I've worked on this during debugging #1843. Turns out, knowing the exit code was not really helpful in this case. However, I believe that it is never wrong to load the exception with it.