### PR TITLE
Fix printing not supported option in restricted mode

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
@@ -32,17 +32,17 @@ object RestrictedCommandsParser {
       d: D,
       nameFormatter: Formatter[Name]
     ): Either[(Error, Arg, List[String]), Option[(D, Arg, List[String])]] =
-      parser.step(args, index, d, nameFormatter) match {
-        case Right(Some(_, arg, _)) if !arg.isSupported =>
+      (parser.step(args, index, d, nameFormatter), args) match {
+        case (Right(Some(_, arg, _)), passedOption :: _) if !arg.isSupported =>
           Left((
             Error.UnrecognizedArgument(
-              s"""`${args(index)}` option is not supported in `scala` command.
+              s"""`$passedOption` option is not supported in `scala` command.
                  |Please run it with `scala-cli` command or with `--power` flag or turn on this flag globally running command `config power true`.""".stripMargin
             ),
             arg,
             Nil
           ))
-        case other =>
+        case (other, _) =>
           other
       }
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -81,7 +81,7 @@ class SipScalaTests extends ScalaCliSuite {
 
     val binary = binaryName.prepareBinary(root)
 
-    val res = os.proc(binary, "--markdown", source).call(
+    val res = os.proc(binary, "--scala", "3", "--markdown", source).call(
       cwd = root,
       check = false,
       mergeErrIntoOut = true
@@ -90,6 +90,7 @@ class SipScalaTests extends ScalaCliSuite {
       expect(res.exitCode == 1)
       val output = res.out.text()
       expect(output.contains(s"option is not supported"))
+      expect(output.contains("--markdown"))
     }
     else expect(res.exitCode == 0)
   }


### PR DESCRIPTION
When I run: 

```
./scala --scala -3 --markdown .
```

it throw the following error:
```
Exception in thread "main" java.lang.IndexOutOfBoundsException: 2
        at scala.collection.LinearSeqOps.apply(LinearSeq.scala:131)
        at scala.collection.LinearSeqOps.apply$(LinearSeq.scala:128)
        at scala.collection.immutable.List.apply(List.scala:79)
        at scala.cli.commands.RestrictedCommandsParser$$anon$1.step(RestrictedCommandsParser.scala:39)
        at caseapp.core.parser.EitherParser.step(EitherParser.scala:24)
        at caseapp.core.parser.RecursiveConsParser.step(RecursiveConsParser.scala:26)
        at caseapp.core.parser.ConsParser.step(ConsParser.scala:36)
        at caseapp.core.parser.ConsParser.step(ConsParser.scala:36)
        at caseapp.core.parser.MappedParser.step(MappedParser.scala:25)
        at caseapp.core.parser.MappedParser.step(MappedParser.scala:25)
        at caseapp.core.parser.RecursiveConsParser.step(RecursiveConsParser.scala:26)
        at caseapp.core.parser.MappedParser.step(MappedParser.scala:25)
        at caseapp.core.parser.MappedParser.step(MappedParser.scala:25)
        at caseapp.core.parser.ParserWithNameFormatter.step(ParserWithNameFormatter.scala:21)
        at caseapp.core.parser.ParserMethods.step(ParserMethods.scala:25)
        at caseapp.core.parser.ParserMethods.step$(ParserMethods.scala:12)
        at caseapp.core.parser.Parser.step(Parser.scala:15)
        at caseapp.core.parser.ParserMethods.helper$1(ParserMethods.scala:214)
        at caseapp.core.parser.ParserMethods.scan(ParserMethods.scala:276)
        at caseapp.core.parser.ParserMethods.scan$(ParserMethods.scala:12)
        at caseapp.core.parser.Parser.scan(Parser.scala:15)
        at caseapp.core.parser.ParserMethods.detailedParse(ParserMethods.scala:128)
```

I fixed extracting option passed by user in `RestrictedCommandsParser`.