### PR TITLE
Trim passwords obtained as command result

### DIFF
--- a/modules/config/src/main/scala/scala/cli/config/PasswordOption.scala
+++ b/modules/config/src/main/scala/scala/cli/config/PasswordOption.scala
@@ -76,7 +76,7 @@ object PasswordOption extends LowPriorityPasswordOption {
 
       import sys.process._
       val res = command.!!<
-      Secret(res) // should we trim that?
+      Secret(res.trim)
     }
     def asString: Secret[String] = {
       val json = writeToString(command.toList)(commandCodec)


### PR DESCRIPTION
If you follow the instruction for publishing from github actions,
when providing github token with this snippet:
[`scala-cli config github.token command:pbpaste --password-value`](https://scala-cli.virtuslab.org/docs/commands/publishing/publish-setup/#github-token)
and then proceeding to:
[`scala-cli publish setup . --ci`](https://scala-cli.virtuslab.org/docs/commands/publishing/publish-setup/#github-actions-setup)
one gets an error `Error: java.lang.IllegalArgumentException: Illegal character(s) in message header value` due to the value in config ending with `'\n'`.

Trimming the value obtained by calling a command fixes that.