### PR TITLE
blooprifle: add -XX:+IgnoreUnrecognizedVMOptions to hardCodedDefaultJavaOpts

### DIFF
--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifleConfig.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifleConfig.scala
@@ -77,6 +77,7 @@ object BloopRifleConfig {
       "-XX:+UseZGC", // ZGC returns unused memory back to the OS, so Bloop does not occupy so much memory if unused
       "-XX:ZUncommitDelay=30",
       "-XX:ZCollectionInterval=5",
+      "-XX:+IgnoreUnrecognizedVMOptions", // Do not fail if an non-standard (-X, -XX) VM option is not recognized.
       "-Dbloop.ignore-sig-int=true"
     )
 

--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -56,20 +56,6 @@ class BloopTests extends ScalaCliSuite {
     testScalaTermination(Constants.bloopVersion, shouldRestart = false)
   }
 
-  test("invalid bloop options passed via cli cause bloop start failure") {
-    TestInputs.empty.fromRoot { root =>
-      runScalaCli("bloop", "exit").call(cwd = root)
-      val res = runScalaCli("bloop", "start", "--bloop-java-opt", "-zzefhjzl").call(
-        cwd = root,
-        stderr = os.Pipe,
-        check = false,
-        mergeErrIntoOut = true
-      )
-      expect(res.exitCode == 1)
-      expect(res.out.text().contains("Server failed with exit code 1"))
-    }
-  }
-
   test("invalid bloop options passed via global bloop config json file cause bloop start failure") {
     val inputs = TestInputs(
       os.rel / "bloop.json" ->


### PR DESCRIPTION
This was (is?) an attempt to fix #1843. However, adding this line had no effect. Just like removing the `XX:MaxInlineLevel` line. I assume that the error in #1843 is caused by a different code path. I suspect https://github.com/scalacenter/bloop/blob/a249e0a710ce169ca05d0606778f96f44a398680/bloopgun/src/main/scala/bloop/bloopgun/util/Environment.scala#L87, where, according to the code comment, the code in scala-cli originates from.

I wonder if it is wise to hard code non-standard JVM options like it is done here and in scalacenter/bloop. As apparently #1843 demonstrates, some (most?) JVM will bail out if they are invoked with options they do not recognize (which is IMHO sensible behavior).  I would be great of all TCK compatible JVMs would be supported by scala-cli (and bloop). So either do not use non-standard hard coded options, or add `-XX:+IgnoreUnrecognizedVMOptions` (which, according to [JDK-6788376](https://bugs.openjdk.org/browse/JDK-6788376), is available since Java 6)<sup>1</sup>.

1: A third option would be to only issue the option if it was detected the receiving JVM supports it. But that is probably not trivial to implement.