### PR TITLE
Add non-regression test for forced Scala versions

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -883,7 +883,8 @@ object Build {
           scalaVersion = params.scalaVersion,
           scalaBinaryVersion = params.scalaBinaryVersion,
           scalacOptions = scalacOptions.toSeq.map(_.value),
-          compilerClassPath = scalaArtifacts.compilerClassPath
+          compilerClassPath = scalaArtifacts.compilerClassPath,
+          bridgeJarsOpt = scalaArtifacts.bridgeJarsOpt
         )
         Some(compilerParams)
 

--- a/modules/build/src/main/scala/scala/build/Project.scala
+++ b/modules/build/src/main/scala/scala/build/Project.scala
@@ -47,7 +47,8 @@ final case class Project(
     val scalaConfigOpt = scalaCompiler.map { scalaCompiler0 =>
       bloopScalaConfig("org.scala-lang", "scala-compiler", scalaCompiler0.scalaVersion).copy(
         options = updateScalacOptions(scalaCompiler0.scalacOptions).map(_.value),
-        jars = scalaCompiler0.compilerClassPath.map(_.toNIO).toList
+        jars = scalaCompiler0.compilerClassPath.map(_.toNIO).toList,
+        bridgeJars = scalaCompiler0.bridgeJarsOpt.map(_.map(_.toNIO).toList)
       )
     }
     baseBloopProject(
@@ -228,6 +229,7 @@ object Project {
       options = Nil,
       jars = Nil,
       analysis = None,
-      setup = None
+      setup = None,
+      bridgeJars = None
     )
 }

--- a/modules/build/src/main/scala/scala/build/ScalaCompilerParams.scala
+++ b/modules/build/src/main/scala/scala/build/ScalaCompilerParams.scala
@@ -4,5 +4,6 @@ final case class ScalaCompilerParams(
   scalaVersion: String,
   scalaBinaryVersion: String,
   scalacOptions: Seq[String],
-  compilerClassPath: Seq[os.Path]
+  compilerClassPath: Seq[os.Path],
+  bridgeJarsOpt: Option[Seq[os.Path]]
 )

--- a/modules/options/src/main/scala/scala/build/ScalaArtifacts.scala
+++ b/modules/options/src/main/scala/scala/build/ScalaArtifacts.scala
@@ -10,7 +10,8 @@ final case class ScalaArtifacts(
   scalaNativeCli: Seq[os.Path],
   internalDependencies: Seq[AnyDependency],
   extraDependencies: Seq[AnyDependency],
-  params: ScalaParameters
+  params: ScalaParameters,
+  bridgeJarsOpt: Option[Seq[os.Path]]
 ) {
 
   lazy val compilerClassPath: Seq[os.Path] =

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -258,6 +258,8 @@ final case class BuildOptions(
     val svOpt: Option[String] = scalaOptions.scalaVersion match {
       case Some(MaybeScalaVersion(None)) =>
         None
+      case Some(MaybeScalaVersion(Some(svInput))) if svInput.endsWith("!") =>
+        Some(svInput.stripSuffix("!"))
       case Some(MaybeScalaVersion(Some(svInput))) =>
         val sv = value {
           svInput match {


### PR DESCRIPTION
See https://github.com/VirtusLab/scala-cli/pull/1730.

The test requires passing a custom compiler bridge JAR to Bloop, which requires https://github.com/scalacenter/bloop-config/pull/20 / https://github.com/scala-cli/bloop-core/pull/129.