### PR TITLE
bloop-rifle: increase timeout values

### DIFF
--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifleConfig.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifleConfig.scala
@@ -119,6 +119,10 @@ object BloopRifleConfig {
       .orElse(fromProps)
       .getOrElse(hardCodedDefaultScalaVersion)
   }
+  lazy val extraTimeout: FiniteDuration = Option(System.getenv("SCALA_CLI_EXTRA_TIMEOUT"))
+    .map(Duration(_))
+    .collect { case d: FiniteDuration => d }
+    .getOrElse(Duration.Zero)
 
   def default(
     address: Address,
@@ -136,10 +140,10 @@ object BloopRifleConfig {
       bspStdout = None,
       bspStderr = None,
       period = 100.milliseconds,
-      timeout = 10.seconds,
+      timeout = 10.seconds + extraTimeout,
       startCheckPeriod = 100.millis,
-      startCheckTimeout = 1.minute,
-      initTimeout = 30.seconds,
+      startCheckTimeout = 1.minute + extraTimeout,
+      initTimeout = 30.seconds + extraTimeout,
       minimumBloopJvm = 8,
       retainedBloopVersion = AtLeast(BloopVersion(Constants.bloopVersion))
     )

--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Operations.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Operations.scala
@@ -473,7 +473,7 @@ object Operations {
     val nailgunClient0 = nailgunClient(address)
     val streams        = Streams(None, out, err)
 
-    timeout(30.seconds, scheduler, logger) {
+    timeout(30.seconds + BloopRifleConfig.extraTimeout, scheduler, logger) {
       nailgunClient0.run(
         "about",
         Array.empty,


### PR DESCRIPTION
To allow scala-cli being run on low-end devcies, increase the timeouts to be more generous. Yes, it does not make much fun (yet) to use scala-cli on those devices, waiting 6 minutes for bloop to get exec'ed, but having larger timeouts at least enables user to run Scala scripts. Whereas with the smaller timeouts, scala-cli aborts for no good reason.

The increased timeouts may also help to prevent sporadic CI failures due to false negatives, i.e., because scala-cli run into such a relative low timeout -- some timeouts where as low as 30 seconds -- on busy CI nodes.