### PR TITLE
Suggest users to clean working directory when Nailgun server failed

### DIFF
--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifleLogger.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/BloopRifleLogger.scala
@@ -9,6 +9,7 @@ trait BloopRifleLogger { self =>
   def debug(msg: => String, ex: Throwable): Unit
   final def debug(msg: => String): Unit = debug(msg, null)
   def error(msg: => String, ex: Throwable): Unit
+  def error(msg: => String): Unit
   def runnable(name: String)(r: Runnable): Runnable = { () =>
     try r.run()
     catch {
@@ -39,6 +40,7 @@ object BloopRifleLogger {
       def info(msg: => String)                 = {}
       def debug(msg: => String, ex: Throwable) = {}
       def error(msg: => String, ex: Throwable) = {}
+      def error(msg: => String)                = {}
       def bloopBspStdout                       = None
       def bloopBspStderr                       = None
       def bloopCliInheritStdout                = false

--- a/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Operations.scala
+++ b/modules/bloop-rifle/src/main/scala/scala/build/blooprifle/internal/Operations.scala
@@ -339,7 +339,7 @@ object Operations {
     }
     val runnable: Runnable = logger.runnable(threadName) { () =>
       val maybeRetCode = Try {
-        nailgunClient0.run(
+        val retCode = nailgunClient0.run(
           "bsp",
           protocolArgs,
           workingDir,
@@ -349,6 +349,12 @@ object Operations {
           stop0,
           interactiveSession = false
         )
+        if (retCode != 0)
+          logger.error(
+            s"""Bloop 'bsp' command exited with code $retCode. Something may be wrong with the current configuration.
+               |Running the ${Console.BOLD}clean${Console.RESET} sub-command to clear the working directory and remove caches might help.
+               |If the error persists, please report the issue as a bug and attach a log with increased verbosity by passing ${Console.BOLD}-v -v -v${Console.RESET}.""".stripMargin)
+        retCode
       }
       try promise.complete(maybeRetCode)
       catch { case _: IllegalStateException => }

--- a/modules/build/src/test/scala/scala/build/tests/TestLogger.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestLogger.scala
@@ -60,6 +60,7 @@ case class TestLogger(info: Boolean = true, debug: Boolean = false) extends Logg
           System.err.println(msg)
           if (ex != null) ex.printStackTrace(System.err)
         }
+        def error(msg: => String): Unit = System.err.println(msg)
         def info(msg: => String): Unit =
           System.err.println(msg)
       }

--- a/modules/cli/src/main/scala/scala/cli/internal/CliLogger.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/CliLogger.scala
@@ -164,10 +164,11 @@ class CliLogger(
             ex.printStackTrace(out)
         }
       def error(msg: => String, ex: Throwable) = {
-        logger.log(s"Error: $msg ($ex)")
+        logger.error(s"Error: $msg ($ex)")
         if (verbosity >= 1 && ex != null)
           ex.printStackTrace(out)
       }
+      def error(msg: => String) = logger.error(msg)
       def bloopBspStdout =
         if (verbosity >= 2) Some(out)
         else None


### PR DESCRIPTION
Fixes #1882.

I reproduced bug from #1882, and now when users run `scala-cli` it print the following error:
```
➜  scala-demo /Users/lwronski/projects/scala-cli/out/cli/standaloneLauncher.dest/launcher Hello.scala 
[E] Failed to load project from /private/tmp/scala-demo/.scala-build/.bloop/project_853f6d1dbb-25fccf1679.json
Something is wrong with the current configuration. Nailgun server failed with exit code 1.
To resolve the problem, please run the clean sub-command to clear the working directory and remove caches.
If the error persists, please report the issue as a bug and attach a log with increased verbosity by passing -v -v -v.
Error: java.lang.RuntimeException: Bloop BSP connection in /Users/lwronski/Library/Caches/ScalaCli/bsp-sockets/proc-91655 was unexpectedly closed or bloop didn't start.
For more details, please see '/private/tmp/scala-demo/.scala-build/stacktraces/1678358545-18379785233871606763.log'
```