### PR TITLE
Add a reference for available config keys in help & docs

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
@@ -93,11 +93,11 @@ object ConfigOptions {
     s"""$helpHeader
        |
        |Available keys:
-       |  ${configKeysBulletPoints(includeHidden = false).mkString(s"${System.lineSeparator}  ")}
+       |  ${configKeyMessages(includeHidden = false).mkString(s"${System.lineSeparator}  ")}
        |
        |${HelpMessages.commandFullHelpReference(cmdName)}
        |${HelpMessages.commandDocWebsiteReference(websiteSuffix)}""".stripMargin
-  private def configKeysBulletPoints(includeHidden: Boolean): Seq[String] = {
+  private def configKeyMessages(includeHidden: Boolean): Seq[String] = {
     val allKeys: Seq[Key[_]] = Keys.map.values.toSeq
     val keys: Seq[Key[_]]    = if includeHidden then allKeys else allKeys.filterNot(_.hidden)
     val maxFullNameLength    = keys.map(_.fullName.length).max
@@ -108,7 +108,7 @@ object ConfigOptions {
           if currentKeyFullNameLength > 0 then " " * currentKeyFullNameLength else ""
         val hiddenString =
           if key.hidden then s"${ScalaCliConsole.GRAY}(hidden)${Console.RESET} " else ""
-        s"- ${Console.YELLOW}${key.fullName}${Console.RESET}$extraSpaces  $hiddenString${key.description}"
+        s"${Console.YELLOW}${key.fullName}${Console.RESET}$extraSpaces  $hiddenString${key.description}"
       }
   }
   val detailedHelpMessage: String =
@@ -120,7 +120,7 @@ object ConfigOptions {
        |  ${Console.BOLD}$progName $cmdName interactive true${Console.RESET}
        |  
        |Available keys:
-       |  ${configKeysBulletPoints(includeHidden = true).mkString(s"${System.lineSeparator}  ")}
+       |  ${configKeyMessages(includeHidden = true).mkString(s"${System.lineSeparator}  ")}
        |
        |${HelpMessages.commandDocWebsiteReference(websiteSuffix)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
@@ -88,7 +88,6 @@ object ConfigOptions {
   implicit lazy val help: Help[ConfigOptions]     = Help.derive
   private val helpHeader: String = s"Configure global settings for $fullRunnerName."
   private val cmdName            = "config"
-  private val websiteSuffix      = s"misc/$cmdName"
   val helpMessage: String =
     s"""$helpHeader
        |
@@ -96,7 +95,7 @@ object ConfigOptions {
        |  ${configKeyMessages(includeHidden = false).mkString(s"${System.lineSeparator}  ")}
        |
        |${HelpMessages.commandFullHelpReference(cmdName)}
-       |${HelpMessages.commandDocWebsiteReference(websiteSuffix)}""".stripMargin
+       |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
   private def configKeyMessages(includeHidden: Boolean): Seq[String] = {
     val allKeys: Seq[Key[_]] = Keys.map.values.toSeq
     val keys: Seq[Key[_]]    = if includeHidden then allKeys else allKeys.filterNot(_.hidden)
@@ -122,5 +121,5 @@ object ConfigOptions {
        |Available keys:
        |  ${configKeyMessages(includeHidden = true).mkString(s"${System.lineSeparator}  ")}
        |
-       |${HelpMessages.commandDocWebsiteReference(websiteSuffix)}""".stripMargin
+       |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
@@ -13,7 +13,7 @@ import scala.cli.commands.shared.{
   SharedJvmOptions
 }
 import scala.cli.commands.tags
-import scala.cli.config.Keys
+import scala.cli.config.{Key, Keys}
 
 // format: off
 @HelpMessage(ConfigOptions.helpMessage, "", ConfigOptions.detailedHelpMessage)
@@ -93,7 +93,17 @@ object ConfigOptions {
        |
        |${HelpMessages.commandFullHelpReference(cmdName)}
        |${HelpMessages.commandDocWebsiteReference(websiteSuffix)}""".stripMargin
-  private val configKeysBulletPoints: Seq[String] = Keys.map.keys.toSeq.sorted.map("- " + _)
+  private val configKeysBulletPoints: Seq[String] = {
+    val keys: Seq[Key[_]] = Keys.map.values.toSeq
+    val maxFullNameLength = keys.map(_.fullName.length).max
+    keys.sortBy(_.fullName)
+      .map { key =>
+        val currentKeyFullNameLength = maxFullNameLength - key.fullName.length
+        val extraSpaces =
+          if currentKeyFullNameLength > 0 then " " * currentKeyFullNameLength else ""
+        s"- ${key.fullName}$extraSpaces  ${key.description}"
+      }
+  }
   val detailedHelpMessage: String =
     s"""$helpHeader
        |

--- a/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
@@ -13,6 +13,7 @@ import scala.cli.commands.shared.{
   SharedJvmOptions
 }
 import scala.cli.commands.tags
+import scala.cli.config.Keys
 
 // format: off
 @HelpMessage(ConfigOptions.helpMessage, "", ConfigOptions.detailedHelpMessage)
@@ -92,6 +93,7 @@ object ConfigOptions {
        |
        |${HelpMessages.commandFullHelpReference(cmdName)}
        |${HelpMessages.commandDocWebsiteReference(websiteSuffix)}""".stripMargin
+  private val configKeysBulletPoints: Seq[String] = Keys.map.keys.toSeq.sorted.map("- " + _)
   val detailedHelpMessage: String =
     s"""$helpHeader
        |
@@ -99,6 +101,9 @@ object ConfigOptions {
        |  ${Console.BOLD}$progName $cmdName key value${Console.RESET}
        |For example, to globally set the interactive mode:
        |  ${Console.BOLD}$progName $cmdName interactive true${Console.RESET}
+       |  
+       |Available keys:
+       |  ${configKeysBulletPoints.mkString(s"${System.lineSeparator}  ")}
        |
        |${HelpMessages.commandDocWebsiteReference(websiteSuffix)}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
@@ -101,7 +101,7 @@ object ConfigOptions {
         val currentKeyFullNameLength = maxFullNameLength - key.fullName.length
         val extraSpaces =
           if currentKeyFullNameLength > 0 then " " * currentKeyFullNameLength else ""
-        s"- ${key.fullName}$extraSpaces  ${key.description}"
+        s"- ${Console.YELLOW}${key.fullName}${Console.RESET}$extraSpaces  ${key.description}"
       }
   }
   val detailedHelpMessage: String =

--- a/modules/config/src/main/scala/scala/cli/config/Key.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Key.scala
@@ -36,7 +36,10 @@ abstract class Key[T] {
   def fromString(values: Seq[String]): Either[Key.MalformedValue, T]
 
   /** The fully qualified name of this key */
-  final def fullName = (prefix :+ name).mkString(".")
+  final def fullName: String = (prefix :+ name).mkString(".")
+
+  /** A short description of a particular key's purpose and syntax for its values. */
+  def description: String
 
   /** Whether this key corresponds to a password (see [[Key.PasswordEntry]]) */
   def isPasswordOption: Boolean = false
@@ -76,7 +79,8 @@ object Key {
 
   final class StringEntry(
     val prefix: Seq[String],
-    val name: String
+    val name: String,
+    val description: String = ""
   ) extends Key[String] {
     def parse(json: Array[Byte]): Either[EntryError, String] =
       try Right(readFromArray(json)(stringCodec))
@@ -97,7 +101,8 @@ object Key {
 
   final class BooleanEntry(
     val prefix: Seq[String],
-    val name: String
+    val name: String,
+    val description: String = ""
   ) extends Key[Boolean] {
     def parse(json: Array[Byte]): Either[EntryError, Boolean] =
       try Right(readFromArray(json)(booleanCodec))
@@ -118,7 +123,8 @@ object Key {
 
   final class PasswordEntry(
     val prefix: Seq[String],
-    val name: String
+    val name: String,
+    val description: String = ""
   ) extends Key[PasswordOption] {
     def parse(json: Array[Byte]): Either[EntryError, PasswordOption] =
       try {
@@ -150,7 +156,8 @@ object Key {
 
   final class StringListEntry(
     val prefix: Seq[String],
-    val name: String
+    val name: String,
+    val description: String = ""
   ) extends Key[List[String]] {
     def parse(json: Array[Byte]): Either[EntryError, List[String]] =
       try Right(readFromArray(json)(stringListCodec))

--- a/modules/config/src/main/scala/scala/cli/config/Key.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Key.scala
@@ -41,6 +41,9 @@ abstract class Key[T] {
   /** A short description of a particular key's purpose and syntax for its values. */
   def description: String
 
+  /** A flag indicating whether the key should by default be hidden in help outputs or not. */
+  def hidden: Boolean = false
+
   /** Whether this key corresponds to a password (see [[Key.PasswordEntry]]) */
   def isPasswordOption: Boolean = false
 }
@@ -80,7 +83,8 @@ object Key {
   final class StringEntry(
     val prefix: Seq[String],
     val name: String,
-    val description: String = ""
+    val description: String = "",
+    override val hidden: Boolean = false
   ) extends Key[String] {
     def parse(json: Array[Byte]): Either[EntryError, String] =
       try Right(readFromArray(json)(stringCodec))
@@ -102,7 +106,8 @@ object Key {
   final class BooleanEntry(
     val prefix: Seq[String],
     val name: String,
-    val description: String = ""
+    val description: String = "",
+    override val hidden: Boolean = false
   ) extends Key[Boolean] {
     def parse(json: Array[Byte]): Either[EntryError, Boolean] =
       try Right(readFromArray(json)(booleanCodec))
@@ -124,7 +129,8 @@ object Key {
   final class PasswordEntry(
     val prefix: Seq[String],
     val name: String,
-    val description: String = ""
+    val description: String = "",
+    override val hidden: Boolean = false
   ) extends Key[PasswordOption] {
     def parse(json: Array[Byte]): Either[EntryError, PasswordOption] =
       try {
@@ -157,7 +163,8 @@ object Key {
   final class StringListEntry(
     val prefix: Seq[String],
     val name: String,
-    val description: String = ""
+    val description: String = "",
+    override val hidden: Boolean = false
   ) extends Key[List[String]] {
     def parse(json: Array[Byte]): Either[EntryError, List[String]] =
       try Right(readFromArray(json)(stringListCodec))

--- a/modules/config/src/main/scala/scala/cli/config/Keys.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Keys.scala
@@ -7,37 +7,112 @@ import scala.collection.mutable.ListBuffer
 
 object Keys {
 
-  val userName  = new Key.StringEntry(Seq("publish", "user"), "name")
-  val userEmail = new Key.StringEntry(Seq("publish", "user"), "email")
-  val userUrl   = new Key.StringEntry(Seq("publish", "user"), "url")
+  val userName = new Key.StringEntry(
+    prefix = Seq("publish", "user"),
+    name = "name",
+    description = "The 'name' user detail, used for publishing."
+  )
+  val userEmail = new Key.StringEntry(
+    prefix = Seq("publish", "user"),
+    name = "email",
+    description = "The 'email' user detail, used for publishing."
+  )
+  val userUrl = new Key.StringEntry(
+    prefix = Seq("publish", "user"),
+    name = "url",
+    description = "The 'url' user detail, used for publishing."
+  )
 
-  val ghToken = new Key.PasswordEntry(Seq("github"), "token")
+  val ghToken = new Key.PasswordEntry(
+    prefix = Seq("github"),
+    name = "token",
+    description = "GitHub token."
+  )
 
-  val pgpSecretKey         = new Key.PasswordEntry(Seq("pgp"), "secret-key")
-  val pgpSecretKeyPassword = new Key.PasswordEntry(Seq("pgp"), "secret-key-password")
-  val pgpPublicKey         = new Key.PasswordEntry(Seq("pgp"), "public-key")
+  val pgpSecretKey = new Key.PasswordEntry(
+    prefix = Seq("pgp"),
+    name = "secret-key",
+    description = "The PGP secret key, used for signing."
+  )
+  val pgpSecretKeyPassword = new Key.PasswordEntry(
+    prefix = Seq("pgp"),
+    name = "secret-key-password",
+    description = "The PGP secret key password, used for signing."
+  )
+  val pgpPublicKey = new Key.PasswordEntry(
+    prefix = Seq("pgp"),
+    name = "public-key",
+    description = "The PGP public key, used for signing."
+  )
 
-  val actions     = new Key.BooleanEntry(Seq.empty, "actions")
-  val interactive = new Key.BooleanEntry(Seq.empty, "interactive")
-  val power       = new Key.BooleanEntry(Seq.empty, "power")
+  val actions = new Key.BooleanEntry(
+    prefix = Seq.empty,
+    name = "actions",
+    description = "Globally enables actionable diagnostics. Enabled by default."
+  )
+  val interactive = new Key.BooleanEntry(
+    prefix = Seq.empty,
+    name = "interactive",
+    description = "Globally enables interactive mode (the '--interactive' flag)."
+  )
+  val power = new Key.BooleanEntry(
+    prefix = Seq.empty,
+    name = "power",
+    description = "Globally enables power mode (the '--power' launcher flag)."
+  )
 
   val suppressDirectivesInMultipleFilesWarning =
-    new Key.BooleanEntry(Seq("suppress-warning"), "directives-in-multiple-files")
+    new Key.BooleanEntry(
+      prefix = Seq("suppress-warning"),
+      name = "directives-in-multiple-files",
+      description =
+        "Globally suppresses warnings about directives declared in multiple source files."
+    )
   val suppressOutdatedDependenciessWarning =
-    new Key.BooleanEntry(Seq("suppress-warning"), "outdated-dependencies-files")
+    new Key.BooleanEntry(
+      prefix = Seq("suppress-warning"),
+      name = "outdated-dependencies-files",
+      description = "Globally suppresses warnings about outdated dependencies."
+    )
 
-  val proxyAddress  = new Key.StringEntry(Seq("httpProxy"), "address")
-  val proxyUser     = new Key.PasswordEntry(Seq("httpProxy"), "user")
-  val proxyPassword = new Key.PasswordEntry(Seq("httpProxy"), "password")
+  val proxyAddress = new Key.StringEntry(
+    prefix = Seq("httpProxy"),
+    name = "address",
+    description = "HTTP proxy address."
+  )
+  val proxyUser = new Key.PasswordEntry(
+    prefix = Seq("httpProxy"),
+    name = "user",
+    description = "HTTP proxy user (used for authentication)."
+  )
+  val proxyPassword = new Key.PasswordEntry(
+    prefix = Seq("httpProxy"),
+    name = "password",
+    description = "HTTP proxy password (used for authentication)."
+  )
 
-  val repositoryMirrors   = new Key.StringListEntry(Seq("repositories"), "mirrors")
-  val defaultRepositories = new Key.StringListEntry(Seq("repositories"), "default")
+  val repositoryMirrors = new Key.StringListEntry(
+    prefix = Seq("repositories"),
+    name = "mirrors",
+    description =
+      s"Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven"
+  )
+  val defaultRepositories = new Key.StringListEntry(
+    prefix = Seq("repositories"),
+    name = "default",
+    description =
+      "Default repository, syntax: https://first-repo.company.com https://second-repo.company.com"
+  )
 
   // Kept for binary compatibility
   val repositoriesMirrors = repositoryMirrors
 
   // setting indicating if the global interactive mode was suggested
-  val globalInteractiveWasSuggested = new Key.BooleanEntry(Seq.empty, "interactive-was-suggested")
+  val globalInteractiveWasSuggested = new Key.BooleanEntry(
+    prefix = Seq.empty,
+    name = "interactive-was-suggested",
+    description = "Setting indicating if the global interactive mode was already suggested."
+  )
 
   def all: Seq[Key[_]] = Seq[Key[_]](
     actions,
@@ -120,6 +195,7 @@ object Keys {
 
   val repositoryCredentials: Key[List[RepositoryCredentials]] =
     new Key[List[RepositoryCredentials]] {
+      override val description: String = "Repository credentials, syntax: value:user value:password"
 
       private def asJson(credentials: RepositoryCredentials): RepositoryCredentialsAsJson =
         RepositoryCredentialsAsJson(
@@ -242,6 +318,8 @@ object Keys {
   }
 
   val publishCredentials: Key[List[PublishCredentials]] = new Key[List[PublishCredentials]] {
+    override val description: String =
+      "Publishing credentials, syntax: s1.oss.sonatype.org value:user value:password"
 
     private def asJson(credentials: PublishCredentials): PublishCredentialsAsJson =
       PublishCredentialsAsJson(

--- a/modules/config/src/main/scala/scala/cli/config/Keys.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Keys.scala
@@ -134,6 +134,7 @@ object Keys {
     globalInteractiveWasSuggested,
     interactive,
     suppressDirectivesInMultipleFilesWarning,
+    suppressOutdatedDependenciessWarning,
     pgpPublicKey,
     pgpSecretKey,
     pgpSecretKeyPassword,

--- a/modules/config/src/main/scala/scala/cli/config/Keys.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Keys.scala
@@ -10,39 +10,46 @@ object Keys {
   val userName = new Key.StringEntry(
     prefix = Seq("publish", "user"),
     name = "name",
-    description = "The 'name' user detail, used for publishing."
+    description = "The 'name' user detail, used for publishing.",
+    hidden = true
   )
   val userEmail = new Key.StringEntry(
     prefix = Seq("publish", "user"),
     name = "email",
-    description = "The 'email' user detail, used for publishing."
+    description = "The 'email' user detail, used for publishing.",
+    hidden = true
   )
   val userUrl = new Key.StringEntry(
     prefix = Seq("publish", "user"),
     name = "url",
-    description = "The 'url' user detail, used for publishing."
+    description = "The 'url' user detail, used for publishing.",
+    hidden = true
   )
 
   val ghToken = new Key.PasswordEntry(
     prefix = Seq("github"),
     name = "token",
-    description = "GitHub token."
+    description = "GitHub token.",
+    hidden = true
   )
 
   val pgpSecretKey = new Key.PasswordEntry(
     prefix = Seq("pgp"),
     name = "secret-key",
-    description = "The PGP secret key, used for signing."
+    description = "The PGP secret key, used for signing.",
+    hidden = true
   )
   val pgpSecretKeyPassword = new Key.PasswordEntry(
     prefix = Seq("pgp"),
     name = "secret-key-password",
-    description = "The PGP secret key password, used for signing."
+    description = "The PGP secret key password, used for signing.",
+    hidden = true
   )
   val pgpPublicKey = new Key.PasswordEntry(
     prefix = Seq("pgp"),
     name = "public-key",
-    description = "The PGP public key, used for signing."
+    description = "The PGP public key, used for signing.",
+    hidden = true
   )
 
   val actions = new Key.BooleanEntry(
@@ -78,30 +85,35 @@ object Keys {
   val proxyAddress = new Key.StringEntry(
     prefix = Seq("httpProxy"),
     name = "address",
-    description = "HTTP proxy address."
+    description = "HTTP proxy address.",
+    hidden = true
   )
   val proxyUser = new Key.PasswordEntry(
     prefix = Seq("httpProxy"),
     name = "user",
-    description = "HTTP proxy user (used for authentication)."
+    description = "HTTP proxy user (used for authentication).",
+    hidden = true
   )
   val proxyPassword = new Key.PasswordEntry(
     prefix = Seq("httpProxy"),
     name = "password",
-    description = "HTTP proxy password (used for authentication)."
+    description = "HTTP proxy password (used for authentication).",
+    hidden = true
   )
 
   val repositoryMirrors = new Key.StringListEntry(
     prefix = Seq("repositories"),
     name = "mirrors",
     description =
-      s"Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven"
+      s"Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven",
+    hidden = true
   )
   val defaultRepositories = new Key.StringListEntry(
     prefix = Seq("repositories"),
     name = "default",
     description =
-      "Default repository, syntax: https://first-repo.company.com https://second-repo.company.com"
+      "Default repository, syntax: https://first-repo.company.com https://second-repo.company.com",
+    hidden = true
   )
 
   // Kept for binary compatibility
@@ -111,7 +123,8 @@ object Keys {
   val globalInteractiveWasSuggested = new Key.BooleanEntry(
     prefix = Seq.empty,
     name = "interactive-was-suggested",
-    description = "Setting indicating if the global interactive mode was already suggested."
+    description = "Setting indicating if the global interactive mode was already suggested.",
+    hidden = true
   )
 
   def all: Seq[Key[_]] = Seq[Key[_]](
@@ -196,6 +209,7 @@ object Keys {
   val repositoryCredentials: Key[List[RepositoryCredentials]] =
     new Key[List[RepositoryCredentials]] {
       override val description: String = "Repository credentials, syntax: value:user value:password"
+      override val hidden: Boolean     = true
 
       private def asJson(credentials: RepositoryCredentials): RepositoryCredentialsAsJson =
         RepositoryCredentialsAsJson(
@@ -320,6 +334,7 @@ object Keys {
   val publishCredentials: Key[List[PublishCredentials]] = new Key[List[PublishCredentials]] {
     override val description: String =
       "Publishing credentials, syntax: s1.oss.sonatype.org value:user value:password"
+    override val hidden: Boolean = true
 
     private def asJson(credentials: PublishCredentials): PublishCredentialsAsJson =
       PublishCredentialsAsJson(

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/ReferenceDocUtils.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/ReferenceDocUtils.scala
@@ -4,32 +4,45 @@ import caseapp.HelpMessage
 
 import java.util.stream.IntStream
 
+import scala.annotation.tailrec
 import scala.build.internal.util.ConsoleUtils.*
 
 object ReferenceDocUtils {
   extension (s: String) {
-    def consoleToFence: String =
-      s
-        .linesIterator
-        .fold("") { (acc, line) =>
-          val maybeOpenFence =
-            if line.contains(Console.BOLD) then
-              """```sh
-                |""".stripMargin
-            else if line.contains(ScalaCliConsole.GRAY) then
-              """```scala
-                |""".stripMargin
-            else ""
-          val maybeCloseFence =
-            if line.contains(Console.RESET) then
-              """
-                |```""".stripMargin
-            else ""
-          val newLine = s"$maybeOpenFence${line.noConsoleKeys}$maybeCloseFence"
-          if acc.isEmpty then newLine
-          else s"""$acc
-                  |$newLine""".stripMargin
-        }
+    def consoleToFence: String = {
+      @tailrec
+      def consoleToFenceRec(
+        remainingLines: Seq[String],
+        fenceOpen: Boolean = false,
+        acc: String = ""
+      ): String =
+        remainingLines.headOption match
+          case None => acc
+          case Some(line) =>
+            val openFenceString =
+              if line.contains(Console.BOLD) then
+                """```sh
+                  |""".stripMargin
+              else if line.contains(ScalaCliConsole.GRAY) then
+                """```scala
+                  |""".stripMargin
+              else ""
+            val currentFenceOpen = fenceOpen || openFenceString.nonEmpty
+            val closeFenceString =
+              if currentFenceOpen && line.contains(Console.RESET) then
+                """
+                  |```""".stripMargin
+              else ""
+            val newFenceOpen = currentFenceOpen && closeFenceString.isEmpty
+            val newLine      = s"$openFenceString${line.noConsoleKeys}$closeFenceString"
+            val newAcc =
+              if acc.isEmpty then newLine
+              else
+                s"""$acc
+                   |$newLine""".stripMargin
+            consoleToFenceRec(remainingLines.tail, newFenceOpen, newAcc)
+      consoleToFenceRec(s.linesIterator.toSeq)
+    }
   }
   extension (helpMessage: HelpMessage) {
     def referenceDocMessage: String = helpMessage.message.consoleToFence.noConsoleKeys

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/ReferenceDocUtils.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/ReferenceDocUtils.scala
@@ -43,14 +43,16 @@ object ReferenceDocUtils {
             consoleToFenceRec(remainingLines.tail, newFenceOpen, newAcc)
       consoleToFenceRec(s.linesIterator.toSeq)
     }
+    def filterOutHiddenStrings: String =
+      s.replace(s"${ScalaCliConsole.GRAY}(hidden)${Console.RESET} ", "")
   }
   extension (helpMessage: HelpMessage) {
-    def referenceDocMessage: String = helpMessage.message.consoleToFence.noConsoleKeys
+    def referenceDocMessage: String = helpMessage.message.filterOutHiddenStrings.consoleToFence
     def referenceDocDetailedMessage: String = {
       val msg =
         if helpMessage.detailedMessage.nonEmpty then helpMessage.detailedMessage
         else helpMessage.message
-      msg.consoleToFence
+      msg.filterOutHiddenStrings.consoleToFence
     }
   }
 

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/ReferenceDocUtils.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/ReferenceDocUtils.scala
@@ -45,14 +45,16 @@ object ReferenceDocUtils {
     }
     def filterOutHiddenStrings: String =
       s.replace(s"${ScalaCliConsole.GRAY}(hidden)${Console.RESET} ", "")
+    def consoleYellowToMdBullets: String = s.replace(Console.YELLOW, "- ")
+    def consoleToMarkdown: String = s.filterOutHiddenStrings.consoleYellowToMdBullets.consoleToFence
   }
   extension (helpMessage: HelpMessage) {
-    def referenceDocMessage: String = helpMessage.message.filterOutHiddenStrings.consoleToFence
+    def referenceDocMessage: String = helpMessage.message.consoleToMarkdown
     def referenceDocDetailedMessage: String = {
       val msg =
         if helpMessage.detailedMessage.nonEmpty then helpMessage.detailedMessage
         else helpMessage.message
-      msg.filterOutHiddenStrings.consoleToFence
+      msg.consoleToMarkdown
     }
   }
 

--- a/website/docs/commands/config.md
+++ b/website/docs/commands/config.md
@@ -1,21 +1,29 @@
 ---
-title: Config ⚡️
-sidebar_position: 1
+title: Config
+sidebar_position: 17
 ---
 
-:::caution
-The Config command is restricted and requires setting the `--power` option to be used.
-You can pass it explicitly or set it globally by running:
-
-    scala-cli config power true
-:::
-
-import {ChainedSnippets} from "../../../src/components/MarkdownComponents.js";
+import {ChainedSnippets} from "../../src/components/MarkdownComponents.js";
 
 The `config` sub-command makes it possible to get and set various configuration values, used by
 other Scala CLI sub-commands.
 
+The full list of the available configuration keys is available in [the reference docs](../reference/commands.md#config).
+
 Examples of use:
+<ChainedSnippets>
+
+```bash ignore
+scala-cli config power true
+scala-cli config power
+```
+
+```text
+true
+```
+
+</ChainedSnippets>
+
 <ChainedSnippets>
 
 ```bash

--- a/website/docs/commands/publishing/publish-setup.md
+++ b/website/docs/commands/publishing/publish-setup.md
@@ -36,7 +36,7 @@ In particular, one can configure:
 - Sonatype credentials (to upload artifacts to Maven Central)
 - a GitHub token (to upload repository secrets to GitHub, and artifacts to Maven repositories of GitHub Packages)
 
-User-wide configuration in Scala CLI is handled by the [`config` command](/docs/commands/misc/config.md), and
+User-wide configuration in Scala CLI is handled by the [`config` command](/docs/commands/config.md), and
 the sections below show how to use it to configure things for `publish setup`.
 
 ### User details

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -48,25 +48,25 @@ For example, to globally set the interactive mode:
 ```
   
 Available keys:
-  - actions
-  - github.token
-  - httpProxy.address
-  - httpProxy.password
-  - httpProxy.user
-  - interactive
-  - interactive-was-suggested
-  - pgp.public-key
-  - pgp.secret-key
-  - pgp.secret-key-password
-  - power
-  - publish.credentials
-  - publish.user.email
-  - publish.user.name
-  - publish.user.url
-  - repositories.credentials
-  - repositories.default
-  - repositories.mirrors
-  - suppress-warning.directives-in-multiple-files
+  - actions                                        Globally enables actionable diagnostics. Enabled by default.
+  - github.token                                   GitHub token.
+  - httpProxy.address                              HTTP proxy address.
+  - httpProxy.password                             HTTP proxy password (used for authentication).
+  - httpProxy.user                                 HTTP proxy user (used for authentication).
+  - interactive                                    Globally enables interactive mode (the '--interactive' flag).
+  - interactive-was-suggested                      Setting indicating if the global interactive mode was already suggested.
+  - pgp.public-key                                 The PGP public key, used for signing.
+  - pgp.secret-key                                 The PGP secret key, used for signing.
+  - pgp.secret-key-password                        The PGP secret key password, used for signing.
+  - power                                          Globally enables power mode (the '--power' launcher flag).
+  - publish.credentials                            Publishing credentials, syntax: s1.oss.sonatype.org value:user value:password
+  - publish.user.email                             The 'email' user detail, used for publishing.
+  - publish.user.name                              The 'name' user detail, used for publishing.
+  - publish.user.url                               The 'url' user detail, used for publishing.
+  - repositories.credentials                       Repository credentials, syntax: value:user value:password
+  - repositories.default                           Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
+  - repositories.mirrors                           Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
+  - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -67,6 +67,7 @@ Available keys:
   - repositories.default                           Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
   - repositories.mirrors                           Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
+  - suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -46,6 +46,27 @@ For example, to globally set the interactive mode:
 ```sh
   scala-cli config interactive true
 ```
+  
+Available keys:
+  - actions
+  - github.token
+  - httpProxy.address
+  - httpProxy.password
+  - httpProxy.user
+  - interactive
+  - interactive-was-suggested
+  - pgp.public-key
+  - pgp.secret-key
+  - pgp.secret-key-password
+  - power
+  - publish.credentials
+  - publish.user.email
+  - publish.user.name
+  - publish.user.url
+  - repositories.credentials
+  - repositories.default
+  - repositories.mirrors
+  - suppress-warning.directives-in-multiple-files
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -69,7 +69,7 @@ Available keys:
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
   - suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
 
-For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
+For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/config
 
 Accepts option groups: [config](./cli-options.md#config-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [verbosity](./cli-options.md#verbosity-options)
 

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -68,7 +68,7 @@ Available keys:
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
   - suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
 
-For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
+For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/config
 
 Accepts option groups: [config](./cli-options.md#config-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [verbosity](./cli-options.md#verbosity-options)
 

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -66,6 +66,7 @@ Available keys:
   - repositories.default                           Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
   - repositories.mirrors                           Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
+  - suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -45,6 +45,27 @@ For example, to globally set the interactive mode:
 ```sh
   scala-cli config interactive true
 ```
+  
+Available keys:
+  - actions
+  - github.token
+  - httpProxy.address
+  - httpProxy.password
+  - httpProxy.user
+  - interactive
+  - interactive-was-suggested
+  - pgp.public-key
+  - pgp.secret-key
+  - pgp.secret-key-password
+  - power
+  - publish.credentials
+  - publish.user.email
+  - publish.user.name
+  - publish.user.url
+  - repositories.credentials
+  - repositories.default
+  - repositories.mirrors
+  - suppress-warning.directives-in-multiple-files
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -47,25 +47,25 @@ For example, to globally set the interactive mode:
 ```
   
 Available keys:
-  - actions
-  - github.token
-  - httpProxy.address
-  - httpProxy.password
-  - httpProxy.user
-  - interactive
-  - interactive-was-suggested
-  - pgp.public-key
-  - pgp.secret-key
-  - pgp.secret-key-password
-  - power
-  - publish.credentials
-  - publish.user.email
-  - publish.user.name
-  - publish.user.url
-  - repositories.credentials
-  - repositories.default
-  - repositories.mirrors
-  - suppress-warning.directives-in-multiple-files
+  - actions                                        Globally enables actionable diagnostics. Enabled by default.
+  - github.token                                   GitHub token.
+  - httpProxy.address                              HTTP proxy address.
+  - httpProxy.password                             HTTP proxy password (used for authentication).
+  - httpProxy.user                                 HTTP proxy user (used for authentication).
+  - interactive                                    Globally enables interactive mode (the '--interactive' flag).
+  - interactive-was-suggested                      Setting indicating if the global interactive mode was already suggested.
+  - pgp.public-key                                 The PGP public key, used for signing.
+  - pgp.secret-key                                 The PGP secret key, used for signing.
+  - pgp.secret-key-password                        The PGP secret key password, used for signing.
+  - power                                          Globally enables power mode (the '--power' launcher flag).
+  - publish.credentials                            Publishing credentials, syntax: s1.oss.sonatype.org value:user value:password
+  - publish.user.email                             The 'email' user detail, used for publishing.
+  - publish.user.name                              The 'name' user detail, used for publishing.
+  - publish.user.url                               The 'url' user detail, used for publishing.
+  - repositories.credentials                       Repository credentials, syntax: value:user value:password
+  - repositories.default                           Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
+  - repositories.mirrors                           Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
+  - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -606,7 +606,7 @@ Available keys:
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
   - suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
 
-For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
+For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/config
 
 ### SHOULD have options
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -583,6 +583,27 @@ For example, to globally set the interactive mode:
 ```sh
   scala-cli config interactive true
 ```
+  
+Available keys:
+  - actions
+  - github.token
+  - httpProxy.address
+  - httpProxy.password
+  - httpProxy.user
+  - interactive
+  - interactive-was-suggested
+  - pgp.public-key
+  - pgp.secret-key
+  - pgp.secret-key-password
+  - power
+  - publish.credentials
+  - publish.user.email
+  - publish.user.name
+  - publish.user.url
+  - repositories.credentials
+  - repositories.default
+  - repositories.mirrors
+  - suppress-warning.directives-in-multiple-files
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -585,25 +585,25 @@ For example, to globally set the interactive mode:
 ```
   
 Available keys:
-  - actions
-  - github.token
-  - httpProxy.address
-  - httpProxy.password
-  - httpProxy.user
-  - interactive
-  - interactive-was-suggested
-  - pgp.public-key
-  - pgp.secret-key
-  - pgp.secret-key-password
-  - power
-  - publish.credentials
-  - publish.user.email
-  - publish.user.name
-  - publish.user.url
-  - repositories.credentials
-  - repositories.default
-  - repositories.mirrors
-  - suppress-warning.directives-in-multiple-files
+  - actions                                        Globally enables actionable diagnostics. Enabled by default.
+  - github.token                                   GitHub token.
+  - httpProxy.address                              HTTP proxy address.
+  - httpProxy.password                             HTTP proxy password (used for authentication).
+  - httpProxy.user                                 HTTP proxy user (used for authentication).
+  - interactive                                    Globally enables interactive mode (the '--interactive' flag).
+  - interactive-was-suggested                      Setting indicating if the global interactive mode was already suggested.
+  - pgp.public-key                                 The PGP public key, used for signing.
+  - pgp.secret-key                                 The PGP secret key, used for signing.
+  - pgp.secret-key-password                        The PGP secret key password, used for signing.
+  - power                                          Globally enables power mode (the '--power' launcher flag).
+  - publish.credentials                            Publishing credentials, syntax: s1.oss.sonatype.org value:user value:password
+  - publish.user.email                             The 'email' user detail, used for publishing.
+  - publish.user.name                              The 'name' user detail, used for publishing.
+  - publish.user.url                               The 'url' user detail, used for publishing.
+  - repositories.credentials                       Repository credentials, syntax: value:user value:password
+  - repositories.default                           Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
+  - repositories.mirrors                           Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
+  - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -604,6 +604,7 @@ Available keys:
   - repositories.default                           Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
   - repositories.mirrors                           Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
+  - suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
 


### PR DESCRIPTION
Fixes #1623 

These changes add the available config keys to the `config` sub-command's `--help` and `--full-help` output (and thus, to the reference docs).
Only non-hidden (important for the average user) keys are listed in the short `--help`.

I also tweaked the `config` sub-command doc:
- it will now be in the main `commands` website level
- it's no longer a power command, so I fixed it not to be tagged as such

Short `config` help output:
```bash
scala-cli config -h
# Usage: scala-cli config [options]
# Configure global settings for Scala CLI.
# 
# Available keys:
#   actions                                        Globally enables actionable diagnostics. Enabled by default.
#   interactive                                    Globally enables interactive mode (the '--interactive' flag).
#   power                                          Globally enables power mode (the '--power' launcher flag).
#   suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
#   suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
# 
# You are currently viewing the basic help for the config sub-command. You can view the full help by running: 
#    scala-cli config --help-full
# For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
# 
# Config options:
#   --unset, --remove  Remove an entry from config
```

Full `config` help output:
```bash
scala-cli config --full-help
# Usage: scala-cli config [options]
# Configure global settings for Scala CLI.
# 
# Syntax:
#   scala-cli config key value
# For example, to globally set the interactive mode:
#   scala-cli config interactive true
#   
# Available keys:
#   actions                                        Globally enables actionable diagnostics. Enabled by default.
#   github.token                                   (hidden) GitHub token.
#   httpProxy.address                              (hidden) HTTP proxy address.
#   httpProxy.password                             (hidden) HTTP proxy password (used for authentication).
#   httpProxy.user                                 (hidden) HTTP proxy user (used for authentication).
#   interactive                                    Globally enables interactive mode (the '--interactive' flag).
#   interactive-was-suggested                      (hidden) Setting indicating if the global interactive mode was already suggested.
#   pgp.public-key                                 (hidden) The PGP public key, used for signing.
#   pgp.secret-key                                 (hidden) The PGP secret key, used for signing.
#   pgp.secret-key-password                        (hidden) The PGP secret key password, used for signing.
#   power                                          Globally enables power mode (the '--power' launcher flag).
#   publish.credentials                            (hidden) Publishing credentials, syntax: s1.oss.sonatype.org value:user value:password
#   publish.user.email                             (hidden) The 'email' user detail, used for publishing.
#   publish.user.name                              (hidden) The 'name' user detail, used for publishing.
#   publish.user.url                               (hidden) The 'url' user detail, used for publishing.
#   repositories.credentials                       (hidden) Repository credentials, syntax: value:user value:password
#   repositories.default                           (hidden) Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
#   repositories.mirrors                           (hidden) Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
#   suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
#   suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
# 
# For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/config
# 
# Config options:
#   --dump             (hidden) Dump config DB as JSON
#   --unset, --remove  Remove an entry from config
#  (...)
```