### PR TITLE
Shorter options help

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOptions.scala
@@ -6,13 +6,7 @@ import scala.cli.commands.shared.{CoursierOptions, HasLoggingOptions, HelpMessag
 import scala.cli.commands.tags
 
 // format: off
-@HelpMessage(
-  s"""Interact with Bloop (the build server) or check its status.
-     |
-     |This sub-command allows to check the current status of Bloop.
-     |If Bloop isn't currently running, it will be started.
-     |
-     |${HelpMessages.bloopInfo}""".stripMargin)
+@HelpMessage(BloopOptions.helpMessage, "", BloopOptions.detailedHelpMessage)
 final case class BloopOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
@@ -39,4 +33,12 @@ final case class BloopOptions(
 object BloopOptions {
   implicit lazy val parser: Parser[BloopOptions] = Parser.derive
   implicit lazy val help: Help[BloopOptions]   = Help.derive
+  val helpMessage: String = "Interact with Bloop (the build server) or check its status."
+  val detailedHelpMessage: String =
+    s"""$helpMessage
+       |
+       |This sub-command allows to check the current status of Bloop.
+       |If Bloop isn't currently running, it will be started.
+       |
+       |${HelpMessages.bloopInfo}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/bsp/BspOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bsp/BspOptions.scala
@@ -7,16 +7,7 @@ import scala.cli.commands.shared.{HasSharedOptions, HelpMessages, SharedOptions}
 import scala.cli.commands.tags
 
 // format: off
-@HelpMessage(
-  s"""Start BSP server.
-     |
-     |BSP stands for Build Server Protocol.
-     |For more information refer to https://build-server-protocol.github.io/
-     |
-     |This sub-command is not designed to be used by a human.
-     |It is normally supposed to be invoked by your IDE when a $fullRunnerName project is imported.
-     |
-     |${HelpMessages.docsWebsiteReference}""".stripMargin)
+@HelpMessage(BspOptions.helpMessage, "", BspOptions.detailedHelpMessage)
 final case class BspOptions(
   // FIXME There might be too many options in SharedOptions for the bsp command…
   @Recurse
@@ -34,4 +25,21 @@ final case class BspOptions(
 object BspOptions {
   implicit lazy val parser: Parser[BspOptions] = Parser.derive
   implicit lazy val help: Help[BspOptions]     = Help.derive
+  val cmdName                                  = "bsp"
+  private val helpHeader                       = "Start BSP server."
+  val helpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.commandFullHelpReference(cmdName)}
+       |${HelpMessages.docsWebsiteReference}""".stripMargin
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |BSP stands for Build Server Protocol.
+       |For more information refer to https://build-server-protocol.github.io/
+       |
+       |This sub-command is not designed to be used by a human.
+       |It is normally supposed to be invoked by your IDE when a $fullRunnerName project is imported.
+       |
+       |${HelpMessages.docsWebsiteReference}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/clean/CleanOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/clean/CleanOptions.scala
@@ -12,12 +12,7 @@ import scala.cli.commands.shared.{
 }
 
 // format: off
-@HelpMessage(
-  s"""Clean the workspace.
-    |
-    |Passed inputs will establish the $fullRunnerName project, for which the workspace will be cleaned.
-    |
-    |${HelpMessages.commandDocWebsiteReference("clean")}""".stripMargin)
+@HelpMessage(CleanOptions.helpMessage, "", CleanOptions.detailedHelpMessage)
 final case class CleanOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
@@ -31,4 +26,13 @@ final case class CleanOptions(
 object CleanOptions {
   implicit lazy val parser: Parser[CleanOptions] = Parser.derive
   implicit lazy val help: Help[CleanOptions]     = Help.derive
+  val cmdName                                    = "clean"
+  private val helpHeader                         = "Clean the workspace."
+  val helpMessage: String = HelpMessages.shortHelpMessage(cmdName, helpHeader)
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |Passed inputs will establish the $fullRunnerName project, for which the workspace will be cleaned.
+       |
+       |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/compile/Compile.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/compile/Compile.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.compile
 
 import caseapp.*
+import caseapp.core.help.HelpFormat
 
 import java.io.File
 
@@ -14,6 +15,7 @@ import scala.cli.commands.update.Update
 import scala.cli.commands.util.BuildCommandHelpers
 import scala.cli.commands.{CommandUtils, ScalaCommand, WatchUtil}
 import scala.cli.config.{ConfigDb, Keys}
+import scala.cli.util.ArgHelpers.*
 
 object Compile extends ScalaCommand[CompileOptions] with BuildCommandHelpers {
   override def group = "Main"
@@ -21,6 +23,10 @@ object Compile extends ScalaCommand[CompileOptions] with BuildCommandHelpers {
   override def sharedOptions(options: CompileOptions): Option[SharedOptions] = Some(options.shared)
 
   override def scalaSpecificationLevel = SpecificationLevel.MUST
+  val primaryHelpGroups: Seq[String] =
+    Seq("Compilation", "Scala", "Java", "Watch", "Compilation server")
+
+  override def helpFormat: HelpFormat = super.helpFormat.withPrimaryGroups(primaryHelpGroups)
 
   override def runCommand(options: CompileOptions, args: RemainingArgs, logger: Logger): Unit = {
     val buildOptions = buildOptionsOrExit(options)

--- a/modules/cli/src/main/scala/scala/cli/commands/compile/CompileOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/compile/CompileOptions.scala
@@ -12,16 +12,7 @@ import scala.cli.commands.shared.{
 }
 import scala.cli.commands.tags
 
-@HelpMessage({
-  val cmdName = "compile"
-  s"""Compile Scala code.
-     |
-     |${HelpMessages.commandConfigurations(cmdName)}
-     |
-     |${HelpMessages.acceptedInputs}
-     |
-     |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
-})
+@HelpMessage(CompileOptions.helpMessage, "", CompileOptions.detailedHelpMessage)
 // format: off
 final case class CompileOptions(
   @Recurse
@@ -31,14 +22,18 @@ final case class CompileOptions(
   @Recurse
     cross: CrossOptions = CrossOptions(),
 
+  @Group("Compilation")
   @Name("p")
   @Name("printClasspath")
   @HelpMessage("Print the resulting class path")
   @Tag(tags.should)
+  @Tag(tags.important)
     printClassPath: Boolean = false,
 
+  @Group("Compilation")
   @HelpMessage("Compile test scope")
   @Tag(tags.should)
+  @Tag(tags.important)
     test: Boolean = false
 ) extends HasSharedOptions
   // format: on
@@ -46,4 +41,15 @@ final case class CompileOptions(
 object CompileOptions {
   implicit lazy val parser: Parser[CompileOptions] = Parser.derive
   implicit lazy val help: Help[CompileOptions]     = Help.derive
+  val cmdName                                      = "compile"
+  private val helpHeader                           = "Compile Scala code."
+  val helpMessage: String = HelpMessages.shortHelpMessage(cmdName, helpHeader)
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.commandConfigurations(cmdName)}
+       |
+       |${HelpMessages.acceptedInputs}
+       |
+       |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/compile/CompileOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/compile/CompileOptions.scala
@@ -27,13 +27,13 @@ final case class CompileOptions(
   @Name("printClasspath")
   @HelpMessage("Print the resulting class path")
   @Tag(tags.should)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     printClassPath: Boolean = false,
 
   @Group("Compilation")
   @HelpMessage("Compile test scope")
   @Tag(tags.should)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     test: Boolean = false
 ) extends HasSharedOptions
   // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.config
 
 import caseapp.core.RemainingArgs
+import caseapp.core.help.HelpFormat
 import coursier.cache.ArchiveCache
 
 import java.util.Base64
@@ -20,10 +21,13 @@ import scala.cli.config.{
   RepositoryCredentials,
   Secret
 }
-
+import scala.cli.util.ArgHelpers.*
 object Config extends ScalaCommand[ConfigOptions] {
-  override def hidden                  = true
   override def scalaSpecificationLevel = SpecificationLevel.MUST
+
+  override def helpFormat: HelpFormat = super.helpFormat
+    .copy(hiddenGroups = Some(Seq("Java")))
+    .withPrimaryGroup("Config")
 
   override def runCommand(options: ConfigOptions, args: RemainingArgs, logger: Logger): Unit = {
     val directories = Directories.directories

--- a/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
@@ -14,15 +14,7 @@ import scala.cli.commands.shared.{
 import scala.cli.commands.tags
 
 // format: off
-@HelpMessage(
-  s"""Configure global settings for $fullRunnerName.
-     |
-     |Syntax:
-     |  $progName config key value
-     |For example, to globally set the interactive mode:
-     |  $progName config interactive true
-     |
-     |${HelpMessages.commandDocWebsiteReference("misc/config")}""".stripMargin)
+@HelpMessage(ConfigOptions.helpMessage, "", ConfigOptions.detailedHelpMessage)
 final case class ConfigOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
@@ -37,41 +29,53 @@ final case class ConfigOptions(
   @HelpMessage("Dump config DB as JSON")
   @Hidden
   @Tag(tags.implementation)
+  @Tag(tags.important)
     dump: Boolean = false,
   @Group("Config")
   @HelpMessage("Create PGP key in config")
+  @Tag(tags.important)
+  @Tag(tags.restricted)
     createPgpKey: Boolean = false,
   @Group("Config")
   @HelpMessage("Email to use to create PGP key in config")
   @Tag(tags.restricted)
+  @Tag(tags.important)
     email: Option[String] = None,
   @Group("Config")
   @HelpMessage("If the entry is a password, print the password value rather than how to get the password")
   @Tag(tags.restricted)
+  @Tag(tags.important)
     password: Boolean = false,
   @Group("Config")
   @HelpMessage("If the entry is a password, save the password value rather than how to get the password")
   @Tag(tags.restricted)
+  @Tag(tags.important)
     passwordValue: Boolean = false,
   @Group("Config")
   @HelpMessage("Remove an entry from config")
+  @Tag(tags.important)
+  @Tag(tags.should)
   @ExtraName("remove")
     unset: Boolean = false,
   @Group("Config")
   @HelpMessage("For repository.credentials and publish.credentials, whether these credentials should be HTTPS only (default: true)")
   @Tag(tags.restricted)
+  @Tag(tags.important)
     httpsOnly: Option[Boolean] = None,
   @Group("Config")
   @HelpMessage("For repository.credentials, whether to use these credentials automatically based on the host")
   @Tag(tags.restricted)
+  @Tag(tags.important)
     matchHost: Option[Boolean] = None,
   @Group("Config")
   @HelpMessage("For repository.credentials, whether to use these credentials are optional")
   @Tag(tags.restricted)
+  @Tag(tags.important)
     optional: Option[Boolean] = None,
   @Group("Config")
   @HelpMessage("For repository.credentials, whether to use these credentials should be passed upon redirection")
   @Tag(tags.restricted)
+  @Tag(tags.important)
     passOnRedirect: Option[Boolean] = None
 ) extends HasLoggingOptions
 // format: on
@@ -79,4 +83,21 @@ final case class ConfigOptions(
 object ConfigOptions {
   implicit lazy val parser: Parser[ConfigOptions] = Parser.derive
   implicit lazy val help: Help[ConfigOptions]     = Help.derive
+  private val helpHeader: String = s"Configure global settings for $fullRunnerName."
+  private val cmdName            = "config"
+  private val websiteSuffix      = s"misc/$cmdName"
+  val helpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.commandFullHelpReference(cmdName)}
+       |${HelpMessages.commandDocWebsiteReference(websiteSuffix)}""".stripMargin
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |Syntax:
+       |  $progName $cmdName key value
+       |For example, to globally set the interactive mode:
+       |  $progName $cmdName interactive true
+       |
+       |${HelpMessages.commandDocWebsiteReference(websiteSuffix)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
@@ -29,53 +29,53 @@ final case class ConfigOptions(
   @HelpMessage("Dump config DB as JSON")
   @Hidden
   @Tag(tags.implementation)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     dump: Boolean = false,
   @Group("Config")
   @HelpMessage("Create PGP key in config")
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @Tag(tags.restricted)
     createPgpKey: Boolean = false,
   @Group("Config")
   @HelpMessage("Email to use to create PGP key in config")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     email: Option[String] = None,
   @Group("Config")
   @HelpMessage("If the entry is a password, print the password value rather than how to get the password")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     password: Boolean = false,
   @Group("Config")
   @HelpMessage("If the entry is a password, save the password value rather than how to get the password")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     passwordValue: Boolean = false,
   @Group("Config")
   @HelpMessage("Remove an entry from config")
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @Tag(tags.should)
   @ExtraName("remove")
     unset: Boolean = false,
   @Group("Config")
   @HelpMessage("For repository.credentials and publish.credentials, whether these credentials should be HTTPS only (default: true)")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     httpsOnly: Option[Boolean] = None,
   @Group("Config")
   @HelpMessage("For repository.credentials, whether to use these credentials automatically based on the host")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     matchHost: Option[Boolean] = None,
   @Group("Config")
   @HelpMessage("For repository.credentials, whether to use these credentials are optional")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     optional: Option[Boolean] = None,
   @Group("Config")
   @HelpMessage("For repository.credentials, whether to use these credentials should be passed upon redirection")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     passOnRedirect: Option[Boolean] = None
 ) extends HasLoggingOptions
 // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/dependencyupdate/DependencyUpdate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/dependencyupdate/DependencyUpdate.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.dependencyupdate
 
 import caseapp.*
+import caseapp.core.help.HelpFormat
 
 import scala.build.actionable.ActionableDependencyHandler
 import scala.build.actionable.ActionableDiagnostic.ActionableDependencyUpdateDiagnostic
@@ -10,10 +11,12 @@ import scala.build.{CrossSources, Logger, Position, Sources}
 import scala.cli.CurrentParams
 import scala.cli.commands.ScalaCommand
 import scala.cli.commands.shared.SharedOptions
+import scala.cli.util.ArgHelpers.*
 
 object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
   override def group                   = "Main"
   override def scalaSpecificationLevel = SpecificationLevel.RESTRICTED
+  override def helpFormat: HelpFormat  = super.helpFormat.withPrimaryGroup("Dependency")
   override def sharedOptions(options: DependencyUpdateOptions): Option[SharedOptions] =
     Some(options.shared)
   override def runCommand(

--- a/modules/cli/src/main/scala/scala/cli/commands/dependencyupdate/DependencyUpdateOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/dependencyupdate/DependencyUpdateOptions.scala
@@ -11,9 +11,10 @@ import scala.cli.commands.tags
 final case class DependencyUpdateOptions(
   @Recurse
     shared: SharedOptions = SharedOptions(),
-  @Group("DependencyUpdate")
+  @Group("Dependency")
   @HelpMessage("Update all dependencies if a newer version was released")
   @Tag(tags.restricted)
+  @Tag(tags.important)
     all: Boolean = false,
 ) extends HasSharedOptions
   // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/dependencyupdate/DependencyUpdateOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/dependencyupdate/DependencyUpdateOptions.scala
@@ -14,7 +14,7 @@ final case class DependencyUpdateOptions(
   @Group("Dependency")
   @HelpMessage("Update all dependencies if a newer version was released")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     all: Boolean = false,
 ) extends HasSharedOptions
   // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.doc
 
 import caseapp.*
+import caseapp.core.help.HelpFormat
 import dependency.*
 
 import java.io.File
@@ -18,12 +19,15 @@ import scala.cli.commands.shared.SharedOptions
 import scala.cli.commands.{CommandUtils, ScalaCommand}
 import scala.cli.config.{ConfigDb, Keys}
 import scala.cli.errors.ScaladocGenerationFailedError
+import scala.cli.util.ArgHelpers.*
 import scala.util.Properties
 
 object Doc extends ScalaCommand[DocOptions] {
   override def group = "Main"
 
   override def sharedOptions(options: DocOptions): Option[SharedOptions] = Some(options.shared)
+
+  override def helpFormat: HelpFormat = super.helpFormat.withPrimaryGroup("Doc")
 
   override def scalaSpecificationLevel = SpecificationLevel.MUST
 

--- a/modules/cli/src/main/scala/scala/cli/commands/doc/DocOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/doc/DocOptions.scala
@@ -8,15 +8,7 @@ import scala.cli.commands.shared.{HasSharedOptions, HelpMessages, SharedOptions}
 import scala.cli.commands.tags
 
 // format: off
-@HelpMessage(
-  message =
-    s"""Generate Scaladoc documentation.
-       |
-       |${HelpMessages.acceptedInputs}
-       |
-       |${HelpMessages.commandDocWebsiteReference("doc")}""".stripMargin,
-  messageMd = s"By default, $fullRunnerName sets common `scaladoc` options and this mechanism can be disabled by using `--default-scaladoc-opts:false`."
-)
+@HelpMessage(DocOptions.helpMessage, DocOptions.messageMd, DocOptions.detailedHelpMessage)
 final case class DocOptions(
   @Recurse
     shared: SharedOptions = SharedOptions(),
@@ -41,4 +33,15 @@ final case class DocOptions(
 object DocOptions {
   implicit lazy val parser: Parser[DocOptions] = Parser.derive
   implicit lazy val help: Help[DocOptions]     = Help.derive
+  val cmdName                                  = "doc"
+  private val helpHeader                       = "Generate Scaladoc documentation."
+  val helpMessage: String                      = HelpMessages.shortHelpMessage(cmdName, helpHeader)
+  val detailedHelpMessage: String =
+    s"""Generate Scaladoc documentation.
+       |
+       |${HelpMessages.acceptedInputs}
+       |
+       |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
+  val messageMd =
+    s"By default, $fullRunnerName sets common `scaladoc` options and this mechanism can be disabled by using `--default-scaladoc-opts:false`."
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/export0/Export.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/export0/Export.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.export0
 
 import caseapp.*
+import caseapp.core.help.HelpFormat
 import com.github.plokhotnyuk.jsoniter_scala.core.*
 import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 import com.google.gson.{Gson, GsonBuilder}
@@ -20,10 +21,13 @@ import scala.cli.CurrentParams
 import scala.cli.commands.ScalaCommand
 import scala.cli.commands.shared.SharedOptions
 import scala.cli.exportCmd.*
+import scala.cli.util.ArgHelpers.*
 import scala.util.Using
 
 object Export extends ScalaCommand[ExportOptions] {
   override def scalaSpecificationLevel = SpecificationLevel.RESTRICTED
+
+  override def helpFormat: HelpFormat = super.helpFormat.withPrimaryGroup("Build Tool export")
 
   private def prepareBuild(
     inputs: Inputs,

--- a/modules/cli/src/main/scala/scala/cli/commands/export0/ExportOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/export0/ExportOptions.scala
@@ -26,6 +26,8 @@ final case class ExportOptions(
   @HelpMessage("Sets the export format to Mill")
     mill: Option[Boolean] = None,
   @Tag(tags.restricted)
+  @Tag(tags.inShortHelp)
+  @Group("Build Tool export")
   @HelpMessage("Sets the export format to Json")
     json: Option[Boolean] = None,
 

--- a/modules/cli/src/main/scala/scala/cli/commands/export0/ExportOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/export0/ExportOptions.scala
@@ -7,16 +7,7 @@ import scala.cli.commands.shared.{HasSharedOptions, HelpMessages, MainClassOptio
 import scala.cli.commands.tags
 
 // format: off
-@HelpMessage(
-  s"""Export current project to an external build tool (like SBT or Mill).
-     |
-     |The whole $fullRunnerName project should get exported along with its dependencies configuration.
-     |
-     |Unless otherwise configured, the default export format is SBT.
-     |
-     |${HelpMessages.acceptedInputs}
-     |
-     |${HelpMessages.docsWebsiteReference}""".stripMargin)
+@HelpMessage(ExportOptions.helpMessage, "", ExportOptions.detailedHelpMessage)
 final case class ExportOptions(
   // FIXME There might be too many options for 'scala-cli export' there
   @Recurse
@@ -24,12 +15,14 @@ final case class ExportOptions(
   @Recurse
     mainClass: MainClassOptions = MainClassOptions(),
 
-  @Group("Build Tool export options")
+  @Group("Build Tool export")
   @Tag(tags.restricted)
+  @Tag(tags.important)
   @HelpMessage("Sets the export format to SBT")
     sbt: Option[Boolean] = None,
-  @Group("Build Tool export options")
+  @Group("Build Tool export")
   @Tag(tags.restricted)
+  @Tag(tags.important)
   @HelpMessage("Sets the export format to Mill")
     mill: Option[Boolean] = None,
   @Tag(tags.restricted)
@@ -37,20 +30,20 @@ final case class ExportOptions(
     json: Option[Boolean] = None,
 
   @Name("setting")
-  @Group("Build Tool export options")
+  @Group("Build Tool export")
   @Tag(tags.restricted)
     sbtSetting: List[String] = Nil,
   @Name("p")
-  @Group("Build Tool export options")
+  @Group("Build Tool export")
   @Tag(tags.restricted)
   @HelpMessage("Project name to be used on Mill build file")
     project: Option[String] = None,
-  @Group("Build Tool export options")
+  @Group("Build Tool export")
   @Tag(tags.restricted)
   @HelpMessage("Version of SBT to be used for the export")
     sbtVersion: Option[String] = None,
   @Name("o")
-  @Group("Build Tool export options")
+  @Group("Build Tool export")
   @Tag(tags.restricted)
     output: Option[String] = None
 ) extends HasSharedOptions
@@ -58,4 +51,20 @@ final case class ExportOptions(
 object ExportOptions {
   implicit lazy val parser: Parser[ExportOptions] = Parser.derive
   implicit lazy val help: Help[ExportOptions]     = Help.derive
+
+  private val helpHeader = "Export current project to an external build tool (like SBT or Mill)."
+  val helpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.docsWebsiteReference}""".stripMargin
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |The whole $fullRunnerName project should get exported along with its dependencies configuration.
+       |
+       |Unless otherwise configured, the default export format is SBT.
+       |
+       |${HelpMessages.acceptedInputs}
+       |
+       |${HelpMessages.docsWebsiteReference}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/export0/ExportOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/export0/ExportOptions.scala
@@ -17,12 +17,12 @@ final case class ExportOptions(
 
   @Group("Build Tool export")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("Sets the export format to SBT")
     sbt: Option[Boolean] = None,
   @Group("Build Tool export")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("Sets the export format to Mill")
     mill: Option[Boolean] = None,
   @Tag(tags.restricted)

--- a/modules/cli/src/main/scala/scala/cli/commands/fmt/Fmt.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/fmt/Fmt.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.fmt
 
 import caseapp.*
+import caseapp.core.help.HelpFormat
 import dependency.*
 
 import scala.build.input.{Inputs, Script, SourceScalaFile}
@@ -11,11 +12,21 @@ import scala.cli.CurrentParams
 import scala.cli.commands.ScalaCommand
 import scala.cli.commands.fmt.FmtUtil.*
 import scala.cli.commands.shared.SharedOptions
+import scala.cli.util.ArgHelpers.*
 
 object Fmt extends ScalaCommand[FmtOptions] {
   override def group: String                                             = "Main"
   override def sharedOptions(options: FmtOptions): Option[SharedOptions] = Some(options.shared)
   override def scalaSpecificationLevel                                   = SpecificationLevel.SHOULD
+
+  val hiddenHelpGroups: Seq[String] =
+    Seq("Scala", "Java", "Dependency", "Scala.js", "Scala Native", "Compilation server", "Debug")
+  override def helpFormat: HelpFormat = super.helpFormat
+    .copy(
+      hiddenGroups = Some(hiddenHelpGroups),
+      hiddenGroupsWhenShowHidden = Some(hiddenHelpGroups)
+    )
+    .withPrimaryGroup("Format")
   override def names: List[List[String]] = List(
     List("fmt"),
     List("format"),

--- a/modules/cli/src/main/scala/scala/cli/commands/fmt/FmtOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/fmt/FmtOptions.scala
@@ -13,23 +13,14 @@ import scala.cli.commands.{Constants, tags}
 import scala.util.Properties
 
 // format: off
-@HelpMessage(
-  s"""Formats Scala code.
-     |
-     |`scalafmt` is used to perform the formatting under the hood.
-     |
-     |The `.scalafmt.conf` configuration file is optional.
-     |Default configuration values will be assumed by $fullRunnerName.
-     |
-     |All standard $fullRunnerName inputs are accepted, but only Scala sources will be formatted (.scala and .sc files).
-     |
-     |${HelpMessages.commandDocWebsiteReference("fmt")}""".stripMargin)
+@HelpMessage(FmtOptions.helpMessage, "", FmtOptions.detailedHelpMessage)
 final case class FmtOptions(
   @Recurse
     shared: SharedOptions = SharedOptions(),
 
   @Group("Format")
   @Tag(tags.should)
+  @Tag(tags.important)
   @HelpMessage("Check if sources are well formatted")
     check: Boolean = false,
 
@@ -40,6 +31,7 @@ final case class FmtOptions(
 
   @Group("Format")
   @Tag(tags.implementation)
+  @Tag(tags.important)
   @HelpMessage("Saves .scalafmt.conf file if it was created or overwritten")
     saveScalafmtConf: Boolean = false,
 
@@ -67,12 +59,14 @@ final case class FmtOptions(
   @Group("Format")
   @Name("F")
   @Tag(tags.implementation)
-  @HelpMessage("Pass argument to scalafmt.")
+  @HelpMessage("Pass an argument to scalafmt.")
+  @Tag(tags.important)
     scalafmtArg: List[String] = Nil,
 
   @Group("Format")
   @HelpMessage("Custom path to the scalafmt configuration file.")
   @Tag(tags.implementation)
+  @Tag(tags.important)
   @Name("scalafmtConfig")
     scalafmtConf: Option[String] = None,
   @Group("Format")
@@ -86,11 +80,13 @@ final case class FmtOptions(
   @HelpMessage("Pass a global dialect for scalafmt. This overrides whatever value is configured in the .scalafmt.conf file or inferred based on Scala version used.")
   @Tag(tags.implementation)
   @Name("dialect")
+  @Tag(tags.important)
     scalafmtDialect: Option[String] = None,
   @Tag(tags.implementation)
   @Group("Format")
   @HelpMessage(s"Pass scalafmt version before running it (${Constants.defaultScalafmtVersion} by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.")
   @Name("fmtVersion")
+  @Tag(tags.important)
     scalafmtVersion: Option[String] = None
 ) extends HasSharedOptions {
   // format: on
@@ -124,4 +120,19 @@ final case class FmtOptions(
 object FmtOptions {
   implicit lazy val parser: Parser[FmtOptions] = Parser.derive
   implicit lazy val help: Help[FmtOptions]     = Help.derive
+
+  val cmdName             = "fmt"
+  private val helpHeader  = "Formats Scala code."
+  val helpMessage: String = HelpMessages.shortHelpMessage(cmdName, helpHeader)
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |`scalafmt` is used to perform the formatting under the hood.
+       |
+       |The `.scalafmt.conf` configuration file is optional.
+       |Default configuration values will be assumed by $fullRunnerName.
+       |
+       |All standard $fullRunnerName inputs are accepted, but only Scala sources will be formatted (.scala and .sc files).
+       |
+       |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/fmt/FmtOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/fmt/FmtOptions.scala
@@ -20,7 +20,7 @@ final case class FmtOptions(
 
   @Group("Format")
   @Tag(tags.should)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("Check if sources are well formatted")
     check: Boolean = false,
 
@@ -31,7 +31,7 @@ final case class FmtOptions(
 
   @Group("Format")
   @Tag(tags.implementation)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("Saves .scalafmt.conf file if it was created or overwritten")
     saveScalafmtConf: Boolean = false,
 
@@ -60,13 +60,13 @@ final case class FmtOptions(
   @Name("F")
   @Tag(tags.implementation)
   @HelpMessage("Pass an argument to scalafmt.")
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     scalafmtArg: List[String] = Nil,
 
   @Group("Format")
   @HelpMessage("Custom path to the scalafmt configuration file.")
   @Tag(tags.implementation)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @Name("scalafmtConfig")
     scalafmtConf: Option[String] = None,
   @Group("Format")
@@ -80,13 +80,13 @@ final case class FmtOptions(
   @HelpMessage("Pass a global dialect for scalafmt. This overrides whatever value is configured in the .scalafmt.conf file or inferred based on Scala version used.")
   @Tag(tags.implementation)
   @Name("dialect")
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     scalafmtDialect: Option[String] = None,
   @Tag(tags.implementation)
   @Group("Format")
   @HelpMessage(s"Pass scalafmt version before running it (${Constants.defaultScalafmtVersion} by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.")
   @Name("fmtVersion")
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     scalafmtVersion: Option[String] = None
 ) extends HasSharedOptions {
   // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/github/SecretCreate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/SecretCreate.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.github
 
 import caseapp.core.RemainingArgs
+import caseapp.core.help.HelpFormat
 import com.github.plokhotnyuk.jsoniter_scala.core.*
 import coursier.cache.ArchiveCache
 import sttp.client3.*
@@ -15,10 +16,12 @@ import scala.cli.commands.util.ScalaCliSttpBackend
 import scala.cli.commands.{ScalaCommand, SpecificationLevel}
 import scala.cli.config.{PasswordOption, Secret}
 import scala.cli.errors.GitHubApiError
+import scala.cli.util.ArgHelpers.*
 
 object SecretCreate extends ScalaCommand[SecretCreateOptions] {
 
   override def scalaSpecificationLevel = SpecificationLevel.RESTRICTED
+  override def helpFormat: HelpFormat  = super.helpFormat.withPrimaryGroup("Secret")
   override def names = List(
     List("github", "secret", "create"),
     List("gh", "secret", "create")

--- a/modules/cli/src/main/scala/scala/cli/commands/github/SecretCreateOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/SecretCreateOptions.scala
@@ -9,14 +9,16 @@ import scala.cli.commands.tags
 // format: off
 @HelpMessage(
   s"""Creates or updates a GitHub repository secret.
-    |  $progName --power github secret create --repo repo-org/repo-name SECRET_VALUE=value:secret
-    |""".stripMargin)
+    |  $progName --power github secret create --repo repo-org/repo-name SECRET_VALUE=value:secret""".stripMargin
+)
 final case class SecretCreateOptions(
   @Recurse
     shared: SharedSecretOptions = SharedSecretOptions(),
   @Recurse
     coursier: CoursierOptions = CoursierOptions(),
+  @Group("Secret")
   @Tag(tags.restricted)
+  @Tag(tags.important)
   @ExtraName("pubKey")
     publicKey: Option[String] = None,
   @Tag(tags.implementation)
@@ -24,6 +26,7 @@ final case class SecretCreateOptions(
     dummy: Boolean = false,
   @Hidden
   @Tag(tags.implementation)
+  @Group("Secret")
     printRequest: Boolean = false
 ) extends HasSharedSecretOptions
 // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/github/SecretCreateOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/SecretCreateOptions.scala
@@ -18,7 +18,7 @@ final case class SecretCreateOptions(
     coursier: CoursierOptions = CoursierOptions(),
   @Group("Secret")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @ExtraName("pubKey")
     publicKey: Option[String] = None,
   @Tag(tags.implementation)

--- a/modules/cli/src/main/scala/scala/cli/commands/github/SecretList.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/SecretList.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.github
 
 import caseapp.core.RemainingArgs
+import caseapp.core.help.HelpFormat
 import com.github.plokhotnyuk.jsoniter_scala.core.*
 import sttp.client3.*
 
@@ -11,10 +12,13 @@ import scala.cli.commands.publish.ConfigUtil.*
 import scala.cli.commands.util.ScalaCliSttpBackend
 import scala.cli.config.Secret
 import scala.cli.errors.GitHubApiError
+import scala.cli.util.ArgHelpers.*
 
 object SecretList extends ScalaCommand[SecretListOptions] {
 
   override def scalaSpecificationLevel = SpecificationLevel.RESTRICTED
+
+  override def helpFormat: HelpFormat = super.helpFormat.withPrimaryGroup("Secret")
   override def names = List(
     List("github", "secret", "list"),
     List("gh", "secret", "list")

--- a/modules/cli/src/main/scala/scala/cli/commands/github/SharedSecretOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/SharedSecretOptions.scala
@@ -13,12 +13,12 @@ final case class SharedSecretOptions(
     logging: LoggingOptions = LoggingOptions(),
   @Group("Secret")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     token: PasswordOption = PasswordOption.Value(Secret("")),
   @ExtraName("repo")
   @Group("Secret")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     repository: String = ""
 ) extends HasLoggingOptions {
   // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/github/SharedSecretOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/SharedSecretOptions.scala
@@ -11,10 +11,14 @@ import scala.cli.signing.util.ArgParsers.*
 final case class SharedSecretOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
-  @Tag(tags.experimental)
+  @Group("Secret")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     token: PasswordOption = PasswordOption.Value(Secret("")),
   @ExtraName("repo")
-  @Tag(tags.experimental)
+  @Group("Secret")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     repository: String = ""
 ) extends HasLoggingOptions {
   // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/installcompletions/InstallCompletions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/installcompletions/InstallCompletions.scala
@@ -2,6 +2,7 @@ package scala.cli.commands.installcompletions
 
 import caseapp.*
 import caseapp.core.complete.{Bash, Zsh}
+import caseapp.core.help.HelpFormat
 
 import java.io.File
 import java.nio.charset.Charset
@@ -11,13 +12,15 @@ import java.util
 import scala.build.{Directories, Logger}
 import scala.cli.commands.ScalaCommand
 import scala.cli.internal.{Argv0, ProfileFileUpdater}
+import scala.cli.util.ArgHelpers.*
 import scala.cli.{CurrentParams, ScalaCli}
-
 object InstallCompletions extends ScalaCommand[InstallCompletionsOptions] {
   override def names = List(
     List("install", "completions"),
     List("install-completions")
   )
+
+  override def helpFormat: HelpFormat = super.helpFormat.withPrimaryGroup("Install")
 
   override def scalaSpecificationLevel = SpecificationLevel.IMPLEMENTATION
 

--- a/modules/cli/src/main/scala/scala/cli/commands/installcompletions/InstallCompletionsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/installcompletions/InstallCompletionsOptions.scala
@@ -7,39 +7,44 @@ import scala.cli.commands.shared.{HasLoggingOptions, HelpMessages, LoggingOption
 import scala.cli.commands.tags
 
 // format: off
-@HelpMessage(
-  s"""Installs $fullRunnerName completions into your shell
-     |
-     |${HelpMessages.commandDocWebsiteReference("completions")}""".stripMargin)
+@HelpMessage(InstallCompletionsOptions.helpMessage, "", InstallCompletionsOptions.detailedHelpMessage)
 final case class InstallCompletionsOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
+  @Group("Install")
   @Name("shell")
   @Tag(tags.implementation)
+  @Tag(tags.important)
   @HelpMessage("Name of the shell, either zsh or bash")
     format: Option[String] = None,
 
   @Tag(tags.implementation)
+  @Group("Install")
+  @Tag(tags.important)
   @HelpMessage("Path to `*rc` file, defaults to `.bashrc` or `.zshrc` depending on shell")
   rcFile: Option[String] = None,
 
   @Tag(tags.implementation)
   @HelpMessage("Completions output directory")
+  @Group("Install")
   @Name("o")
   output: Option[String] = None,
 
   @Hidden
   @Tag(tags.implementation)
   @HelpMessage("Custom banner in comment placed in rc file")
+  @Group("Install")
   banner: String = "{NAME} completions",
 
   @Hidden
   @Tag(tags.implementation)
   @HelpMessage("Custom completions name")
+  @Group("Install")
   name: Option[String] = None,
 
   @Tag(tags.implementation)
   @HelpMessage("Print completions to stdout")
+  @Group("Install")
     env: Boolean = false,
 ) extends HasLoggingOptions
 // format: on
@@ -47,4 +52,15 @@ final case class InstallCompletionsOptions(
 object InstallCompletionsOptions {
   implicit lazy val parser: Parser[InstallCompletionsOptions] = Parser.derive
   implicit lazy val help: Help[InstallCompletionsOptions]     = Help.derive
+
+  private val helpHeader = s"Installs $fullRunnerName completions into your shell"
+  val helpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.commandFullHelpReference("install completions")}
+       |${HelpMessages.commandDocWebsiteReference("completions")}""".stripMargin
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.commandDocWebsiteReference("completions")}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/installcompletions/InstallCompletionsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/installcompletions/InstallCompletionsOptions.scala
@@ -14,13 +14,13 @@ final case class InstallCompletionsOptions(
   @Group("Install")
   @Name("shell")
   @Tag(tags.implementation)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("Name of the shell, either zsh or bash")
     format: Option[String] = None,
 
   @Tag(tags.implementation)
   @Group("Install")
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("Path to `*rc` file, defaults to `.bashrc` or `.zshrc` depending on shell")
   rcFile: Option[String] = None,
 

--- a/modules/cli/src/main/scala/scala/cli/commands/installhome/InstallHome.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/installhome/InstallHome.scala
@@ -1,17 +1,21 @@
 package scala.cli.commands.installhome
 
 import caseapp.*
+import caseapp.core.help.HelpFormat
 import coursier.env.{EnvironmentUpdate, ProfileUpdater}
 
 import scala.build.Logger
 import scala.cli.CurrentParams
 import scala.cli.commands.{CommandUtils, CustomWindowsEnvVarUpdater, ScalaCommand}
+import scala.cli.util.ArgHelpers.*
 import scala.io.StdIn.readLine
 import scala.util.Properties
 
 object InstallHome extends ScalaCommand[InstallHomeOptions] {
   override def hidden: Boolean         = true
   override def scalaSpecificationLevel = SpecificationLevel.IMPLEMENTATION
+
+  override def helpFormat: HelpFormat = super.helpFormat.withPrimaryGroup("Install")
 
   private def logEqual(version: String, logger: Logger) = {
     logger.message(s"$fullRunnerName $version is already installed and up-to-date.")

--- a/modules/cli/src/main/scala/scala/cli/commands/installhome/InstallHomeOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/installhome/InstallHomeOptions.scala
@@ -11,21 +11,24 @@ import scala.cli.commands.tags
 final case class InstallHomeOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
-  @Group("InstallHome")
+  @Group("Install")
   @Tag(tags.implementation)
     scalaCliBinaryPath: String,
-  @Group("InstallHome")
+  @Group("Install")
   @Name("f")
   @Tag(tags.implementation)
   @HelpMessage("Overwrite if it exists")
     force: Boolean = false,
+  @Group("Install")
   @Hidden
   @Tag(tags.implementation)
   @HelpMessage("Binary name")
     binaryName: String = baseRunnerName,
+  @Group("Install")
   @Tag(tags.implementation)
   @HelpMessage("Print the update to `env` variable")
     env: Boolean = false,
+  @Group("Install")
   @Hidden
   @Tag(tags.implementation)
   @HelpMessage("Binary directory")

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
@@ -2,6 +2,7 @@ package scala.cli.commands.package0
 
 import ai.kien.python.Python
 import caseapp.*
+import caseapp.core.help.HelpFormat
 import coursier.launcher.*
 import dependency.*
 import packager.config.*
@@ -30,7 +31,7 @@ import scala.cli.CurrentParams
 import scala.cli.commands.OptionsHelper.*
 import scala.cli.commands.doc.Doc
 import scala.cli.commands.packaging.Spark
-import scala.cli.commands.publish.ConfigUtil._
+import scala.cli.commands.publish.ConfigUtil.*
 import scala.cli.commands.run.Run.orPythonDetectionError
 import scala.cli.commands.shared.{MainClassOptions, SharedOptions}
 import scala.cli.commands.util.BuildCommandHelpers
@@ -39,11 +40,28 @@ import scala.cli.config.{ConfigDb, Keys}
 import scala.cli.errors.ScalaJsLinkingError
 import scala.cli.internal.{CachedBinary, Constants, ProcUtil, ScalaJsLinker}
 import scala.cli.packaging.{Library, NativeImage}
+import scala.cli.util.ArgHelpers.*
 import scala.util.Properties
 
 object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
-  override def name                                                          = "package"
-  override def group                                                         = "Main"
+  override def name  = "package"
+  override def group = "Main"
+
+  val primaryHelpGroups: Seq[String] = Seq(
+    "Package",
+    "Scala",
+    "Java",
+    "Debian",
+    "MacOS",
+    "RedHat",
+    "Windows",
+    "Docker",
+    "Native image"
+  )
+  val hiddenHelpGroups: Seq[String] = Seq("Entrypoint", "Watch")
+  override def helpFormat: HelpFormat = super.helpFormat
+    .copy(hiddenGroups = Some(hiddenHelpGroups))
+    .withPrimaryGroups(primaryHelpGroups)
   override def sharedOptions(options: PackageOptions): Option[SharedOptions] = Some(options.shared)
   override def scalaSpecificationLevel = SpecificationLevel.RESTRICTED
   override def buildOptions(options: PackageOptions): Option[BuildOptions] =

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
@@ -32,41 +32,41 @@ final case class PackageOptions(
   @HelpMessage("Set the destination path")
   @Name("o")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     output: Option[String] = None,
   @Group("Package")
   @HelpMessage("Overwrite the destination file, if it exists")
   @Name("f")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     force: Boolean = false,
 
   @Group("Package")
   @HelpMessage("Generate a library JAR rather than an executable JAR")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     library: Boolean = false,
   @Group("Package")
   @HelpMessage("Generate a source JAR rather than an executable JAR")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     source: Boolean = false,
   @Group("Package")
   @HelpMessage("Generate a scaladoc JAR rather than an executable JAR")
   @ExtraName("scaladoc")
   @ExtraName("javadoc")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     doc: Boolean = false,
   @Group("Package")
   @HelpMessage("Generate an assembly JAR")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     assembly: Boolean = false,
   @Group("Package")
   @HelpMessage("For assembly JAR, whether to add a bash / bat preamble")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     preamble: Boolean = true,
   @Group("Package")
   @Hidden
@@ -81,39 +81,39 @@ final case class PackageOptions(
   @Group("Package")
   @HelpMessage("Package standalone JARs")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     standalone: Option[Boolean] = None,
   @Recurse
     packager: PackagerOptions = PackagerOptions(),
   @Group("Package")
   @HelpMessage("Build Debian package, available only on Linux")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     deb: Boolean = false,
   @Group("Package")
   @HelpMessage("Build dmg package, available only on macOS")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     dmg: Boolean = false,
   @Group("Package")
   @HelpMessage("Build rpm package, available only on Linux")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     rpm: Boolean = false,
   @Group("Package")
   @HelpMessage("Build msi package, available only on Windows")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     msi: Boolean = false,
   @Group("Package")
   @HelpMessage("Build pkg package, available only on macOS")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     pkg: Boolean = false,
   @Group("Package")
   @HelpMessage("Build Docker image")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     docker: Boolean = false,
 
   @Group("Package")
@@ -121,7 +121,7 @@ final case class PackageOptions(
   @HelpMessage("Exclude modules *and their transitive dependencies* from the JAR to be packaged")
   @ValueDescription("org:name")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     provided: List[String] = Nil,
 
   @Group("Package")
@@ -134,7 +134,7 @@ final case class PackageOptions(
   @HelpMessage("Build GraalVM native image")
   @ExtraName("graal")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     nativeImage: Boolean = false
 ) extends HasSharedOptions {
   // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
@@ -12,17 +12,9 @@ import scala.build.options.packaging.*
 import scala.build.{BuildThreads, Positioned}
 import scala.cli.commands.package0.PackageOptions
 import scala.cli.commands.shared.*
+import scala.cli.commands.tags
 
-@HelpMessage({
-  val cmdName = "package"
-  s"""Compile and package Scala code.
-     |
-     |${HelpMessages.commandConfigurations(cmdName)}
-     |
-     |${HelpMessages.acceptedInputs}
-     |
-     |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
-})
+@HelpMessage(PackageOptions.helpMessage, "", PackageOptions.detailedHelpMessage)
 // format: off
 final case class PackageOptions(
   @Recurse
@@ -39,75 +31,110 @@ final case class PackageOptions(
   @Group("Package")
   @HelpMessage("Set the destination path")
   @Name("o")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     output: Option[String] = None,
   @Group("Package")
   @HelpMessage("Overwrite the destination file, if it exists")
   @Name("f")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     force: Boolean = false,
 
   @Group("Package")
   @HelpMessage("Generate a library JAR rather than an executable JAR")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     library: Boolean = false,
   @Group("Package")
   @HelpMessage("Generate a source JAR rather than an executable JAR")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     source: Boolean = false,
   @Group("Package")
   @HelpMessage("Generate a scaladoc JAR rather than an executable JAR")
   @ExtraName("scaladoc")
   @ExtraName("javadoc")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     doc: Boolean = false,
   @Group("Package")
   @HelpMessage("Generate an assembly JAR")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     assembly: Boolean = false,
   @Group("Package")
   @HelpMessage("For assembly JAR, whether to add a bash / bat preamble")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     preamble: Boolean = true,
   @Group("Package")
   @Hidden
   @HelpMessage("For assembly JAR, whether to specify a main class in the JAR manifest")
+  @Tag(tags.restricted)
     mainClassInManifest: Option[Boolean] = None,
   @Group("Package")
   @Hidden
   @HelpMessage("Generate an assembly JAR for Spark (assembly that doesn't contain Spark, nor any of its dependencies)")
+  @Tag(tags.experimental)
     spark: Boolean = false,
   @Group("Package")
   @HelpMessage("Package standalone JARs")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     standalone: Option[Boolean] = None,
   @Recurse
     packager: PackagerOptions = PackagerOptions(),
   @Group("Package")
   @HelpMessage("Build Debian package, available only on Linux")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     deb: Boolean = false,
   @Group("Package")
   @HelpMessage("Build dmg package, available only on macOS")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     dmg: Boolean = false,
   @Group("Package")
   @HelpMessage("Build rpm package, available only on Linux")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     rpm: Boolean = false,
   @Group("Package")
   @HelpMessage("Build msi package, available only on Windows")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     msi: Boolean = false,
   @Group("Package")
   @HelpMessage("Build pkg package, available only on macOS")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     pkg: Boolean = false,
   @Group("Package")
   @HelpMessage("Build Docker image")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     docker: Boolean = false,
 
   @Group("Package")
   @Hidden
   @HelpMessage("Exclude modules *and their transitive dependencies* from the JAR to be packaged")
   @ValueDescription("org:name")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     provided: List[String] = Nil,
 
   @Group("Package")
   @HelpMessage("Use default scaladoc options")
   @ExtraName("defaultScaladocOpts")
+  @Tag(tags.implementation)
     defaultScaladocOptions: Option[Boolean] = None,
 
   @Group("Package")
   @HelpMessage("Build GraalVM native image")
   @ExtraName("graal")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     nativeImage: Boolean = false
 ) extends HasSharedOptions {
   // format: on
@@ -235,4 +262,16 @@ final case class PackageOptions(
 object PackageOptions {
   implicit lazy val parser: Parser[PackageOptions] = Parser.derive
   implicit lazy val help: Help[PackageOptions]     = Help.derive
+
+  val cmdName             = "package"
+  private val helpHeader  = "Compile and package Scala code."
+  val helpMessage: String = HelpMessages.shortHelpMessage(cmdName, helpHeader, needsPower = true)
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.commandConfigurations(cmdName)}
+       |
+       |${HelpMessages.acceptedInputs}
+       |
+       |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/PackagerOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/PackagerOptions.scala
@@ -136,10 +136,12 @@ final case class PackagerOptions(
   @HelpMessage(s"GraalVM Java major version to use to build GraalVM native images (${Constants.defaultGraalVMJavaVersion} by default)")
   @ValueDescription("java-major-version")
   @Tag(tags.restricted)
+  @Tag(tags.important)
     graalvmJavaVersion: Option[Int] = None,
   @Group("Native image")
   @HelpMessage(s"GraalVM version to use to build GraalVM native images (${Constants.defaultGraalVMVersion} by default)")
   @ValueDescription("version")
+  @Tag(tags.important)
     graalvmVersion: Option[String] = None,
   @Group("Native image")
   @HelpMessage("JVM id of GraalVM distribution to build GraalVM native images (like \"graalvm-java17:22.0.0\")")

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/PackagerOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/PackagerOptions.scala
@@ -136,12 +136,12 @@ final case class PackagerOptions(
   @HelpMessage(s"GraalVM Java major version to use to build GraalVM native images (${Constants.defaultGraalVMJavaVersion} by default)")
   @ValueDescription("java-major-version")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     graalvmJavaVersion: Option[Int] = None,
   @Group("Native image")
   @HelpMessage(s"GraalVM version to use to build GraalVM native images (${Constants.defaultGraalVMVersion} by default)")
   @ValueDescription("version")
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     graalvmVersion: Option[String] = None,
   @Group("Native image")
   @HelpMessage("JVM id of GraalVM distribution to build GraalVM native images (like \"graalvm-java17:22.0.0\")")

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/PackagerOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/PackagerOptions.scala
@@ -1,18 +1,21 @@
 package scala.cli.commands.package0
 
-import caseapp.{Group, Help, HelpMessage, Name, Parser, ValueDescription}
+import caseapp._
 
-import scala.cli.commands.Constants
+import scala.cli.commands.{Constants, tags}
 
 // format: off
 final case class PackagerOptions(
   @HelpMessage("Set the version of the generated package")
+  @Tag(tags.restricted)
     version: String = "1.0.0",
   @HelpMessage(
     "Path to application logo in PNG format, it will be used to generate icon and banner/dialog in msi installer"
   )
+  @Tag(tags.restricted)
     logoPath: Option[String] = None,
   @HelpMessage("Set launcher app name, which will be linked to the PATH")
+  @Tag(tags.restricted)
     launcherApp: Option[String] = None,
   @ValueDescription("Description")
     description: Option[String] = None,
@@ -24,93 +27,115 @@ final case class PackagerOptions(
     "The list of Debian package that this package is not compatible with"
   )
   @ValueDescription("Debian dependencies conflicts")
+  @Tag(tags.restricted)
     debianConflicts: List[String] = Nil,
   @Group("Debian")
   @HelpMessage("The list of Debian packages that this package depends on")
   @ValueDescription("Debian dependencies")
+  @Tag(tags.restricted)
     debianDependencies: List[String] = Nil,
   @Group("Debian")
   @HelpMessage(
     "Architectures that are supported by the repository (default: all)"
   )
+  @Tag(tags.restricted)
     debArchitecture: String = "all",
   @Group("Debian")
   @HelpMessage(
     "This field represents how important it is that the user have the package installed"
   )
+  @Tag(tags.restricted)
   priority: Option[String] = None,
   @Group("Debian")
   @HelpMessage(
     "This field specifies an application area into which the package has been classified"
   )
+  @Tag(tags.restricted)
   section: Option[String] = None,
   @Group("MacOS")
   @HelpMessage(
   "CF Bundle Identifier"
   )
+  @Tag(tags.restricted)
     identifier: Option[String] = None,
   @Group("RedHat")
   @HelpMessage(
     "Licenses that are supported by the repository (list of licenses: https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing)"
   )
+  @Tag(tags.restricted)
     license: Option[String] = None,
   @Group("RedHat")
   @HelpMessage(
     "The number of times this version of the software was released (default: 1)"
   )
+  @Tag(tags.restricted)
     release: String = "1",
   @HelpMessage("Architectures that are supported by the repository (default: noarch)")
+  @Tag(tags.restricted)
     rpmArchitecture: String = "noarch",
   @Group("Windows")
   @HelpMessage("Path to the license file")
+  @Tag(tags.restricted)
     licensePath: Option[String] = None,
   @Group("Windows")
   @HelpMessage("Name of product (default: Scala packager)")
+  @Tag(tags.restricted)
     productName: String = "Scala packager",
   @Group("Windows")
   @HelpMessage("Text that will be displayed on the exit dialog")
+  @Tag(tags.restricted)
     exitDialog: Option[String] = None,
   @Group("Windows")
+  @Tag(tags.restricted)
   @HelpMessage("Suppress Wix ICE validation (required for users that are neither interactive, not local administrators)")
     suppressValidation: Option[Boolean] = None,
   @Group("Windows")
+  @Tag(tags.restricted)
   @HelpMessage("Path to extra WIX configuration content")
   @ValueDescription("path")
     extraConfig: List[String] = Nil,
   @Group("Windows")
+  @Tag(tags.restricted)
   @HelpMessage("Whether a 64-bit executable is being packaged")
   @Name("64")
     is64Bits: Boolean = true,
   @Group("Windows")
   @HelpMessage("WIX installer version")
+  @Tag(tags.restricted)
     installerVersion: Option[String] = None,
   @Group("Windows")
   @HelpMessage("The GUID to identify that the windows package can be upgraded.")
+  @Tag(tags.restricted)
     wixUpgradeCodeGuid: Option[String] = None,
   @Group("Docker")
   @HelpMessage(
     "Building the container from base image"
   )
+  @Tag(tags.restricted)
   dockerFrom: Option[String] = None,
   @Group("Docker")
   @HelpMessage(
     "The image registry; if empty, it will use the default registry"
   )
+  @Tag(tags.restricted)
   dockerImageRegistry: Option[String] = None,
   @Group("Docker")
   @HelpMessage(
     "The image repository"
   )
+  @Tag(tags.restricted)
   dockerImageRepository: Option[String] = None,
   @Group("Docker")
   @HelpMessage(
     "The image tag; the default tag is `latest`"
   )
+  @Tag(tags.restricted)
   dockerImageTag: Option[String] = None,
 
   @Group("Native image")
   @HelpMessage(s"GraalVM Java major version to use to build GraalVM native images (${Constants.defaultGraalVMJavaVersion} by default)")
   @ValueDescription("java-major-version")
+  @Tag(tags.restricted)
     graalvmJavaVersion: Option[Int] = None,
   @Group("Native image")
   @HelpMessage(s"GraalVM version to use to build GraalVM native images (${Constants.defaultGraalVMVersion} by default)")
@@ -119,9 +144,11 @@ final case class PackagerOptions(
   @Group("Native image")
   @HelpMessage("JVM id of GraalVM distribution to build GraalVM native images (like \"graalvm-java17:22.0.0\")")
   @ValueDescription("jvm-id")
+  @Tag(tags.restricted)
     graalvmJvmId: Option[String] = None,
   @Group("Native image")
   @HelpMessage("Pass args to GraalVM")
+  @Tag(tags.restricted)
    graalvmArgs: List[String] = Nil
 )
 // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpScalaSigningOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpScalaSigningOptions.scala
@@ -4,14 +4,21 @@ import caseapp.*
 
 import scala.build.options as bo
 import scala.cli.commands.shared.{CoursierOptions, LoggingOptions, SharedJvmOptions}
+import scala.cli.commands.tags
 
 // format: off
 final case class PgpScalaSigningOptions(
+  @Group("Signing")
+  @Tag(tags.restricted)
   @Hidden
     signingCliVersion: Option[String] = None,
+  @Group("Signing")
+  @Tag(tags.restricted)
   @ValueDescription("option")
   @Hidden
     signingCliJavaArg: List[String] = Nil,
+  @Group("Signing")
+  @Tag(tags.restricted)
   @HelpMessage("Whether to run the Scala Signing CLI on the JVM or using a native executable")
   @Hidden
     forceJvmSigningCli: Option[Boolean] = None

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/SharedPgpPushPullOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/SharedPgpPushPullOptions.scala
@@ -5,12 +5,15 @@ import sttp.model.Uri
 
 import scala.build.Logger
 import scala.cli.commands.shared.LoggingOptions
+import scala.cli.commands.tags
 
 // format: off
 final case class SharedPgpPushPullOptions(
   @Group("PGP")
   @HelpMessage("Key server to push / pull keys from")
   @ValueDescription("URL")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     keyServer: List[String] = Nil
 ) {
   // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/SharedPgpPushPullOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/SharedPgpPushPullOptions.scala
@@ -13,7 +13,7 @@ final case class SharedPgpPushPullOptions(
   @HelpMessage("Key server to push / pull keys from")
   @ValueDescription("URL")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     keyServer: List[String] = Nil
 ) {
   // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.publish
 
 import caseapp.core.RemainingArgs
+import caseapp.core.help.HelpFormat
 import coursier.cache.{ArchiveCache, FileCache}
 import coursier.core.{Authentication, Configuration}
 import coursier.maven.MavenRepository
@@ -39,7 +40,7 @@ import scala.build.options.{
   Scope
 }
 import scala.cli.CurrentParams
-import scala.cli.commands.package0.{Package => PackageCmd}
+import scala.cli.commands.package0.Package as PackageCmd
 import scala.cli.commands.pgp.{PgpExternalCommand, PgpScalaSigningOptions}
 import scala.cli.commands.publish.ConfigUtil.*
 import scala.cli.commands.publish.{PublishParamsOptions, PublishRepositoryOptions}
@@ -55,13 +56,16 @@ import scala.cli.errors.{
 }
 import scala.cli.packaging.Library
 import scala.cli.publish.BouncycastleSignerMaker
+import scala.cli.util.ArgHelpers.*
 import scala.cli.util.ConfigPasswordOptionHelpers.*
 import scala.util.control.NonFatal
 
 object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
 
   override def scalaSpecificationLevel = SpecificationLevel.RESTRICTED
-  override def group: String           = "Main"
+
+  override def helpFormat: HelpFormat = super.helpFormat.withPrimaryGroup("Publishing")
+  override def group: String          = "Main"
   override def sharedOptions(options: PublishOptions): Option[SharedOptions] =
     Some(options.shared)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -63,9 +63,9 @@ import scala.util.control.NonFatal
 object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
 
   override def scalaSpecificationLevel = SpecificationLevel.RESTRICTED
-
-  override def helpFormat: HelpFormat = super.helpFormat.withPrimaryGroup("Publishing")
-  override def group: String          = "Main"
+  val primaryHelpGroups: Seq[String]   = Seq("Publishing", "Signing", "PGP")
+  override def helpFormat: HelpFormat  = super.helpFormat.withPrimaryGroups(primaryHelpGroups)
+  override def group: String           = "Main"
   override def sharedOptions(options: PublishOptions): Option[SharedOptions] =
     Some(options.shared)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -64,8 +64,11 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
 
   override def scalaSpecificationLevel = SpecificationLevel.RESTRICTED
   val primaryHelpGroups: Seq[String]   = Seq("Publishing", "Signing", "PGP")
-  override def helpFormat: HelpFormat  = super.helpFormat.withPrimaryGroups(primaryHelpGroups)
-  override def group: String           = "Main"
+  val hiddenHelpGroups: Seq[String]    = Seq("Scala", "Java", "Entrypoint", "Dependency", "Watch")
+  override def helpFormat: HelpFormat = super.helpFormat
+    .copy(hiddenGroups = Some(hiddenHelpGroups))
+    .withPrimaryGroups(primaryHelpGroups)
+  override def group: String = "Main"
   override def sharedOptions(options: PublishOptions): Option[SharedOptions] =
     Some(options.shared)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
@@ -16,7 +16,9 @@ object PublishLocal extends ScalaCommand[PublishLocalOptions] {
   override def group: String           = "Main"
   override def scalaSpecificationLevel = SpecificationLevel.RESTRICTED
   override def helpFormat: HelpFormat =
-    super.helpFormat.withPrimaryGroups(Publish.primaryHelpGroups)
+    super.helpFormat
+      .copy(hiddenGroups = Some(Publish.hiddenHelpGroups))
+      .withPrimaryGroups(Publish.primaryHelpGroups)
   override def sharedOptions(options: PublishLocalOptions): Option[SharedOptions] =
     Some(options.shared)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.publish
 
 import caseapp.core.RemainingArgs
+import caseapp.core.help.HelpFormat
 
 import scala.build.options.BuildOptions
 import scala.build.{BuildThreads, Logger}
@@ -8,11 +9,14 @@ import scala.cli.CurrentParams
 import scala.cli.commands.ScalaCommand
 import scala.cli.commands.shared.SharedOptions
 import scala.cli.config.ConfigDb
+import scala.cli.util.ArgHelpers.*
 
 object PublishLocal extends ScalaCommand[PublishLocalOptions] {
 
   override def group: String           = "Main"
   override def scalaSpecificationLevel = SpecificationLevel.RESTRICTED
+  override def helpFormat: HelpFormat =
+    super.helpFormat.withPrimaryGroups(Publish.primaryHelpGroups)
   override def sharedOptions(options: PublishLocalOptions): Option[SharedOptions] =
     Some(options.shared)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocalOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocalOptions.scala
@@ -3,20 +3,11 @@ package scala.cli.commands.publish
 import caseapp.*
 
 import scala.cli.commands.pgp.PgpScalaSigningOptions
-import scala.cli.commands.shared._
+import scala.cli.commands.publish.PublishSetupOptions.{cmdName, docWebsiteSuffix, helpHeader}
+import scala.cli.commands.shared.*
 
 // format: off
-@HelpMessage(
-  s"""Publishes build artifacts to the local Ivy2 repository.
-     |
-     |The local Ivy2 repository usually lives under `~/.ivy2/local`.
-     |It is taken into account most of the time by most Scala tools when fetching artifacts.
-     |
-     |${HelpMessages.commandConfigurations("publish local")}
-     |
-     |${HelpMessages.acceptedInputs}
-     |
-     |${HelpMessages.commandDocWebsiteReference("publishing/publish-local")}""".stripMargin)
+@HelpMessage(PublishLocalOptions.helpMessage, "", PublishLocalOptions.detailedHelpMessage)
 final case class PublishLocalOptions(
   @Recurse
     shared: SharedOptions = SharedOptions(),
@@ -38,4 +29,16 @@ final case class PublishLocalOptions(
 object PublishLocalOptions {
   implicit lazy val parser: Parser[PublishLocalOptions] = Parser.derive
   implicit lazy val help: Help[PublishLocalOptions]     = Help.derive
+  val cmdName                                           = "publish local"
+  private val helpHeader       = "Publishes build artifacts to the local Ivy2 repository."
+  private val docWebsiteSuffix = "publishing/publish-local"
+  val helpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.commandFullHelpReference(cmdName)}
+       |${HelpMessages.commandDocWebsiteReference(docWebsiteSuffix)}""".stripMargin
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.commandDocWebsiteReference(docWebsiteSuffix)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishOptions.scala
@@ -5,21 +5,10 @@ import caseapp.*
 import scala.cli.ScalaCli.baseRunnerName
 import scala.cli.commands.pgp.PgpScalaSigningOptions
 import scala.cli.commands.shared.*
+import scala.cli.commands.tags
 
 // format: off
-@HelpMessage(
-  s"""Publishes build artifacts to Maven repositories.
-     |
-     |We recommend running the `publish setup` sub-command once prior to
-     |running `publish` in order to set missing `using` directives for publishing.
-     |(but this is not mandatory)
-     |    $baseRunnerName --power publish setup .
-     |
-     |${HelpMessages.commandConfigurations("publish")}
-     |
-     |${HelpMessages.acceptedInputs}
-     |
-     |${HelpMessages.commandDocWebsiteReference("publishing/publish")}""".stripMargin)
+@HelpMessage(PublishOptions.helpMessage, "", PublishOptions.detailedHelpMessage)
 final case class PublishOptions(
   @Recurse
     shared: SharedOptions = SharedOptions(),
@@ -39,10 +28,12 @@ final case class PublishOptions(
     signingCli: PgpScalaSigningOptions = PgpScalaSigningOptions(),
 
   @Group("Publishing")
+  @Tag(tags.restricted)
   @Hidden
     ivy2LocalLike: Option[Boolean] = None,
 
   @Group("Publishing")
+  @Tag(tags.restricted)
   @Hidden
     parallelUpload: Option[Boolean] = None
 ) extends HasSharedOptions
@@ -51,4 +42,25 @@ final case class PublishOptions(
 object PublishOptions {
   implicit lazy val parser: Parser[PublishOptions] = Parser.derive
   implicit lazy val help: Help[PublishOptions]     = Help.derive
+
+  val cmdName            = "publish"
+  private val helpHeader = "Publishes build artifacts to Maven repositories."
+  val helpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.commandFullHelpReference(cmdName, needsPower = true)}
+       |${HelpMessages.commandDocWebsiteReference(s"publishing/$cmdName")}""".stripMargin
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |We recommend running the `publish setup` sub-command once prior to
+       |running `publish` in order to set missing `using` directives for publishing.
+       |(but this is not mandatory)
+       |    $baseRunnerName --power publish setup .
+       |
+       |${HelpMessages.commandConfigurations(cmdName)}
+       |
+       |${HelpMessages.acceptedInputs}
+       |
+       |${HelpMessages.commandDocWebsiteReference(s"publishing/$cmdName")}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishParamsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishParamsOptions.scala
@@ -14,22 +14,22 @@ final case class PublishParamsOptions(
   @Group("Publishing")
   @HelpMessage("Organization to publish artifacts under")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     organization: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("Name to publish artifacts as")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     name: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("Final name to publish artifacts as, including Scala version and platform suffixes if any")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     moduleName: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("Version to publish artifacts as")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     version: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("How to compute the version to publish artifacts as")
@@ -38,35 +38,35 @@ final case class PublishParamsOptions(
   @Group("Publishing")
   @HelpMessage("URL to put in publishing metadata")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     url: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("License to put in publishing metadata")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @ValueDescription("name:URL")
     license: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("VCS information to put in publishing metadata")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     vcs: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("Description to put in publishing metadata")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     description: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("Developer(s) to add in publishing metadata, like \"alex|Alex|https://alex.info\" or \"alex|Alex|https://alex.info|alex@alex.me\"")
   @ValueDescription("id|name|URL|email")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     developer: List[String] = Nil,
 
   @Group("Publishing")
   @HelpMessage("Secret key to use to sign artifacts with Bouncy Castle")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     secretKey: Option[MaybeConfigPasswordOption] = None,
 
   @Group("Publishing")
@@ -74,13 +74,13 @@ final case class PublishParamsOptions(
   @ValueDescription("value:…")
   @ExtraName("secretKeyPass")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     secretKeyPassword: Option[MaybeConfigPasswordOption] = None,
 
   @Group("Publishing")
   @HelpMessage("Use or setup publish parameters meant to be used on continuous integration")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     ci: Option[Boolean] = None
 
 ) {

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishParamsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishParamsOptions.scala
@@ -2,6 +2,7 @@ package scala.cli.commands.publish
 
 import caseapp.*
 
+import scala.cli.commands.tags
 import scala.cli.signing.shared.PasswordOption
 import scala.cli.signing.util.ArgParsers.*
 import scala.cli.util.ArgParsers.*
@@ -12,49 +13,74 @@ final case class PublishParamsOptions(
 
   @Group("Publishing")
   @HelpMessage("Organization to publish artifacts under")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     organization: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("Name to publish artifacts as")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     name: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("Final name to publish artifacts as, including Scala version and platform suffixes if any")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     moduleName: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("Version to publish artifacts as")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     version: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("How to compute the version to publish artifacts as")
+  @Tag(tags.restricted)
     computeVersion: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("URL to put in publishing metadata")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     url: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("License to put in publishing metadata")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
   @ValueDescription("name:URL")
     license: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("VCS information to put in publishing metadata")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     vcs: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("Description to put in publishing metadata")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     description: Option[String] = None,
   @Group("Publishing")
   @HelpMessage("Developer(s) to add in publishing metadata, like \"alex|Alex|https://alex.info\" or \"alex|Alex|https://alex.info|alex@alex.me\"")
   @ValueDescription("id|name|URL|email")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     developer: List[String] = Nil,
 
   @Group("Publishing")
   @HelpMessage("Secret key to use to sign artifacts with Bouncy Castle")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     secretKey: Option[MaybeConfigPasswordOption] = None,
 
   @Group("Publishing")
   @HelpMessage("Password of secret key to use to sign artifacts with Bouncy Castle")
   @ValueDescription("value:…")
   @ExtraName("secretKeyPass")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     secretKeyPassword: Option[MaybeConfigPasswordOption] = None,
 
   @Group("Publishing")
   @HelpMessage("Use or setup publish parameters meant to be used on continuous integration")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     ci: Option[Boolean] = None
 
 ) {

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishRepositoryOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishRepositoryOptions.scala
@@ -2,6 +2,7 @@ package scala.cli.commands.publish
 
 import caseapp.*
 
+import scala.cli.commands.tags
 import scala.cli.signing.shared.PasswordOption
 import scala.cli.signing.util.ArgParsers.*
 
@@ -13,21 +14,29 @@ final case class PublishRepositoryOptions(
   @ValueDescription("URL or path")
   @ExtraName("R")
   @ExtraName("publishRepo")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     publishRepository: Option[String] = None,
 
   @Group("Publishing")
   @HelpMessage("User to use with publishing repository")
   @ValueDescription("user")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     user: Option[PasswordOption] = None,
 
   @Group("Publishing")
   @HelpMessage("Password to use with publishing repository")
   @ValueDescription("value:…")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     password: Option[PasswordOption] = None,
 
   @Group("Publishing")
   @HelpMessage("Realm to use when passing credentials to publishing repository")
   @ValueDescription("realm")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     realm: Option[String] = None
 
 )

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishRepositoryOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishRepositoryOptions.scala
@@ -15,28 +15,28 @@ final case class PublishRepositoryOptions(
   @ExtraName("R")
   @ExtraName("publishRepo")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     publishRepository: Option[String] = None,
 
   @Group("Publishing")
   @HelpMessage("User to use with publishing repository")
   @ValueDescription("user")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     user: Option[PasswordOption] = None,
 
   @Group("Publishing")
   @HelpMessage("Password to use with publishing repository")
   @ValueDescription("value:…")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     password: Option[PasswordOption] = None,
 
   @Group("Publishing")
   @HelpMessage("Realm to use when passing credentials to publishing repository")
   @ValueDescription("realm")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     realm: Option[String] = None
 
 )

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.publish
 
 import caseapp.core.RemainingArgs
+import caseapp.core.help.HelpFormat
 import coursier.cache.ArchiveCache
 
 import java.nio.charset.StandardCharsets
@@ -18,11 +19,15 @@ import scala.cli.commands.util.ScalaCliSttpBackend
 import scala.cli.commands.{CommandUtils, ScalaCommand}
 import scala.cli.config.{ConfigDb, Keys}
 import scala.cli.internal.Constants
+import scala.cli.util.ArgHelpers.*
 
 object PublishSetup extends ScalaCommand[PublishSetupOptions] {
 
   override def group                   = "Main"
   override def scalaSpecificationLevel = SpecificationLevel.RESTRICTED
+
+  override def helpFormat: HelpFormat =
+    super.helpFormat.withPrimaryGroups(Publish.primaryHelpGroups)
 
   override def names = List(
     List("publish", "setup")

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
@@ -27,7 +27,9 @@ object PublishSetup extends ScalaCommand[PublishSetupOptions] {
   override def scalaSpecificationLevel = SpecificationLevel.RESTRICTED
 
   override def helpFormat: HelpFormat =
-    super.helpFormat.withPrimaryGroups(Publish.primaryHelpGroups)
+    super.helpFormat
+      .copy(hiddenGroups = Some(Publish.hiddenHelpGroups))
+      .withPrimaryGroups(Publish.primaryHelpGroups)
 
   override def names = List(
     List("publish", "setup")

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetupOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetupOptions.scala
@@ -33,28 +33,28 @@ final case class PublishSetupOptions(
 
   @Group("Publishing")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("Public key to use to verify artifacts (to be uploaded to a key server)")
     publicKey: Option[PasswordOption] = None,
 
   @Group("Publishing")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("Check if some options for publishing are missing, and exit with non-zero return code if that's the case")
     check: Boolean = false,
   @Group("Publishing")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("GitHub token to use to upload secrets to GitHub - password encoded")
     token: Option[PasswordOption] = None,
   @Group("Publishing")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("Generate a random key pair for publishing, with a secret key protected by a random password")
     randomSecretKey: Option[Boolean] = None,
   @Group("Publishing")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("When generating a random key pair, the mail to associate to it")
     randomSecretKeyMail: Option[String] = None,
   @Group("Publishing")

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetupOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetupOptions.scala
@@ -4,14 +4,12 @@ import caseapp.*
 
 import scala.cli.commands.pgp.{PgpScalaSigningOptions, SharedPgpPushPullOptions}
 import scala.cli.commands.shared.*
+import scala.cli.commands.tags
 import scala.cli.signing.shared.PasswordOption
 import scala.cli.signing.util.ArgParsers.*
 
 // format: off
-@HelpMessage(
-  s"""Configures the project for publishing.
-     |
-     |${HelpMessages.commandDocWebsiteReference("publishing/publish-setup")}""".stripMargin)
+@HelpMessage(PublishSetupOptions.helpMessage, "", PublishSetupOptions.detailedHelpMessage)
 final case class PublishSetupOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
@@ -34,28 +32,41 @@ final case class PublishSetupOptions(
 
 
   @Group("Publishing")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
   @HelpMessage("Public key to use to verify artifacts (to be uploaded to a key server)")
     publicKey: Option[PasswordOption] = None,
 
   @Group("Publishing")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
   @HelpMessage("Check if some options for publishing are missing, and exit with non-zero return code if that's the case")
     check: Boolean = false,
   @Group("Publishing")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
   @HelpMessage("GitHub token to use to upload secrets to GitHub - password encoded")
     token: Option[PasswordOption] = None,
   @Group("Publishing")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
   @HelpMessage("Generate a random key pair for publishing, with a secret key protected by a random password")
     randomSecretKey: Option[Boolean] = None,
   @Group("Publishing")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
   @HelpMessage("When generating a random key pair, the mail to associate to it")
     randomSecretKeyMail: Option[String] = None,
   @Group("Publishing")
+  @Tag(tags.restricted)
   @HelpMessage("The option groups to check - can be \"all\", or a comma-separated list of \"core\", \"signing\", \"repo\", \"extra\"")
     checks: Option[String] = None,
   @Group("Publishing")
+  @Tag(tags.restricted)
   @HelpMessage("Whether to check if a GitHub workflow already exists (one for publishing is written if none is found)")
     checkWorkflow: Option[Boolean] = None,
   @Group("Publishing")
+  @Tag(tags.implementation)
   @HelpMessage("Dummy mode - don't upload any secret to GitHub")
     dummy: Boolean = false
 ) extends HasLoggingOptions
@@ -64,4 +75,16 @@ final case class PublishSetupOptions(
 object PublishSetupOptions {
   implicit lazy val parser: Parser[PublishSetupOptions] = Parser.derive
   implicit lazy val help: Help[PublishSetupOptions]     = Help.derive
+  val cmdName                                           = "publish setup"
+  private val helpHeader                                = "Configures the project for publishing."
+  private val docWebsiteSuffix                          = "publishing/publish-setup"
+  val helpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.commandFullHelpReference(cmdName)}
+       |${HelpMessages.commandDocWebsiteReference(docWebsiteSuffix)}""".stripMargin
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.commandDocWebsiteReference(docWebsiteSuffix)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/SharedPublishOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/SharedPublishOptions.scala
@@ -2,11 +2,15 @@ package scala.cli.commands.publish
 
 import caseapp.*
 
+import scala.cli.commands.tags
+
 // format: off
 final case class SharedPublishOptions(
 
   @Group("Publishing")
   @HelpMessage("Directory where temporary files for publishing should be written")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
   @Hidden
     workingDir: Option[String] = None,
 
@@ -14,32 +18,42 @@ final case class SharedPublishOptions(
   @Hidden
   @HelpMessage("Scala version suffix to append to the module name, like \"_2.13\" or \"_3\"")
   @ValueDescription("suffix")
+  @Tag(tags.restricted)
     scalaVersionSuffix: Option[String] = None,
   @Group("Publishing")
   @Hidden
   @HelpMessage("Scala platform suffix to append to the module name, like \"_sjs1\" or \"_native0.4\"")
   @ValueDescription("suffix")
+  @Tag(tags.restricted)
     scalaPlatformSuffix: Option[String] = None,
 
   @Group("Publishing")
   @HelpMessage("Whether to build and publish source JARs")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     sources: Option[Boolean] = None,
 
   @Group("Publishing")
   @HelpMessage("Whether to build and publish doc JARs")
   @ExtraName("scaladoc")
   @ExtraName("javadoc")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     doc: Option[Boolean] = None,
 
   @Group("Publishing")
   @HelpMessage("ID of the GPG key to use to sign artifacts")
   @ValueDescription("key-id")
   @ExtraName("K")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     gpgKey: Option[String] = None,
 
   @Group("Publishing")
   @HelpMessage("Method to use to sign artifacts")
   @ValueDescription("gpg|bc|none")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     signer: Option[String] = None,
 
   @Group("Publishing")
@@ -47,23 +61,29 @@ final case class SharedPublishOptions(
   @ValueDescription("argument")
   @ExtraName("G")
   @ExtraName("gpgOpt")
+  @Tag(tags.restricted)
+  @Tag(tags.important)
     gpgOption: List[String] = Nil,
 
   @Group("Publishing")
   @HelpMessage("Set Ivy 2 home directory")
   @ValueDescription("path")
+  @Tag(tags.restricted)
     ivy2Home: Option[String] = None,
 
   @Group("Publishing")
   @Hidden
+  @Tag(tags.restricted)
     forceSigningBinary: Boolean = false,
 
   @Group("Publishing")
   @Hidden
+  @Tag(tags.restricted)
     checksum: List[String] = Nil,
 
   @Group("Publishing")
   @HelpMessage("Proceed as if publishing, but do not upload / write artifacts to the remote repository")
+  @Tag(tags.implementation)
     dummy: Boolean = false
 )
 // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/SharedPublishOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/SharedPublishOptions.scala
@@ -10,7 +10,7 @@ final case class SharedPublishOptions(
   @Group("Publishing")
   @HelpMessage("Directory where temporary files for publishing should be written")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @Hidden
     workingDir: Option[String] = None,
 
@@ -30,7 +30,7 @@ final case class SharedPublishOptions(
   @Group("Publishing")
   @HelpMessage("Whether to build and publish source JARs")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     sources: Option[Boolean] = None,
 
   @Group("Publishing")
@@ -38,7 +38,7 @@ final case class SharedPublishOptions(
   @ExtraName("scaladoc")
   @ExtraName("javadoc")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     doc: Option[Boolean] = None,
 
   @Group("Publishing")
@@ -46,14 +46,14 @@ final case class SharedPublishOptions(
   @ValueDescription("key-id")
   @ExtraName("K")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     gpgKey: Option[String] = None,
 
   @Group("Publishing")
   @HelpMessage("Method to use to sign artifacts")
   @ValueDescription("gpg|bc|none")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     signer: Option[String] = None,
 
   @Group("Publishing")
@@ -62,7 +62,7 @@ final case class SharedPublishOptions(
   @ExtraName("G")
   @ExtraName("gpgOpt")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     gpgOption: List[String] = Nil,
 
   @Group("Publishing")

--- a/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
@@ -2,6 +2,7 @@ package scala.cli.commands.repl
 
 import ai.kien.python.Python
 import caseapp.*
+import caseapp.core.help.HelpFormat
 import coursier.cache.FileCache
 import coursier.error.{FetchError, ResolutionError}
 import dependency.*
@@ -23,11 +24,15 @@ import scala.cli.commands.run.RunMode
 import scala.cli.commands.shared.SharedOptions
 import scala.cli.commands.{ScalaCommand, WatchUtil}
 import scala.cli.config.{ConfigDb, Keys}
+import scala.cli.util.ArgHelpers.*
 import scala.util.Properties
 
 object Repl extends ScalaCommand[ReplOptions] {
   override def group                   = "Main"
   override def scalaSpecificationLevel = SpecificationLevel.MUST
+  override def helpFormat: HelpFormat = super.helpFormat
+    .copy(hiddenGroups = Some(Seq("Watch")))
+    .withPrimaryGroup("Repl")
   override def names: List[List[String]] = List(
     List("repl"),
     List("console")

--- a/modules/cli/src/main/scala/scala/cli/commands/repl/ReplOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/ReplOptions.scala
@@ -5,18 +5,7 @@ import caseapp.*
 import scala.cli.ScalaCli.fullRunnerName
 import scala.cli.commands.shared.{HasSharedOptions, HelpMessages, SharedOptions}
 
-@HelpMessage({
-  val cmdName = "repl"
-  s"""Fire-up a Scala REPL.
-     |
-     |The entire $fullRunnerName project's classpath is loaded to the repl.
-     |
-     |${HelpMessages.commandConfigurations(cmdName)}
-     |
-     |${HelpMessages.acceptedInputs}
-     |
-     |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
-})
+@HelpMessage(ReplOptions.helpMessage, "", ReplOptions.detailedHelpMessage)
 // format: off
 final case class ReplOptions(
   @Recurse
@@ -29,4 +18,17 @@ final case class ReplOptions(
 object ReplOptions {
   implicit lazy val parser: Parser[ReplOptions] = Parser.derive
   implicit lazy val help: Help[ReplOptions]     = Help.derive
+  val cmdName                                   = "repl"
+  private val helpHeader                        = "Fire-up a Scala REPL."
+  val helpMessage: String                       = HelpMessages.shortHelpMessage(cmdName, helpHeader)
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |The entire $fullRunnerName project's classpath is loaded to the repl.
+       |
+       |${HelpMessages.commandConfigurations(cmdName)}
+       |
+       |${HelpMessages.acceptedInputs}
+       |
+       |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/repl/SharedReplOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/SharedReplOptions.scala
@@ -22,7 +22,7 @@ final case class SharedReplOptions(
 
   @Group("Repl")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("Use Ammonite (instead of the default Scala REPL)")
   @Name("A")
   @Name("amm")
@@ -32,13 +32,13 @@ final case class SharedReplOptions(
   @Tag(tags.restricted)
   @HelpMessage(s"Set the Ammonite version (${Constants.ammoniteVersion} by default)")
   @Name("ammoniteVer")
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     ammoniteVersion: Option[String] = None,
 
   @Group("Repl")
   @Name("a")
   @Tag(tags.restricted)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("Provide arguments for ammonite repl")
   @Hidden
     ammoniteArg: List[String] = Nil,

--- a/modules/cli/src/main/scala/scala/cli/commands/repl/SharedReplOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/SharedReplOptions.scala
@@ -32,6 +32,7 @@ final case class SharedReplOptions(
   @Tag(tags.restricted)
   @HelpMessage(s"Set the Ammonite version (${Constants.ammoniteVersion} by default)")
   @Name("ammoniteVer")
+  @Tag(tags.important)
     ammoniteVersion: Option[String] = None,
 
   @Group("Repl")

--- a/modules/cli/src/main/scala/scala/cli/commands/repl/SharedReplOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/SharedReplOptions.scala
@@ -22,6 +22,7 @@ final case class SharedReplOptions(
 
   @Group("Repl")
   @Tag(tags.restricted)
+  @Tag(tags.important)
   @HelpMessage("Use Ammonite (instead of the default Scala REPL)")
   @Name("A")
   @Name("amm")
@@ -36,6 +37,7 @@ final case class SharedReplOptions(
   @Group("Repl")
   @Name("a")
   @Tag(tags.restricted)
+  @Tag(tags.important)
   @HelpMessage("Provide arguments for ammonite repl")
   @Hidden
     ammoniteArg: List[String] = Nil,

--- a/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
@@ -2,6 +2,7 @@ package scala.cli.commands.run
 
 import ai.kien.python.Python
 import caseapp.*
+import caseapp.core.help.HelpFormat
 
 import java.io.File
 import java.util.Locale
@@ -24,11 +25,14 @@ import scala.cli.commands.util.{BuildCommandHelpers, RunHadoop, RunSpark}
 import scala.cli.commands.{CommandUtils, ScalaCommand, WatchUtil}
 import scala.cli.config.{ConfigDb, Keys}
 import scala.cli.internal.ProcUtil
+import scala.cli.util.ArgHelpers.*
 import scala.util.{Properties, Try}
 
 object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
-  override def group                                                     = "Main"
-  override def scalaSpecificationLevel                                   = SpecificationLevel.MUST
+  override def group                   = "Main"
+  override def scalaSpecificationLevel = SpecificationLevel.MUST
+  val primaryHelpGroups: Seq[String]   = Seq("Run", "Entrypoint", "Watch")
+  override def helpFormat: HelpFormat  = super.helpFormat.withPrimaryGroups(primaryHelpGroups)
   override def sharedOptions(options: RunOptions): Option[SharedOptions] = Some(options.shared)
 
   private def runMode(options: RunOptions): RunMode =

--- a/modules/cli/src/main/scala/scala/cli/commands/run/RunOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/RunOptions.scala
@@ -6,25 +6,7 @@ import caseapp.core.help.Help
 import scala.cli.ScalaCli
 import scala.cli.commands.shared.{HasSharedOptions, HelpMessages, SharedOptions}
 
-@HelpMessage({
-  val cmdName = "run"
-  s"""|Compile and run Scala code.
-      |
-      |${HelpMessages.commandConfigurations(cmdName)}
-      |
-      |For a run to be successful, a main method must be present on the classpath.
-      |.sc scripts are an exception, as a main class is provided in their wrapper.
-      |
-      |${HelpMessages.acceptedInputs}
-      |
-      |To pass arguments to the actual application, just add them after `--`, like:
-      |
-      |```sh
-      |${ScalaCli.progName} run Main.scala AnotherSource.scala -- first-arg second-arg
-      |```
-      |
-      |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
-})
+@HelpMessage(RunOptions.helpMessage, "", RunOptions.detailedHelpMessage)
 // format: off
 final case class RunOptions(
   @Recurse
@@ -37,4 +19,29 @@ final case class RunOptions(
 object RunOptions {
   implicit lazy val parser: Parser[RunOptions] = Parser.derive
   implicit lazy val help: Help[RunOptions]     = Help.derive
+
+  val cmdName            = "run"
+  private val helpHeader = "Compile and run Scala code."
+  val helpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.commandFullHelpReference(cmdName)}
+       |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.commandConfigurations(cmdName)}
+       |
+       |For a run to be successful, a main method must be present on the classpath.
+       |.sc scripts are an exception, as a main class is provided in their wrapper.
+       |
+       |${HelpMessages.acceptedInputs}
+       |
+       |To pass arguments to the actual application, just add them after `--`, like:
+       |
+       |```sh
+       |${ScalaCli.progName} run Main.scala AnotherSource.scala -- first-arg second-arg
+       |```
+       |
+       |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/run/RunOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/RunOptions.scala
@@ -20,13 +20,9 @@ object RunOptions {
   implicit lazy val parser: Parser[RunOptions] = Parser.derive
   implicit lazy val help: Help[RunOptions]     = Help.derive
 
-  val cmdName            = "run"
-  private val helpHeader = "Compile and run Scala code."
-  val helpMessage: String =
-    s"""$helpHeader
-       |
-       |${HelpMessages.commandFullHelpReference(cmdName)}
-       |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
+  val cmdName             = "run"
+  private val helpHeader  = "Compile and run Scala code."
+  val helpMessage: String = HelpMessages.shortHelpMessage(cmdName, helpHeader)
   val detailedHelpMessage: String =
     s"""$helpHeader
        |

--- a/modules/cli/src/main/scala/scala/cli/commands/run/SharedRunOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/SharedRunOptions.scala
@@ -28,6 +28,7 @@ final case class SharedRunOptions(
   @Group("Run")
   @Hidden
   @Tag(tags.experimental)
+  @Tag(tags.important)
   @HelpMessage("Run as a Spark job, using the spark-submit command")
   @ExtraName("spark")
     sparkSubmit: Option[Boolean] = None,
@@ -49,6 +50,7 @@ final case class SharedRunOptions(
     hadoopJar: Boolean = false,
   @Group("Run")
   @Tag(tags.should)
+  @Tag(tags.important)
   @HelpMessage("Print the command that would have been run (one argument per line), rather than running it")
     command: Boolean = false,
   @Group("Run")

--- a/modules/cli/src/main/scala/scala/cli/commands/run/SharedRunOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/SharedRunOptions.scala
@@ -28,7 +28,7 @@ final case class SharedRunOptions(
   @Group("Run")
   @Hidden
   @Tag(tags.experimental)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("Run as a Spark job, using the spark-submit command")
   @ExtraName("spark")
     sparkSubmit: Option[Boolean] = None,
@@ -50,7 +50,7 @@ final case class SharedRunOptions(
     hadoopJar: Boolean = false,
   @Group("Run")
   @Tag(tags.should)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("Print the command that would have been run (one argument per line), rather than running it")
     command: Boolean = false,
   @Group("Run")

--- a/modules/cli/src/main/scala/scala/cli/commands/setupide/SetupIdeOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/setupide/SetupIdeOptions.scala
@@ -11,20 +11,7 @@ import scala.cli.commands.shared.{
 }
 import scala.cli.commands.tags
 
-@HelpMessage({
-  val cmdName = "setup-ide"
-  s"""Generates a BSP file that you can import into your IDE.
-     |
-     |The `setup-ide` sub-command allows to pre-configure a $fullRunnerName project to import to an IDE with BSP support.
-     |It is also ran implicitly when `compile`, `run`, `shebang` or `test` sub-commands are called.
-     |
-     |The pre-configuration should be saved in a BSP json connection file under the path:
-     |    {project-root}/.bsp/$baseRunnerName.json
-     |
-     |${HelpMessages.commandConfigurations(cmdName)}
-     |
-     |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
-})
+@HelpMessage(SetupIdeOptions.helpMessage, "", SetupIdeOptions.detailedHelpMessage)
 // format: off
 final case class SetupIdeOptions(
   @Recurse
@@ -40,4 +27,19 @@ final case class SetupIdeOptions(
 object SetupIdeOptions {
   implicit lazy val parser: Parser[SetupIdeOptions] = Parser.derive
   implicit lazy val help: Help[SetupIdeOptions]     = Help.derive
+  val cmdName                                       = "setup-ide"
+  private val helpHeader  = "Generates a BSP file that you can import into your IDE."
+  val helpMessage: String = HelpMessages.shortHelpMessage(cmdName, helpHeader)
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |The $cmdName sub-command allows to pre-configure a $fullRunnerName project to import to an IDE with BSP support.
+       |It is also ran implicitly when `compile`, `run`, `shebang` or `test` sub-commands are called.
+       |
+       |The pre-configuration should be saved in a BSP json connection file under the path:
+       |    {project-root}/.bsp/$baseRunnerName.json
+       |
+       |${HelpMessages.commandConfigurations(cmdName)}
+       |
+       |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HelpGroupOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HelpGroupOptions.scala
@@ -13,12 +13,12 @@ case class HelpGroupOptions(
   @Group("Help")
   @HelpMessage("Show options for ScalaJS")
   @Tag(tags.implementation)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   helpJs: Boolean = false,
   @Group("Help")
   @HelpMessage("Show options for ScalaNative")
   @Tag(tags.implementation)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   helpNative: Boolean = false,
   @Group("Help")
   @HelpMessage("Show options for Scaladoc")
@@ -26,13 +26,13 @@ case class HelpGroupOptions(
   @Name("docHelp")
   @Name("helpDoc")
   @Tag(tags.implementation)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   helpScaladoc: Boolean = false,
   @Group("Help")
   @HelpMessage("Show options for Scala REPL")
   @Name("replHelp")
   @Tag(tags.implementation)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   helpRepl: Boolean = false,
   @Group("Help")
   @HelpMessage("Show options for Scalafmt")
@@ -40,7 +40,7 @@ case class HelpGroupOptions(
   @Name("fmtHelp")
   @Name("helpFmt")
   @Tag(tags.implementation)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   helpScalafmt: Boolean = false
 ) {
 

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HelpGroupOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HelpGroupOptions.scala
@@ -10,27 +10,37 @@ import scala.cli.commands.tags
 
 @HelpMessage("Print help message")
 case class HelpGroupOptions(
+  @Group("Help")
   @HelpMessage("Show options for ScalaJS")
   @Tag(tags.implementation)
+  @Tag(tags.important)
   helpJs: Boolean = false,
+  @Group("Help")
   @HelpMessage("Show options for ScalaNative")
   @Tag(tags.implementation)
+  @Tag(tags.important)
   helpNative: Boolean = false,
+  @Group("Help")
   @HelpMessage("Show options for Scaladoc")
   @Name("scaladocHelp")
   @Name("docHelp")
   @Name("helpDoc")
   @Tag(tags.implementation)
+  @Tag(tags.important)
   helpScaladoc: Boolean = false,
+  @Group("Help")
   @HelpMessage("Show options for Scala REPL")
   @Name("replHelp")
   @Tag(tags.implementation)
+  @Tag(tags.important)
   helpRepl: Boolean = false,
+  @Group("Help")
   @HelpMessage("Show options for Scalafmt")
   @Name("scalafmtHelp")
   @Name("fmtHelp")
   @Name("helpFmt")
   @Tag(tags.implementation)
+  @Tag(tags.important)
   helpScalafmt: Boolean = false
 ) {
 

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HelpGroupOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HelpGroupOptions.scala
@@ -45,9 +45,15 @@ case class HelpGroupOptions(
 ) {
 
   private def printHelpWithGroup(help: Help[_], helpFormat: HelpFormat, group: String): Nothing = {
-    println(help.help(helpFormat.withHiddenGroups(
-      helpFormat.hiddenGroups.map(_.filterNot(_ == group))
-    )))
+    val oldHiddenGroups = helpFormat.hiddenGroups.toSeq.flatten
+    val oldSortedGroups = helpFormat.sortedGroups.toSeq.flatten
+    val newHiddenGroups = (oldHiddenGroups ++ oldSortedGroups).filterNot(_ == group)
+    println(
+      help.help(
+        helpFormat.withHiddenGroupsWhenShowHidden(Some(newHiddenGroups)),
+        showHidden = true
+      )
+    )
     sys.exit(0)
   }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
@@ -8,6 +8,12 @@ object HelpMessages {
   private val docsWebsiteUrl   = "https://scala-cli.virtuslab.org"
   val docsWebsiteReference =
     s"Detailed documentation can be found on our website: $docsWebsiteUrl"
+  def commandFullHelpReference(commandName: String, needsPower: Boolean = false) = {
+    val maybePowerString = if needsPower then PowerString else ""
+    s"""You are currently viewing the basic help for the $commandName sub-command. You can view the full help by running: 
+       |   ${Console.BOLD}${ScalaCli.progName} $maybePowerString$commandName --help-full${Console.RESET}""".stripMargin
+  }
+
   def commandDocWebsiteReference(websiteSuffix: String): String =
     s"For detailed documentation refer to our website: $docsWebsiteUrl/docs/commands/$websiteSuffix"
   val installationDocsWebsiteReference =

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
@@ -9,12 +9,13 @@ object HelpMessages {
   def shortHelpMessage(
     cmdName: String,
     helpHeader: String,
-    includeFullHelpReference: Boolean = true
+    includeFullHelpReference: Boolean = true,
+    needsPower: Boolean = false
   ): String = {
     val maybeFullHelpReference =
       if includeFullHelpReference then
         s"""
-           |${HelpMessages.commandFullHelpReference(cmdName)}""".stripMargin
+           |${HelpMessages.commandFullHelpReference(cmdName, needsPower)}""".stripMargin
       else ""
     s"""$helpHeader
        |$maybeFullHelpReference

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
@@ -24,7 +24,7 @@ object HelpMessages {
   val docsWebsiteReference =
     s"Detailed documentation can be found on our website: $docsWebsiteUrl"
   def commandFullHelpReference(commandName: String, needsPower: Boolean = false) = {
-    val maybePowerString = if needsPower then PowerString else ""
+    val maybePowerString = if needsPower then "--power " else ""
     s"""You are currently viewing the basic help for the $commandName sub-command. You can view the full help by running: 
        |   ${Console.BOLD}${ScalaCli.progName} $maybePowerString$commandName --help-full${Console.RESET}""".stripMargin
   }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
@@ -6,6 +6,21 @@ object HelpMessages {
   lazy val PowerString: String = if ScalaCli.allowRestrictedFeatures then "" else "--power "
   val passwordOption           = "A github token used to access GitHub. Not needed in most cases."
   private val docsWebsiteUrl   = "https://scala-cli.virtuslab.org"
+  def shortHelpMessage(
+    cmdName: String,
+    helpHeader: String,
+    includeFullHelpReference: Boolean = true
+  ): String = {
+    val maybeFullHelpReference =
+      if includeFullHelpReference then
+        s"""
+           |${HelpMessages.commandFullHelpReference(cmdName)}""".stripMargin
+      else ""
+    s"""$helpHeader
+       |$maybeFullHelpReference
+       |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
+  }
+
   val docsWebsiteReference =
     s"Detailed documentation can be found on our website: $docsWebsiteUrl"
   def commandFullHelpReference(commandName: String, needsPower: Boolean = false) = {

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
@@ -24,10 +24,10 @@ object HelpMessages {
 
   val docsWebsiteReference =
     s"Detailed documentation can be found on our website: $docsWebsiteUrl"
-  def commandFullHelpReference(commandName: String, needsPower: Boolean = false) = {
+  def commandFullHelpReference(commandName: String, needsPower: Boolean = false): String = {
     val maybePowerString = if needsPower then "--power " else ""
     s"""You are currently viewing the basic help for the $commandName sub-command. You can view the full help by running: 
-       |   ${Console.BOLD}${ScalaCli.progName} $maybePowerString$commandName --help-full${Console.RESET}""".stripMargin
+       |   ${ScalaCli.progName} $maybePowerString$commandName --help-full""".stripMargin
   }
 
   def commandDocWebsiteReference(websiteSuffix: String): String =
@@ -50,5 +50,5 @@ object HelpMessages {
   lazy val restrictedCommandUsedInSip: String =
     s"""This command is restricted and requires setting the `--power` option to be used.
        |You can pass it explicitly or set it globally by running:
-       |   ${Console.BOLD}${ScalaCli.progName} config power true""".stripMargin
+       |   ${Console.BOLD}${ScalaCli.progName} config power true${Console.RESET}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/JavaPropOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/JavaPropOptions.scala
@@ -16,7 +16,6 @@ final case class JavaPropOptions(
   @HelpMessage("Set java properties")
   @ValueDescription("key=value|key")
   @Tag(tags.must)
-  @Tag(tags.important)
     javaProp: List[String] = Nil
 )                                  
 // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/JavaPropOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/JavaPropOptions.scala
@@ -16,6 +16,7 @@ final case class JavaPropOptions(
   @HelpMessage("Set java properties")
   @ValueDescription("key=value|key")
   @Tag(tags.must)
+  @Tag(tags.important)
     javaProp: List[String] = Nil
 )                                  
 // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/MainClassOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/MainClassOptions.scala
@@ -11,7 +11,6 @@ final case class MainClassOptions(
   @HelpMessage("Specify which main class to run")
   @ValueDescription("main-class")
   @Tag(tags.must)
-  @Tag(tags.important)
   @Name("M")
     mainClass: Option[String] = None,
 
@@ -21,7 +20,7 @@ final case class MainClassOptions(
   @Name("listMainClass")
   @Name("listMainClasses")
   @Tag(tags.should)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     mainClassLs: Option[Boolean] = None
 ) {
   // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/MainClassOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/MainClassOptions.scala
@@ -11,6 +11,7 @@ final case class MainClassOptions(
   @HelpMessage("Specify which main class to run")
   @ValueDescription("main-class")
   @Tag(tags.must)
+  @Tag(tags.important)
   @Name("M")
     mainClass: Option[String] = None,
 
@@ -20,6 +21,7 @@ final case class MainClassOptions(
   @Name("listMainClass")
   @Name("listMainClasses")
   @Tag(tags.should)
+  @Tag(tags.important)
     mainClassLs: Option[Boolean] = None
 ) {
   // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
@@ -10,7 +10,7 @@ import scala.util.{Properties, Try}
 object ScalaCliHelp {
   val helpFormat: HelpFormat = HelpFormat.default()
     .copy(
-      filterArgs = Some(_.isSupported),
+      filterArgs = Some(arg => arg.isSupported && (arg.isMust || arg.isImportant)),
       filterArgsWhenShowHidden = Some(_.isSupported),
       sortedGroups = Some(
         Seq(

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
@@ -17,6 +17,8 @@ object ScalaCliHelp {
           "Help",
           "Scala",
           "Java",
+          "Watch",
+          "Dependency",
           "Repl",
           "Package",
           "Logging",

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
@@ -14,7 +14,6 @@ object ScalaCliHelp {
       filterArgsWhenShowHidden = Some(_.isSupported),
       sortedGroups = Some(
         Seq(
-          "Help",
           "Scala",
           "Java",
           "Watch",
@@ -23,7 +22,8 @@ object ScalaCliHelp {
           "Package",
           "Logging",
           "Runner",
-          "Launcher"
+          "Launcher",
+          "Help"
         )
       ),
       sortedCommandGroups = Some(

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
@@ -18,11 +18,18 @@ object ScalaCliHelp {
           "Java",
           "Watch",
           "Dependency",
+          "Entrypoint",
+          "Debug",
           "Repl",
+          "Run",
           "Package",
+          "Compilation server",
           "Logging",
           "Runner",
           "Launcher",
+          "Legacy Scala runner",
+          "Scala.js",
+          "Scala Native",
           "Help"
         )
       ),

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
@@ -11,6 +11,7 @@ object ScalaCliHelp {
   val helpFormat: HelpFormat = HelpFormat.default()
     .copy(
       filterArgs = Some(_.isSupported),
+      filterArgsWhenShowHidden = Some(_.isSupported),
       sortedGroups = Some(
         Seq(
           "Help",

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
@@ -19,7 +19,6 @@ final case class ScalacOptions(
   @Name("scala-option")
   @Name("O")
   @Tag(tags.must)
-  @Tag(tags.important)
     scalacOption: List[String] = Nil
 )
 // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
@@ -19,6 +19,7 @@ final case class ScalacOptions(
   @Name("scala-option")
   @Name("O")
   @Tag(tags.must)
+  @Tag(tags.important)
     scalacOption: List[String] = Nil
 )
 // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedBspFileOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedBspFileOptions.scala
@@ -6,11 +6,13 @@ import scala.cli.commands.tags
 
 // format: off
 final case class SharedBspFileOptions(
+  @Group("BSP")
   @Name("bspDir")
   @HelpMessage("Custom BSP configuration location")
   @Tag(tags.implementation)
   @Hidden
     bspDirectory: Option[String] = None,
+  @Group("BSP")
   @Name("name")
   @HelpMessage("Name of BSP")
   @Hidden

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedDependencyOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedDependencyOptions.scala
@@ -11,13 +11,12 @@ final case class SharedDependencyOptions(
   @Group("Dependency")
   @HelpMessage("Add dependencies")
   @Tag(tags.must)
-  @Tag(tags.important)
   @Name("dep")
     dependency: List[String] = Nil,
 
   @Group("Dependency")
   @Tag(tags.should)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("Add repositories")
   @Name("repo")
   @Name("r")

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedDependencyOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedDependencyOptions.scala
@@ -11,11 +11,13 @@ final case class SharedDependencyOptions(
   @Group("Dependency")
   @HelpMessage("Add dependencies")
   @Tag(tags.must)
+  @Tag(tags.important)
   @Name("dep")
     dependency: List[String] = Nil,
 
   @Group("Dependency")
   @Tag(tags.should)
+  @Tag(tags.important)
   @HelpMessage("Add repositories")
   @Name("repo")
   @Name("r")

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedJavaOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedJavaOptions.scala
@@ -10,6 +10,7 @@ final case class SharedJavaOptions(
   @HelpMessage("Set Java options, such as `-Xmx1g`")
   @ValueDescription("java-options")
   @Tag(tags.must)
+  @Tag(tags.important)
   @Name("J")
     javaOpt: List[String] = Nil,
   @Recurse

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedJavaOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedJavaOptions.scala
@@ -10,7 +10,6 @@ final case class SharedJavaOptions(
   @HelpMessage("Set Java options, such as `-Xmx1g`")
   @ValueDescription("java-options")
   @Tag(tags.must)
-  @Tag(tags.important)
   @Name("J")
     javaOpt: List[String] = Nil,
   @Recurse

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedJvmOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedJvmOptions.scala
@@ -22,7 +22,7 @@ final case class SharedJvmOptions(
   @ValueDescription("jvm-name")
   @Tag(tags.should)
   @Name("j")
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     jvm: Option[String] = None,
   @Group("Java")
   @HelpMessage("JVM index URL")
@@ -53,7 +53,7 @@ final case class SharedJvmOptions(
   @HelpMessage("Javac options")
   @Name("javacOpt")
   @Tag(tags.should)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @Hidden
     javacOption: List[String] = Nil,
 

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedJvmOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedJvmOptions.scala
@@ -22,6 +22,7 @@ final case class SharedJvmOptions(
   @ValueDescription("jvm-name")
   @Tag(tags.should)
   @Name("j")
+  @Tag(tags.important)
     jvm: Option[String] = None,
   @Group("Java")
   @HelpMessage("JVM index URL")
@@ -52,6 +53,7 @@ final case class SharedJvmOptions(
   @HelpMessage("Javac options")
   @Name("javacOpt")
   @Tag(tags.should)
+  @Tag(tags.important)
   @Hidden
     javacOption: List[String] = Nil,
 

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -76,6 +76,7 @@ final case class SharedOptions(
   @Name("scala")
   @Name("S")
   @Tag(tags.must)
+  @Tag(tags.important)
     scalaVersion: Option[String] = None,
   @Group("Scala")
   @HelpMessage("Set the Scala binary version")
@@ -142,6 +143,7 @@ final case class SharedOptions(
   @HelpMessage("Specify platform")
   @ValueDescription("scala-js|scala-native|jvm")
   @Tag(tags.should)
+  @Tag(tags.important)
     platform: Option[String] = None,
 
   @Group("Scala")

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -76,7 +76,6 @@ final case class SharedOptions(
   @Name("scala")
   @Name("S")
   @Tag(tags.must)
-  @Tag(tags.important)
     scalaVersion: Option[String] = None,
   @Group("Scala")
   @HelpMessage("Set the Scala binary version")
@@ -144,7 +143,7 @@ final case class SharedOptions(
   @HelpMessage("Specify platform")
   @ValueDescription("scala-js|scala-native|jvm")
   @Tag(tags.should)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     platform: Option[String] = None,
 
   @Group("Scala")
@@ -199,7 +198,7 @@ final case class SharedOptions(
   @ValueDescription("version|latest")
   @Name("toolkit")
   @Tag(tags.implementation)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     withToolkit: Option[String] = None
 ) extends HasLoggingOptions {
   // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -140,6 +140,7 @@ final case class SharedOptions(
   @Tag(tags.must)
     resourceDirs: List[String] = Nil,
 
+  @Group("Scala")
   @HelpMessage("Specify platform")
   @ValueDescription("scala-js|scala-native|jvm")
   @Tag(tags.should)
@@ -183,6 +184,7 @@ final case class SharedOptions(
   @Hidden
     strictBloopJsonCheck: Option[Boolean] = None,
 
+  @Group("Scala")
   @Name("output-directory")
   @Name("d")
   @Name("destination")
@@ -192,9 +194,12 @@ final case class SharedOptions(
   @ValueDescription("/example/path")
   @Tag(tags.must)
     compilationOutput: Option[String] = None,
+  @Group("Scala")
   @HelpMessage("Add toolkit to classPath")
   @ValueDescription("version|latest")
   @Name("toolkit")
+  @Tag(tags.implementation)
+  @Tag(tags.important)
     withToolkit: Option[String] = None
 ) extends HasLoggingOptions {
   // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedWatchOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedWatchOptions.scala
@@ -10,13 +10,13 @@ final case class SharedWatchOptions(
   @Group("Watch")
   @HelpMessage("Run the application in the background, automatically wake the thread and re-run if sources have been changed")
   @Tag(tags.should)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @Name("w")
     watch: Boolean = false,
   @Group("Watch")
   @HelpMessage("Run the application in the background, automatically kill the process and restart if sources have been changed")
   @Tag(tags.should)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @Name("revolver")
     restart: Boolean = false
 ) { // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedWatchOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedWatchOptions.scala
@@ -7,12 +7,16 @@ import scala.cli.commands.tags
 // format: off
 final case class SharedWatchOptions(
 
+  @Group("Watch")
   @HelpMessage("Run the application in the background, automatically wake the thread and re-run if sources have been changed")
   @Tag(tags.should)
+  @Tag(tags.important)
   @Name("w")
     watch: Boolean = false,
+  @Group("Watch")
   @HelpMessage("Run the application in the background, automatically kill the process and restart if sources have been changed")
   @Tag(tags.should)
+  @Tag(tags.important)
   @Name("revolver")
     restart: Boolean = false
 ) { // format: on

--- a/modules/cli/src/main/scala/scala/cli/commands/shebang/Shebang.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shebang/Shebang.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.shebang
 
 import caseapp.RemainingArgs
+import caseapp.core.help.HelpFormat
 
 import scala.build.Logger
 import scala.build.input.{ScalaCliInvokeData, SubCommand}
@@ -9,11 +10,13 @@ import scala.cli.CurrentParams
 import scala.cli.commands.ScalaCommand
 import scala.cli.commands.run.Run
 import scala.cli.commands.shared.SharedOptions
+import scala.cli.util.ArgHelpers.*
 
 object Shebang extends ScalaCommand[ShebangOptions] {
   override def stopAtFirstUnrecognized: Boolean = true
 
   override def scalaSpecificationLevel = SpecificationLevel.MUST
+  override def helpFormat: HelpFormat  = super.helpFormat.withPrimaryGroups(Run.primaryHelpGroups)
 
   override def sharedOptions(options: ShebangOptions): Option[SharedOptions] =
     Run.sharedOptions(options.runOptions)

--- a/modules/cli/src/main/scala/scala/cli/commands/shebang/ShebangOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shebang/ShebangOptions.scala
@@ -6,35 +6,7 @@ import scala.cli.ScalaCli.{baseRunnerName, fullRunnerName, progName}
 import scala.cli.commands.run.RunOptions
 import scala.cli.commands.shared.{HasSharedOptions, HelpMessages, SharedOptions}
 
-@HelpMessage(
-  s"""|Like `run`, but handier for shebang scripts.
-      |
-      |This command is equivalent to the `run` sub-command, but it changes the way
-      |$fullRunnerName parses its command-line arguments in order to be compatible
-      |with shebang scripts.
-      |
-      |When relying on the `run` sub-command, inputs and $baseRunnerName options can be mixed,
-      |while program args have to be specified after `--`
-      |
-      |```sh
-      |$progName [command] [${baseRunnerName}_options | input]... -- [program_arguments]...
-      |```
-      |
-      |However, for the `shebang` sub-command, only a single input file can be set, while all $baseRunnerName options
-      |have to be set before the input file.
-      |All inputs after the first are treated as program arguments, without the need for `--`
-      |```sh
-      |$progName shebang [${baseRunnerName}_options]... input [program_arguments]...
-      |```
-      |
-      |Using this, it is possible to conveniently set up Unix shebang scripts. For example:
-      |```sh
-      |#!/usr/bin/env -S $progName shebang --scala-version 2.13
-      |println("Hello, world")
-      |```
-      |
-      |${HelpMessages.commandDocWebsiteReference("shebang")}""".stripMargin
-)
+@HelpMessage(ShebangOptions.helpMessage, "", ShebangOptions.detailedHelpMessage)
 final case class ShebangOptions(
   @Recurse
   runOptions: RunOptions = RunOptions()
@@ -45,4 +17,36 @@ final case class ShebangOptions(
 object ShebangOptions {
   implicit lazy val parser: Parser[ShebangOptions] = Parser.derive
   implicit lazy val help: Help[ShebangOptions]     = Help.derive
+
+  val cmdName             = "shebang"
+  private val helpHeader  = "Like `run`, but handier for shebang scripts."
+  val helpMessage: String = HelpMessages.shortHelpMessage(cmdName, helpHeader)
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |This command is equivalent to the `run` sub-command, but it changes the way
+       |$fullRunnerName parses its command-line arguments in order to be compatible
+       |with shebang scripts.
+       |
+       |When relying on the `run` sub-command, inputs and $baseRunnerName options can be mixed,
+       |while program args have to be specified after `--`
+       |
+       |```sh
+       |$progName [command] [${baseRunnerName}_options | input]... -- [program_arguments]...
+       |```
+       |
+       |However, for the `shebang` sub-command, only a single input file can be set, while all $baseRunnerName options
+       |have to be set before the input file.
+       |All inputs after the first are treated as program arguments, without the need for `--`
+       |```sh
+       |$progName shebang [${baseRunnerName}_options]... input [program_arguments]...
+       |```
+       |
+       |Using this, it is possible to conveniently set up Unix shebang scripts. For example:
+       |```sh
+       |#!/usr/bin/env -S $progName shebang --scala-version 2.13
+       |println("Hello, world")
+       |```
+       |
+       |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.test
 
 import caseapp.*
+import caseapp.core.help.HelpFormat
 
 import java.nio.file.Path
 
@@ -19,11 +20,14 @@ import scala.cli.commands.shared.SharedOptions
 import scala.cli.commands.update.Update
 import scala.cli.commands.{CommandUtils, ScalaCommand, WatchUtil}
 import scala.cli.config.{ConfigDb, Keys}
+import scala.cli.util.ArgHelpers.*
 
 object Test extends ScalaCommand[TestOptions] {
   override def group                                                      = "Main"
   override def sharedOptions(options: TestOptions): Option[SharedOptions] = Some(options.shared)
   override def scalaSpecificationLevel = SpecificationLevel.SHOULD
+
+  override def helpFormat: HelpFormat = super.helpFormat.withPrimaryGroups(Seq("Test", "Watch"))
 
   private def gray  = "\u001b[90m"
   private def reset = Console.RESET

--- a/modules/cli/src/main/scala/scala/cli/commands/test/TestOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/TestOptions.scala
@@ -29,17 +29,17 @@ final case class TestOptions(
   @HelpMessage("Name of the test framework's runner class to use while running tests")
   @ValueDescription("class-name")
   @Tag(tags.should)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     testFramework: Option[String] = None,
 
   @Group("Test")
   @Tag(tags.should)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("Fail if no test suites were run")
     requireTests: Boolean = false,
   @Group("Test")
   @Tag(tags.should)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage("Specify a glob pattern to filter the tests suite to be run.")
     testOnly: Option[String] = None
 

--- a/modules/cli/src/main/scala/scala/cli/commands/test/TestOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/TestOptions.scala
@@ -13,22 +13,7 @@ import scala.cli.commands.shared.{
 }
 import scala.cli.commands.tags
 
-@HelpMessage({
-  val cmdName = "test"
-  s"""Compile and test Scala code.
-     |
-     |Test sources are compiled separately (after the 'main' sources), and may use different dependencies, compiler options, and other configurations.
-     |A source file is treated as a test source if:
-     |  - it contains the `//> using target.scope "test"` directive
-     |  - the file name ends with `.test.scala`
-     |  - the file comes from a directory that is provided as input, and the relative path from that file to its original directory contains a `test` directory
-     |
-     |${HelpMessages.commandConfigurations(cmdName)}
-     |
-     |${HelpMessages.acceptedInputs}
-     |
-     |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
-})
+@HelpMessage(TestOptions.helpMessage, "", TestOptions.detailedHelpMessage)
 // format: off
 final case class TestOptions(
   @Recurse
@@ -44,14 +29,17 @@ final case class TestOptions(
   @HelpMessage("Name of the test framework's runner class to use while running tests")
   @ValueDescription("class-name")
   @Tag(tags.should)
+  @Tag(tags.important)
     testFramework: Option[String] = None,
 
   @Group("Test")
   @Tag(tags.should)
+  @Tag(tags.important)
   @HelpMessage("Fail if no test suites were run")
     requireTests: Boolean = false,
   @Group("Test")
   @Tag(tags.should)
+  @Tag(tags.important)
   @HelpMessage("Specify a glob pattern to filter the tests suite to be run.")
     testOnly: Option[String] = None
 
@@ -61,4 +49,22 @@ final case class TestOptions(
 object TestOptions {
   implicit lazy val parser: Parser[TestOptions] = Parser.derive
   implicit lazy val help: Help[TestOptions]     = Help.derive
+
+  val cmdName             = "test"
+  private val helpHeader  = "Compile and test Scala code."
+  val helpMessage: String = HelpMessages.shortHelpMessage(cmdName, helpHeader)
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |Test sources are compiled separately (after the 'main' sources), and may use different dependencies, compiler options, and other configurations.
+       |A source file is treated as a test source if:
+       |  - it contains the `//> using target.scope "test"` directive
+       |  - the file name ends with `.test.scala`
+       |  - the file comes from a directory that is provided as input, and the relative path from that file to its original directory contains a `test` directory
+       |
+       |${HelpMessages.commandConfigurations(cmdName)}
+       |
+       |${HelpMessages.acceptedInputs}
+       |
+       |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/SharedUninstallCompletionsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/SharedUninstallCompletionsOptions.scala
@@ -9,7 +9,7 @@ final case class SharedUninstallCompletionsOptions(
   @Group("Uninstall")
   @HelpMessage("Path to `*rc` file, defaults to `.bashrc` or `.zshrc` depending on shell")
   @Tag(tags.implementation)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   rcFile: Option[String] = None,
   @Group("Uninstall")
   @Hidden

--- a/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/SharedUninstallCompletionsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/SharedUninstallCompletionsOptions.scala
@@ -6,13 +6,17 @@ import scala.cli.commands.tags
 
 // format: off
 final case class SharedUninstallCompletionsOptions(
+  @Group("Uninstall")
   @HelpMessage("Path to `*rc` file, defaults to `.bashrc` or `.zshrc` depending on shell")
   @Tag(tags.implementation)
+  @Tag(tags.important)
   rcFile: Option[String] = None,
+  @Group("Uninstall")
   @Hidden
   @HelpMessage("Custom banner in comment placed in rc file")
   @Tag(tags.implementation)
   banner: String = "{NAME} completions",
+  @Group("Uninstall")
   @Hidden
   @HelpMessage("Custom completions name")
   @Tag(tags.implementation)

--- a/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/UninstallCompletions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/UninstallCompletions.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.uninstallcompletions
 
 import caseapp.*
+import caseapp.core.help.HelpFormat
 
 import java.nio.charset.Charset
 
@@ -9,10 +10,13 @@ import scala.cli.CurrentParams
 import scala.cli.commands.ScalaCommand
 import scala.cli.commands.installcompletions.InstallCompletions
 import scala.cli.internal.ProfileFileUpdater
+import scala.cli.util.ArgHelpers.*
 
 object UninstallCompletions extends ScalaCommand[UninstallCompletionsOptions] {
 
   override def scalaSpecificationLevel = SpecificationLevel.IMPLEMENTATION
+
+  override def helpFormat: HelpFormat = super.helpFormat.withPrimaryGroup("Uninstall")
 
   override def names = List(
     List("uninstall", "completions"),

--- a/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/UninstallCompletionsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/UninstallCompletionsOptions.scala
@@ -6,10 +6,7 @@ import scala.cli.commands.shared.{HasLoggingOptions, HelpMessages, LoggingOption
 import scala.cli.commands.uninstallcompletions.SharedUninstallCompletionsOptions
 
 // format: off
-@HelpMessage(
-  s"""Uninstalls completions from your shell
-     |
-     |${HelpMessages.commandDocWebsiteReference("completions")}""".stripMargin)
+@HelpMessage(UninstallCompletionsOptions.helpMessage, "", UninstallCompletionsOptions.detailedHelpMessage)
 final case class UninstallCompletionsOptions(
   @Recurse
     shared: SharedUninstallCompletionsOptions = SharedUninstallCompletionsOptions(),
@@ -21,4 +18,15 @@ final case class UninstallCompletionsOptions(
 object UninstallCompletionsOptions {
   implicit lazy val parser: Parser[UninstallCompletionsOptions] = Parser.derive
   implicit lazy val help: Help[UninstallCompletionsOptions]     = Help.derive
+
+  private val helpHeader = "Uninstalls completions from your shell."
+  val helpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.commandFullHelpReference("uninstall completions")}
+       |${HelpMessages.commandDocWebsiteReference("completions")}""".stripMargin
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.installationDocsWebsiteReference}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/UninstallCompletionsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/UninstallCompletionsOptions.scala
@@ -2,6 +2,7 @@ package scala.cli.commands.uninstallcompletions
 
 import caseapp.*
 
+import scala.cli.ScalaCli.fullRunnerName
 import scala.cli.commands.shared.{HasLoggingOptions, HelpMessages, LoggingOptions}
 import scala.cli.commands.uninstallcompletions.SharedUninstallCompletionsOptions
 
@@ -19,7 +20,7 @@ object UninstallCompletionsOptions {
   implicit lazy val parser: Parser[UninstallCompletionsOptions] = Parser.derive
   implicit lazy val help: Help[UninstallCompletionsOptions]     = Help.derive
 
-  private val helpHeader = "Uninstalls completions from your shell."
+  private val helpHeader = s"Uninstalls $fullRunnerName completions from your shell."
   val helpMessage: String =
     s"""$helpHeader
        |
@@ -28,5 +29,5 @@ object UninstallCompletionsOptions {
   val detailedHelpMessage: String =
     s"""$helpHeader
        |
-       |${HelpMessages.installationDocsWebsiteReference}""".stripMargin
+       |${HelpMessages.commandDocWebsiteReference("completions")}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/update/Update.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/update/Update.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.update
 
 import caseapp.*
+import caseapp.core.help.HelpFormat
 import com.github.plokhotnyuk.jsoniter_scala.core.*
 import com.github.plokhotnyuk.jsoniter_scala.macros.*
 import coursier.core
@@ -12,12 +13,15 @@ import scala.cli.CurrentParams
 import scala.cli.commands.{CommandUtils, ScalaCommand}
 import scala.cli.internal.ProcUtil
 import scala.cli.signing.shared.Secret
+import scala.cli.util.ArgHelpers.*
 import scala.util.Properties
 import scala.util.control.NonFatal
 
 object Update extends ScalaCommand[UpdateOptions] {
 
   override def scalaSpecificationLevel = SpecificationLevel.IMPLEMENTATION
+
+  override def helpFormat: HelpFormat = super.helpFormat.withPrimaryGroup("Update")
 
   private final case class Release(
     draft: Boolean,

--- a/modules/cli/src/main/scala/scala/cli/commands/update/UpdateOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/update/UpdateOptions.scala
@@ -53,5 +53,6 @@ object UpdateOptions {
        |${HelpMessages.installationDocsWebsiteReference}""".stripMargin
   val detailedHelpMessage: String =
     s"""$helpHeader
+       |
        |${HelpMessages.installationDocsWebsiteReference}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/update/UpdateOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/update/UpdateOptions.scala
@@ -9,10 +9,7 @@ import scala.cli.signing.shared.PasswordOption
 import scala.cli.signing.util.ArgParsers.*
 
 // format: off
-@HelpMessage(s"""Updates $fullRunnerName.
-                |Works only when installed with the installation script.
-                |If $fullRunnerName was installed with an external tool, refer to its update methods.
-                |${HelpMessages.installationDocsWebsiteReference}""".stripMargin)
+@HelpMessage(UpdateOptions.helpMessage, "", UpdateOptions.detailedHelpMessage)
 final case class UpdateOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
@@ -29,6 +26,7 @@ final case class UpdateOptions(
   @Name("f")
   @HelpMessage(s"Force update $fullRunnerName if it is outdated")
   @Tag(tags.implementation)
+  @Tag(tags.important)
     force: Boolean = false,
   @Hidden
   @Tag(tags.implementation)
@@ -43,4 +41,17 @@ final case class UpdateOptions(
 object UpdateOptions {
   implicit lazy val parser: Parser[UpdateOptions] = Parser.derive
   implicit lazy val help: Help[UpdateOptions]     = Help.derive
+
+  private val helpHeader =
+    s"""Updates $fullRunnerName.
+       |Works only when installed with the installation script.
+       |If $fullRunnerName was installed with an external tool, refer to its update methods.""".stripMargin
+  val helpMessage: String =
+    s"""$helpHeader
+       |
+       |${HelpMessages.commandFullHelpReference("update")}
+       |${HelpMessages.installationDocsWebsiteReference}""".stripMargin
+  val detailedHelpMessage: String =
+    s"""$helpHeader
+       |${HelpMessages.installationDocsWebsiteReference}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/update/UpdateOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/update/UpdateOptions.scala
@@ -26,7 +26,7 @@ final case class UpdateOptions(
   @Name("f")
   @HelpMessage(s"Force update $fullRunnerName if it is outdated")
   @Tag(tags.implementation)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
     force: Boolean = false,
   @Hidden
   @Tag(tags.implementation)

--- a/modules/cli/src/main/scala/scala/cli/commands/version/Version.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/version/Version.scala
@@ -9,16 +9,18 @@ import scala.cli.CurrentParams
 import scala.cli.commands.update.Update
 import scala.cli.commands.{CommandUtils, ScalaCommand}
 import scala.cli.config.PasswordOption
+import scala.cli.util.ArgHelpers.*
 
 object Version extends ScalaCommand[VersionOptions] {
   override def group = "Miscellaneous"
 
   override def scalaSpecificationLevel = SpecificationLevel.SHOULD
-  override def helpFormat: HelpFormat = super.helpFormat.copy(
-    hiddenGroups = Some(Seq("Logging")),
-    hiddenGroupsWhenShowHidden = Some(Seq("Logging")),
-    sortedGroups = Some(Seq("Version"))
-  )
+  override def helpFormat: HelpFormat = super.helpFormat
+    .copy(
+      hiddenGroups = Some(Seq("Logging")),
+      hiddenGroupsWhenShowHidden = Some(Seq("Logging"))
+    )
+    .withPrimaryGroup("Version")
 
   override def runCommand(options: VersionOptions, args: RemainingArgs, logger: Logger): Unit = {
     lazy val maybeNewerScalaCliVersion: Option[String] =

--- a/modules/cli/src/main/scala/scala/cli/commands/version/Version.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/version/Version.scala
@@ -14,15 +14,10 @@ object Version extends ScalaCommand[VersionOptions] {
   override def group = "Miscellaneous"
 
   override def scalaSpecificationLevel = SpecificationLevel.SHOULD
-  override def hasFullHelp: Boolean    = false
   override def helpFormat: HelpFormat = super.helpFormat.copy(
     hiddenGroups = Some(Seq("Logging")),
-    sortedGroups = Some(
-      Seq(
-        "Version",
-        "Help"
-      )
-    )
+    hiddenGroupsWhenShowHidden = Some(Seq("Logging")),
+    sortedGroups = Some(Seq("Version"))
   )
 
   override def runCommand(options: VersionOptions, args: RemainingArgs, logger: Logger): Unit = {

--- a/modules/cli/src/main/scala/scala/cli/commands/version/VersionOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/version/VersionOptions.scala
@@ -14,7 +14,7 @@ final case class VersionOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
   @Tag(tags.implementation)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @Group("Version")
   @HelpMessage(s"Show plain $fullRunnerName version only")
   @Name("cli")
@@ -22,7 +22,7 @@ final case class VersionOptions(
   @Group("Version")
   @HelpMessage("Show plain Scala version only")
   @Tag(tags.implementation)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @Name("scala")
     scalaVersion: Boolean = false,
   @Hidden
@@ -31,7 +31,7 @@ final case class VersionOptions(
     ghToken: Option[PasswordOption] = None,
   @Group("Version")
   @Tag(tags.implementation)
-  @Tag(tags.important)
+  @Tag(tags.inShortHelp)
   @HelpMessage(s"Don't check for the newest available $fullRunnerName version upstream")
     offline: Boolean = false
 ) extends HasLoggingOptions

--- a/modules/cli/src/main/scala/scala/cli/commands/version/VersionOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/version/VersionOptions.scala
@@ -9,21 +9,12 @@ import scala.cli.signing.shared.PasswordOption
 import scala.cli.signing.util.ArgParsers.*
 
 // format: off
-@HelpMessage(
-  s"""|Prints the version of the $fullRunnerName and the default version of Scala (which can be overridden in the project).
-      |If network connection is available, this sub-command also checks if the installed $fullRunnerName is up-to-date.
-      |
-      |The version of the $fullRunnerName is the version of the command-line tool that runs Scala programs, which
-      |is distinct from the Scala version of the compiler. We recommend to specify the version of the Scala compiler
-      |for a project in its sources (via a using directive). Otherwise, $fullRunnerName falls back to the default
-      |Scala version defined by the runner.
-      |
-      |${HelpMessages.commandDocWebsiteReference("version")}""".stripMargin
-)
+@HelpMessage(VersionOptions.helpMessage, "", VersionOptions.detailedHelpMessage)
 final case class VersionOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
   @Tag(tags.implementation)
+  @Tag(tags.important)
   @Group("Version")
   @HelpMessage(s"Show plain $fullRunnerName version only")
   @Name("cli")
@@ -31,6 +22,7 @@ final case class VersionOptions(
   @Group("Version")
   @HelpMessage("Show plain Scala version only")
   @Tag(tags.implementation)
+  @Tag(tags.important)
   @Name("scala")
     scalaVersion: Boolean = false,
   @Hidden
@@ -38,6 +30,8 @@ final case class VersionOptions(
   @Tag(tags.implementation)
     ghToken: Option[PasswordOption] = None,
   @Group("Version")
+  @Tag(tags.implementation)
+  @Tag(tags.important)
   @HelpMessage(s"Don't check for the newest available $fullRunnerName version upstream")
     offline: Boolean = false
 ) extends HasLoggingOptions
@@ -46,4 +40,19 @@ final case class VersionOptions(
 object VersionOptions {
   implicit lazy val parser: Parser[VersionOptions] = Parser.derive
   implicit lazy val help: Help[VersionOptions]     = Help.derive
+
+  val cmdName = "version"
+  private val helpHeader =
+    s"Prints the version of the $fullRunnerName and the default version of Scala."
+  val helpMessage: String = HelpMessages.shortHelpMessage(cmdName, helpHeader)
+  val detailedHelpMessage: String =
+    s"""$helpHeader (which can be overridden in the project)
+       |If network connection is available, this sub-command also checks if the installed $fullRunnerName is up-to-date.
+       |
+       |The version of the $fullRunnerName is the version of the command-line tool that runs Scala programs, which
+       |is distinct from the Scala version of the compiler. We recommend to specify the version of the Scala compiler
+       |for a project in its sources (via a using directive). Otherwise, $fullRunnerName falls back to the default
+       |Scala version defined by the runner.
+       |
+       |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/launcher/LauncherOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/launcher/LauncherOptions.scala
@@ -2,19 +2,25 @@ package scala.cli.launcher
 
 import caseapp.*
 
+import scala.cli.commands.tags
+
 @HelpMessage("Run another Scala CLI version")
 final case class LauncherOptions(
   @Group("Launcher")
   @HelpMessage("Set the Scala CLI version")
   @ValueDescription("nightly|version")
+  @Tag(tags.implementation)
+  @Tag(tags.inShortHelp)
   cliVersion: Option[String] = None,
   @Group("Launcher")
   @HelpMessage("The version of Scala on which Scala CLI was published")
   @ValueDescription("2.12|2.13|3")
   @Hidden
+  @Tag(tags.implementation)
   cliScalaVersion: Option[String] = None,
   @Group("Launcher")
   @HelpMessage("When called as 'scala', allow to use power commands too")
+  @Tag(tags.must)
   power: Boolean = false
 )
 

--- a/modules/cli/src/main/scala/scala/cli/util/ArgHelpers.scala
+++ b/modules/cli/src/main/scala/scala/cli/util/ArgHelpers.scala
@@ -23,9 +23,12 @@ object ArgHelpers {
   }
 
   extension (helpFormat: HelpFormat) {
-    def withPrimaryGroup(primaryGroup: String): HelpFormat = {
-      val oldSortedGroups = helpFormat.sortedGroups.getOrElse(Seq.empty)
-      helpFormat.copy(sortedGroups = Some(oldSortedGroups.prepended(primaryGroup)))
+    def withPrimaryGroup(primaryGroup: String): HelpFormat =
+      helpFormat.withPrimaryGroups(Seq(primaryGroup))
+    def withPrimaryGroups(primaryGroups: Seq[String]): HelpFormat = {
+      val oldSortedGroups         = helpFormat.sortedGroups.getOrElse(Seq.empty)
+      val filteredOldSortedGroups = oldSortedGroups.filterNot(primaryGroups.contains)
+      helpFormat.copy(sortedGroups = Some(primaryGroups ++ filteredOldSortedGroups))
     }
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/util/ArgHelpers.scala
+++ b/modules/cli/src/main/scala/scala/cli/util/ArgHelpers.scala
@@ -12,7 +12,7 @@ object ArgHelpers {
       arg.tags.exists(_.name == tags.restricted) || arg.tags.exists(_.name == tags.experimental)
 
     def isSupported: Boolean = allowRestrictedFeatures || !arg.isExperimentalOrRestricted
-    def isImportant: Boolean = arg.tags.exists(_.name == tags.important)
+    def isImportant: Boolean = arg.tags.exists(_.name == tags.inShortHelp)
 
     def isMust: Boolean = arg.tags.exists(_.name == tags.must)
 

--- a/modules/cli/src/main/scala/scala/cli/util/ArgHelpers.scala
+++ b/modules/cli/src/main/scala/scala/cli/util/ArgHelpers.scala
@@ -1,6 +1,7 @@
 package scala.cli.util
 
 import caseapp.core.Arg
+import caseapp.core.help.HelpFormat
 
 import scala.cli.ScalaCli.allowRestrictedFeatures
 import scala.cli.commands.{SpecificationLevel, tags}
@@ -19,5 +20,12 @@ object ArgHelpers {
       .flatMap(t => tags.levelFor(t.name))
       .headOption
       .getOrElse(SpecificationLevel.IMPLEMENTATION)
+  }
+
+  extension (helpFormat: HelpFormat) {
+    def withPrimaryGroup(primaryGroup: String): HelpFormat = {
+      val oldSortedGroups = helpFormat.sortedGroups.getOrElse(Seq.empty)
+      helpFormat.copy(sortedGroups = Some(oldSortedGroups.prepended(primaryGroup)))
+    }
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/util/ArgHelpers.scala
+++ b/modules/cli/src/main/scala/scala/cli/util/ArgHelpers.scala
@@ -11,6 +11,9 @@ object ArgHelpers {
       arg.tags.exists(_.name == tags.restricted) || arg.tags.exists(_.name == tags.experimental)
 
     def isSupported: Boolean = allowRestrictedFeatures || !arg.isExperimentalOrRestricted
+    def isImportant: Boolean = arg.tags.exists(_.name == tags.important)
+
+    def isMust: Boolean = arg.tags.exists(_.name == tags.must)
 
     def level: SpecificationLevel = arg.tags
       .flatMap(t => tags.levelFor(t.name))

--- a/modules/cli/src/test/scala/cli/tests/HelpCheck.scala
+++ b/modules/cli/src/test/scala/cli/tests/HelpCheck.scala
@@ -20,7 +20,7 @@ class HelpCheck extends munit.FunSuite {
 
     expect(helpMessage.contains("Version options:"))
 
-    expect(!helpMessage.contains("-help-full"))
+    expect(!helpMessage.contains("--usage"))
     expect(!helpMessage.contains("Logging options:"))
     expect(!helpMessage.contains("Other options:"))
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishSetupTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishSetupTests.scala
@@ -20,14 +20,15 @@ class PublishSetupTests extends ScalaCliSuite {
 
   private def configSetup(homeDir: os.Path, root: os.Path): Unit = {
     val envs = Map("SCALA_CLI_HOME" -> homeDir.toString)
-    os.proc(TestUtil.cli, "config", "publish.user.name", devName)
+    os.proc(TestUtil.cli, "--power", "config", "publish.user.name", devName)
       .call(cwd = root, stdout = os.Inherit, env = envs)
-    os.proc(TestUtil.cli, "config", "publish.user.email", devMail)
+    os.proc(TestUtil.cli, "--power", "config", "publish.user.email", devMail)
       .call(cwd = root, stdout = os.Inherit, env = envs)
-    os.proc(TestUtil.cli, "config", "publish.user.url", devUrl)
+    os.proc(TestUtil.cli, "--power", "config", "publish.user.url", devUrl)
       .call(cwd = root, stdout = os.Inherit, env = envs)
     os.proc(
       TestUtil.cli,
+      "--power",
       "config",
       "publish.credentials",
       "s01.oss.sonatype.org",
@@ -35,7 +36,7 @@ class PublishSetupTests extends ScalaCliSuite {
       "value:1234"
     )
       .call(cwd = root, stdout = os.Inherit, env = envs)
-    os.proc(TestUtil.cli, "config", "--create-pgp-key")
+    os.proc(TestUtil.cli, "--power", "config", "--create-pgp-key")
       .call(cwd = root, stdout = os.Inherit, env = envs)
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
@@ -108,12 +108,10 @@ abstract class ReplTestDefinitions(val scalaVersionOpt: Option[String])
       val res   = os.proc(TestUtil.cli, "--power", "repl", extraOptions, "--help").call(cwd = root)
       val lines = removeAnsiColors(res.out.trim()).linesIterator.toVector
 
-      val scalaVersionHelp   = lines.find(_.contains("--scala-version")).getOrElse("")
-      val scalaPyVersionHelp = lines.find(_.contains("--scalapy-version")).getOrElse("")
-      val ammVersionHelp     = lines.find(_.contains("--ammonite-ver")).getOrElse("")
+      val scalaVersionHelp = lines.find(_.contains("--scala-version")).getOrElse("")
+      val ammVersionHelp   = lines.find(_.contains("--ammonite-ver")).getOrElse("")
 
       expect(scalaVersionHelp.contains(s"(${Constants.defaultScala} by default)"))
-      expect(scalaPyVersionHelp.contains(s"(${Constants.scalaPyVersion} by default)"))
       expect(ammVersionHelp.contains(s"(${Constants.ammoniteVersion} by default)"))
     }
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -109,7 +109,9 @@ class SipScalaTests extends ScalaCliSuite {
 
   def testReplHelpOutput(isRestricted: Boolean): Unit = TestInputs.empty.fromRoot { root =>
     val output =
-      os.proc(TestUtil.cli, powerArgs(isRestricted), "repl", "-help").call(cwd = root).out.trim()
+      os.proc(TestUtil.cli, powerArgs(isRestricted), "repl", "--help-full").call(cwd =
+        root
+      ).out.trim()
     val restrictedFeaturesMentioned   = output.contains("--amm")
     val experimentalFeaturesMentioned = output.contains("--python")
     if (isRestricted) expect(!restrictedFeaturesMentioned && !experimentalFeaturesMentioned)

--- a/modules/specification-level/src/main/scala/scala/cli/commands/SpecificationLevel.scala
+++ b/modules/specification-level/src/main/scala/scala/cli/commands/SpecificationLevel.scala
@@ -65,6 +65,9 @@ object tags {
   val must: String           = SpecificationLevel.MUST.toString
   val should: String         = SpecificationLevel.SHOULD.toString
 
+  // other tags
+  val important: String = "important"
+
   def levelFor(name: String): Option[SpecificationLevel] = name match {
     case `experimental`   => Some(SpecificationLevel.EXPERIMENTAL)
     case `restricted`     => Some(SpecificationLevel.RESTRICTED)

--- a/modules/specification-level/src/main/scala/scala/cli/commands/SpecificationLevel.scala
+++ b/modules/specification-level/src/main/scala/scala/cli/commands/SpecificationLevel.scala
@@ -62,11 +62,13 @@ object tags {
   val experimental: String   = SpecificationLevel.EXPERIMENTAL.toString
   val restricted: String     = SpecificationLevel.RESTRICTED.toString
   val implementation: String = SpecificationLevel.IMPLEMENTATION.toString
-  val must: String           = SpecificationLevel.MUST.toString
+  val must: String           = SpecificationLevel.MUST.toString // included in --help by default
   val should: String         = SpecificationLevel.SHOULD.toString
 
   // other tags
-  val important: String = "important"
+  // the `inShortHelp` tag whitelists options to be included in --help
+  // this is in contrast to blacklisting options in --help with the @Hidden annotation
+  val inShortHelp: String = "inShortHelp" // included in --help by default
 
   def levelFor(name: String): Option[SpecificationLevel] = name match {
     case `experimental`   => Some(SpecificationLevel.EXPERIMENTAL)

--- a/modules/specification-level/src/main/scala/scala/cli/commands/SpecificationLevel.scala
+++ b/modules/specification-level/src/main/scala/scala/cli/commands/SpecificationLevel.scala
@@ -1,7 +1,7 @@
 package scala.cli.commands
 
 sealed trait SpecificationLevel extends Product with Serializable {
-  def md = toString() + " have"
+  def md: String = toString + " have"
 }
 
 /** Specification levels in the context of Scala CLI runner specification. For more refer to
@@ -32,7 +32,7 @@ object SpecificationLevel {
     * This also means that that thing should be sable and we need to support it.
     */
   case object IMPLEMENTATION extends SpecificationLevel {
-    override def md = toString() + " specific"
+    override def md: String = toString + " specific"
   }
 
   /** Annotated option, directive or command will not be a part of the Scala Runner Specification
@@ -51,20 +51,21 @@ object SpecificationLevel {
     * all new options should be experimental.
     */
   case object EXPERIMENTAL extends SpecificationLevel {
-    override def md: String = toString()
+    override def md: String = toString
   }
 
   val inSpecification = Seq(MUST, SHOULD)
 }
 
 object tags {
-  val experimental   = SpecificationLevel.EXPERIMENTAL.toString()
-  val restricted     = SpecificationLevel.RESTRICTED.toString()
-  val implementation = SpecificationLevel.IMPLEMENTATION.toString()
-  val must           = SpecificationLevel.MUST.toString()
-  val should         = SpecificationLevel.SHOULD.toString()
+  // specification level tags
+  val experimental: String   = SpecificationLevel.EXPERIMENTAL.toString
+  val restricted: String     = SpecificationLevel.RESTRICTED.toString
+  val implementation: String = SpecificationLevel.IMPLEMENTATION.toString
+  val must: String           = SpecificationLevel.MUST.toString
+  val should: String         = SpecificationLevel.SHOULD.toString
 
-  def levelFor(name: String) = name match {
+  def levelFor(name: String): Option[SpecificationLevel] = name match {
     case `experimental`   => Some(SpecificationLevel.EXPERIMENTAL)
     case `restricted`     => Some(SpecificationLevel.RESTRICTED)
     case `implementation` => Some(SpecificationLevel.IMPLEMENTATION)

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -89,7 +89,7 @@ object Deps {
     def scalaMeta          = "4.7.1"
     def scalaNative        = "0.4.9"
     def scalaPackager      = "0.1.29"
-    def signingCli         = "0.1.15"
+    def signingCli         = "0.1.16"
   }
   // DO NOT hardcode a Scala version in this dependency string
   // This dependency is used to ensure that Ammonite is available for Scala versions
@@ -100,7 +100,7 @@ object Deps {
   // Force using of 2.13 - is there a better way?
   def bloopConfig      = ivy"ch.epfl.scala:bloop-config_2.13:1.5.5"
   def bsp4j            = ivy"ch.epfl.scala:bsp4j:2.1.0-M3"
-  def caseApp          = ivy"com.github.alexarchambault::case-app:2.1.0-M23"
+  def caseApp          = ivy"com.github.alexarchambault::case-app:2.1.0-M24"
   def collectionCompat = ivy"org.scala-lang.modules::scala-collection-compat:2.9.0"
   // Force using of 2.13 - is there a better way?
   def coursier           = ivy"io.get-coursier:coursier_2.13:${Versions.coursier}"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -325,7 +325,7 @@ Saves .scalafmt.conf file if it was created or overwritten
 
 Aliases: `-F`
 
-Pass argument to scalafmt.
+Pass an argument to scalafmt.
 
 ### `--scalafmt-conf`
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -152,6 +152,57 @@ Print the resulting class path
 
 Compile test scope
 
+## Config options
+
+Available in commands:
+
+[`config`](./commands.md#config)
+
+<!-- Automatically generated, DO NOT EDIT MANUALLY -->
+
+### `--dump`
+
+[Internal]
+Dump config DB as JSON
+
+### `--create-pgp-key`
+
+Create PGP key in config
+
+### `--email`
+
+Email to use to create PGP key in config
+
+### `--password`
+
+If the entry is a password, print the password value rather than how to get the password
+
+### `--password-value`
+
+If the entry is a password, save the password value rather than how to get the password
+
+### `--unset`
+
+Aliases: `--remove`
+
+Remove an entry from config
+
+### `--https-only`
+
+For repository.credentials and publish.credentials, whether these credentials should be HTTPS only (default: true)
+
+### `--match-host`
+
+For repository.credentials, whether to use these credentials automatically based on the host
+
+### `--optional`
+
+For repository.credentials, whether to use these credentials are optional
+
+### `--pass-on-redirect`
+
+For repository.credentials, whether to use these credentials should be passed upon redirection
+
 ## Cross options
 
 Available in commands:
@@ -1731,66 +1782,6 @@ Aliases: `--name`
 
 [Internal]
 Name of BSP
-
-### Config options
-
-Available in commands:
-
-[`config`](./commands.md#config)
-
-<!-- Automatically generated, DO NOT EDIT MANUALLY -->
-
-### `--dump`
-
-[Internal]
-Dump config DB as JSON
-
-### `--create-pgp-key`
-
-[Internal]
-Create PGP key in config
-
-### `--email`
-
-[Internal]
-Email to use to create PGP key in config
-
-### `--password`
-
-[Internal]
-If the entry is a password, print the password value rather than how to get the password
-
-### `--password-value`
-
-[Internal]
-If the entry is a password, save the password value rather than how to get the password
-
-### `--unset`
-
-Aliases: `--remove`
-
-[Internal]
-Remove an entry from config
-
-### `--https-only`
-
-[Internal]
-For repository.credentials and publish.credentials, whether these credentials should be HTTPS only (default: true)
-
-### `--match-host`
-
-[Internal]
-For repository.credentials, whether to use these credentials automatically based on the host
-
-### `--optional`
-
-[Internal]
-For repository.credentials, whether to use these credentials are optional
-
-### `--pass-on-redirect`
-
-[Internal]
-For repository.credentials, whether to use these credentials should be passed upon redirection
 
 ### Coursier options
 

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -44,12 +44,8 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Generate Scaladoc documentation.
 
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
+You are currently viewing the basic help for the doc sub-command. You can view the full help by running: 
+   [1mscala-cli doc --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/doc
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [doc](./cli-options.md#doc-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -111,18 +111,8 @@ Aliases: `console`
 
 Fire-up a Scala REPL.
 
-The entire Scala CLI project's classpath is loaded to the repl.
-
-Specific repl configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
+You are currently viewing the basic help for the repl sub-command. You can view the full help by running: 
+   [1mscala-cli repl --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/repl
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [repl](./cli-options.md#repl-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -279,22 +279,8 @@ Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [c
 
 Compile and test Scala code.
 
-Test sources are compiled separately (after the 'main' sources), and may use different dependencies, compiler options, and other configurations.
-A source file is treated as a test source if:
-  - it contains the `//> using target.scope "test"` directive
-  - the file name ends with `.test.scala`
-  - the file comes from a directory that is provided as input, and the relative path from that file to its original directory contains a `test` directory
-
-Specific test configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
+You are currently viewing the basic help for the test sub-command. You can view the full help by running: 
+   [1mscala-cli test --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/test
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [test](./cli-options.md#test-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -58,16 +58,6 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Export current project to an external build tool (like SBT or Mill).
 
-The whole Scala CLI project should get exported along with its dependencies configuration.
-
-Unless otherwise configured, the default export format is SBT.
-
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [export](./cli-options.md#export-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -247,30 +247,8 @@ Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [compilati
 
 Like `run`, but handier for shebang scripts.
 
-This command is equivalent to the `run` sub-command, but it changes the way
-Scala CLI parses its command-line arguments in order to be compatible
-with shebang scripts.
-
-When relying on the `run` sub-command, inputs and scala-cli options can be mixed,
-while program args have to be specified after `--`
-
-```sh
-scala-cli [command] [scala-cli_options | input]... -- [program_arguments]...
-```
-
-However, for the `shebang` sub-command, only a single input file can be set, while all scala-cli options
-have to be set before the input file.
-All inputs after the first are treated as program arguments, without the need for `--`
-```sh
-scala-cli shebang [scala-cli_options]... input [program_arguments]...
-```
-
-Using this, it is possible to conveniently set up Unix shebang scripts. For example:
-```sh
-#!/usr/bin/env -S scala-cli shebang --scala-version 2.13
-println("Hello, world")
-```
-
+You are currently viewing the basic help for the shebang sub-command. You can view the full help by running: 
+   [1mscala-cli shebang --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/shebang
 
 Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -201,25 +201,8 @@ Accepts option groups: [coursier](./cli-options.md#coursier-options), [debug](./
 
 Compile and run Scala code.
 
-Specific run configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
-For a run to be successful, a main method must be present on the classpath.
-.sc scripts are an exception, as a main class is provided in their wrapper.
-
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
-To pass arguments to the actual application, just add them after `--`, like:
-
-```sh
-scala-cli run Main.scala AnotherSource.scala -- first-arg second-arg
-```
-
+You are currently viewing the basic help for the run sub-command. You can view the full help by running: 
+   [1mscala-cli run --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/run
 
 Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -34,6 +34,16 @@ For detailed documentation refer to our website: https://scala-cli.virtuslab.org
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [compile](./cli-options.md#compile-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
+## config
+
+Configure global settings for Scala CLI.
+
+You are currently viewing the basic help for the config sub-command. You can view the full help by running: 
+   [1mscala-cli config --help-full[0m
+For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
+
+Accepts option groups: [config](./cli-options.md#config-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [verbosity](./cli-options.md#verbosity-options)
+
 ## dependency-update
 
 Update dependency directives in the project
@@ -299,19 +309,6 @@ It is normally supposed to be invoked by your IDE when a Scala CLI project is im
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
 Accepts option groups: [bsp](./cli-options.md#bsp-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
-
-### config
-
-Configure global settings for Scala CLI.
-
-Syntax:
-  scala-cli config key value
-For example, to globally set the interactive mode:
-  scala-cli config interactive true
-
-For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
-
-Accepts option groups: [config](./cli-options.md#config-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### default-file
 

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -20,16 +20,8 @@ Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [logging](
 
 Compile Scala code.
 
-Specific compile configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
+You are currently viewing the basic help for the compile sub-command. You can view the full help by running: 
+   [1mscala-cli compile --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/compile
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [compile](./cli-options.md#compile-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -229,16 +229,8 @@ Accepts option groups: [logging](./cli-options.md#logging-options), [secret](./c
 
 Generates a BSP file that you can import into your IDE.
 
-The `setup-ide` sub-command allows to pre-configure a Scala CLI project to import to an IDE with BSP support.
-It is also ran implicitly when `compile`, `run`, `shebang` or `test` sub-commands are called.
-
-The pre-configuration should be saved in a BSP json connection file under the path:
-    {project-root}/.bsp/scala-cli.json
-
-Specific setup-ide configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
+You are currently viewing the basic help for the setup-ide sub-command. You can view the full help by running: 
+   [1mscala-cli setup-ide --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/setup-ide
 
 Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [setup IDE](./cli-options.md#setup-ide-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -311,8 +311,10 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Aliases: `uninstall-completions`
 
-Uninstalls completions from your shell
+Uninstalls completions from your shell.
 
+You are currently viewing the basic help for the uninstall completions sub-command. You can view the full help by running: 
+   [1mscala-cli uninstall completions --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [uninstall completions](./cli-options.md#uninstall-completions-options), [verbosity](./cli-options.md#verbosity-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -101,6 +101,8 @@ Aliases: `install-completions`
 
 Installs Scala CLI completions into your shell
 
+You are currently viewing the basic help for the install completions sub-command. You can view the full help by running: 
+   [1mscala-cli install completions --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 Accepts option groups: [install completions](./cli-options.md#install-completions-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
@@ -227,7 +229,7 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Aliases: `uninstall-completions`
 
-Uninstalls completions from your shell.
+Uninstalls Scala CLI completions from your shell.
 
 You are currently viewing the basic help for the uninstall completions sub-command. You can view the full help by running: 
    [1mscala-cli uninstall completions --help-full[0m

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -322,6 +322,9 @@ Accepts option groups: [logging](./cli-options.md#logging-options), [uninstall c
 Updates Scala CLI.
 Works only when installed with the installation script.
 If Scala CLI was installed with an external tool, refer to its update methods.
+
+You are currently viewing the basic help for the update sub-command. You can view the full help by running: 
+   [1mscala-cli update --help-full[0m
 For detailed installation instructions refer to our website: https://scala-cli.virtuslab.org/install
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [update](./cli-options.md#update-options), [verbosity](./cli-options.md#verbosity-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -11,7 +11,7 @@ sidebar_position: 3
 Clean the workspace.
 
 You are currently viewing the basic help for the clean sub-command. You can view the full help by running: 
-   [1mscala-cli clean --help-full[0m
+   scala-cli clean --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/clean
 
 Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -21,7 +21,7 @@ Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [logging](
 Compile Scala code.
 
 You are currently viewing the basic help for the compile sub-command. You can view the full help by running: 
-   [1mscala-cli compile --help-full[0m
+   scala-cli compile --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/compile
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [compile](./cli-options.md#compile-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -31,7 +31,7 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 Configure global settings for Scala CLI.
 
 You are currently viewing the basic help for the config sub-command. You can view the full help by running: 
-   [1mscala-cli config --help-full[0m
+   scala-cli config --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 
 Accepts option groups: [config](./cli-options.md#config-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [verbosity](./cli-options.md#verbosity-options)
@@ -47,7 +47,7 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 Generate Scaladoc documentation.
 
 You are currently viewing the basic help for the doc sub-command. You can view the full help by running: 
-   [1mscala-cli doc --help-full[0m
+   scala-cli doc --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/doc
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [doc](./cli-options.md#doc-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -67,7 +67,7 @@ Aliases: `format`, `scalafmt`
 Formats Scala code.
 
 You are currently viewing the basic help for the fmt sub-command. You can view the full help by running: 
-   [1mscala-cli fmt --help-full[0m
+   scala-cli fmt --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/fmt
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [fmt](./cli-options.md#fmt-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -85,7 +85,7 @@ Aliases: `install-completions`
 Installs Scala CLI completions into your shell
 
 You are currently viewing the basic help for the install completions sub-command. You can view the full help by running: 
-   [1mscala-cli install completions --help-full[0m
+   scala-cli install completions --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 Accepts option groups: [install completions](./cli-options.md#install-completions-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
@@ -97,7 +97,7 @@ Aliases: `console`
 Fire-up a Scala REPL.
 
 You are currently viewing the basic help for the repl sub-command. You can view the full help by running: 
-   [1mscala-cli repl --help-full[0m
+   scala-cli repl --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/repl
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [repl](./cli-options.md#repl-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -107,7 +107,7 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 Compile and package Scala code.
 
 You are currently viewing the basic help for the package sub-command. You can view the full help by running: 
-   [1mscala-cli --power package --help-full[0m
+   scala-cli --power package --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/package
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [package](./cli-options.md#package-options), [packager](./cli-options.md#packager-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -117,7 +117,7 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 Publishes build artifacts to Maven repositories.
 
 You are currently viewing the basic help for the publish sub-command. You can view the full help by running: 
-   [1mscala-cli --power publish --help-full[0m
+   scala-cli --power publish --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish](./cli-options.md#publish-options), [publish params](./cli-options.md#publish-params-options), [publish repository](./cli-options.md#publish-repository-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -127,7 +127,7 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 Publishes build artifacts to the local Ivy2 repository.
 
 You are currently viewing the basic help for the publish local sub-command. You can view the full help by running: 
-   [1mscala-cli publish local --help-full[0m
+   scala-cli publish local --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish-local
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish](./cli-options.md#publish-options), [publish params](./cli-options.md#publish-params-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -137,7 +137,7 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 Configures the project for publishing.
 
 You are currently viewing the basic help for the publish setup sub-command. You can view the full help by running: 
-   [1mscala-cli publish setup --help-full[0m
+   scala-cli publish setup --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish-setup
 
 Accepts option groups: [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp push pull](./cli-options.md#pgp-push-pull-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish params](./cli-options.md#publish-params-options), [publish repository](./cli-options.md#publish-repository-options), [publish setup](./cli-options.md#publish-setup-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -147,7 +147,7 @@ Accepts option groups: [coursier](./cli-options.md#coursier-options), [debug](./
 Compile and run Scala code.
 
 You are currently viewing the basic help for the run sub-command. You can view the full help by running: 
-   [1mscala-cli run --help-full[0m
+   scala-cli run --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/run
 
 Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -174,7 +174,7 @@ Accepts option groups: [logging](./cli-options.md#logging-options), [secret](./c
 Generates a BSP file that you can import into your IDE.
 
 You are currently viewing the basic help for the setup-ide sub-command. You can view the full help by running: 
-   [1mscala-cli setup-ide --help-full[0m
+   scala-cli setup-ide --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/setup-ide
 
 Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [setup IDE](./cli-options.md#setup-ide-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -184,7 +184,7 @@ Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [compilati
 Like `run`, but handier for shebang scripts.
 
 You are currently viewing the basic help for the shebang sub-command. You can view the full help by running: 
-   [1mscala-cli shebang --help-full[0m
+   scala-cli shebang --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/shebang
 
 Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -194,7 +194,7 @@ Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [c
 Compile and test Scala code.
 
 You are currently viewing the basic help for the test sub-command. You can view the full help by running: 
-   [1mscala-cli test --help-full[0m
+   scala-cli test --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/test
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [test](./cli-options.md#test-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -214,7 +214,7 @@ Aliases: `uninstall-completions`
 Uninstalls Scala CLI completions from your shell.
 
 You are currently viewing the basic help for the uninstall completions sub-command. You can view the full help by running: 
-   [1mscala-cli uninstall completions --help-full[0m
+   scala-cli uninstall completions --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [uninstall completions](./cli-options.md#uninstall-completions-options), [verbosity](./cli-options.md#verbosity-options)
@@ -226,7 +226,7 @@ Works only when installed with the installation script.
 If Scala CLI was installed with an external tool, refer to its update methods.
 
 You are currently viewing the basic help for the update sub-command. You can view the full help by running: 
-   [1mscala-cli update --help-full[0m
+   scala-cli update --help-full
 For detailed installation instructions refer to our website: https://scala-cli.virtuslab.org/install
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [update](./cli-options.md#update-options), [verbosity](./cli-options.md#verbosity-options)
@@ -236,7 +236,7 @@ Accepts option groups: [logging](./cli-options.md#logging-options), [update](./c
 Prints the version of the Scala CLI and the default version of Scala.
 
 You are currently viewing the basic help for the version sub-command. You can view the full help by running: 
-   [1mscala-cli version --help-full[0m
+   scala-cli version --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/version
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [version](./cli-options.md#version-options)
@@ -287,7 +287,7 @@ Accepts option groups: [bloop start](./cli-options.md#bloop-start-options), [com
 Start BSP server.
 
 You are currently viewing the basic help for the bsp sub-command. You can view the full help by running: 
-   [1mscala-cli bsp --help-full[0m
+   scala-cli bsp --help-full
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
 Accepts option groups: [bsp](./cli-options.md#bsp-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -78,13 +78,8 @@ Aliases: `format`, `scalafmt`
 
 Formats Scala code.
 
-`scalafmt` is used to perform the formatting under the hood.
-
-The `.scalafmt.conf` configuration file is optional.
-Default configuration values will be assumed by Scala CLI.
-
-All standard Scala CLI inputs are accepted, but only Scala sources will be formatted (.scala and .sc files).
-
+You are currently viewing the basic help for the fmt sub-command. You can view the full help by running: 
+   [1mscala-cli fmt --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/fmt
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [fmt](./cli-options.md#fmt-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -10,8 +10,8 @@ sidebar_position: 3
 
 Clean the workspace.
 
-Passed inputs will establish the Scala CLI project, for which the workspace will be cleaned.
-
+You are currently viewing the basic help for the clean sub-command. You can view the full help by running: 
+   [1mscala-cli clean --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/clean
 
 Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -292,12 +292,8 @@ Accepts option groups: [bloop start](./cli-options.md#bloop-start-options), [com
 
 Start BSP server.
 
-BSP stands for Build Server Protocol.
-For more information refer to https://build-server-protocol.github.io/
-
-This sub-command is not designed to be used by a human.
-It is normally supposed to be invoked by your IDE when a Scala CLI project is imported.
-
+You are currently viewing the basic help for the bsp sub-command. You can view the full help by running: 
+   [1mscala-cli bsp --help-full[0m
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
 Accepts option groups: [bsp](./cli-options.md#bsp-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -139,21 +139,8 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Publishes build artifacts to Maven repositories.
 
-We recommend running the `publish setup` sub-command once prior to
-running `publish` in order to set missing `using` directives for publishing.
-(but this is not mandatory)
-    scala-cli --power publish setup .
-
-Specific publish configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
+You are currently viewing the basic help for the publish sub-command. You can view the full help by running: 
+   [1mscala-cli --power publish --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish](./cli-options.md#publish-options), [publish params](./cli-options.md#publish-params-options), [publish repository](./cli-options.md#publish-repository-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -183,6 +170,8 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Configures the project for publishing.
 
+You are currently viewing the basic help for the publish setup sub-command. You can view the full help by running: 
+   [1mscala-cli publish setup --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish-setup
 
 Accepts option groups: [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp push pull](./cli-options.md#pgp-push-pull-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish params](./cli-options.md#publish-params-options), [publish repository](./cli-options.md#publish-repository-options), [publish setup](./cli-options.md#publish-setup-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -149,19 +149,8 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Publishes build artifacts to the local Ivy2 repository.
 
-The local Ivy2 repository usually lives under `~/.ivy2/local`.
-It is taken into account most of the time by most Scala tools when fetching artifacts.
-
-Specific publish local configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
+You are currently viewing the basic help for the publish local sub-command. You can view the full help by running: 
+   [1mscala-cli publish local --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish-local
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish](./cli-options.md#publish-options), [publish params](./cli-options.md#publish-params-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -176,7 +176,6 @@ Aliases: `gh secret create`
 Creates or updates a GitHub repository secret.
   scala-cli --power github secret create --repo repo-org/repo-name SECRET_VALUE=value:secret
 
-
 Accepts option groups: [coursier](./cli-options.md#coursier-options), [logging](./cli-options.md#logging-options), [secret](./cli-options.md#secret-options), [secret create](./cli-options.md#secret-create-options), [verbosity](./cli-options.md#verbosity-options)
 
 ## github secret list

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -121,16 +121,8 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Compile and package Scala code.
 
-Specific package configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
+You are currently viewing the basic help for the package sub-command. You can view the full help by running: 
+   [1mscala-cli --power package --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/package
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [package](./cli-options.md#package-options), [packager](./cli-options.md#packager-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -253,12 +253,6 @@ Accepts option groups: [add path](./cli-options.md#add-path-options), [logging](
 
 Interact with Bloop (the build server) or check its status.
 
-This sub-command allows to check the current status of Bloop.
-If Bloop isn't currently running, it will be started.
-
-Bloop is the build server used by Scala CLI.
-For more information about Bloop, refer to https://scalacenter.github.io/bloop/
-
 Accepts option groups: [bloop](./cli-options.md#bloop-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### bloop exit

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -328,14 +328,10 @@ Accepts option groups: [logging](./cli-options.md#logging-options), [update](./c
 
 ## version
 
-Prints the version of the Scala CLI and the default version of Scala (which can be overridden in the project).
-If network connection is available, this sub-command also checks if the installed Scala CLI is up-to-date.
+Prints the version of the Scala CLI and the default version of Scala.
 
-The version of the Scala CLI is the version of the command-line tool that runs Scala programs, which
-is distinct from the Scala version of the compiler. We recommend to specify the version of the Scala compiler
-for a project in its sources (via a using directive). Otherwise, Scala CLI falls back to the default
-Scala version defined by the runner.
-
+You are currently viewing the basic help for the version sub-command. You can view the full help by running: 
+   [1mscala-cli version --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/version
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [version](./cli-options.md#version-options)

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -156,6 +156,28 @@ Print the resulting class path
 
 Compile test scope
 
+## Config options
+
+Available in commands:
+
+[`config`](./commands.md#config)
+
+<!-- Automatically generated, DO NOT EDIT MANUALLY -->
+
+### `--dump`
+
+`IMPLEMENTATION specific` per Scala Runner specification
+
+Dump config DB as JSON
+
+### `--unset`
+
+Aliases: `--remove`
+
+`SHOULD have` per Scala Runner specification
+
+Remove an entry from config
+
 ## Debug options
 
 Available in commands:
@@ -1290,34 +1312,6 @@ Aliases: `--name`
 `IMPLEMENTATION specific` per Scala Runner specification
 
 Name of BSP
-
-### Config options
-
-Available in commands:
-
-[`config`](./commands.md#config)
-
-<!-- Automatically generated, DO NOT EDIT MANUALLY -->
-
-### `--dump`
-
-`IMPLEMENTATION specific` per Scala Runner specification
-
-Dump config DB as JSON
-
-### `--create-pgp-key`
-
-`IMPLEMENTATION specific` per Scala Runner specification
-
-Create PGP key in config
-
-### `--unset`
-
-Aliases: `--remove`
-
-`IMPLEMENTATION specific` per Scala Runner specification
-
-Remove an entry from config
 
 ### Coursier options
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -1399,28 +1399,6 @@ Print the update to `env` variable
 
 Binary directory
 
-### Pgp scala signing options
-
-Available in commands:
-
-[`config`](./commands.md#config)
-
-<!-- Automatically generated, DO NOT EDIT MANUALLY -->
-
-### `--signing-cli-version`
-
-`IMPLEMENTATION specific` per Scala Runner specification
-
-### `--signing-cli-java-arg`
-
-`IMPLEMENTATION specific` per Scala Runner specification
-
-### `--force-jvm-signing-cli`
-
-`IMPLEMENTATION specific` per Scala Runner specification
-
-Whether to run the Scala Signing CLI on the JVM or using a native executable
-
 ### Repl options
 
 Available in commands:

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -298,7 +298,7 @@ Aliases: `-F`
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Pass argument to scalafmt.
+Pass an argument to scalafmt.
 
 ### `--scalafmt-conf`
 

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -19,16 +19,8 @@ that is reserved for commands that need to be present for Scala CLI to work prop
 
 Compile Scala code.
 
-Specific compile configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
+You are currently viewing the basic help for the compile sub-command. You can view the full help by running: 
+   [1mscala-cli compile --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/compile
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [compile](./cli-options.md#compile-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -20,7 +20,7 @@ that is reserved for commands that need to be present for Scala CLI to work prop
 Compile Scala code.
 
 You are currently viewing the basic help for the compile sub-command. You can view the full help by running: 
-   [1mscala-cli compile --help-full[0m
+   scala-cli compile --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/compile
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [compile](./cli-options.md#compile-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -30,7 +30,7 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 Configure global settings for Scala CLI.
 
 You are currently viewing the basic help for the config sub-command. You can view the full help by running: 
-   [1mscala-cli config --help-full[0m
+   scala-cli config --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 
 Accepts option groups: [config](./cli-options.md#config-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [verbosity](./cli-options.md#verbosity-options)
@@ -40,7 +40,7 @@ Accepts option groups: [config](./cli-options.md#config-options), [coursier](./c
 Generate Scaladoc documentation.
 
 You are currently viewing the basic help for the doc sub-command. You can view the full help by running: 
-   [1mscala-cli doc --help-full[0m
+   scala-cli doc --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/doc
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [doc](./cli-options.md#doc-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -52,7 +52,7 @@ Aliases: `console`
 Fire-up a Scala REPL.
 
 You are currently viewing the basic help for the repl sub-command. You can view the full help by running: 
-   [1mscala-cli repl --help-full[0m
+   scala-cli repl --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/repl
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [repl](./cli-options.md#repl-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -62,7 +62,7 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 Compile and run Scala code.
 
 You are currently viewing the basic help for the run sub-command. You can view the full help by running: 
-   [1mscala-cli run --help-full[0m
+   scala-cli run --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/run
 
 Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -72,7 +72,7 @@ Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [c
 Like `run`, but handier for shebang scripts.
 
 You are currently viewing the basic help for the shebang sub-command. You can view the full help by running: 
-   [1mscala-cli shebang --help-full[0m
+   scala-cli shebang --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/shebang
 
 Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -86,7 +86,7 @@ Aliases: `format`, `scalafmt`
 Formats Scala code.
 
 You are currently viewing the basic help for the fmt sub-command. You can view the full help by running: 
-   [1mscala-cli fmt --help-full[0m
+   scala-cli fmt --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/fmt
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [fmt](./cli-options.md#fmt-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -96,7 +96,7 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 Compile and test Scala code.
 
 You are currently viewing the basic help for the test sub-command. You can view the full help by running: 
-   [1mscala-cli test --help-full[0m
+   scala-cli test --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/test
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [test](./cli-options.md#test-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -106,7 +106,7 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 Prints the version of the Scala CLI and the default version of Scala.
 
 You are currently viewing the basic help for the version sub-command. You can view the full help by running: 
-   [1mscala-cli version --help-full[0m
+   scala-cli version --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/version
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [version](./cli-options.md#version-options)
@@ -120,7 +120,7 @@ Commands which are used within Scala CLI and should be a part of the `scala` com
 Start BSP server.
 
 You are currently viewing the basic help for the bsp sub-command. You can view the full help by running: 
-   [1mscala-cli bsp --help-full[0m
+   scala-cli bsp --help-full
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
 Accepts option groups: [bsp](./cli-options.md#bsp-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -130,7 +130,7 @@ Accepts option groups: [bsp](./cli-options.md#bsp-options), [compilation server]
 Clean the workspace.
 
 You are currently viewing the basic help for the clean sub-command. You can view the full help by running: 
-   [1mscala-cli clean --help-full[0m
+   scala-cli clean --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/clean
 
 Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -148,7 +148,7 @@ Aliases: `install-completions`
 Installs Scala CLI completions into your shell
 
 You are currently viewing the basic help for the install completions sub-command. You can view the full help by running: 
-   [1mscala-cli install completions --help-full[0m
+   scala-cli install completions --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 Accepts option groups: [install completions](./cli-options.md#install-completions-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
@@ -164,7 +164,7 @@ Accepts option groups: [install home](./cli-options.md#install-home-options), [l
 Generates a BSP file that you can import into your IDE.
 
 You are currently viewing the basic help for the setup-ide sub-command. You can view the full help by running: 
-   [1mscala-cli setup-ide --help-full[0m
+   scala-cli setup-ide --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/setup-ide
 
 Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [setup IDE](./cli-options.md#setup-ide-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -184,7 +184,7 @@ Aliases: `uninstall-completions`
 Uninstalls Scala CLI completions from your shell.
 
 You are currently viewing the basic help for the uninstall completions sub-command. You can view the full help by running: 
-   [1mscala-cli uninstall completions --help-full[0m
+   scala-cli uninstall completions --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [uninstall completions](./cli-options.md#uninstall-completions-options), [verbosity](./cli-options.md#verbosity-options)
@@ -196,7 +196,7 @@ Works only when installed with the installation script.
 If Scala CLI was installed with an external tool, refer to its update methods.
 
 You are currently viewing the basic help for the update sub-command. You can view the full help by running: 
-   [1mscala-cli update --help-full[0m
+   scala-cli update --help-full
 For detailed installation instructions refer to our website: https://scala-cli.virtuslab.org/install
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [update](./cli-options.md#update-options), [verbosity](./cli-options.md#verbosity-options)

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -147,22 +147,8 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Compile and test Scala code.
 
-Test sources are compiled separately (after the 'main' sources), and may use different dependencies, compiler options, and other configurations.
-A source file is treated as a test source if:
-  - it contains the `//> using target.scope "test"` directive
-  - the file name ends with `.test.scala`
-  - the file comes from a directory that is provided as input, and the relative path from that file to its original directory contains a `test` directory
-
-Specific test configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
+You are currently viewing the basic help for the test sub-command. You can view the full help by running: 
+   [1mscala-cli test --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/test
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [test](./cli-options.md#test-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -169,14 +169,10 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 ### version
 
-Prints the version of the Scala CLI and the default version of Scala (which can be overridden in the project).
-If network connection is available, this sub-command also checks if the installed Scala CLI is up-to-date.
+Prints the version of the Scala CLI and the default version of Scala.
 
-The version of the Scala CLI is the version of the command-line tool that runs Scala programs, which
-is distinct from the Scala version of the compiler. We recommend to specify the version of the Scala compiler
-for a project in its sources (via a using directive). Otherwise, Scala CLI falls back to the default
-Scala version defined by the runner.
-
+You are currently viewing the basic help for the version sub-command. You can view the full help by running: 
+   [1mscala-cli version --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/version
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [version](./cli-options.md#version-options)

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -268,6 +268,9 @@ Accepts option groups: [logging](./cli-options.md#logging-options), [uninstall c
 Updates Scala CLI.
 Works only when installed with the installation script.
 If Scala CLI was installed with an external tool, refer to its update methods.
+
+You are currently viewing the basic help for the update sub-command. You can view the full help by running: 
+   [1mscala-cli update --help-full[0m
 For detailed installation instructions refer to our website: https://scala-cli.virtuslab.org/install
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [update](./cli-options.md#update-options), [verbosity](./cli-options.md#verbosity-options)

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -133,8 +133,8 @@ Accepts option groups: [bsp](./cli-options.md#bsp-options), [compilation server]
 
 Clean the workspace.
 
-Passed inputs will establish the Scala CLI project, for which the workspace will be cleaned.
-
+You are currently viewing the basic help for the clean sub-command. You can view the full help by running: 
+   [1mscala-cli clean --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/clean
 
 Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -257,8 +257,10 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Aliases: `uninstall-completions`
 
-Uninstalls completions from your shell
+Uninstalls completions from your shell.
 
+You are currently viewing the basic help for the uninstall completions sub-command. You can view the full help by running: 
+   [1mscala-cli uninstall completions --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [uninstall completions](./cli-options.md#uninstall-completions-options), [verbosity](./cli-options.md#verbosity-options)

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -86,25 +86,8 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Compile and run Scala code.
 
-Specific run configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
-For a run to be successful, a main method must be present on the classpath.
-.sc scripts are an exception, as a main class is provided in their wrapper.
-
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
-To pass arguments to the actual application, just add them after `--`, like:
-
-```sh
-scala-cli run Main.scala AnotherSource.scala -- first-arg second-arg
-```
-
+You are currently viewing the basic help for the run sub-command. You can view the full help by running: 
+   [1mscala-cli run --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/run
 
 Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -50,12 +50,8 @@ Accepts option groups: [config](./cli-options.md#config-options), [coursier](./c
 
 Generate Scaladoc documentation.
 
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
+You are currently viewing the basic help for the doc sub-command. You can view the full help by running: 
+   [1mscala-cli doc --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/doc
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [doc](./cli-options.md#doc-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -37,11 +37,8 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Configure global settings for Scala CLI.
 
-Syntax:
-  scala-cli config key value
-For example, to globally set the interactive mode:
-  scala-cli config interactive true
-
+You are currently viewing the basic help for the config sub-command. You can view the full help by running: 
+   [1mscala-cli config --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 
 Accepts option groups: [config](./cli-options.md#config-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [verbosity](./cli-options.md#verbosity-options)

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -96,30 +96,8 @@ Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [c
 
 Like `run`, but handier for shebang scripts.
 
-This command is equivalent to the `run` sub-command, but it changes the way
-Scala CLI parses its command-line arguments in order to be compatible
-with shebang scripts.
-
-When relying on the `run` sub-command, inputs and scala-cli options can be mixed,
-while program args have to be specified after `--`
-
-```sh
-scala-cli [command] [scala-cli_options | input]... -- [program_arguments]...
-```
-
-However, for the `shebang` sub-command, only a single input file can be set, while all scala-cli options
-have to be set before the input file.
-All inputs after the first are treated as program arguments, without the need for `--`
-```sh
-scala-cli shebang [scala-cli_options]... input [program_arguments]...
-```
-
-Using this, it is possible to conveniently set up Unix shebang scripts. For example:
-```sh
-#!/usr/bin/env -S scala-cli shebang --scala-version 2.13
-println("Hello, world")
-```
-
+You are currently viewing the basic help for the shebang sub-command. You can view the full help by running: 
+   [1mscala-cli shebang --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/shebang
 
 Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -100,13 +100,8 @@ Aliases: `format`, `scalafmt`
 
 Formats Scala code.
 
-`scalafmt` is used to perform the formatting under the hood.
-
-The `.scalafmt.conf` configuration file is optional.
-Default configuration values will be assumed by Scala CLI.
-
-All standard Scala CLI inputs are accepted, but only Scala sources will be formatted (.scala and .sc files).
-
+You are currently viewing the basic help for the fmt sub-command. You can view the full help by running: 
+   [1mscala-cli fmt --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/fmt
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [fmt](./cli-options.md#fmt-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -119,12 +119,8 @@ Commands which are used within Scala CLI and should be a part of the `scala` com
 
 Start BSP server.
 
-BSP stands for Build Server Protocol.
-For more information refer to https://build-server-protocol.github.io/
-
-This sub-command is not designed to be used by a human.
-It is normally supposed to be invoked by your IDE when a Scala CLI project is imported.
-
+You are currently viewing the basic help for the bsp sub-command. You can view the full help by running: 
+   [1mscala-cli bsp --help-full[0m
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
 Accepts option groups: [bsp](./cli-options.md#bsp-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -171,6 +171,8 @@ Aliases: `install-completions`
 
 Installs Scala CLI completions into your shell
 
+You are currently viewing the basic help for the install completions sub-command. You can view the full help by running: 
+   [1mscala-cli install completions --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 Accepts option groups: [install completions](./cli-options.md#install-completions-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
@@ -203,7 +205,7 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Aliases: `uninstall-completions`
 
-Uninstalls completions from your shell.
+Uninstalls Scala CLI completions from your shell.
 
 You are currently viewing the basic help for the uninstall completions sub-command. You can view the full help by running: 
    [1mscala-cli uninstall completions --help-full[0m

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -195,16 +195,8 @@ Accepts option groups: [install home](./cli-options.md#install-home-options), [l
 
 Generates a BSP file that you can import into your IDE.
 
-The `setup-ide` sub-command allows to pre-configure a Scala CLI project to import to an IDE with BSP support.
-It is also ran implicitly when `compile`, `run`, `shebang` or `test` sub-commands are called.
-
-The pre-configuration should be saved in a BSP json connection file under the path:
-    {project-root}/.bsp/scala-cli.json
-
-Specific setup-ide configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
+You are currently viewing the basic help for the setup-ide sub-command. You can view the full help by running: 
+   [1mscala-cli setup-ide --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/setup-ide
 
 Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [setup IDE](./cli-options.md#setup-ide-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -66,18 +66,8 @@ Aliases: `console`
 
 Fire-up a Scala REPL.
 
-The entire Scala CLI project's classpath is loaded to the repl.
-
-Specific repl configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
+You are currently viewing the basic help for the repl sub-command. You can view the full help by running: 
+   [1mscala-cli repl --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/repl
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [repl](./cli-options.md#repl-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -1783,25 +1783,8 @@ Don't actually run the REPL, just fetch it
 
 Compile and run Scala code.
 
-Specific run configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
-For a run to be successful, a main method must be present on the classpath.
-.sc scripts are an exception, as a main class is provided in their wrapper.
-
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
-To pass arguments to the actual application, just add them after `--`, like:
-
-```sh
-scala-cli run Main.scala AnotherSource.scala -- first-arg second-arg
-```
-
+You are currently viewing the basic help for the run sub-command. You can view the full help by running: 
+   [1mscala-cli run --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/run
 
 ### MUST have options

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -692,18 +692,6 @@ CPU architecture to use when looking up in the JVM index
 
 Port for BSP debugging
 
-**--signing-cli-version**
-
-
-
-**--signing-cli-java-arg**
-
-
-
-**--force-jvm-signing-cli**
-
-Whether to run the Scala Signing CLI on the JVM or using a native executable
-
 **--dump**
 
 Dump config DB as JSON

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -4011,12 +4011,8 @@ Don't check for the newest available Scala CLI version upstream
 
 Start BSP server.
 
-BSP stands for Build Server Protocol.
-For more information refer to https://build-server-protocol.github.io/
-
-This sub-command is not designed to be used by a human.
-It is normally supposed to be invoked by your IDE when a Scala CLI project is imported.
-
+You are currently viewing the basic help for the bsp sub-command. You can view the full help by running: 
+   [1mscala-cli bsp --help-full[0m
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
 ### MUST have options

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -4676,6 +4676,8 @@ Aliases: `install-completions`
 
 Installs Scala CLI completions into your shell
 
+You are currently viewing the basic help for the install completions sub-command. You can view the full help by running: 
+   [1mscala-cli install completions --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 <details><summary>
@@ -5516,7 +5518,7 @@ Binary directory
 
 Aliases: `uninstall-completions`
 
-Uninstalls completions from your shell.
+Uninstalls Scala CLI completions from your shell.
 
 You are currently viewing the basic help for the uninstall completions sub-command. You can view the full help by running: 
    [1mscala-cli uninstall completions --help-full[0m

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -715,12 +715,8 @@ Aliases: `--remove`
 
 Generate Scaladoc documentation.
 
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
+You are currently viewing the basic help for the doc sub-command. You can view the full help by running: 
+   [1mscala-cli doc --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/doc
 
 ### MUST have options

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -4008,14 +4008,10 @@ Aliases: `--java-prop`
 ## `version` command
 **SHOULD have for Scala Runner specification.**
 
-Prints the version of the Scala CLI and the default version of Scala (which can be overridden in the project).
-If network connection is available, this sub-command also checks if the installed Scala CLI is up-to-date.
+Prints the version of the Scala CLI and the default version of Scala.
 
-The version of the Scala CLI is the version of the command-line tool that runs Scala programs, which
-is distinct from the Scala version of the compiler. We recommend to specify the version of the Scala compiler
-for a project in its sources (via a using directive). Otherwise, Scala CLI falls back to the default
-Scala version defined by the runner.
-
+You are currently viewing the basic help for the version sub-command. You can view the full help by running: 
+   [1mscala-cli version --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/version
 
 <details><summary>
@@ -4033,6 +4029,12 @@ Print usage and exit
 Print help message and exit
 
 Aliases: `-h` ,`-help`
+
+**--help-full**
+
+Print help message, including hidden options, and exit
+
+Aliases: `--full-help` ,`-help-full` ,`-full-help`
 
 **--verbose**
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -5656,6 +5656,9 @@ Use progress bars
 Updates Scala CLI.
 Works only when installed with the installation script.
 If Scala CLI was installed with an external tool, refer to its update methods.
+
+You are currently viewing the basic help for the update sub-command. You can view the full help by running: 
+   [1mscala-cli update --help-full[0m
 For detailed installation instructions refer to our website: https://scala-cli.virtuslab.org/install
 
 <details><summary>

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -48,16 +48,8 @@ are assumed to be Scala compiler options and will be propagated to Scala Compile
 
 Compile Scala code.
 
-Specific compile configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
+You are currently viewing the basic help for the compile sub-command. You can view the full help by running: 
+   [1mscala-cli compile --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/compile
 
 ### MUST have options

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -49,7 +49,7 @@ are assumed to be Scala compiler options and will be propagated to Scala Compile
 Compile Scala code.
 
 You are currently viewing the basic help for the compile sub-command. You can view the full help by running: 
-   [1mscala-cli compile --help-full[0m
+   scala-cli compile --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/compile
 
 ### MUST have options
@@ -568,7 +568,7 @@ Aliases: `--toolkit`
 Configure global settings for Scala CLI.
 
 You are currently viewing the basic help for the config sub-command. You can view the full help by running: 
-   [1mscala-cli config --help-full[0m
+   scala-cli config --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 
 ### SHOULD have options
@@ -701,7 +701,7 @@ Dump config DB as JSON
 Generate Scaladoc documentation.
 
 You are currently viewing the basic help for the doc sub-command. You can view the full help by running: 
-   [1mscala-cli doc --help-full[0m
+   scala-cli doc --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/doc
 
 ### MUST have options
@@ -1218,7 +1218,7 @@ Aliases: `console`
 Fire-up a Scala REPL.
 
 You are currently viewing the basic help for the repl sub-command. You can view the full help by running: 
-   [1mscala-cli repl --help-full[0m
+   scala-cli repl --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/repl
 
 ### MUST have options
@@ -1743,7 +1743,7 @@ Don't actually run the REPL, just fetch it
 Compile and run Scala code.
 
 You are currently viewing the basic help for the run sub-command. You can view the full help by running: 
-   [1mscala-cli run --help-full[0m
+   scala-cli run --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/run
 
 ### MUST have options
@@ -2288,7 +2288,7 @@ Run Java commands using a manifest-based class path (shortens command length)
 Like `run`, but handier for shebang scripts.
 
 You are currently viewing the basic help for the shebang sub-command. You can view the full help by running: 
-   [1mscala-cli shebang --help-full[0m
+   scala-cli shebang --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/shebang
 
 ### MUST have options
@@ -2837,7 +2837,7 @@ Aliases: `format`, `scalafmt`
 Formats Scala code.
 
 You are currently viewing the basic help for the fmt sub-command. You can view the full help by running: 
-   [1mscala-cli fmt --help-full[0m
+   scala-cli fmt --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/fmt
 
 ### MUST have options
@@ -3396,7 +3396,7 @@ Aliases: `--fmt-version`
 Compile and test Scala code.
 
 You are currently viewing the basic help for the test sub-command. You can view the full help by running: 
-   [1mscala-cli test --help-full[0m
+   scala-cli test --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/test
 
 ### MUST have options
@@ -3929,7 +3929,7 @@ Aliases: `--java-prop`
 Prints the version of the Scala CLI and the default version of Scala.
 
 You are currently viewing the basic help for the version sub-command. You can view the full help by running: 
-   [1mscala-cli version --help-full[0m
+   scala-cli version --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/version
 
 <details><summary>
@@ -4012,7 +4012,7 @@ Don't check for the newest available Scala CLI version upstream
 Start BSP server.
 
 You are currently viewing the basic help for the bsp sub-command. You can view the full help by running: 
-   [1mscala-cli bsp --help-full[0m
+   scala-cli bsp --help-full
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
 ### MUST have options
@@ -4513,7 +4513,7 @@ Command-line options JSON file
 Clean the workspace.
 
 You are currently viewing the basic help for the clean sub-command. You can view the full help by running: 
-   [1mscala-cli clean --help-full[0m
+   scala-cli clean --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/clean
 
 <details><summary>
@@ -4649,7 +4649,7 @@ Aliases: `install-completions`
 Installs Scala CLI completions into your shell
 
 You are currently viewing the basic help for the install completions sub-command. You can view the full help by running: 
-   [1mscala-cli install completions --help-full[0m
+   scala-cli install completions --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 <details><summary>
@@ -4817,7 +4817,7 @@ Binary directory
 Generates a BSP file that you can import into your IDE.
 
 You are currently viewing the basic help for the setup-ide sub-command. You can view the full help by running: 
-   [1mscala-cli setup-ide --help-full[0m
+   scala-cli setup-ide --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/setup-ide
 
 ### MUST have options
@@ -5493,7 +5493,7 @@ Aliases: `uninstall-completions`
 Uninstalls Scala CLI completions from your shell.
 
 You are currently viewing the basic help for the uninstall completions sub-command. You can view the full help by running: 
-   [1mscala-cli uninstall completions --help-full[0m
+   scala-cli uninstall completions --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 <details><summary>
@@ -5568,7 +5568,7 @@ Works only when installed with the installation script.
 If Scala CLI was installed with an external tool, refer to its update methods.
 
 You are currently viewing the basic help for the update sub-command. You can view the full help by running: 
-   [1mscala-cli update --help-full[0m
+   scala-cli update --help-full
 For detailed installation instructions refer to our website: https://scala-cli.virtuslab.org/install
 
 <details><summary>

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -4864,16 +4864,8 @@ Binary directory
 
 Generates a BSP file that you can import into your IDE.
 
-The `setup-ide` sub-command allows to pre-configure a Scala CLI project to import to an IDE with BSP support.
-It is also ran implicitly when `compile`, `run`, `shebang` or `test` sub-commands are called.
-
-The pre-configuration should be saved in a BSP json connection file under the path:
-    {project-root}/.bsp/scala-cli.json
-
-Specific setup-ide configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
+You are currently viewing the basic help for the setup-ide sub-command. You can view the full help by running: 
+   [1mscala-cli setup-ide --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/setup-ide
 
 ### MUST have options

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -1248,18 +1248,8 @@ Aliases: `console`
 
 Fire-up a Scala REPL.
 
-The entire Scala CLI project's classpath is loaded to the repl.
-
-Specific repl configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
+You are currently viewing the basic help for the repl sub-command. You can view the full help by running: 
+   [1mscala-cli repl --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/repl
 
 ### MUST have options

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -2855,13 +2855,8 @@ Aliases: `format`, `scalafmt`
 
 Formats Scala code.
 
-`scalafmt` is used to perform the formatting under the hood.
-
-The `.scalafmt.conf` configuration file is optional.
-Default configuration values will be assumed by Scala CLI.
-
-All standard Scala CLI inputs are accepted, but only Scala sources will be formatted (.scala and .sc files).
-
+You are currently viewing the basic help for the fmt sub-command. You can view the full help by running: 
+   [1mscala-cli fmt --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/fmt
 
 ### MUST have options
@@ -3382,7 +3377,7 @@ Saves .scalafmt.conf file if it was created or overwritten
 
 **--scalafmt-arg**
 
-Pass argument to scalafmt.
+Pass an argument to scalafmt.
 
 Aliases: `-F`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -575,11 +575,8 @@ Aliases: `--toolkit`
 
 Configure global settings for Scala CLI.
 
-Syntax:
-  scala-cli config key value
-For example, to globally set the interactive mode:
-  scala-cli config interactive true
-
+You are currently viewing the basic help for the config sub-command. You can view the full help by running: 
+   [1mscala-cli config --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 
 ### SHOULD have options
@@ -615,6 +612,12 @@ Javac plugin dependencies or files
 Javac options
 
 Aliases: `--javac-opt`
+
+**--unset**
+
+Remove an entry from config
+
+Aliases: `--remove`
 
 <details><summary>
 
@@ -695,16 +698,6 @@ Port for BSP debugging
 **--dump**
 
 Dump config DB as JSON
-
-**--create-pgp-key**
-
-Create PGP key in config
-
-**--unset**
-
-Remove an entry from config
-
-Aliases: `--remove`
 
 </details>
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -2328,30 +2328,8 @@ Run Java commands using a manifest-based class path (shortens command length)
 
 Like `run`, but handier for shebang scripts.
 
-This command is equivalent to the `run` sub-command, but it changes the way
-Scala CLI parses its command-line arguments in order to be compatible
-with shebang scripts.
-
-When relying on the `run` sub-command, inputs and scala-cli options can be mixed,
-while program args have to be specified after `--`
-
-```sh
-scala-cli [command] [scala-cli_options | input]... -- [program_arguments]...
-```
-
-However, for the `shebang` sub-command, only a single input file can be set, while all scala-cli options
-have to be set before the input file.
-All inputs after the first are treated as program arguments, without the need for `--`
-```sh
-scala-cli shebang [scala-cli_options]... input [program_arguments]...
-```
-
-Using this, it is possible to conveniently set up Unix shebang scripts. For example:
-```sh
-#!/usr/bin/env -S scala-cli shebang --scala-version 2.13
-println("Hello, world")
-```
-
+You are currently viewing the basic help for the shebang sub-command. You can view the full help by running: 
+   [1mscala-cli shebang --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/shebang
 
 ### MUST have options

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -5582,8 +5582,10 @@ Binary directory
 
 Aliases: `uninstall-completions`
 
-Uninstalls completions from your shell
+Uninstalls completions from your shell.
 
+You are currently viewing the basic help for the uninstall completions sub-command. You can view the full help by running: 
+   [1mscala-cli uninstall completions --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 <details><summary>

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -3463,22 +3463,8 @@ Aliases: `--fmt-version`
 
 Compile and test Scala code.
 
-Test sources are compiled separately (after the 'main' sources), and may use different dependencies, compiler options, and other configurations.
-A source file is treated as a test source if:
-  - it contains the `//> using target.scope "test"` directive
-  - the file name ends with `.test.scala`
-  - the file comes from a directory that is provided as input, and the relative path from that file to its original directory contains a `test` directory
-
-Specific test configurations can be specified with both command line options and using directives defined in sources.
-Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
-Using directives can be defined in all supported input source file types.
-
-Multiple inputs can be passed at once.
-Paths to directories, URLs and supported file types are accepted as inputs.
-Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
-For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
-All supported types of inputs can be mixed with each other.
-
+You are currently viewing the basic help for the test sub-command. You can view the full help by running: 
+   [1mscala-cli test --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/test
 
 ### MUST have options

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -4516,8 +4516,8 @@ Command-line options JSON file
 
 Clean the workspace.
 
-Passed inputs will establish the Scala CLI project, for which the workspace will be cleaned.
-
+You are currently viewing the basic help for the clean sub-command. You can view the full help by running: 
+   [1mscala-cli clean --help-full[0m
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/clean
 
 <details><summary>


### PR DESCRIPTION
Fixes #1669 

- bump `scala-cli-signing` and `case-app`
- only show `tags.important` or `tags.must` help options in the short help (`sub-command --help`)
- example output:
```bash
$ scala-cli fmt -h
Usage: scala-cli fmt [options]
Formats Scala code.

You are currently viewing the basic help for the fmt sub-command. You can view the full help by running: 
   scala-cli fmt --help-full
For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/fmt

Format options:
  --check                                     Check if sources are well formatted
  --save-scalafmt-conf                        Saves .scalafmt.conf file if it was created or overwritten
  -F, --scalafmt-arg string*                  Pass an argument to scalafmt.
  --scalafmt-conf, --scalafmt-config string?  Custom path to the scalafmt configuration file.
  --dialect, --scalafmt-dialect string?       Pass a global dialect for scalafmt. This overrides whatever value is configured in the .scalafmt.conf file or inferred based on Scala version used.
  --fmt-version, --scalafmt-version string?   Pass scalafmt version before running it (3.6.1 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.

Help options:
  --help-js                                      Show options for ScalaJS
  --help-native                                  Show options for ScalaNative
  --help-doc, --doc-help, --help-scaladoc, --scaladoc-help  Show options for Scaladoc
  --help-repl, --repl-help                       Show options for Scala REPL
  --help-fmt, --fmt-help, --help-scalafmt, --scalafmt-help  Show options for Scalafmt
```