### PR TITLE
Ensure no console-syntax in reference docs and no `md` fenced blocks in `--help`

### DIFF
--- a/modules/build/src/main/scala/scala/build/ConsoleBloopBuildClient.scala
+++ b/modules/build/src/main/scala/scala/build/ConsoleBloopBuildClient.scala
@@ -7,9 +7,10 @@ import java.net.URI
 import java.nio.file.Paths
 
 import scala.build.errors.Severity
+import scala.build.internal.util.ConsoleUtils.ScalaCliConsole
 import scala.build.options.Scope
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class ConsoleBloopBuildClient(
   logger: Logger,
@@ -147,7 +148,7 @@ class ConsoleBloopBuildClient(
 }
 
 object ConsoleBloopBuildClient {
-  private val gray   = "\u001b[90m"
+  private val gray   = ScalaCliConsole.GRAY
   private val reset  = Console.RESET
   private val red    = Console.RED
   private val yellow = Console.YELLOW

--- a/modules/build/src/main/scala/scala/build/internal/util/ConsoleUtils.scala
+++ b/modules/build/src/main/scala/scala/build/internal/util/ConsoleUtils.scala
@@ -1,9 +1,15 @@
-package scala.cli.commands.util
+package scala.build.internal.util
 
 object ConsoleUtils {
   import Console.*
+
+  object ScalaCliConsole {
+    val GRAY: String = "\u001b[90m"
+  }
+
   val ansiFormattingKeys: Set[String] = Set(RESET, BOLD, UNDERLINED, REVERSED, INVISIBLE)
-  val ansiColors: Set[String]         = Set(BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE)
+  val ansiColors: Set[String] =
+    Set(BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE, ScalaCliConsole.GRAY)
   val ansiBoldColors: Set[String] =
     Set(BLACK_B, RED_B, GREEN_B, YELLOW_B, BLUE_B, MAGENTA_B, CYAN_B, WHITE_B)
   val allAnsiColors: Set[String]  = ansiColors ++ ansiBoldColors

--- a/modules/cli/src/main/scala/scala/cli/commands/WatchUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/WatchUtil.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands
 
 import scala.annotation.tailrec
+import scala.build.internal.util.ConsoleUtils.ScalaCliConsole
 
 object WatchUtil {
 
@@ -15,7 +16,7 @@ object WatchUtil {
   }
 
   private def gray(message: String): String = {
-    val gray  = "\u001b[90m"
+    val gray  = ScalaCliConsole.GRAY
     val reset = Console.RESET
     s"$gray$message$reset"
   }

--- a/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
@@ -96,9 +96,9 @@ object ConfigOptions {
     s"""$helpHeader
        |
        |Syntax:
-       |  $progName $cmdName key value
+       |  ${Console.BOLD}$progName $cmdName key value${Console.RESET}
        |For example, to globally set the interactive mode:
-       |  $progName $cmdName interactive true
+       |  ${Console.BOLD}$progName $cmdName interactive true${Console.RESET}
        |
        |${HelpMessages.commandDocWebsiteReference(websiteSuffix)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/github/SecretCreateOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/SecretCreateOptions.scala
@@ -9,7 +9,7 @@ import scala.cli.commands.tags
 // format: off
 @HelpMessage(
   s"""Creates or updates a GitHub repository secret.
-    |  $progName --power github secret create --repo repo-org/repo-name SECRET_VALUE=value:secret""".stripMargin
+    |  ${Console.BOLD}$progName --power github secret create --repo repo-org/repo-name SECRET_VALUE=value:secret${Console.RESET}""".stripMargin
 )
 final case class SecretCreateOptions(
   @Recurse

--- a/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
@@ -12,6 +12,7 @@ import scala.build.EitherCps.{either, value}
 import scala.build.*
 import scala.build.errors.BuildException
 import scala.build.input.{Inputs, ScalaCliInvokeData}
+import scala.build.internal.util.ConsoleUtils.ScalaCliConsole
 import scala.build.internal.{Constants, Runner, ScalaJsLinkerConfig}
 import scala.build.options.{BuildOptions, JavaOpt, Platform, ScalacOpt}
 import scala.cli.CurrentParams
@@ -165,7 +166,7 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
               (retCode, allowTerminate) match {
                 case (0, true) =>
                 case (0, false) =>
-                  val gray  = "\u001b[90m"
+                  val gray  = ScalaCliConsole.GRAY
                   val reset = Console.RESET
                   System.err.println(s"${gray}Program exited with return code $retCode.$reset")
                 case (_, true) =>

--- a/modules/cli/src/main/scala/scala/cli/commands/run/RunOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/RunOptions.scala
@@ -34,10 +34,7 @@ object RunOptions {
        |${HelpMessages.acceptedInputs}
        |
        |To pass arguments to the actual application, just add them after `--`, like:
-       |
-       |```sh
-       |${ScalaCli.progName} run Main.scala AnotherSource.scala -- first-arg second-arg
-       |```
+       |  ${Console.BOLD}${ScalaCli.progName} run Main.scala AnotherSource.scala -- first-arg second-arg${Console.RESET}
        |
        |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/setupide/SetupIdeOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/setupide/SetupIdeOptions.scala
@@ -37,7 +37,7 @@ object SetupIdeOptions {
        |It is also ran implicitly when `compile`, `run`, `shebang` or `test` sub-commands are called.
        |
        |The pre-configuration should be saved in a BSP json connection file under the path:
-       |    {project-root}/.bsp/$baseRunnerName.json
+       |    ${Console.BOLD}{project-root}/.bsp/$baseRunnerName.json${Console.RESET}
        |
        |${HelpMessages.commandConfigurations(cmdName)}
        |

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
@@ -27,7 +27,7 @@ object HelpMessages {
   def commandFullHelpReference(commandName: String, needsPower: Boolean = false): String = {
     val maybePowerString = if needsPower then "--power " else ""
     s"""You are currently viewing the basic help for the $commandName sub-command. You can view the full help by running: 
-       |   ${ScalaCli.progName} $maybePowerString$commandName --help-full""".stripMargin
+       |   ${Console.BOLD}${ScalaCli.progName} $maybePowerString$commandName --help-full${Console.RESET}""".stripMargin
   }
 
   def commandDocWebsiteReference(websiteSuffix: String): String =

--- a/modules/cli/src/main/scala/scala/cli/commands/shebang/ShebangOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shebang/ShebangOptions.scala
@@ -2,6 +2,7 @@ package scala.cli.commands.shebang
 
 import caseapp.*
 
+import scala.build.internal.util.ConsoleUtils.ScalaCliConsole
 import scala.cli.ScalaCli.{baseRunnerName, fullRunnerName, progName}
 import scala.cli.commands.run.RunOptions
 import scala.cli.commands.shared.{HasSharedOptions, HelpMessages, SharedOptions}
@@ -30,23 +31,16 @@ object ShebangOptions {
        |
        |When relying on the `run` sub-command, inputs and $baseRunnerName options can be mixed,
        |while program args have to be specified after `--`
-       |
-       |```sh
-       |$progName [command] [${baseRunnerName}_options | input]... -- [program_arguments]...
-       |```
+       |  ${Console.BOLD}$progName [command] [${baseRunnerName}_options | input]... -- [program_arguments]...${Console.RESET}
        |
        |However, for the `shebang` sub-command, only a single input file can be set, while all $baseRunnerName options
        |have to be set before the input file.
        |All inputs after the first are treated as program arguments, without the need for `--`
-       |```sh
-       |$progName shebang [${baseRunnerName}_options]... input [program_arguments]...
-       |```
+       |  ${Console.BOLD}$progName shebang [${baseRunnerName}_options]... input [program_arguments]...${Console.RESET}
        |
        |Using this, it is possible to conveniently set up Unix shebang scripts. For example:
-       |```sh
-       |#!/usr/bin/env -S $progName shebang --scala-version 2.13
-       |println("Hello, world")
-       |```
+       |  ${ScalaCliConsole.GRAY}#!/usr/bin/env -S $progName shebang --scala-version 2.13
+       |  println("Hello, world")${Console.RESET}
        |
        |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
@@ -9,6 +9,7 @@ import scala.build.EitherCps.{either, value}
 import scala.build.Ops.*
 import scala.build.*
 import scala.build.errors.{BuildException, CompositeBuildException}
+import scala.build.internal.util.ConsoleUtils.ScalaCliConsole
 import scala.build.internal.{Constants, Runner}
 import scala.build.options.{BuildOptions, JavaOpt, Platform, Scope}
 import scala.build.testrunner.AsmTestRunner
@@ -30,7 +31,7 @@ object Test extends ScalaCommand[TestOptions] {
   override def helpFormat: HelpFormat =
     super.helpFormat.withPrimaryGroups(Seq(HelpGroup.Test, HelpGroup.Watch))
 
-  private def gray  = "\u001b[90m"
+  private def gray  = ScalaCliConsole.GRAY
   private def reset = Console.RESET
 
   override def buildOptions(opts: TestOptions): Option[BuildOptions] = Some {

--- a/modules/cli/src/main/scala/scala/cli/commands/util/ConsoleUtils.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/ConsoleUtils.scala
@@ -1,0 +1,16 @@
+package scala.cli.commands.util
+
+object ConsoleUtils {
+  import Console.*
+  val ansiFormattingKeys: Set[String] = Set(RESET, BOLD, UNDERLINED, REVERSED, INVISIBLE)
+  val ansiColors: Set[String]         = Set(BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE)
+  val ansiBoldColors: Set[String] =
+    Set(BLACK_B, RED_B, GREEN_B, YELLOW_B, BLUE_B, MAGENTA_B, CYAN_B, WHITE_B)
+  val allAnsiColors: Set[String]  = ansiColors ++ ansiBoldColors
+  val allConsoleKeys: Set[String] = allAnsiColors ++ ansiFormattingKeys
+
+  extension (s: String) {
+    def noConsoleKeys: String =
+      allConsoleKeys.fold(s)((acc, consoleKey) => acc.replace(consoleKey, ""))
+  }
+}

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
@@ -10,10 +10,12 @@ import shapeless.tag
 
 import java.nio.charset.StandardCharsets
 import java.util
+
 import scala.build.options.{BuildOptions, BuildRequirements}
 import scala.build.preprocessing.ScalaPreprocessor
 import scala.build.preprocessing.directives.DirectiveHandler
 import scala.cli.commands.{ScalaCommand, SpecificationLevel, tags}
+import scala.cli.doc.ReferenceDocUtils.*
 import scala.cli.util.ArgHelpers.*
 import scala.cli.{ScalaCli, ScalaCliCommands}
 
@@ -204,7 +206,7 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
             b.section(s"`${arg.level.md}` per Scala Runner specification")
           else if (isInternal || arg.noHelp) b.append("[Internal]\n")
 
-          for (desc <- arg.helpMessage.map(_.message))
+          for (desc <- arg.helpMessage.map(_.referenceDocMessage))
             b.append(
               s"""$desc
                  |
@@ -268,7 +270,7 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
           args.foreach { arg =>
             val names = (arg.name +: arg.extraNames).map(_.option(nameFormatter))
             b.section(s"**${names.head}**")
-            b.section(arg.helpMessage.fold("")(_.message))
+            b.section(arg.helpMessage.fold("")(_.referenceDocMessage))
             if (names.tail.nonEmpty) b.section(names.tail.mkString("Aliases: `", "` ,`", "`"))
 
           }
@@ -291,7 +293,7 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
 
         if (command.names.tail.nonEmpty)
           b.section(command.names.map(_.mkString(" ")).tail.mkString("Aliases: `", "`, `", "`"))
-        for (desc <- command.messages.helpMessage.map(_.message)) b.section(desc)
+        for (desc <- command.messages.helpMessage.map(_.referenceDocMessage)) b.section(desc)
         optionsForCommand(command)
         b.section("---")
       }
@@ -331,7 +333,7 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
       b.append(s"$headerPrefix## ${names.head}\n\n")
       if (names.tail.nonEmpty) b.append(names.tail.sorted.mkString("Aliases: `", "`, `", "`\n\n"))
 
-      for (desc <- c.messages.helpMessage.map(_.message)) b.section(desc)
+      for (desc <- c.messages.helpMessage.map(_.referenceDocMessage)) b.section(desc)
 
       if (origins.nonEmpty) {
         val links = origins.map { origin =>

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
@@ -9,8 +9,7 @@ import munit.internal.difflib.Diff
 import shapeless.tag
 
 import java.nio.charset.StandardCharsets
-import java.util.{Arrays, Locale}
-
+import java.util
 import scala.build.options.{BuildOptions, BuildRequirements}
 import scala.build.preprocessing.ScalaPreprocessor
 import scala.build.preprocessing.directives.DirectiveHandler
@@ -21,7 +20,7 @@ import scala.cli.{ScalaCli, ScalaCliCommands}
 object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
 
   implicit class PBUtils(sb: StringBuilder) {
-    def section(t: String*) =
+    def section(t: String*): StringBuilder =
       sb.append(t.mkString("", "\n", "\n\n"))
   }
 
@@ -58,7 +57,7 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
     val content0 = content.getBytes(StandardCharsets.UTF_8)
     val needsUpdate = !os.exists(dest) || {
       val currentContent = os.read.bytes(dest)
-      !Arrays.equals(content0, currentContent)
+      !util.Arrays.equals(content0, currentContent)
     }
     if (needsUpdate) {
       os.write.over(dest, content0, createFolders = true)
@@ -222,11 +221,8 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
 
   private def optionsReference(
     commands: Seq[Command[_]],
-    allArgs: Seq[Arg],
     nameFormatter: Formatter[Name]
   ): String = {
-    val argsToShow = allArgs.filterNot(_.isExperimentalOrRestricted)
-
     val b = new StringBuilder
 
     b.section(
@@ -253,7 +249,7 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
 
     b.section(scalacOptionForwarding)
 
-    def optionsForCommand(command: Command[_]) = {
+    def optionsForCommand(command: Command[_]): Unit = {
       val supportedArgs = actualHelp(command).args
       val argsByLevel   = supportedArgs.groupBy(_.level)
 
@@ -342,7 +338,7 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
           val cleanedUp = formatOrigin(origin, keepCapitalization = false)
           val linkPart = cleanedUp
             .split("\\s+")
-            .map(_.toLowerCase(Locale.ROOT).filter(_ != '.'))
+            .map(_.toLowerCase(util.Locale.ROOT).filter(_ != '.'))
             .mkString("-")
           s"[$cleanedUp](./cli-options.md#$linkPart-options)"
         }
@@ -501,7 +497,7 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
     val allCommandsContent        = commandsContent(commands, onlyRestricted = false)
     val restrictedCommandsContent = commandsContent(restrictedCommands, onlyRestricted = true)
 
-    val scalaOptionsReference = optionsReference(restrictedCommands, allArgs, nameFormatter)
+    val scalaOptionsReference = optionsReference(restrictedCommands, nameFormatter)
 
     val allDirectivesContent = usingContent(
       ScalaPreprocessor.usingDirectiveHandlers,

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
@@ -293,7 +293,8 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
 
         if (command.names.tail.nonEmpty)
           b.section(command.names.map(_.mkString(" ")).tail.mkString("Aliases: `", "`, `", "`"))
-        for (desc <- command.messages.helpMessage.map(_.referenceDocMessage)) b.section(desc)
+        for (desc <- command.messages.helpMessage.map(_.referenceDocDetailedMessage))
+          b.section(desc)
         optionsForCommand(command)
         b.section("---")
       }
@@ -333,7 +334,7 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
       b.append(s"$headerPrefix## ${names.head}\n\n")
       if (names.tail.nonEmpty) b.append(names.tail.sorted.mkString("Aliases: `", "`, `", "`\n\n"))
 
-      for (desc <- c.messages.helpMessage.map(_.referenceDocMessage)) b.section(desc)
+      for (desc <- c.messages.helpMessage.map(_.referenceDocDetailedMessage)) b.section(desc)
 
       if (origins.nonEmpty) {
         val links = origins.map { origin =>

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/ReferenceDocUtils.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/ReferenceDocUtils.scala
@@ -1,0 +1,12 @@
+package scala.cli.doc
+
+import caseapp.HelpMessage
+
+import scala.cli.commands.util.ConsoleUtils.*
+
+object ReferenceDocUtils {
+  extension (helpMessage: HelpMessage) {
+    def referenceDocMessage: String = helpMessage.message.noConsoleKeys
+  }
+
+}

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/ReferenceDocUtils.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/ReferenceDocUtils.scala
@@ -2,11 +2,43 @@ package scala.cli.doc
 
 import caseapp.HelpMessage
 
-import scala.cli.commands.util.ConsoleUtils.*
+import java.util.stream.IntStream
+
+import scala.build.internal.util.ConsoleUtils.*
 
 object ReferenceDocUtils {
+  extension (s: String) {
+    def consoleToFence: String =
+      s
+        .linesIterator
+        .fold("") { (acc, line) =>
+          val maybeOpenFence =
+            if line.contains(Console.BOLD) then
+              """```sh
+                |""".stripMargin
+            else if line.contains(ScalaCliConsole.GRAY) then
+              """```scala
+                |""".stripMargin
+            else ""
+          val maybeCloseFence =
+            if line.contains(Console.RESET) then
+              """
+                |```""".stripMargin
+            else ""
+          val newLine = s"$maybeOpenFence${line.noConsoleKeys}$maybeCloseFence"
+          if acc.isEmpty then newLine
+          else s"""$acc
+                  |$newLine""".stripMargin
+        }
+  }
   extension (helpMessage: HelpMessage) {
-    def referenceDocMessage: String = helpMessage.message.noConsoleKeys
+    def referenceDocMessage: String = helpMessage.message.consoleToFence.noConsoleKeys
+    def referenceDocDetailedMessage: String = {
+      val msg =
+        if helpMessage.detailedMessage.nonEmpty then helpMessage.detailedMessage
+        else helpMessage.message
+      msg.consoleToFence
+    }
   }
 
 }

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -10,8 +10,8 @@ sidebar_position: 3
 
 Clean the workspace.
 
-You are currently viewing the basic help for the clean sub-command. You can view the full help by running: 
-   scala-cli clean --help-full
+Passed inputs will establish the Scala CLI project, for which the workspace will be cleaned.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/clean
 
 Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -20,8 +20,16 @@ Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [logging](
 
 Compile Scala code.
 
-You are currently viewing the basic help for the compile sub-command. You can view the full help by running: 
-   scala-cli compile --help-full
+Specific compile configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/compile
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [compile](./cli-options.md#compile-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -30,8 +38,15 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Configure global settings for Scala CLI.
 
-You are currently viewing the basic help for the config sub-command. You can view the full help by running: 
-   scala-cli config --help-full
+Syntax:
+```sh
+  scala-cli config key value
+```
+For example, to globally set the interactive mode:
+```sh
+  scala-cli config interactive true
+```
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 
 Accepts option groups: [config](./cli-options.md#config-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [verbosity](./cli-options.md#verbosity-options)
@@ -46,8 +61,12 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Generate Scaladoc documentation.
 
-You are currently viewing the basic help for the doc sub-command. You can view the full help by running: 
-   scala-cli doc --help-full
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/doc
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [doc](./cli-options.md#doc-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -55,6 +74,16 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 ## export
 
 Export current project to an external build tool (like SBT or Mill).
+
+The whole Scala CLI project should get exported along with its dependencies configuration.
+
+Unless otherwise configured, the default export format is SBT.
+
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
 
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
@@ -66,8 +95,13 @@ Aliases: `format`, `scalafmt`
 
 Formats Scala code.
 
-You are currently viewing the basic help for the fmt sub-command. You can view the full help by running: 
-   scala-cli fmt --help-full
+`scalafmt` is used to perform the formatting under the hood.
+
+The `.scalafmt.conf` configuration file is optional.
+Default configuration values will be assumed by Scala CLI.
+
+All standard Scala CLI inputs are accepted, but only Scala sources will be formatted (.scala and .sc files).
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/fmt
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [fmt](./cli-options.md#fmt-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -84,8 +118,6 @@ Aliases: `install-completions`
 
 Installs Scala CLI completions into your shell
 
-You are currently viewing the basic help for the install completions sub-command. You can view the full help by running: 
-   scala-cli install completions --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 Accepts option groups: [install completions](./cli-options.md#install-completions-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
@@ -96,8 +128,18 @@ Aliases: `console`
 
 Fire-up a Scala REPL.
 
-You are currently viewing the basic help for the repl sub-command. You can view the full help by running: 
-   scala-cli repl --help-full
+The entire Scala CLI project's classpath is loaded to the repl.
+
+Specific repl configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/repl
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [repl](./cli-options.md#repl-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -106,8 +148,16 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Compile and package Scala code.
 
-You are currently viewing the basic help for the package sub-command. You can view the full help by running: 
-   scala-cli --power package --help-full
+Specific package configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/package
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [package](./cli-options.md#package-options), [packager](./cli-options.md#packager-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -116,8 +166,21 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Publishes build artifacts to Maven repositories.
 
-You are currently viewing the basic help for the publish sub-command. You can view the full help by running: 
-   scala-cli --power publish --help-full
+We recommend running the `publish setup` sub-command once prior to
+running `publish` in order to set missing `using` directives for publishing.
+(but this is not mandatory)
+    scala-cli --power publish setup .
+
+Specific publish configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish](./cli-options.md#publish-options), [publish params](./cli-options.md#publish-params-options), [publish repository](./cli-options.md#publish-repository-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -126,8 +189,6 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Publishes build artifacts to the local Ivy2 repository.
 
-You are currently viewing the basic help for the publish local sub-command. You can view the full help by running: 
-   scala-cli publish local --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish-local
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish](./cli-options.md#publish-options), [publish params](./cli-options.md#publish-params-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -136,8 +197,6 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Configures the project for publishing.
 
-You are currently viewing the basic help for the publish setup sub-command. You can view the full help by running: 
-   scala-cli publish setup --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish-setup
 
 Accepts option groups: [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp push pull](./cli-options.md#pgp-push-pull-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish params](./cli-options.md#publish-params-options), [publish repository](./cli-options.md#publish-repository-options), [publish setup](./cli-options.md#publish-setup-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -146,8 +205,24 @@ Accepts option groups: [coursier](./cli-options.md#coursier-options), [debug](./
 
 Compile and run Scala code.
 
-You are currently viewing the basic help for the run sub-command. You can view the full help by running: 
-   scala-cli run --help-full
+Specific run configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
+For a run to be successful, a main method must be present on the classpath.
+.sc scripts are an exception, as a main class is provided in their wrapper.
+
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
+To pass arguments to the actual application, just add them after `--`, like:
+```sh
+  scala-cli run Main.scala AnotherSource.scala -- first-arg second-arg
+```
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/run
 
 Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -157,7 +232,9 @@ Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [c
 Aliases: `gh secret create`
 
 Creates or updates a GitHub repository secret.
+```sh
   scala-cli --power github secret create --repo repo-org/repo-name SECRET_VALUE=value:secret
+```
 
 Accepts option groups: [coursier](./cli-options.md#coursier-options), [logging](./cli-options.md#logging-options), [secret](./cli-options.md#secret-options), [secret create](./cli-options.md#secret-create-options), [verbosity](./cli-options.md#verbosity-options)
 
@@ -173,8 +250,18 @@ Accepts option groups: [logging](./cli-options.md#logging-options), [secret](./c
 
 Generates a BSP file that you can import into your IDE.
 
-You are currently viewing the basic help for the setup-ide sub-command. You can view the full help by running: 
-   scala-cli setup-ide --help-full
+The setup-ide sub-command allows to pre-configure a Scala CLI project to import to an IDE with BSP support.
+It is also ran implicitly when `compile`, `run`, `shebang` or `test` sub-commands are called.
+
+The pre-configuration should be saved in a BSP json connection file under the path:
+```sh
+    {project-root}/.bsp/scala-cli.json
+```
+
+Specific setup-ide configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/setup-ide
 
 Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [setup IDE](./cli-options.md#setup-ide-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -183,8 +270,29 @@ Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [compilati
 
 Like `run`, but handier for shebang scripts.
 
-You are currently viewing the basic help for the shebang sub-command. You can view the full help by running: 
-   scala-cli shebang --help-full
+This command is equivalent to the `run` sub-command, but it changes the way
+Scala CLI parses its command-line arguments in order to be compatible
+with shebang scripts.
+
+When relying on the `run` sub-command, inputs and scala-cli options can be mixed,
+while program args have to be specified after `--`
+```sh
+  scala-cli [command] [scala-cli_options | input]... -- [program_arguments]...
+```
+
+However, for the `shebang` sub-command, only a single input file can be set, while all scala-cli options
+have to be set before the input file.
+All inputs after the first are treated as program arguments, without the need for `--`
+```sh
+  scala-cli shebang [scala-cli_options]... input [program_arguments]...
+```
+
+Using this, it is possible to conveniently set up Unix shebang scripts. For example:
+```scala
+  #!/usr/bin/env -S scala-cli shebang --scala-version 2.13
+  println("Hello, world")
+```
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/shebang
 
 Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -193,8 +301,22 @@ Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [c
 
 Compile and test Scala code.
 
-You are currently viewing the basic help for the test sub-command. You can view the full help by running: 
-   scala-cli test --help-full
+Test sources are compiled separately (after the 'main' sources), and may use different dependencies, compiler options, and other configurations.
+A source file is treated as a test source if:
+  - it contains the `//> using target.scope "test"` directive
+  - the file name ends with `.test.scala`
+  - the file comes from a directory that is provided as input, and the relative path from that file to its original directory contains a `test` directory
+
+Specific test configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/test
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [test](./cli-options.md#test-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -213,8 +335,6 @@ Aliases: `uninstall-completions`
 
 Uninstalls Scala CLI completions from your shell.
 
-You are currently viewing the basic help for the uninstall completions sub-command. You can view the full help by running: 
-   scala-cli uninstall completions --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [uninstall completions](./cli-options.md#uninstall-completions-options), [verbosity](./cli-options.md#verbosity-options)
@@ -225,18 +345,20 @@ Updates Scala CLI.
 Works only when installed with the installation script.
 If Scala CLI was installed with an external tool, refer to its update methods.
 
-You are currently viewing the basic help for the update sub-command. You can view the full help by running: 
-   scala-cli update --help-full
 For detailed installation instructions refer to our website: https://scala-cli.virtuslab.org/install
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [update](./cli-options.md#update-options), [verbosity](./cli-options.md#verbosity-options)
 
 ## version
 
-Prints the version of the Scala CLI and the default version of Scala.
+Prints the version of the Scala CLI and the default version of Scala. (which can be overridden in the project)
+If network connection is available, this sub-command also checks if the installed Scala CLI is up-to-date.
 
-You are currently viewing the basic help for the version sub-command. You can view the full help by running: 
-   scala-cli version --help-full
+The version of the Scala CLI is the version of the command-line tool that runs Scala programs, which
+is distinct from the Scala version of the compiler. We recommend to specify the version of the Scala compiler
+for a project in its sources (via a using directive). Otherwise, Scala CLI falls back to the default
+Scala version defined by the runner.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/version
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [version](./cli-options.md#version-options)
@@ -252,6 +374,12 @@ Accepts option groups: [add path](./cli-options.md#add-path-options), [logging](
 ### bloop
 
 Interact with Bloop (the build server) or check its status.
+
+This sub-command allows to check the current status of Bloop.
+If Bloop isn't currently running, it will be started.
+
+Bloop is the build server used by Scala CLI.
+For more information about Bloop, refer to https://scalacenter.github.io/bloop/
 
 Accepts option groups: [bloop](./cli-options.md#bloop-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 
@@ -286,8 +414,12 @@ Accepts option groups: [bloop start](./cli-options.md#bloop-start-options), [com
 
 Start BSP server.
 
-You are currently viewing the basic help for the bsp sub-command. You can view the full help by running: 
-   scala-cli bsp --help-full
+BSP stands for Build Server Protocol.
+For more information refer to https://build-server-protocol.github.io/
+
+This sub-command is not designed to be used by a human.
+It is normally supposed to be invoked by your IDE when a Scala CLI project is imported.
+
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
 Accepts option groups: [bsp](./cli-options.md#bsp-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -19,8 +19,16 @@ that is reserved for commands that need to be present for Scala CLI to work prop
 
 Compile Scala code.
 
-You are currently viewing the basic help for the compile sub-command. You can view the full help by running: 
-   scala-cli compile --help-full
+Specific compile configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/compile
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [compile](./cli-options.md#compile-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -29,8 +37,15 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Configure global settings for Scala CLI.
 
-You are currently viewing the basic help for the config sub-command. You can view the full help by running: 
-   scala-cli config --help-full
+Syntax:
+```sh
+  scala-cli config key value
+```
+For example, to globally set the interactive mode:
+```sh
+  scala-cli config interactive true
+```
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 
 Accepts option groups: [config](./cli-options.md#config-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [verbosity](./cli-options.md#verbosity-options)
@@ -39,8 +54,12 @@ Accepts option groups: [config](./cli-options.md#config-options), [coursier](./c
 
 Generate Scaladoc documentation.
 
-You are currently viewing the basic help for the doc sub-command. You can view the full help by running: 
-   scala-cli doc --help-full
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/doc
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [doc](./cli-options.md#doc-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -51,8 +70,18 @@ Aliases: `console`
 
 Fire-up a Scala REPL.
 
-You are currently viewing the basic help for the repl sub-command. You can view the full help by running: 
-   scala-cli repl --help-full
+The entire Scala CLI project's classpath is loaded to the repl.
+
+Specific repl configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/repl
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [repl](./cli-options.md#repl-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -61,8 +90,24 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Compile and run Scala code.
 
-You are currently viewing the basic help for the run sub-command. You can view the full help by running: 
-   scala-cli run --help-full
+Specific run configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
+For a run to be successful, a main method must be present on the classpath.
+.sc scripts are an exception, as a main class is provided in their wrapper.
+
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
+To pass arguments to the actual application, just add them after `--`, like:
+```sh
+  scala-cli run Main.scala AnotherSource.scala -- first-arg second-arg
+```
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/run
 
 Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -71,8 +116,29 @@ Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [c
 
 Like `run`, but handier for shebang scripts.
 
-You are currently viewing the basic help for the shebang sub-command. You can view the full help by running: 
-   scala-cli shebang --help-full
+This command is equivalent to the `run` sub-command, but it changes the way
+Scala CLI parses its command-line arguments in order to be compatible
+with shebang scripts.
+
+When relying on the `run` sub-command, inputs and scala-cli options can be mixed,
+while program args have to be specified after `--`
+```sh
+  scala-cli [command] [scala-cli_options | input]... -- [program_arguments]...
+```
+
+However, for the `shebang` sub-command, only a single input file can be set, while all scala-cli options
+have to be set before the input file.
+All inputs after the first are treated as program arguments, without the need for `--`
+```sh
+  scala-cli shebang [scala-cli_options]... input [program_arguments]...
+```
+
+Using this, it is possible to conveniently set up Unix shebang scripts. For example:
+```scala
+  #!/usr/bin/env -S scala-cli shebang --scala-version 2.13
+  println("Hello, world")
+```
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/shebang
 
 Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
@@ -85,8 +151,13 @@ Aliases: `format`, `scalafmt`
 
 Formats Scala code.
 
-You are currently viewing the basic help for the fmt sub-command. You can view the full help by running: 
-   scala-cli fmt --help-full
+`scalafmt` is used to perform the formatting under the hood.
+
+The `.scalafmt.conf` configuration file is optional.
+Default configuration values will be assumed by Scala CLI.
+
+All standard Scala CLI inputs are accepted, but only Scala sources will be formatted (.scala and .sc files).
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/fmt
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [fmt](./cli-options.md#fmt-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -95,18 +166,36 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 
 Compile and test Scala code.
 
-You are currently viewing the basic help for the test sub-command. You can view the full help by running: 
-   scala-cli test --help-full
+Test sources are compiled separately (after the 'main' sources), and may use different dependencies, compiler options, and other configurations.
+A source file is treated as a test source if:
+  - it contains the `//> using target.scope "test"` directive
+  - the file name ends with `.test.scala`
+  - the file comes from a directory that is provided as input, and the relative path from that file to its original directory contains a `test` directory
+
+Specific test configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/test
 
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [test](./cli-options.md#test-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
 ### version
 
-Prints the version of the Scala CLI and the default version of Scala.
+Prints the version of the Scala CLI and the default version of Scala. (which can be overridden in the project)
+If network connection is available, this sub-command also checks if the installed Scala CLI is up-to-date.
 
-You are currently viewing the basic help for the version sub-command. You can view the full help by running: 
-   scala-cli version --help-full
+The version of the Scala CLI is the version of the command-line tool that runs Scala programs, which
+is distinct from the Scala version of the compiler. We recommend to specify the version of the Scala compiler
+for a project in its sources (via a using directive). Otherwise, Scala CLI falls back to the default
+Scala version defined by the runner.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/version
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [version](./cli-options.md#version-options)
@@ -119,8 +208,12 @@ Commands which are used within Scala CLI and should be a part of the `scala` com
 
 Start BSP server.
 
-You are currently viewing the basic help for the bsp sub-command. You can view the full help by running: 
-   scala-cli bsp --help-full
+BSP stands for Build Server Protocol.
+For more information refer to https://build-server-protocol.github.io/
+
+This sub-command is not designed to be used by a human.
+It is normally supposed to be invoked by your IDE when a Scala CLI project is imported.
+
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
 Accepts option groups: [bsp](./cli-options.md#bsp-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -129,8 +222,8 @@ Accepts option groups: [bsp](./cli-options.md#bsp-options), [compilation server]
 
 Clean the workspace.
 
-You are currently viewing the basic help for the clean sub-command. You can view the full help by running: 
-   scala-cli clean --help-full
+Passed inputs will establish the Scala CLI project, for which the workspace will be cleaned.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/clean
 
 Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -147,8 +240,6 @@ Aliases: `install-completions`
 
 Installs Scala CLI completions into your shell
 
-You are currently viewing the basic help for the install completions sub-command. You can view the full help by running: 
-   scala-cli install completions --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 Accepts option groups: [install completions](./cli-options.md#install-completions-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
@@ -163,8 +254,18 @@ Accepts option groups: [install home](./cli-options.md#install-home-options), [l
 
 Generates a BSP file that you can import into your IDE.
 
-You are currently viewing the basic help for the setup-ide sub-command. You can view the full help by running: 
-   scala-cli setup-ide --help-full
+The setup-ide sub-command allows to pre-configure a Scala CLI project to import to an IDE with BSP support.
+It is also ran implicitly when `compile`, `run`, `shebang` or `test` sub-commands are called.
+
+The pre-configuration should be saved in a BSP json connection file under the path:
+```sh
+    {project-root}/.bsp/scala-cli.json
+```
+
+Specific setup-ide configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/setup-ide
 
 Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [setup IDE](./cli-options.md#setup-ide-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
@@ -183,8 +284,6 @@ Aliases: `uninstall-completions`
 
 Uninstalls Scala CLI completions from your shell.
 
-You are currently viewing the basic help for the uninstall completions sub-command. You can view the full help by running: 
-   scala-cli uninstall completions --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [uninstall completions](./cli-options.md#uninstall-completions-options), [verbosity](./cli-options.md#verbosity-options)
@@ -195,8 +294,6 @@ Updates Scala CLI.
 Works only when installed with the installation script.
 If Scala CLI was installed with an external tool, refer to its update methods.
 
-You are currently viewing the basic help for the update sub-command. You can view the full help by running: 
-   scala-cli update --help-full
 For detailed installation instructions refer to our website: https://scala-cli.virtuslab.org/install
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [update](./cli-options.md#update-options), [verbosity](./cli-options.md#verbosity-options)

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -48,8 +48,16 @@ are assumed to be Scala compiler options and will be propagated to Scala Compile
 
 Compile Scala code.
 
-You are currently viewing the basic help for the compile sub-command. You can view the full help by running: 
-   scala-cli compile --help-full
+Specific compile configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/compile
 
 ### MUST have options
@@ -567,8 +575,15 @@ Aliases: `--toolkit`
 
 Configure global settings for Scala CLI.
 
-You are currently viewing the basic help for the config sub-command. You can view the full help by running: 
-   scala-cli config --help-full
+Syntax:
+```sh
+  scala-cli config key value
+```
+For example, to globally set the interactive mode:
+```sh
+  scala-cli config interactive true
+```
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 
 ### SHOULD have options
@@ -700,8 +715,12 @@ Dump config DB as JSON
 
 Generate Scaladoc documentation.
 
-You are currently viewing the basic help for the doc sub-command. You can view the full help by running: 
-   scala-cli doc --help-full
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/doc
 
 ### MUST have options
@@ -1217,8 +1236,18 @@ Aliases: `console`
 
 Fire-up a Scala REPL.
 
-You are currently viewing the basic help for the repl sub-command. You can view the full help by running: 
-   scala-cli repl --help-full
+The entire Scala CLI project's classpath is loaded to the repl.
+
+Specific repl configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/repl
 
 ### MUST have options
@@ -1742,8 +1771,24 @@ Don't actually run the REPL, just fetch it
 
 Compile and run Scala code.
 
-You are currently viewing the basic help for the run sub-command. You can view the full help by running: 
-   scala-cli run --help-full
+Specific run configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
+For a run to be successful, a main method must be present on the classpath.
+.sc scripts are an exception, as a main class is provided in their wrapper.
+
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
+To pass arguments to the actual application, just add them after `--`, like:
+```sh
+  scala-cli run Main.scala AnotherSource.scala -- first-arg second-arg
+```
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/run
 
 ### MUST have options
@@ -2287,8 +2332,29 @@ Run Java commands using a manifest-based class path (shortens command length)
 
 Like `run`, but handier for shebang scripts.
 
-You are currently viewing the basic help for the shebang sub-command. You can view the full help by running: 
-   scala-cli shebang --help-full
+This command is equivalent to the `run` sub-command, but it changes the way
+Scala CLI parses its command-line arguments in order to be compatible
+with shebang scripts.
+
+When relying on the `run` sub-command, inputs and scala-cli options can be mixed,
+while program args have to be specified after `--`
+```sh
+  scala-cli [command] [scala-cli_options | input]... -- [program_arguments]...
+```
+
+However, for the `shebang` sub-command, only a single input file can be set, while all scala-cli options
+have to be set before the input file.
+All inputs after the first are treated as program arguments, without the need for `--`
+```sh
+  scala-cli shebang [scala-cli_options]... input [program_arguments]...
+```
+
+Using this, it is possible to conveniently set up Unix shebang scripts. For example:
+```scala
+  #!/usr/bin/env -S scala-cli shebang --scala-version 2.13
+  println("Hello, world")
+```
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/shebang
 
 ### MUST have options
@@ -2836,8 +2902,13 @@ Aliases: `format`, `scalafmt`
 
 Formats Scala code.
 
-You are currently viewing the basic help for the fmt sub-command. You can view the full help by running: 
-   scala-cli fmt --help-full
+`scalafmt` is used to perform the formatting under the hood.
+
+The `.scalafmt.conf` configuration file is optional.
+Default configuration values will be assumed by Scala CLI.
+
+All standard Scala CLI inputs are accepted, but only Scala sources will be formatted (.scala and .sc files).
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/fmt
 
 ### MUST have options
@@ -3395,8 +3466,22 @@ Aliases: `--fmt-version`
 
 Compile and test Scala code.
 
-You are currently viewing the basic help for the test sub-command. You can view the full help by running: 
-   scala-cli test --help-full
+Test sources are compiled separately (after the 'main' sources), and may use different dependencies, compiler options, and other configurations.
+A source file is treated as a test source if:
+  - it contains the `//> using target.scope "test"` directive
+  - the file name ends with `.test.scala`
+  - the file comes from a directory that is provided as input, and the relative path from that file to its original directory contains a `test` directory
+
+Specific test configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
+Multiple inputs can be passed at once.
+Paths to directories, URLs and supported file types are accepted as inputs.
+Accepted file extensions: .scala, .sc, .java, .jar, .md, .jar, .c, .h, .zip
+For piped inputs use the corresponding alias: _.scala, _.java, _.sc, _.md
+All supported types of inputs can be mixed with each other.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/test
 
 ### MUST have options
@@ -3926,10 +4011,14 @@ Aliases: `--java-prop`
 ## `version` command
 **SHOULD have for Scala Runner specification.**
 
-Prints the version of the Scala CLI and the default version of Scala.
+Prints the version of the Scala CLI and the default version of Scala. (which can be overridden in the project)
+If network connection is available, this sub-command also checks if the installed Scala CLI is up-to-date.
 
-You are currently viewing the basic help for the version sub-command. You can view the full help by running: 
-   scala-cli version --help-full
+The version of the Scala CLI is the version of the command-line tool that runs Scala programs, which
+is distinct from the Scala version of the compiler. We recommend to specify the version of the Scala compiler
+for a project in its sources (via a using directive). Otherwise, Scala CLI falls back to the default
+Scala version defined by the runner.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/version
 
 <details><summary>
@@ -4011,8 +4100,12 @@ Don't check for the newest available Scala CLI version upstream
 
 Start BSP server.
 
-You are currently viewing the basic help for the bsp sub-command. You can view the full help by running: 
-   scala-cli bsp --help-full
+BSP stands for Build Server Protocol.
+For more information refer to https://build-server-protocol.github.io/
+
+This sub-command is not designed to be used by a human.
+It is normally supposed to be invoked by your IDE when a Scala CLI project is imported.
+
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
 ### MUST have options
@@ -4512,8 +4605,8 @@ Command-line options JSON file
 
 Clean the workspace.
 
-You are currently viewing the basic help for the clean sub-command. You can view the full help by running: 
-   scala-cli clean --help-full
+Passed inputs will establish the Scala CLI project, for which the workspace will be cleaned.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/clean
 
 <details><summary>
@@ -4648,8 +4741,6 @@ Aliases: `install-completions`
 
 Installs Scala CLI completions into your shell
 
-You are currently viewing the basic help for the install completions sub-command. You can view the full help by running: 
-   scala-cli install completions --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 <details><summary>
@@ -4816,8 +4907,18 @@ Binary directory
 
 Generates a BSP file that you can import into your IDE.
 
-You are currently viewing the basic help for the setup-ide sub-command. You can view the full help by running: 
-   scala-cli setup-ide --help-full
+The setup-ide sub-command allows to pre-configure a Scala CLI project to import to an IDE with BSP support.
+It is also ran implicitly when `compile`, `run`, `shebang` or `test` sub-commands are called.
+
+The pre-configuration should be saved in a BSP json connection file under the path:
+```sh
+    {project-root}/.bsp/scala-cli.json
+```
+
+Specific setup-ide configurations can be specified with both command line options and using directives defined in sources.
+Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
+Using directives can be defined in all supported input source file types.
+
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/setup-ide
 
 ### MUST have options
@@ -5492,8 +5593,6 @@ Aliases: `uninstall-completions`
 
 Uninstalls Scala CLI completions from your shell.
 
-You are currently viewing the basic help for the uninstall completions sub-command. You can view the full help by running: 
-   scala-cli uninstall completions --help-full
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
 <details><summary>
@@ -5567,8 +5666,6 @@ Updates Scala CLI.
 Works only when installed with the installation script.
 If Scala CLI was installed with an external tool, refer to its update methods.
 
-You are currently viewing the basic help for the update sub-command. You can view the full help by running: 
-   scala-cli update --help-full
 For detailed installation instructions refer to our website: https://scala-cli.virtuslab.org/install
 
 <details><summary>


### PR DESCRIPTION
A follow-up for https://github.com/VirtusLab/scala-cli/pull/1872#discussion_r1112272252
~~Depends on #1872~~

Tweaks:
- console color/font keys (`Console.BOLD`, `Console.RESET` etc.) don't go into the reference doc (as they're then not encoded properly)
- ensure markdown fenced code blocks don't get printed in the command line
- command line help outputs are still reused in the reference docs, but now console keys get converted into markdown on the fly
- `--full-help` detailed messages are included in the reference docs where applicable (`HelpMessage.detailedMessage`)