### PR TITLE
Prevent null exception, throw exception on secret key / password missing

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -942,7 +942,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
               "secret key",
               "--secret-key",
               directiveName = "",
-              configKeys = Seq("pgp.secret-key"),
+              configKeys = Seq(Keys.pgpSecretKey.fullName),
               extraMessage = shouldSignMsg
             )
           )

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -865,6 +865,9 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
         }
       }
 
+      if (secretKeyPasswordOpt.isEmpty)
+        logger.diagnostic("PGP signing with no password is not recommended since it's not stable")
+
       if (forceSigningBinary)
         (new scala.cli.internal.BouncycastleSignerMakerSubst).get(
           secretKeyPasswordOpt.fold(null)(_.toCliSigning),

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -948,7 +948,10 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
           )
         } yield getBouncyCastleSigner(secretKey, getSecretKeyPasswordOpt)
       case _ =>
-        logger.message("Artifacts not signed as it's not required nor has it been specified")
+        if (!publishOptions.contextual(isCi).signer.contains(PSigner.Nop))
+          logger.message(
+            "\ud83d\udd13 Artifacts NOT signed as it's not required nor has it been specified"
+          )
         Right(NopSigner)
     }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -948,7 +948,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
           )
         } yield getBouncyCastleSigner(secretKey, getSecretKeyPasswordOpt)
       case _ =>
-        logger.diagnostic("Not signing files as it's not needed nor has it been specified")
+        logger.message("Artifacts not signed as it's not required nor has it been specified")
         Right(NopSigner)
     }
 
@@ -1074,7 +1074,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
                 Seq(mod.organization.value, mod.name.value, version)
               else
                 mod.organization.value.split('.').toSeq ++ Seq(mod.name.value, version)
-            elems.map("/" + _).mkString + "/"
+            elems.mkString("/", "/", "/")
           }
           val path = {
             val url = checkRepo.root.stripSuffix("/") + relPath

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/checks/PgpSecretKeyCheck.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/checks/PgpSecretKeyCheck.scala
@@ -91,7 +91,7 @@ final case class PgpSecretKeyCheck(
                 options.randomSecretKeyMail
                   .toRight(
                     new MissingPublishOptionError(
-                      "random secret key mail",
+                      "the e-mail address to associate to the random key pair",
                       "--random-secret-key-mail",
                       ""
                     )

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/checks/PgpSecretKeyCheck.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/checks/PgpSecretKeyCheck.scala
@@ -143,7 +143,7 @@ final case class PgpSecretKeyCheck(
                         "publish.secretKey",
                         configKeys = Seq(Keys.pgpSecretKey.fullName),
                         extraMessage =
-                          ", and specify publish.secretKeyPassword / --secret-key-password if needed." +
+                          "also specify publish.secretKeyPassword / --secret-key-password if needed." +
                             (if (options.publishParams.setupCi)
                                " Alternatively, pass --random-secret-key"
                              else "")

--- a/modules/cli/src/main/scala/scala/cli/errors/MissingPublishOptionError.scala
+++ b/modules/cli/src/main/scala/scala/cli/errors/MissingPublishOptionError.scala
@@ -17,7 +17,7 @@ final class MissingPublishOptionError(
         val configPart =
           if (configKeys.isEmpty) ""
           else
-            s" or by setting ${configKeys.mkString(", ")} in the Scala CLI configuration"
+            s" or by setting ${configKeys.mkString(", ")} in the configuration"
         val extraPart =
           if (extraMessage.isEmpty) "" else s", ${extraMessage.dropWhile(_.isWhitespace)}"
 

--- a/modules/cli/src/main/scala/scala/cli/errors/MissingPublishOptionError.scala
+++ b/modules/cli/src/main/scala/scala/cli/errors/MissingPublishOptionError.scala
@@ -18,9 +18,12 @@ final class MissingPublishOptionError(
           if (configKeys.isEmpty) ""
           else
             s" or by setting ${configKeys.mkString(", ")} in the Scala CLI configuration"
+        val extraPart =
+          if (extraMessage.isEmpty) "" else s", ${extraMessage.dropWhile(_.isWhitespace)}"
+
         s"Missing $name for publishing, specify one with $optionName" +
           directivePart +
           configPart +
-          extraMessage
+          extraPart
       }
     )

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
@@ -274,90 +274,91 @@ abstract class PublishTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
 
-  test("missing secret key password") {
-    // format: off
-    val signingOptions = Seq(
-      "--secret-key", s"file:key.skr",
-      "--signer", "bc"
-    )
-    // format: on
+  if (!TestUtil.isNativeCli)
+    test("missing secret key password") {
+      // format: off
+      val signingOptions = Seq(
+        "--secret-key", s"file:key.skr",
+        "--signer", "bc"
+      )
+      // format: on
 
-    TestCase.testInputs.fromRoot { root =>
-      val confDir  = root / "config"
-      val confFile = confDir / "test-config.json"
+      TestCase.testInputs.fromRoot { root =>
+        val confDir  = root / "config"
+        val confFile = confDir / "test-config.json"
 
-      os.write(confFile, "{}", createFolders = true)
+        os.write(confFile, "{}", createFolders = true)
 
-      if (!Properties.isWin)
-        os.perms.set(confDir, "rwx------")
+        if (!Properties.isWin)
+          os.perms.set(confDir, "rwx------")
 
-      val extraEnv = Map("SCALA_CLI_CONFIG" -> confFile.toString)
+        val extraEnv = Map("SCALA_CLI_CONFIG" -> confFile.toString)
 
-      os.proc(
-        TestUtil.cli,
-        "--power",
-        "pgp",
-        "create",
-        "--email",
-        "some_email",
-        "--password",
-        "value:"
-      ).call(cwd = root, env = extraEnv)
+        os.proc(
+          TestUtil.cli,
+          "--power",
+          "pgp",
+          "create",
+          "--email",
+          "some_email",
+          "--password",
+          "value:"
+        ).call(cwd = root, env = extraEnv)
 
-      val publicKey = os.Path("key.pub", root)
+        val publicKey = os.Path("key.pub", root)
 
-      os.proc(
-        TestUtil.cli,
-        "--power",
-        "publish",
-        extraOptions,
-        signingOptions,
-        "project",
-        "-R",
-        "test-repo"
-      ).call(cwd = root, env = extraEnv)
+        os.proc(
+          TestUtil.cli,
+          "--power",
+          "publish",
+          extraOptions,
+          signingOptions,
+          "project",
+          "-R",
+          "test-repo"
+        ).call(cwd = root, env = extraEnv)
 
-      val files = os.walk(root / "test-repo")
-        .filter(os.isFile(_))
-        .map(_.relativeTo(root / "test-repo"))
-      val notInDir = files.filter(!_.startsWith(TestCase.expectedArtifactsDir))
-      expect(notInDir.isEmpty)
+        val files = os.walk(root / "test-repo")
+          .filter(os.isFile(_))
+          .map(_.relativeTo(root / "test-repo"))
+        val notInDir = files.filter(!_.startsWith(TestCase.expectedArtifactsDir))
+        expect(notInDir.isEmpty)
 
-      val files0 = files.map(_.relativeTo(TestCase.expectedArtifactsDir)).toSet
+        val files0 = files.map(_.relativeTo(TestCase.expectedArtifactsDir)).toSet
 
-      expect((files0 -- expectedArtifacts).isEmpty)
-      expect((expectedArtifacts -- files0).isEmpty)
-      expect(files0 == expectedArtifacts) // just in case…
+        expect((files0 -- expectedArtifacts).isEmpty)
+        expect((expectedArtifacts -- files0).isEmpty)
+        expect(files0 == expectedArtifacts) // just in case…
 
-      val repoArgs =
-        Seq[os.Shellable]("-r", "!central", "-r", (root / "test-repo").toNIO.toUri.toASCIIString)
-      val dep    = s"org.virtuslab.scalacli.test:simple${TestCase.scalaSuffix}:0.2.0-SNAPSHOT"
-      val res    = os.proc(TestUtil.cs, "launch", repoArgs, dep).call(cwd = root)
-      val output = res.out.trim()
-      expect(output == "Hello")
+        val repoArgs =
+          Seq[os.Shellable]("-r", "!central", "-r", (root / "test-repo").toNIO.toUri.toASCIIString)
+        val dep    = s"org.virtuslab.scalacli.test:simple${TestCase.scalaSuffix}:0.2.0-SNAPSHOT"
+        val res    = os.proc(TestUtil.cs, "launch", repoArgs, dep).call(cwd = root)
+        val output = res.out.trim()
+        expect(output == "Hello")
 
-      val sourceJarViaCsStr =
-        os.proc(TestUtil.cs, "fetch", repoArgs, "--sources", "--intransitive", dep)
-          .call(cwd = root)
-          .out.trim()
-      val sourceJarViaCs = os.Path(sourceJarViaCsStr, os.pwd)
-      val zf             = new ZipFile(sourceJarViaCs.toIO)
-      val entries        = zf.entries().asScala.toVector.map(_.getName).toSet
-      expect(entries == expectedSourceEntries)
+        val sourceJarViaCsStr =
+          os.proc(TestUtil.cs, "fetch", repoArgs, "--sources", "--intransitive", dep)
+            .call(cwd = root)
+            .out.trim()
+        val sourceJarViaCs = os.Path(sourceJarViaCsStr, os.pwd)
+        val zf             = new ZipFile(sourceJarViaCs.toIO)
+        val entries        = zf.entries().asScala.toVector.map(_.getName).toSet
+        expect(entries == expectedSourceEntries)
 
-      val signatures = expectedArtifacts.filter(_.last.endsWith(".asc"))
-      assert(signatures.nonEmpty)
-      os.proc(
-        TestUtil.cli,
-        "--power",
-        "pgp",
-        "verify",
-        "--key",
-        publicKey,
-        signatures.map(os.rel / "test-repo" / TestCase.expectedArtifactsDir / _)
-      ).call(cwd = root, env = extraEnv)
+        val signatures = expectedArtifacts.filter(_.last.endsWith(".asc"))
+        assert(signatures.nonEmpty)
+        os.proc(
+          TestUtil.cli,
+          "--power",
+          "pgp",
+          "verify",
+          "--key",
+          publicKey,
+          signatures.map(os.rel / "test-repo" / TestCase.expectedArtifactsDir / _)
+        ).call(cwd = root, env = extraEnv)
+      }
     }
-  }
 
   test("secret keys in config") {
 

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
@@ -46,7 +46,7 @@ abstract class PublishTestDefinitions(val scalaVersionOpt: Option[String])
       os.rel / "org" / "virtuslab" / "scalacli" / "test" / s"simple_sjs1$scalaSuffix" / "0.2.0-SNAPSHOT"
   }
 
-  val baseExpectedArtifacts = Seq(
+  val baseExpectedArtifacts = Set(
     s"simple${TestCase.scalaSuffix}-0.2.0-SNAPSHOT.pom",
     s"simple${TestCase.scalaSuffix}-0.2.0-SNAPSHOT.jar",
     s"simple${TestCase.scalaSuffix}-0.2.0-SNAPSHOT-javadoc.jar",
@@ -61,7 +61,6 @@ abstract class PublishTestDefinitions(val scalaVersionOpt: Option[String])
       Seq("", ".md5", ".sha1").map(n + _)
     }
     .map(os.rel / _)
-    .toSet
 
   val expectedSourceEntries = Set(
     "foo/Hello.scala",

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestsDefault.scala
@@ -299,12 +299,13 @@ class PublishTestsDefault extends PublishTestDefinitions(scalaVersionOpt = None)
         )
       )
     inputs.fromRoot { root =>
-      val failRes = os.proc(TestUtil.cli, "--power", "publish", "--dummy", "messages")
-        .call(cwd = root, mergeErrIntoOut = true)
+      val failRes =
+        os.proc(TestUtil.cli, "--power", "publish", "--dummy", "--signer", "none", "messages")
+          .call(cwd = root, mergeErrIntoOut = true)
       checkWarnings(failRes.out.text(), hasWarnings = true)
       checkCredentialsWarning(failRes.out.text())
 
-      val okRes = os.proc(TestUtil.cli, "--power", "publish", "--dummy", ".")
+      val okRes = os.proc(TestUtil.cli, "--power", "publish", "--dummy", "--signer", "none", ".")
         .call(cwd = root, mergeErrIntoOut = true)
       checkWarnings(okRes.out.text(), hasWarnings = false)
       checkCredentialsWarning(okRes.out.text())


### PR DESCRIPTION
When using `scala-cli publish` with `--secret-key` but no value for   `--secret-key-password` an ambiguous error is presented to the user due to `null` being referenced (line 888 in old version). This should fix the exception and also warn users if one of the values is missing.

Also fixes #1899 
Follow-up to #1432