### PR TITLE
Further document publish command

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -899,7 +899,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
         PSigner.Nop
       else if (publishOptions.contextual(isCi).gpgSignatureId.isDefined)
         PSigner.Gpg
-      else if (repoParams.shouldSign)
+      else if (repoParams.shouldSign || publishOptions.contextual(isCi).secretKey.isDefined)
         PSigner.BouncyCastle
       else
         PSigner.Nop
@@ -936,7 +936,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
 
       // user specified --signer=bc or --secret-key=... or target repository requires signing
       // --secret-key-password is possibly specified (not mandatory)
-      case PSigner.Nop | PSigner.BouncyCastle
+      case PSigner.BouncyCastle
           if publishOptions.contextual(isCi).secretKey.isDefined =>
         val secretKeyConfigOpt = publishOptions.contextual(isCi).secretKey.get
         for {

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -250,6 +250,8 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
     )
   }
 
+  /** Build artifacts
+    */
   def doRun(
     inputs: Inputs,
     logger: Logger,
@@ -367,6 +369,9 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
   def defaultVersion: Either[BuildException, String] =
     Left(defaultVersionError)
 
+  /** Check if all builds are successful and proceed with preparing files to be uploaded OR print
+    * main classes if the option is specified
+    */
   private def maybePublish(
     builds: Builds,
     workingDir: os.Path,
@@ -403,7 +408,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
         builds.main match {
           case s: Build.Successful if mainClassOptions.mainClassLs.contains(true) =>
             mainClassOptions.maybePrintMainClasses(s.foundMainClasses(), shouldExit = allowExit)
-          case _ => doPublish(
+          case _ => prepareFilesAndUpload(
               builds0,
               docBuilds0,
               workingDir,
@@ -430,6 +435,9 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
     }
   }
 
+  /** Get organization, project name and version from options and directives or try to compute
+    * defaults
+    */
   private def orgNameVersion(
     publishOptions: scala.build.options.PublishOptions,
     workspace: os.Path,
@@ -704,7 +712,9 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
     (fileSet, (mod, ver))
   }
 
-  private def doPublish(
+  /** Sign and checksum files, then upload everything to the target repository
+    */
+  private def prepareFilesAndUpload(
     builds: Seq[Build.Successful],
     docBuilds: Seq[Build.Successful],
     workingDir: os.Path,
@@ -953,7 +963,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
       case _ =>
         if (!publishOptions.contextual(isCi).signer.contains(PSigner.Nop))
           logger.message(
-            "\ud83d\udd13 Artifacts NOT signed as it's not required nor has it been specified"
+            " \ud83d\udd13 Artifacts NOT signed as it's not required nor has it been specified"
           )
         Right(NopSigner)
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
@@ -455,4 +455,62 @@ abstract class PublishTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
 
+  test("signer=none overrides other options") {
+
+    TestCase.testInputs.fromRoot { root =>
+      val confDir  = root / "config"
+      val confFile = confDir / "test-config.json"
+
+      os.write(confFile, "{}", createFolders = true)
+
+      if (!Properties.isWin)
+        os.perms.set(confDir, "rwx------")
+
+      val extraEnv = Map("SCALA_CLI_CONFIG" -> confFile.toString)
+
+      os.proc(
+        TestUtil.cli,
+        "--power",
+        "config",
+        "--create-pgp-key",
+        "--email",
+        "some_email"
+      ).call(cwd = root, env = extraEnv)
+
+      TestCase.testInputs.fromRoot { root =>
+        os.proc(
+          TestUtil.cli,
+          "--power",
+          "publish",
+          extraOptions,
+          "--secret-key",
+          "value:INCORRECT_KEY",
+          "--signer",
+          "none",
+          "project",
+          "-R",
+          "test-repo"
+        ).call(
+          cwd = root,
+          stdin = os.Inherit,
+          stdout = os.Inherit,
+          env = extraEnv
+        )
+
+        val files = os.walk(root / "test-repo")
+          .filter(os.isFile(_))
+          .map(_.relativeTo(root / "test-repo"))
+        val notInDir = files.filter(!_.startsWith(TestCase.expectedArtifactsDir))
+        expect(notInDir.isEmpty)
+
+        val files0 = files.map(_.relativeTo(TestCase.expectedArtifactsDir)).toSet
+
+        val expectedArtifactsNotSigned = expectedArtifacts.filterNot(_.last.contains(".asc"))
+
+        expect((files0 -- expectedArtifactsNotSigned).isEmpty)
+        expect((expectedArtifactsNotSigned -- files0).isEmpty)
+        expect(files0 == expectedArtifactsNotSigned) // just in case…
+      }
+    }
+  }
 }

--- a/website/docs/commands/publishing/publish-setup.md
+++ b/website/docs/commands/publishing/publish-setup.md
@@ -86,7 +86,7 @@ in Scala CLI (via the `publish.credentials` config key in both cases).
 
 These can be written in the Scala CLI configuration the following way:
 ```sh
-SONATYPE_USER=me SONATYPE_PASSWORD=1234 scala-cli config publish.credentials s01.oss.sonatype.org env:SONATYPE_USER env:SONATYPE_PASSWORD --password-value
+scala-cli config publish.credentials s01.oss.sonatype.org env:SONATYPE_USER env:SONATYPE_PASSWORD --password-value
 ```
 
 Note that both user and password arguments are assumed to be secrets, and

--- a/website/docs/commands/publishing/publish-setup.md
+++ b/website/docs/commands/publishing/publish-setup.md
@@ -50,26 +50,26 @@ the sections below show how to use it to configure things for `publish setup`.
 ### User details
 
 Set details with
-```sh
+```bash ignore
 scala-cli config publish.user.name "Alex Me"
 scala-cli config publish.user.email "alex@alex.me"
 scala-cli config publish.user.url "https://alex.me"
 ```
 
 The email can be left empty if you'd rather not put your email in POM files:
-```sh
+```bash ignore
 scala-cli config publish.user.email ""
 ```
 
 ### PGP key pair
 
 Generate a PGP key pair for publishing with
-```sh
+```bash ignore
 scala-cli config --create-pgp-key
 ```
 
 This sets 3 entries in the Scala CLI configuration, that you can print with
-```sh
+```bash ignore
 scala-cli config pgp.public-key
 scala-cli config pgp.secret-key
 scala-cli config pgp.secret-key-password
@@ -85,7 +85,7 @@ to create an account there. Either your real Sonatype username and password, or 
 in Scala CLI (via the `publish.credentials` config key in both cases).
 
 These can be written in the Scala CLI configuration the following way:
-```sh
+```bash ignore
 scala-cli config publish.credentials s01.oss.sonatype.org env:SONATYPE_USER env:SONATYPE_PASSWORD --password-value
 ```
 
@@ -100,7 +100,7 @@ ask the `config` sub-command to read environment variables and persist the passw
 
 If you'd rather persist the environment variable names in the Scala CLI configuration, rather than
 their values, you can do
-```sh
+```bash ignore
 scala-cli config publish.credentials s01.oss.sonatype.org env:SONATYPE_USER env:SONATYPE_PASSWORD
 ```
 
@@ -120,7 +120,7 @@ repository secrets, and the "write:packages" scope is required to upload artifac
 to GitHub packages.
 
 Once created, copy the token in your clipboard, and run
-```sh
+```bash ignore
 # macOS
 scala-cli config github.token command:pbpaste --password-value
 # Linux
@@ -134,7 +134,7 @@ It also uploads repository secrets there, when setting up publishing on GitHub a
 
 To create a new repository from a project, head to <https://repo.new>, pick a name
 for your project and create the repository. Note its URL, and do
-```sh
+```bash ignore
 scala-cli default-file .gitignore --write # if you don't have a .gitignore already
 git init # if git isn't set up already
 git remote add origin https://github.com/org/name # replace org/name with your freshly created repository values
@@ -146,7 +146,7 @@ To setup publishing in order to publish from your local machine, you can run
 
 <ChainedSnippets>
 
-```sh
+```bash ignore
 scala-cli publish setup .
 ```
 
@@ -183,7 +183,7 @@ You can then publish your project from your local machine with
 
 <ChainedSnippets>
 
-```sh
+```bash ignore
 scala-cli publish .
 ```
 
@@ -204,7 +204,7 @@ To setup publishing from GitHub actions, you can run
 
 <ChainedSnippets>
 
-```sh
+```bash ignore
 scala-cli publish setup . --ci
 ```
 
@@ -258,6 +258,6 @@ prefix), or create a release with a tag with the same name from the GitHub UI.
 
 In order to setup publishing to GitHub packages, pass `--publish-repository github` to the
 `publish setup` commands above, like
-```sh
+```bash ignore
 scala-cli publish setup . --publish-repository github
 ```

--- a/website/docs/commands/publishing/publish.md
+++ b/website/docs/commands/publishing/publish.md
@@ -84,14 +84,14 @@ To override this default value, set the `publish.computeVersion` directive, like
 ## Repository settings
 
 A repository is required for the `publish` command, and might need other settings to work fine
-(to pass credentials for example).
+(to pass credentials for example). See [Repositories](#repositories) for more information.
 
 When publishing from you CI, we recommend letting `scala-cli publish setup`
 setting those settings via using directives. When publishing from your local machine to Maven Central,
 we recommend setting the repository via a `publish.repository` directive, and keeping your
 Sonatype credentials in the Scala CLI settings, via commands such as
 ```bash
-SONATYPE_USER=… SONATYPE_PASSWORD=… scala-cli config publish.credentials s01.oss.sonatype.org env:SONATYPE_USER env:SONATYPE_PASSWORD
+scala-cli config publish.credentials s01.oss.sonatype.org env:SONATYPE_USER env:SONATYPE_PASSWORD
 ```
 
 <!-- TODO Automatically generate that? -->
@@ -125,6 +125,9 @@ handled by either
 - the [Bouncy Castle library](https://www.bouncycastle.org) (default, recommended)
 - the local `gpg` binary on your machine
 
+A signing mechanism will be chosen based on options and directives specified,
+it can also be overriden with `--signer` with one of those values: `bc`, `gpg` or `none`.
+
 #### Bouncy Castle
 
 A benefit of using Bouncy Castle to sign artifacts is that it has no external dependencies.
@@ -136,16 +139,26 @@ pass it like `--secret-key-password env:MY_KEY_PASSWORD`.
 
 Scala CLI can generate and keep a secret key for you. For that, create the key with
 ```sh
-scala-cli config --create-key
+scala-cli --power config --create-gpg-key
 ```
 
-You can then ask publish to use the key kept in the Scala CLI config with
-```sh
-scala-cli publish \
-  --secret-key config:pgp.secret-key \
-  --secret-key-password config:pgp.secret-key-password \
-  …
-```
+This generated key kept in config will be used by default unless specified otherwise, e.g.:
+- with directives:
+    ```bash
+    //> using publish.secretKey env:PGP_SECRET
+    //> using publish.secretKeyPassword command:get_my_password
+    ```
+
+- with options:
+    ```sh
+    scala-cli publish \
+      --secret-key env:PGP_SECRET \
+      --secret-key-password file:pgp_password.txt \
+      …
+    ```
+
+Since these values should be kept secret the options and directives accept the format documented [here](/docs/reference/password-options.md).
+Furthermore command line options accept an extra format - `config:…` for using config entries.
 
 #### GPG
 
@@ -153,8 +166,10 @@ Using GPG to sign artifacts requires the `gpg` binary to be installed on your sy
 A benefit of using `gpg` to sign artifacts over Bouncy Castle is: you can use keys from
 your GPG key ring, or from external devices that GPG may support.
 
-To enable signing with GPG, pass `--gpg-key *key_id*` on the command line. If needed,
-you can specify arguments meant to be passed to `gpg`, with `--gpg-option`, like
+To enable signing with GPG, pass `--gpg-key *key_id*` on the command line
+or specify it by `//>using publish.gpgKey "key_id"`.
+If needed, you can specify arguments meant to be passed to `gpg`,
+with `--gpg-option` or `//>using publish.gpgOptions "--opt1" "--opt2"`, like
 ```text
 --gpg-key 1234567890ABCDEF --gpg-option --foo --gpg-option --bar
 ```
@@ -200,9 +215,13 @@ used if it's there. Else the main directive is used.
 
 ### Maven Central
 
+The easiest way right now to publish to Maven Central Repository is to use
+Sonatype repositories - `s01.oss.sonatype.org` or `oss.sonatype.org`
+Since 25.02.2021 `s01` is the default server for new users, if your account is older than that
+you probably need to use the legacy `oss.sonatype.org`. More about this [here](https://central.sonatype.org/news/20210223_new-users-on-s01/#question).
+
 Use `central` as repository to push artifacts to Maven Central via `oss.sonatype.org`.
-To push to it via `s01.oss.sonatype.org` (the default for newly created repositories),
-use `central-s01`.
+To push to it via `s01.oss.sonatype.org`, use `central-s01`.
 
 When using `central` or `central-s01` as repository, artifacts are pushed
 either to `https://oss.sonatype.org/content/repositories/snapshots` (versions
@@ -247,13 +266,14 @@ and the [CI overrides](#ci-overrides).
 ## Publishing
 
 Once all the necessary settings are set, publish a Scala CLI project with a command
-such as this one (`.` is for the Scala CLI project in the current directory):
+such as this one:
 
 <ChainedSnippets>
 
 ```sh
 scala-cli publish .
 ```
+(`.` is for the Scala CLI project in the current directory)
 
 ```text
 Publishing io.github.scala-cli:hello-scala-cli_3:0.1.0-SNAPSHOT

--- a/website/docs/commands/publishing/publish.md
+++ b/website/docs/commands/publishing/publish.md
@@ -90,7 +90,7 @@ When publishing from you CI, we recommend letting `scala-cli publish setup`
 setting those settings via using directives. When publishing from your local machine to Maven Central,
 we recommend setting the repository via a `publish.repository` directive, and keeping your
 Sonatype credentials in the Scala CLI settings, via commands such as
-```bash
+```bash ignore
 scala-cli config publish.credentials s01.oss.sonatype.org env:SONATYPE_USER env:SONATYPE_PASSWORD
 ```
 
@@ -126,39 +126,45 @@ handled by either
 - the local `gpg` binary on your machine
 
 A signing mechanism will be chosen based on options and directives specified,
-it can also be overriden with `--signer` with one of those values: `bc`, `gpg` or `none`.
+it can also be overriden with `--signer` with one of the values:
+- `bc` - Bouncy Castle library will be used for signing, PGP secret key is required
+- `gpg` - a local `gpg` binary will be used for singing, GPG key ID is required
+- `none` - NO singing will take place
 
 #### Bouncy Castle
 
-A benefit of using Bouncy Castle to sign artifacts is that it has no external dependencies.
+Bouncy Castle library is the recommended way of singing artifacts with Scala CLI. 
+A benefit of using it is that it has no external dependencies,
 Scala CLI is able to sign things with Bouncy Castle without further setup on your side.
 
-To enable signing with Bouncy Castle (recommended), pass a secret key with
-`--secret-key file:/path/to/secret-key`. If the key is protected by a password,
-pass it like `--secret-key-password env:MY_KEY_PASSWORD`.
+When the `--signer` option is not specified Bouncy Castle library will be used for signing
+if one of these conditions occur:
+- the `--secret-key` option has been passed
+- target repository requires signing (e.g. `central`)
 
-Scala CLI can generate and keep a secret key for you. For that, create the key with
-```sh
-scala-cli --power config --create-gpg-key
+To succesfully use PGP signing with Bouncy Castle a secret key, possibly protected by a password is required.
+Scala CLI can generate and keep PGP keys for you by using:
+```bash ignore
+scala-cli --power config --create-pgp-key
 ```
 
-This generated key kept in config will be used by default unless specified otherwise, e.g.:
+This generates a public key and password protected private key, all values are kept in config
+and will be used by default unless specified otherwise:
 - with directives:
-    ```bash
+    ```scala
     //> using publish.secretKey env:PGP_SECRET
     //> using publish.secretKeyPassword command:get_my_password
     ```
 
 - with options:
-    ```sh
-    scala-cli publish \
+    ```bash ignore
+    scala-cli --power publish \
       --secret-key env:PGP_SECRET \
       --secret-key-password file:pgp_password.txt \
       …
     ```
 
-Since these values should be kept secret the options and directives accept the format documented [here](/docs/reference/password-options.md).
-Furthermore command line options accept an extra format - `config:…` for using config entries.
+Since these values should be kept secret, the options and directives accept the format documented [here](/docs/reference/password-options.md).
 
 #### GPG
 
@@ -167,7 +173,7 @@ A benefit of using `gpg` to sign artifacts over Bouncy Castle is: you can use ke
 your GPG key ring, or from external devices that GPG may support.
 
 To enable signing with GPG, pass `--gpg-key *key_id*` on the command line
-or specify it by `//>using publish.gpgKey "key_id"`.
+or specify it with a `using` directive: `//>using publish.gpgKey "key_id"`.
 If needed, you can specify arguments meant to be passed to `gpg`,
 with `--gpg-option` or `//>using publish.gpgOptions "--opt1" "--opt2"`, like
 ```text
@@ -215,7 +221,7 @@ used if it's there. Else the main directive is used.
 
 ### Maven Central
 
-The easiest way right now to publish to Maven Central Repository is to use
+Right now the easiest way to publish to Maven Central Repository is to use
 Sonatype repositories - `s01.oss.sonatype.org` or `oss.sonatype.org`
 Since 25.02.2021 `s01` is the default server for new users, if your account is older than that
 you probably need to use the legacy `oss.sonatype.org`. More about this [here](https://central.sonatype.org/news/20210223_new-users-on-s01/#question).
@@ -270,8 +276,8 @@ such as this one:
 
 <ChainedSnippets>
 
-```sh
-scala-cli publish .
+```bash ignore
+scala-cli --power publish .
 ```
 (`.` is for the Scala CLI project in the current directory)
 


### PR DESCRIPTION
Additionaly:
- fix choosing signing mechanism so that `--signer none` always takes priority