### PR TITLE
Tweak error messages for running scripts without file extensions

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
@@ -367,9 +367,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
       ))
 
       if (TestUtil.isShebangCapableShell)
-        expect(output.contains(
-          "to use a script with no file extensions add shebang header"
-        ))
+        expect(output.contains("shebang header"))
     }
   }
 }

--- a/website/docs/guides/shebang.md
+++ b/website/docs/guides/shebang.md
@@ -69,13 +69,13 @@ Note that the extra `--` must be added to make it work. If it is not supplied, t
 ```
 
 ```text
-[error] Hello: file not found
-World: file not found
+[error] Hello: input file not found
+World: input file not found
 ```
 
 <!-- Expected:
-Hello: file not found
-World: file not found
+Hello: input file not found
+World: input file not found
 -->
 
 </ChainedSnippets>
@@ -164,13 +164,13 @@ scala-cli run Main.scala Hello world
 ```
 
 ```text
-[error]  Hello: file not found
-world: file not found
+[error]  Hello: input file not found
+world: input file not found
 ```
 
 <!-- Expected:
-[error]  Hello: file not found
-world: file not found
+[error]  Hello: input file not found
+world: input file not found
 -->
 
 </ChainedSnippets>


### PR DESCRIPTION
Slightly tweaked relevant error messages, so that the user can easily copy/paste the corrected command.

```bash
▶ scala-cli notAShebangScript
# [error]  notAShebangScript: unrecognised source type (expected .scala or .sc extension, or a directory).
# If notAShebangScript is meant to be treated as a script, add a shebang header in its top line.
#   #!/usr/bin/env -S scala-cli shebang
# When a shebang header is provided, the script can then be run with the 'shebang' sub-command, even if no file extension is present.
#   scala-cli shebang notAShebangScript
```

```bash
▶ scala-cli noExtensionScript 
# [error]  noExtensionScript: scripts with no file extension should be run with the 'shebang' sub-command.
#   scala-cli shebang noExtensionScript
```

```bash
▶ scala-cli invalid 
# [error]  invalid is not a scala-cli sub-command and it is not a valid path to an input file or directory.
# Try viewing the relevant help to see the list of available sub-commands and options.
#   scala-cli --help
```