### PR TITLE
Add support for Scala.js 1.13.0 and allow to use newer Scala.js version in older scala-cli

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -364,8 +364,6 @@ trait Core extends ScalaCliSbtModule with ScalaCliPublishModule with HasTests
          |  def scalajsEnvJsdomNodejsVersion = "${Deps.scalaJsEnvJsdomNodejs.dep.version}"
          |  def scalaNativeVersion = "${Deps.nativeTools.dep.version}"
          |
-         |  def scalaJsCliVersion = "${InternalDeps.Versions.scalaJsCli}"
-         |
          |  def testRunnerOrganization = "$testRunnerOrganization"
          |  def testRunnerModuleName = "${`test-runner`(Scala.runnerScala3).artifactName()}"
          |  def testRunnerVersion = "${`test-runner`(Scala.runnerScala3).publishVersion()}"
@@ -704,7 +702,6 @@ trait Cli extends SbtModule with ProtoBuildModule with CliLaunchers
          |object Constants {
          |  def defaultScalaVersion = "${Scala.defaultUser}"
          |  def scalaJsVersion = "${Scala.scalaJs}"
-         |  def scalaJsCliVersion = "${InternalDeps.Versions.scalaJsCli}"
          |  def scalaNativeVersion = "${Deps.nativeTools.dep.version}"
          |  def ammoniteVersion = "${Deps.ammonite.dep.version}"
          |  def defaultScalafmtVersion = "${Deps.scalafmtCli.dep.version}"

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaJsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaJsOptions.scala
@@ -80,7 +80,7 @@ final case class ScalaJsOptions(
   @Hidden
     jsLinkerPath: Option[String] = None,
   @Group(HelpGroup.ScalaJs.toString)
-  @HelpMessage(s"Scala.js CLI version to use for linking (${Constants.scalaJsCliVersion} by default).")
+  @HelpMessage(s"Scala.js CLI version to use for linking (${Constants.scalaJsVersion} by default).")
   @ValueDescription("version")
   @Tag(tags.implementation)
   @Hidden

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -232,6 +232,7 @@ final case class SharedOptions(
       linkerPath = jsLinkerPath
         .filter(_.trim.nonEmpty)
         .map(os.Path(_, Os.pwd)),
+      scalaJsVersion = jsVersion.map(_.trim).filter(_.nonEmpty),
       scalaJsCliVersion = jsCliVersion.map(_.trim).filter(_.nonEmpty),
       javaArgs = jsCliJavaArg,
       useJvm = jsCliOnJvm.map {

--- a/modules/cli/src/main/scala/scala/cli/internal/ScalaJsLinker.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/ScalaJsLinker.scala
@@ -36,15 +36,8 @@ object ScalaJsLinker {
       case None =>
         val scalaJsCliVersion = options.finalScalaJsCliVersion
         val scalaJsCliDep = {
-          val mod =
-            if (scalaJsCliVersion.contains("-sc"))
-              if (Version(scalaJsCliVersion) < Version("1.1.2-sc1"))
-                mod"io.github.alexarchambault.tmp:scalajs-cli_2.13"
-              else
-                mod"io.github.alexarchambault.tmp:scalajscli-${scalaJsVersion}_2.13"
-            else
-              mod"org.scala-js:scalajs-cli_2.13"
-          dependency.Dependency(mod, scalaJsCliVersion)
+          val mod = mod"org.virtuslab.scala-cli:scalajscli_2.13"
+          dependency.Dependency(mod, s"$scalaJsCliVersion+")
         }
 
         val forcedVersions = Seq(
@@ -82,11 +75,11 @@ object ScalaJsLinker {
             command.flatMap(_.value)
 
           case Left(osArch) =>
-            val useLatest = scalaJsCliVersion == "latest"
+            val useLatest = scalaJsVersion == "latest"
             val ext       = if (Properties.isWin) ".zip" else ".gz"
             val tag       = if (useLatest) "launchers" else s"v$scalaJsCliVersion"
             val url =
-              s"https://github.com/scala-cli/scala-js-cli-native-image/releases/download/$tag/scala-js-ld-$scalaJsVersion-$osArch$ext"
+              s"https://github.com/virtusLab/scala-js-cli/releases/download/$tag/scala-js-ld-$osArch$ext"
             val params = ExternalBinaryParams(
               url,
               useLatest,

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportJsonTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportJsonTestDefinitions.scala
@@ -193,10 +193,10 @@ abstract class ExportJsonTestDefinitions(val scalaVersionOpt: Option[String])
       val fileContents = readJson(root / "dest" / "export.json")
 
       expect(fileContents ==
-        """{
+        s"""{
           |"scalaVersion": "3.1.3",
           |"platform": "JS",
-          |"scalaJsVersion": "1.12.0",
+          |"scalaJsVersion": "${Constants.scalaJsVersion}",
           |"jsEsVersion":"es2015",
           |"scopes": {
           | "main": {

--- a/modules/options/src/main/scala/scala/build/Artifacts.scala
+++ b/modules/options/src/main/scala/scala/build/Artifacts.scala
@@ -169,18 +169,13 @@ object Artifacts {
           fetched.fullDetailedArtifacts.collect { case (_, _, _, Some(f)) => os.Path(f, Os.pwd) }
 
         val scalaJsCliDependency =
-          scalaArtifactsParams.scalaJsCliVersion.map { version =>
-            val scalaJsVersion =
-              scalaArtifactsParams.scalaJsVersion.getOrElse(Constants.scalaJsVersion)
-            val mod =
-              if (version.contains("-sc"))
-                Module(
-                  Organization("io.github.alexarchambault.tmp"),
-                  ModuleName(s"scalajscli-${scalaJsVersion}_2.13"),
-                  Map.empty
-                )
-              else cmod"org.scala-js:scalajs-cli_2.13"
-            Seq(coursier.Dependency(mod, version))
+          scalaArtifactsParams.scalaJsCliVersion.map { scalaJsCliVersion =>
+            val mod = Module(
+              Organization("org.virtuslab.scala-cli"),
+              ModuleName(s"scalajscli_2.13"),
+              Map.empty
+            )
+            Seq(coursier.Dependency(mod, s"$scalaJsCliVersion+"))
           }
 
         val fetchedScalaJsCli = scalaJsCliDependency match {

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -344,7 +344,9 @@ final case class BuildOptions(
           scalaJsVersion =
             if (platform.value == Platform.JS) Some(scalaJsOptions.finalVersion) else None,
           scalaJsCliVersion =
-            if (platform.value == Platform.JS) Some(Constants.scalaJsCliVersion) else None,
+            if (platform.value == Platform.JS)
+              Some(notForBloopOptions.scalaJsLinkerOptions.finalScalaJsCliVersion)
+            else None,
           scalaNativeCliVersion =
             if (platform.value == Platform.Native) Some(scalaNativeOptions.finalVersion) else None,
           addScalapy =

--- a/modules/options/src/main/scala/scala/build/options/scalajs/ScalaJsLinkerOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/scalajs/ScalaJsLinkerOptions.scala
@@ -7,11 +7,12 @@ final case class ScalaJsLinkerOptions(
   javaArgs: Seq[String] = Nil,
   /** If right, use JVM, if left, use the value as architecture */
   useJvm: Option[Either[String, Unit]] = None,
+  scalaJsVersion: Option[String] = None,
   scalaJsCliVersion: Option[String] = None,
   linkerPath: Option[os.Path] = None
 ) {
-  def finalScalaJsCliVersion = scalaJsCliVersion.getOrElse {
-    Constants.scalaJsCliVersion
+  def finalScalaJsCliVersion = scalaJsCliVersion.orElse(scalaJsVersion).getOrElse {
+    Constants.scalaJsVersion
   }
 
   /** If right, use JVM, if left, use the value as architecture */

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -74,7 +74,6 @@ object InternalDeps {
   object Versions {
     def mill          = os.read(os.pwd / ".mill-version").trim
     def lefouMillwRef = "166bcdf5741de8569e0630e18c3b2ef7e252cd96"
-    def scalaJsCli    = "1.1.4-sc2"
   }
 }
 

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -14,7 +14,7 @@ object Scala {
   val mainVersions = Seq(scala3, scala213)
   val runnerScalaVersions = runnerScala3 +: allScala2
 
-  def scalaJs = "1.12.0"
+  def scalaJs = "1.13.0"
 
   def listAll: Seq[String] = {
     def patchVer(sv: String): Int =
@@ -74,7 +74,7 @@ object InternalDeps {
   object Versions {
     def mill          = os.read(os.pwd / ".mill-version").trim
     def lefouMillwRef = "166bcdf5741de8569e0630e18c3b2ef7e252cd96"
-    def scalaJsCli    = "1.1.3-sc1"
+    def scalaJsCli    = "1.1.4-sc2"
   }
 }
 

--- a/website/docs/guides/scala-js.md
+++ b/website/docs/guides/scala-js.md
@@ -179,11 +179,12 @@ In the future, the Scala CLI will be able to support any version of Scala.js ind
 
 The table below lists the last supported version of Scala.js in Scala CLI. If you want to use newer Scala.js, update scala-cli.
 
-| Scala CLI versions   |      Scala.js      |
-|----------------------|:------------------:|
-| 0.0.9                |   1.7.1            |
-| 0.1.0 - 0.1.2        |   1.8.0            |
-| 0.1.3                |   1.9.0            |
-| 0.1.4 - 0.1.8        |   1.10.0           |
-| 0.1.9 - 0.1.17       |   1.10.1           |
-| 0.1.18 - current     |   1.12.0           |
+| Scala CLI versions | Scala.js |
+|--------------------|:--------:|
+| 0.0.9              |  1.7.1   |
+| 0.1.0 - 0.1.2      |  1.8.0   |
+| 0.1.3              |  1.9.0   |
+| 0.1.4 - 0.1.8      |  1.10.0  |
+| 0.1.9 - 0.1.17     |  1.10.1  |
+| 0.1.18 - 0.2.0     |  1.12.0  |
+| 0.2.1 - current    |  1.13.0  |

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1185,7 +1185,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 ### `--js-version`
 
-The Scala.js version (1.12.0 by default).
+The Scala.js version (1.13.0 by default).
 
 ### `--js-mode`
 
@@ -1245,7 +1245,7 @@ Path to the Scala.js linker
 ### `--js-cli-version`
 
 [Internal]
-Scala.js CLI version to use for linking (1.1.3-sc1 by default).
+Scala.js CLI version to use for linking (1.13.0 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -658,7 +658,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 `SHOULD have` per Scala Runner specification
 
-The Scala.js version (1.12.0 by default).
+The Scala.js version (1.13.0 by default).
 
 ### `--js-mode`
 
@@ -746,7 +746,7 @@ Path to the Scala.js linker
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Scala.js CLI version to use for linking (1.1.3-sc1 by default).
+Scala.js CLI version to use for linking (1.13.0 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -118,7 +118,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.12.0 by default).
+The Scala.js version (1.13.0 by default).
 
 **--js-mode**
 
@@ -358,7 +358,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.1.3-sc1 by default).
+Scala.js CLI version to use for linking (1.13.0 by default).
 
 **--js-cli-java-arg**
 
@@ -815,7 +815,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.12.0 by default).
+The Scala.js version (1.13.0 by default).
 
 **--js-mode**
 
@@ -1039,7 +1039,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.1.3-sc1 by default).
+Scala.js CLI version to use for linking (1.13.0 by default).
 
 **--js-cli-java-arg**
 
@@ -1336,7 +1336,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.12.0 by default).
+The Scala.js version (1.13.0 by default).
 
 **--js-mode**
 
@@ -1566,7 +1566,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.1.3-sc1 by default).
+Scala.js CLI version to use for linking (1.13.0 by default).
 
 **--js-cli-java-arg**
 
@@ -1883,7 +1883,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.12.0 by default).
+The Scala.js version (1.13.0 by default).
 
 **--js-mode**
 
@@ -2123,7 +2123,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.1.3-sc1 by default).
+Scala.js CLI version to use for linking (1.13.0 by default).
 
 **--js-cli-java-arg**
 
@@ -2449,7 +2449,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.12.0 by default).
+The Scala.js version (1.13.0 by default).
 
 **--js-mode**
 
@@ -2689,7 +2689,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.1.3-sc1 by default).
+Scala.js CLI version to use for linking (1.13.0 by default).
 
 **--js-cli-java-arg**
 
@@ -2991,7 +2991,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.12.0 by default).
+The Scala.js version (1.13.0 by default).
 
 **--js-mode**
 
@@ -3213,7 +3213,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.1.3-sc1 by default).
+Scala.js CLI version to use for linking (1.13.0 by default).
 
 **--js-cli-java-arg**
 
@@ -3570,7 +3570,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.12.0 by default).
+The Scala.js version (1.13.0 by default).
 
 **--js-mode**
 
@@ -3812,7 +3812,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.1.3-sc1 by default).
+Scala.js CLI version to use for linking (1.13.0 by default).
 
 **--js-cli-java-arg**
 
@@ -4188,7 +4188,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.12.0 by default).
+The Scala.js version (1.13.0 by default).
 
 **--js-mode**
 
@@ -4406,7 +4406,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.1.3-sc1 by default).
+Scala.js CLI version to use for linking (1.13.0 by default).
 
 **--js-cli-java-arg**
 
@@ -5001,7 +5001,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.12.0 by default).
+The Scala.js version (1.13.0 by default).
 
 **--js-mode**
 
@@ -5219,7 +5219,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.1.3-sc1 by default).
+Scala.js CLI version to use for linking (1.13.0 by default).
 
 **--js-cli-java-arg**
 


### PR DESCRIPTION
Fixes #1893 and #534.

We have made changes to the release process for [scalajs-cli](https://github.com/VirtusLab/scala-js-cli).

We are now publishing `scalajs-cli` only for the latest version of Scala.js and release with the same version as Scala.js. Here are the details:

- For Maven, we publish` scalajs-cli` for version `1.13.0`. Any fixes will be tagged with the next number at the end of `1.13.0.1`.
- On GitHub, we upload native launchers for release `1.13.0.1` to the tags `1.13.0.1` and `1.13.0`. The same applies to the following releases, e.g. `1.13.0.2`, where we upload to the tags `1.13.0.2` and `1.13.0`.

Dependency in scala-cli:
-  we set the version to `org.virtuslab:scalajscli_2.13:1.13.0+` so that Coursier can download the latest version of `scalajs-cli` for a given version of Scala.js.
- we download the native version from the `1.13.0` tag, and in case of any fixes to the native `scalajs-cli` launchers, we upload the updated launchers to the `1.13.0` tag when publishing `1.13.0.1`.

Advantages:
- We can use new versions of Scala.js in older versions of scala-cli as soon as we publish `scalajs-cli` with the new version of Scala.js.