### PR TITLE
Print warnings when experimental features are used

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -233,7 +233,7 @@ object Build {
           () => options.javaHome().value.javaCommand
         ),
         logger,
-        options.suppressWarningOptions.suppressDirectivesInMultipleFilesWarning
+        options.suppressWarningOptions
       )
     }
     val sharedOptions = crossSources.sharedOptions(options)

--- a/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
@@ -99,16 +99,16 @@ final class BspImpl(
     // allInputs contains elements from using directives
     val (crossSources, allInputs) = value {
       CrossSources.forInputs(
-        inputs,
-        Sources.defaultPreprocessors(
+        inputs = inputs,
+        preprocessors = Sources.defaultPreprocessors(
           buildOptions.scriptOptions.codeWrapper.getOrElse(CustomCodeWrapper),
           buildOptions.archiveCache,
           buildOptions.internal.javaClassNameVersionOpt,
           () => buildOptions.javaHome().value.javaCommand
         ),
-        persistentLogger,
-        suppressDirectivesInMultipleFilesWarning = None,
-        maybeRecoverOnError(Scope.Main)
+        logger = persistentLogger,
+        suppressWarningOptions = buildOptions.suppressWarningOptions,
+        maybeRecoverOnError = maybeRecoverOnError(Scope.Main)
       ).left.map((_, Scope.Main))
     }
 

--- a/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
+++ b/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
@@ -1,0 +1,19 @@
+package scala.build.internal.util
+
+import scala.build.internal.Constants
+
+object WarningMessages {
+  private val scalaCliGithubUrl = s"https://github.com/${Constants.ghOrg}/${Constants.ghName}"
+  def experimentalFeatureUsed(featureName: String): String =
+    s"""$featureName is an experimental feature.
+       |Please bear in mind that non-ideal user experience should be expected.
+       |If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at $scalaCliGithubUrl""".stripMargin
+  def experimentalDirectiveUsed(name: String): String =
+    experimentalFeatureUsed(s"The '$name' directive")
+
+  def experimentalSubcommandUsed(name: String): String =
+    experimentalFeatureUsed(s"The '$name' sub-command")
+
+  def experimentalOptionUsed(name: String): String =
+    experimentalFeatureUsed(s"The '$name' option")
+}

--- a/modules/build/src/main/scala/scala/build/preprocessing/DataPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/DataPreprocessor.scala
@@ -6,7 +6,7 @@ import scala.build.EitherCps.{either, value}
 import scala.build.Logger
 import scala.build.errors.BuildException
 import scala.build.input.{Inputs, SingleElement, VirtualData}
-import scala.build.options.BuildRequirements
+import scala.build.options.{BuildRequirements, SuppressWarningOptions}
 import scala.build.preprocessing.PreprocessingUtil.optionsAndPositionsFromDirectives
 
 case object DataPreprocessor extends Preprocessor {
@@ -14,7 +14,8 @@ case object DataPreprocessor extends Preprocessor {
     input: SingleElement,
     logger: Logger,
     maybeRecoverOnError: BuildException => Option[BuildException] = e => Some(e),
-    allowRestrictedFeatures: Boolean
+    allowRestrictedFeatures: Boolean,
+    suppressWarningOptions: SuppressWarningOptions
   ): Option[Either[BuildException, Seq[PreprocessedSource]]] =
     input match {
       case file: VirtualData =>
@@ -27,7 +28,8 @@ case object DataPreprocessor extends Preprocessor {
               Left(file.subPath.toString),
               logger,
               maybeRecoverOnError,
-              allowRestrictedFeatures
+              allowRestrictedFeatures,
+              suppressWarningOptions
             )
           }
 

--- a/modules/build/src/main/scala/scala/build/preprocessing/JarPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/JarPreprocessor.scala
@@ -6,7 +6,12 @@ import scala.build.EitherCps.{either, value}
 import scala.build.Logger
 import scala.build.errors.BuildException
 import scala.build.input.{Inputs, JarFile, SingleElement}
-import scala.build.options.{BuildOptions, BuildRequirements, ClassPathOptions}
+import scala.build.options.{
+  BuildOptions,
+  BuildRequirements,
+  ClassPathOptions,
+  SuppressWarningOptions
+}
 import scala.build.preprocessing.PreprocessingUtil.optionsAndPositionsFromDirectives
 
 case object JarPreprocessor extends Preprocessor {
@@ -14,7 +19,8 @@ case object JarPreprocessor extends Preprocessor {
     input: SingleElement,
     logger: Logger,
     maybeRecoverOnError: BuildException => Option[BuildException] = e => Some(e),
-    allowRestrictedFeatures: Boolean
+    allowRestrictedFeatures: Boolean,
+    suppressWarningOptions: SuppressWarningOptions
   ): Option[Either[BuildException, Seq[PreprocessedSource]]] =
     input match {
       case jar: JarFile => Some(either {

--- a/modules/build/src/main/scala/scala/build/preprocessing/JavaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/JavaPreprocessor.scala
@@ -11,7 +11,7 @@ import scala.build.Logger
 import scala.build.errors.BuildException
 import scala.build.input.{Inputs, JavaFile, SingleElement, VirtualJavaFile}
 import scala.build.internal.JavaParserProxyMaker
-import scala.build.options.BuildRequirements
+import scala.build.options.{BuildRequirements, SuppressWarningOptions}
 import scala.build.preprocessing.ExtractedDirectives.from
 import scala.build.preprocessing.PreprocessingUtil.optionsAndPositionsFromDirectives
 import scala.build.preprocessing.ScalaPreprocessor.*
@@ -37,7 +37,8 @@ final case class JavaPreprocessor(
     input: SingleElement,
     logger: Logger,
     maybeRecoverOnError: BuildException => Option[BuildException] = e => Some(e),
-    allowRestrictedFeatures: Boolean
+    allowRestrictedFeatures: Boolean,
+    suppressWarningOptions: SuppressWarningOptions
   ): Option[Either[BuildException, Seq[PreprocessedSource]]] =
     input match {
       case j: JavaFile => Some(either {
@@ -50,7 +51,8 @@ final case class JavaPreprocessor(
               Right(j.path),
               logger,
               maybeRecoverOnError,
-              allowRestrictedFeatures
+              allowRestrictedFeatures,
+              suppressWarningOptions
             )
           }
           Seq(PreprocessedSource.OnDisk(
@@ -90,7 +92,8 @@ final case class JavaPreprocessor(
               Left(relPath.toString),
               logger,
               maybeRecoverOnError,
-              allowRestrictedFeatures
+              allowRestrictedFeatures,
+              suppressWarningOptions
             )
           }
           val s = PreprocessedSource.InMemory(

--- a/modules/build/src/main/scala/scala/build/preprocessing/MarkdownPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/MarkdownPreprocessor.scala
@@ -8,7 +8,7 @@ import scala.build.errors.BuildException
 import scala.build.input.{Inputs, MarkdownFile, SingleElement, VirtualMarkdownFile}
 import scala.build.internal.markdown.{MarkdownCodeBlock, MarkdownCodeWrapper}
 import scala.build.internal.{AmmUtil, CodeWrapper, CustomCodeWrapper, Name}
-import scala.build.options.{BuildOptions, BuildRequirements}
+import scala.build.options.{BuildOptions, BuildRequirements, SuppressWarningOptions}
 import scala.build.preprocessing.ScalaPreprocessor.ProcessingOutput
 
 case object MarkdownPreprocessor extends Preprocessor {
@@ -16,7 +16,8 @@ case object MarkdownPreprocessor extends Preprocessor {
     input: SingleElement,
     logger: Logger,
     maybeRecoverOnError: BuildException => Option[BuildException],
-    allowRestrictedFeatures: Boolean
+    allowRestrictedFeatures: Boolean,
+    suppressWarningOptions: SuppressWarningOptions
   ): Option[Either[BuildException, Seq[PreprocessedSource]]] =
     input match {
       case markdown: MarkdownFile =>
@@ -30,7 +31,8 @@ case object MarkdownPreprocessor extends Preprocessor {
               ScopePath.fromPath(markdown.path),
               logger,
               maybeRecoverOnError,
-              allowRestrictedFeatures
+              allowRestrictedFeatures,
+              suppressWarningOptions
             )
           }
           preprocessed
@@ -47,7 +49,8 @@ case object MarkdownPreprocessor extends Preprocessor {
               markdown.scopePath,
               logger,
               maybeRecoverOnError,
-              allowRestrictedFeatures
+              allowRestrictedFeatures,
+              suppressWarningOptions
             )
           }
           preprocessed
@@ -64,7 +67,8 @@ case object MarkdownPreprocessor extends Preprocessor {
     scopePath: ScopePath,
     logger: Logger,
     maybeRecoverOnError: BuildException => Option[BuildException],
-    allowRestrictedFeatures: Boolean
+    allowRestrictedFeatures: Boolean,
+    suppressWarningOptions: SuppressWarningOptions
   ): Either[BuildException, List[PreprocessedSource.InMemory]] = either {
     def preprocessSnippets(
       maybeWrapper: Option[MarkdownCodeWrapper.WrappedMarkdownCode],
@@ -82,7 +86,8 @@ case object MarkdownPreprocessor extends Preprocessor {
                   scopeRoot = scopePath / os.up,
                   logger = logger,
                   maybeRecoverOnError = maybeRecoverOnError,
-                  allowRestrictedFeatures = allowRestrictedFeatures
+                  allowRestrictedFeatures = allowRestrictedFeatures,
+                  suppressWarningOptions = suppressWarningOptions
                 )
               }.getOrElse(ProcessingOutput(BuildRequirements(), Nil, BuildOptions(), None, None))
             val processedCode = processingOutput.updatedContent.getOrElse(wrappedMarkdown.code)

--- a/modules/build/src/main/scala/scala/build/preprocessing/PreprocessingUtil.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/PreprocessingUtil.scala
@@ -7,10 +7,10 @@ import java.nio.charset.StandardCharsets
 import scala.build.EitherCps.{either, value}
 import scala.build.Logger
 import scala.build.errors.{BuildException, FileNotFoundException}
-import scala.build.options.BuildOptions
+import scala.build.options.{BuildOptions, SuppressWarningOptions}
 import scala.build.preprocessing.DirectivesProcessor.DirectivesProcessorOutput
 import scala.build.preprocessing.ExtractedDirectives.from
-import scala.build.preprocessing.ScalaPreprocessor._
+import scala.build.preprocessing.ScalaPreprocessor.*
 
 object PreprocessingUtil {
 
@@ -26,7 +26,8 @@ object PreprocessingUtil {
     path: Either[String, os.Path],
     logger: Logger,
     maybeRecoverOnError: BuildException => Option[BuildException] = e => Some(e),
-    allowRestrictedFeatures: Boolean
+    allowRestrictedFeatures: Boolean,
+    suppressWarningOptions: SuppressWarningOptions
   ): Either[
     BuildException,
     (DirectivesProcessorOutput[BuildOptions], Option[DirectivesPositions])
@@ -46,7 +47,8 @@ object PreprocessingUtil {
       path,
       scopePath,
       logger,
-      allowRestrictedFeatures
+      allowRestrictedFeatures,
+      suppressWarningOptions
     ))
     (updatedOptions, directivesPositions)
   }

--- a/modules/build/src/main/scala/scala/build/preprocessing/Preprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/Preprocessor.scala
@@ -3,12 +3,14 @@ package scala.build.preprocessing
 import scala.build.Logger
 import scala.build.errors.BuildException
 import scala.build.input.{Inputs, SingleElement}
+import scala.build.options.SuppressWarningOptions
 
 trait Preprocessor {
   def preprocess(
     input: SingleElement,
     logger: Logger,
     maybeRecoverOnError: BuildException => Option[BuildException] = e => Some(e),
-    allowRestrictedFeatures: Boolean
+    allowRestrictedFeatures: Boolean,
+    suppressWarningOptions: SuppressWarningOptions
   ): Option[Either[BuildException, Seq[PreprocessedSource]]]
 }

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -12,7 +12,13 @@ import scala.build.directives.{HasBuildOptions, HasBuildRequirements}
 import scala.build.errors.*
 import scala.build.input.{Inputs, ScalaFile, SingleElement, VirtualScalaFile}
 import scala.build.internal.Util
-import scala.build.options.{BuildOptions, BuildRequirements, ClassPathOptions, ShadowingSeq}
+import scala.build.options.{
+  BuildOptions,
+  BuildRequirements,
+  ClassPathOptions,
+  ShadowingSeq,
+  SuppressWarningOptions
+}
 import scala.build.preprocessing.directives
 import scala.build.preprocessing.directives.{DirectiveHandler, DirectiveUtil, ScopedDirective}
 import scala.build.{Logger, Position, Positioned}
@@ -86,7 +92,8 @@ case object ScalaPreprocessor extends Preprocessor {
     input: SingleElement,
     logger: Logger,
     maybeRecoverOnError: BuildException => Option[BuildException] = e => Some(e),
-    allowRestrictedFeatures: Boolean
+    allowRestrictedFeatures: Boolean,
+    suppressWarningOptions: SuppressWarningOptions
   ): Option[Either[BuildException, Seq[PreprocessedSource]]] =
     input match {
       case f: ScalaFile =>
@@ -101,7 +108,8 @@ case object ScalaPreprocessor extends Preprocessor {
                 scopePath / os.up,
                 logger,
                 maybeRecoverOnError,
-                allowRestrictedFeatures
+                allowRestrictedFeatures,
+                suppressWarningOptions
               )
             ) match {
               case None =>
@@ -160,7 +168,8 @@ case object ScalaPreprocessor extends Preprocessor {
                 v.scopePath / os.up,
                 logger,
                 maybeRecoverOnError,
-                allowRestrictedFeatures
+                allowRestrictedFeatures,
+                suppressWarningOptions
               )
             ).map {
               case ProcessingOutput(reqs, scopedReqs, opts, updatedContent, dirsPositions) =>
@@ -192,7 +201,8 @@ case object ScalaPreprocessor extends Preprocessor {
     scopeRoot: ScopePath,
     logger: Logger,
     maybeRecoverOnError: BuildException => Option[BuildException],
-    allowRestrictedFeatures: Boolean
+    allowRestrictedFeatures: Boolean,
+    suppressWarningOptions: SuppressWarningOptions
   ): Either[BuildException, Option[ProcessingOutput]] = either {
     val (contentWithNoShebang, _) = SheBang.ignoreSheBangLines(content)
     val extractedDirectives = value(ExtractedDirectives.from(
@@ -210,7 +220,8 @@ case object ScalaPreprocessor extends Preprocessor {
       scopeRoot,
       logger,
       maybeRecoverOnError,
-      allowRestrictedFeatures
+      allowRestrictedFeatures,
+      suppressWarningOptions
     ))
   }
 
@@ -221,7 +232,8 @@ case object ScalaPreprocessor extends Preprocessor {
     scopeRoot: ScopePath,
     logger: Logger,
     maybeRecoverOnError: BuildException => Option[BuildException],
-    allowRestrictedFeatures: Boolean
+    allowRestrictedFeatures: Boolean,
+    suppressWarningOptions: SuppressWarningOptions
   ): Either[BuildException, Option[ProcessingOutput]] = either {
     val (content0, isSheBang) = SheBang.ignoreSheBangLines(content)
     val afterStrictUsing: StrictDirectivesProcessingOutput =
@@ -231,7 +243,8 @@ case object ScalaPreprocessor extends Preprocessor {
         path,
         scopeRoot,
         logger,
-        allowRestrictedFeatures
+        allowRestrictedFeatures,
+        suppressWarningOptions
       ))
 
     value {
@@ -332,7 +345,8 @@ case object ScalaPreprocessor extends Preprocessor {
     path: Either[String, os.Path],
     cwd: ScopePath,
     logger: Logger,
-    allowRestrictedFeatures: Boolean
+    allowRestrictedFeatures: Boolean,
+    suppressWarningOptions: SuppressWarningOptions
   ): Either[BuildException, StrictDirectivesProcessingOutput] = either {
     val contentChars = content.toCharArray
 
@@ -345,7 +359,8 @@ case object ScalaPreprocessor extends Preprocessor {
         path,
         cwd,
         logger,
-        allowRestrictedFeatures
+        allowRestrictedFeatures,
+        suppressWarningOptions
       )
     }
 
@@ -358,7 +373,8 @@ case object ScalaPreprocessor extends Preprocessor {
         path,
         cwd,
         logger,
-        allowRestrictedFeatures
+        allowRestrictedFeatures,
+        suppressWarningOptions
       )
     }
 

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
@@ -7,7 +7,7 @@ import scala.build.Logger
 import scala.build.errors.BuildException
 import scala.build.input.{Inputs, Script, SingleElement, VirtualScript}
 import scala.build.internal.{AmmUtil, CodeWrapper, CustomCodeWrapper, Name}
-import scala.build.options.{BuildOptions, BuildRequirements}
+import scala.build.options.{BuildOptions, BuildRequirements, SuppressWarningOptions}
 import scala.build.preprocessing.ScalaPreprocessor.ProcessingOutput
 
 final case class ScriptPreprocessor(codeWrapper: CodeWrapper) extends Preprocessor {
@@ -15,7 +15,8 @@ final case class ScriptPreprocessor(codeWrapper: CodeWrapper) extends Preprocess
     input: SingleElement,
     logger: Logger,
     maybeRecoverOnError: BuildException => Option[BuildException] = e => Some(e),
-    allowRestrictedFeatures: Boolean
+    allowRestrictedFeatures: Boolean,
+    suppressWarningOptions: SuppressWarningOptions
   ): Option[Either[BuildException, Seq[PreprocessedSource]]] =
     input match {
       case script: Script =>
@@ -30,7 +31,8 @@ final case class ScriptPreprocessor(codeWrapper: CodeWrapper) extends Preprocess
               ScopePath.fromPath(script.path),
               logger,
               maybeRecoverOnError,
-              allowRestrictedFeatures
+              allowRestrictedFeatures,
+              suppressWarningOptions
             )
           }
           preprocessed
@@ -50,7 +52,8 @@ final case class ScriptPreprocessor(codeWrapper: CodeWrapper) extends Preprocess
               script.scopePath,
               logger,
               maybeRecoverOnError,
-              allowRestrictedFeatures
+              allowRestrictedFeatures,
+              suppressWarningOptions
             )
           }
           preprocessed
@@ -72,7 +75,8 @@ object ScriptPreprocessor {
     scopePath: ScopePath,
     logger: Logger,
     maybeRecoverOnError: BuildException => Option[BuildException],
-    allowRestrictedFeatures: Boolean
+    allowRestrictedFeatures: Boolean,
+    suppressWarningOptions: SuppressWarningOptions
   ): Either[BuildException, List[PreprocessedSource.InMemory]] = either {
 
     val (contentIgnoredSheBangLines, _) = SheBang.ignoreSheBangLines(content)
@@ -86,7 +90,8 @@ object ScriptPreprocessor {
         scopePath / os.up,
         logger,
         maybeRecoverOnError,
-        allowRestrictedFeatures
+        allowRestrictedFeatures,
+        suppressWarningOptions
       ))
         .getOrElse(ProcessingOutput(BuildRequirements(), Nil, BuildOptions(), None, None))
 

--- a/modules/build/src/test/scala/scala/build/tests/PreprocessingTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/PreprocessingTests.scala
@@ -1,10 +1,11 @@
 package scala.build.tests
 
-import scala.build.preprocessing.{ScalaPreprocessor, ScriptPreprocessor, MarkdownPreprocessor}
+import scala.build.preprocessing.{MarkdownPreprocessor, ScalaPreprocessor, ScriptPreprocessor}
 import com.eed3si9n.expecty.Expecty.expect
-import scala.build.input.{Inputs, SourceScalaFile, MarkdownFile, Script}
 
+import scala.build.input.{Inputs, MarkdownFile, Script, SourceScalaFile}
 import scala.build.internal.CustomCodeWrapper
+import scala.build.options.SuppressWarningOptions
 
 class PreprocessingTests extends munit.FunSuite {
 
@@ -12,7 +13,12 @@ class PreprocessingTests extends munit.FunSuite {
     val logger    = TestLogger()
     val scalaFile = SourceScalaFile(os.temp.dir(), os.SubPath("NotExists.scala"))
 
-    val res = ScalaPreprocessor.preprocess(scalaFile, logger, allowRestrictedFeatures = false)
+    val res = ScalaPreprocessor.preprocess(
+      scalaFile,
+      logger,
+      allowRestrictedFeatures = false,
+      suppressWarningOptions = SuppressWarningOptions()
+    )
     val expectedMessage = s"File not found: ${scalaFile.path}"
 
     assert(res.nonEmpty)
@@ -27,7 +33,8 @@ class PreprocessingTests extends munit.FunSuite {
     val res = ScriptPreprocessor(CustomCodeWrapper).preprocess(
       scalaScript,
       logger,
-      allowRestrictedFeatures = false
+      allowRestrictedFeatures = false,
+      suppressWarningOptions = SuppressWarningOptions()
     )
     val expectedMessage = s"File not found: ${scalaScript.path}"
 
@@ -40,7 +47,12 @@ class PreprocessingTests extends munit.FunSuite {
     val logger       = TestLogger()
     val markdownFile = MarkdownFile(os.temp.dir(), os.SubPath("NotExists.md"))
 
-    val res = MarkdownPreprocessor.preprocess(markdownFile, logger, allowRestrictedFeatures = false)
+    val res = MarkdownPreprocessor.preprocess(
+      markdownFile,
+      logger,
+      allowRestrictedFeatures = false,
+      suppressWarningOptions = SuppressWarningOptions()
+    )
     val expectedMessage = s"File not found: ${markdownFile.path}"
 
     assert(res.nonEmpty)

--- a/modules/build/src/test/scala/scala/build/tests/ScalaPreprocessorTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ScalaPreprocessorTests.scala
@@ -3,6 +3,7 @@ package scala.build.tests
 import com.eed3si9n.expecty.Expecty.expect
 
 import scala.build.input.SourceScalaFile
+import scala.build.options.SuppressWarningOptions
 import scala.build.preprocessing.{PreprocessedSource, ScalaPreprocessor}
 
 class ScalaPreprocessorTests extends munit.FunSuite {
@@ -21,7 +22,8 @@ class ScalaPreprocessorTests extends munit.FunSuite {
       val Some(Right(result)) = ScalaPreprocessor.preprocess(
         scalaFile,
         logger = TestLogger(),
-        allowRestrictedFeatures = false
+        allowRestrictedFeatures = false,
+        suppressWarningOptions = SuppressWarningOptions()
       )
       expect(result.nonEmpty)
       val Some(directivesPositions) = result.head.directivesPositions
@@ -40,7 +42,8 @@ class ScalaPreprocessorTests extends munit.FunSuite {
       val Some(Right(result)) = ScalaPreprocessor.preprocess(
         scalaFile,
         logger = TestLogger(),
-        allowRestrictedFeatures = false
+        allowRestrictedFeatures = false,
+        suppressWarningOptions = SuppressWarningOptions()
       )
       expect(result.nonEmpty)
       val Some(directivesPositions) = result.head.directivesPositions

--- a/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
@@ -3,15 +3,15 @@ package scala.build.tests
 import com.eed3si9n.expecty.Expecty.expect
 import coursier.cache.{ArchiveCache, Cache}
 import coursier.util.{Artifact, Task}
-import dependency._
+import dependency.*
 
-import scala.build.Ops._
+import scala.build.Ops.*
 import scala.build.Sources
 import scala.build.internal.CustomCodeWrapper
 import scala.build.CrossSources
 import scala.build.Position
 import scala.build.errors.{UsingDirectiveValueNumError, UsingDirectiveWrongValueTypeError}
-import scala.build.options.{BuildOptions, Scope}
+import scala.build.options.{BuildOptions, Scope, SuppressWarningOptions}
 import scala.build.internal.ScalaJsLinkerConfig
 
 class SourcesTests extends munit.FunSuite {
@@ -60,7 +60,7 @@ class SourcesTests extends munit.FunSuite {
             inputs,
             preprocessors,
             TestLogger(),
-            suppressDirectivesInMultipleFilesWarning = None
+            SuppressWarningOptions()
           ).orThrow
         val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
         val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
@@ -95,7 +95,7 @@ class SourcesTests extends munit.FunSuite {
           inputs,
           preprocessors,
           TestLogger(),
-          suppressDirectivesInMultipleFilesWarning = None
+          SuppressWarningOptions()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
@@ -127,7 +127,7 @@ class SourcesTests extends munit.FunSuite {
           inputs,
           preprocessors,
           TestLogger(),
-          suppressDirectivesInMultipleFilesWarning = None
+          SuppressWarningOptions()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
@@ -159,7 +159,7 @@ class SourcesTests extends munit.FunSuite {
           inputs,
           preprocessors,
           TestLogger(),
-          suppressDirectivesInMultipleFilesWarning = None
+          SuppressWarningOptions()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
@@ -194,7 +194,7 @@ class SourcesTests extends munit.FunSuite {
           inputs,
           preprocessors,
           TestLogger(),
-          suppressDirectivesInMultipleFilesWarning = None
+          SuppressWarningOptions()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
@@ -231,7 +231,7 @@ class SourcesTests extends munit.FunSuite {
           inputs,
           preprocessors,
           TestLogger(),
-          suppressDirectivesInMultipleFilesWarning = None
+          SuppressWarningOptions()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
@@ -260,7 +260,7 @@ class SourcesTests extends munit.FunSuite {
         inputs,
         preprocessors,
         TestLogger(),
-        suppressDirectivesInMultipleFilesWarning = None
+        SuppressWarningOptions()
       )
       expect(crossSources.isLeft)
     }
@@ -282,7 +282,7 @@ class SourcesTests extends munit.FunSuite {
         inputs,
         preprocessors,
         TestLogger(),
-        suppressDirectivesInMultipleFilesWarning = None
+        SuppressWarningOptions()
       ).isLeft)
     }
   }
@@ -339,7 +339,7 @@ class SourcesTests extends munit.FunSuite {
           inputs,
           preprocessors,
           TestLogger(),
-          suppressDirectivesInMultipleFilesWarning = None
+          SuppressWarningOptions()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
@@ -372,7 +372,7 @@ class SourcesTests extends munit.FunSuite {
           inputs,
           preprocessors,
           TestLogger(),
-          suppressDirectivesInMultipleFilesWarning = None
+          SuppressWarningOptions()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
@@ -408,7 +408,7 @@ class SourcesTests extends munit.FunSuite {
           inputs,
           preprocessors,
           TestLogger(),
-          suppressDirectivesInMultipleFilesWarning = None
+          SuppressWarningOptions()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
@@ -435,7 +435,7 @@ class SourcesTests extends munit.FunSuite {
           inputs,
           preprocessors,
           TestLogger(),
-          suppressDirectivesInMultipleFilesWarning = None
+          SuppressWarningOptions()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
       val sources  = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
@@ -473,7 +473,7 @@ class SourcesTests extends munit.FunSuite {
           inputs,
           preprocessors,
           TestLogger(),
-          suppressDirectivesInMultipleFilesWarning = None
+          SuppressWarningOptions()
         ).orThrow
       val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
       val sources   = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
@@ -513,7 +513,7 @@ class SourcesTests extends munit.FunSuite {
           inputs,
           preprocessors,
           TestLogger(),
-          suppressDirectivesInMultipleFilesWarning = None
+          SuppressWarningOptions()
         )
       crossSources match {
         case Left(_: UsingDirectiveValueNumError) =>
@@ -534,7 +534,7 @@ class SourcesTests extends munit.FunSuite {
           inputs,
           preprocessors,
           TestLogger(),
-          suppressDirectivesInMultipleFilesWarning = None
+          SuppressWarningOptions()
         )
       crossSources match {
         case Left(_: UsingDirectiveWrongValueTypeError) =>

--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictableCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictableCommand.scala
@@ -6,7 +6,9 @@ import caseapp.core.parser.Parser
 trait RestrictableCommand[T](implicit myParser: Parser[T]) {
   self: Command[T] =>
 
-  override def parser: Parser[T] = RestrictedCommandsParser(myParser)
+  def shouldSuppressExperimentalFeatureWarnings: Boolean
+  override def parser: Parser[T] =
+    RestrictedCommandsParser(myParser, shouldSuppressExperimentalFeatureWarnings)
 
   final def isRestricted: Boolean = scalaSpecificationLevel == SpecificationLevel.RESTRICTED
 

--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictableCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictableCommand.scala
@@ -3,12 +3,16 @@ package scala.cli.commands
 import caseapp.core.app.Command
 import caseapp.core.parser.Parser
 
+import scala.build.Logger
+import scala.cli.commands.shared.HasGlobalOptions
+
 trait RestrictableCommand[T](implicit myParser: Parser[T]) {
   self: Command[T] =>
 
   def shouldSuppressExperimentalFeatureWarnings: Boolean
+  def logger: Logger
   override def parser: Parser[T] =
-    RestrictedCommandsParser(myParser, shouldSuppressExperimentalFeatureWarnings)
+    RestrictedCommandsParser(myParser, logger, shouldSuppressExperimentalFeatureWarnings)
 
   final def isRestricted: Boolean = scalaSpecificationLevel == SpecificationLevel.RESTRICTED
 

--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
@@ -11,46 +11,51 @@ import scala.cli.ScalaCli
 import scala.cli.util.ArgHelpers.*
 
 object RestrictedCommandsParser {
-  def apply[T](parser: Parser[T]): Parser[T] = new Parser[T] {
+  def apply[T](parser: Parser[T], shouldSuppressExperimentalWarnings: Boolean): Parser[T] =
+    new Parser[T] {
 
-    type D = parser.D
+      type D = parser.D
 
-    def args: Seq[caseapp.core.Arg] = parser.args.filter(_.isSupported)
+      def args: Seq[caseapp.core.Arg] = parser.args.filter(_.isSupported)
 
-    def get(
-      d: D,
-      nameFormatter: caseapp.core.util.Formatter[caseapp.Name]
-    ): Either[caseapp.core.Error, T] =
-      parser.get(d, nameFormatter)
+      def get(
+        d: D,
+        nameFormatter: caseapp.core.util.Formatter[caseapp.Name]
+      ): Either[caseapp.core.Error, T] =
+        parser.get(d, nameFormatter)
 
-    def init: D = parser.init
+      def init: D = parser.init
 
-    def withDefaultOrigin(origin: String): caseapp.core.parser.Parser[T] =
-      RestrictedCommandsParser(parser.withDefaultOrigin(origin))
+      def withDefaultOrigin(origin: String): caseapp.core.parser.Parser[T] =
+        RestrictedCommandsParser(
+          parser.withDefaultOrigin(origin),
+          shouldSuppressExperimentalWarnings
+        )
 
-    override def step(
-      args: List[String],
-      index: Int,
-      d: D,
-      nameFormatter: Formatter[Name]
-    ): Either[(Error, Arg, List[String]), Option[(D, Arg, List[String])]] =
-      (parser.step(args, index, d, nameFormatter), args) match {
-        case (Right(Some(_, arg: Arg, _)), passedOption :: _) if !arg.isSupported =>
-          val powerOptionType = if arg.isExperimental then "experimental" else "restricted"
-          Left((
-            Error.UnrecognizedArgument(
-              s"""The '$passedOption' option is $powerOptionType.
-                 |You can run it with the '--power' flag or turn the power mode on globally by running:
-                 |  ${Console.BOLD}${ScalaCli.progName} config power true${Console.RESET}.""".stripMargin
-            ),
-            arg,
-            Nil
-          ))
-        case (r @ Right(Some(_, arg: Arg, _)), passedOption :: _) if arg.isExperimental =>
-          System.err.println(WarningMessages.experimentalOptionUsed(passedOption))
-          r
-        case (other, _) =>
-          other
-      }
-  }
+      override def step(
+        args: List[String],
+        index: Int,
+        d: D,
+        nameFormatter: Formatter[Name]
+      ): Either[(Error, Arg, List[String]), Option[(D, Arg, List[String])]] =
+        (parser.step(args, index, d, nameFormatter), args) match {
+          case (Right(Some(_, arg: Arg, _)), passedOption :: _) if !arg.isSupported =>
+            val powerOptionType = if arg.isExperimental then "experimental" else "restricted"
+            Left((
+              Error.UnrecognizedArgument(
+                s"""The '$passedOption' option is $powerOptionType.
+                   |You can run it with the '--power' flag or turn the power mode on globally by running:
+                   |  ${Console.BOLD}${ScalaCli.progName} config power true${Console.RESET}.""".stripMargin
+              ),
+              arg,
+              Nil
+            ))
+          case (r @ Right(Some(_, arg: Arg, _)), passedOption :: _)
+              if arg.isExperimental && !shouldSuppressExperimentalWarnings =>
+            System.err.println(WarningMessages.experimentalOptionUsed(passedOption))
+            r
+          case (other, _) =>
+            other
+        }
+    }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
@@ -6,12 +6,17 @@ import caseapp.core.parser.Parser
 import caseapp.core.util.Formatter
 import caseapp.core.{Arg, Error}
 
+import scala.build.Logger
 import scala.build.internal.util.WarningMessages
 import scala.cli.ScalaCli
 import scala.cli.util.ArgHelpers.*
 
 object RestrictedCommandsParser {
-  def apply[T](parser: Parser[T], shouldSuppressExperimentalWarnings: Boolean): Parser[T] =
+  def apply[T](
+    parser: Parser[T],
+    logger: Logger,
+    shouldSuppressExperimentalWarnings: Boolean
+  ): Parser[T] =
     new Parser[T] {
 
       type D = parser.D
@@ -29,6 +34,7 @@ object RestrictedCommandsParser {
       def withDefaultOrigin(origin: String): caseapp.core.parser.Parser[T] =
         RestrictedCommandsParser(
           parser.withDefaultOrigin(origin),
+          logger,
           shouldSuppressExperimentalWarnings
         )
 
@@ -52,7 +58,7 @@ object RestrictedCommandsParser {
             ))
           case (r @ Right(Some(_, arg: Arg, _)), passedOption :: _)
               if arg.isExperimental && !shouldSuppressExperimentalWarnings =>
-            System.err.println(WarningMessages.experimentalOptionUsed(passedOption))
+            logger.message(WarningMessages.experimentalOptionUsed(passedOption))
             r
           case (other, _) =>
             other

--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
@@ -6,6 +6,7 @@ import caseapp.core.parser.Parser
 import caseapp.core.util.Formatter
 import caseapp.core.{Arg, Error}
 
+import scala.build.internal.util.WarningMessages
 import scala.cli.ScalaCli
 import scala.cli.util.ArgHelpers.*
 
@@ -45,6 +46,9 @@ object RestrictedCommandsParser {
             arg,
             Nil
           ))
+        case (r @ Right(Some(_, arg: Arg, _)), passedOption :: _) if arg.isExperimental =>
+          System.err.println(WarningMessages.experimentalOptionUsed(passedOption))
+          r
         case (other, _) =>
           other
       }

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -15,6 +15,7 @@ import scala.build.EitherCps.{either, value}
 import scala.build.compiler.SimpleScalaCompiler
 import scala.build.errors.BuildException
 import scala.build.input.{ScalaCliInvokeData, SubCommand}
+import scala.build.internal.util.WarningMessages
 import scala.build.internal.{Constants, Runner}
 import scala.build.options.{BuildOptions, ScalacOpt, Scope}
 import scala.build.{Artifacts, Logger, Positioned, ReplArtifacts}
@@ -309,10 +310,12 @@ abstract class ScalaCommand[T <: HasLoggingOptions](implicit myParser: Parser[T]
     * start of running every [[ScalaCommand]].
     */
   final override def run(options: T, remainingArgs: RemainingArgs): Unit = {
-    if (shouldExcludeInSip)
-      System.err.println(HelpMessages.powerCommandUsedInSip(scalaSpecificationLevel))
-      sys.exit(1)
     CurrentParams.verbosity = options.logging.verbosity
+    val logger = options.logging.logger
+    if shouldExcludeInSip then
+      logger.error(HelpMessages.powerCommandUsedInSip(scalaSpecificationLevel))
+      sys.exit(1)
+    else if isExperimental then logger.message(WarningMessages.experimentalSubcommandUsed(name))
     maybePrintWarnings(options)
     maybePrintGroupHelp(options)
     buildOptions(options).foreach { bo =>

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -276,9 +276,26 @@ abstract class ScalaCommand[T <: HasLoggingOptions](implicit myParser: Parser[T]
   override def helpFormat: HelpFormat = ScalaCliHelp.helpFormat
 
   override val messages: Help[T] =
-    if (shouldExcludeInSip)
+    if shouldExcludeInSip then
       Help[T](helpMessage =
         Some(HelpMessage(HelpMessages.powerCommandUsedInSip(scalaSpecificationLevel)))
+      )
+    else if isExperimental then
+      help.copy(helpMessage =
+        help.helpMessage.map(hm =>
+          hm.copy(
+            message =
+              s"""${hm.message}
+                 |
+                 |${WarningMessages.experimentalSubcommandUsed(name)}""".stripMargin,
+            detailedMessage =
+              if hm.detailedMessage.nonEmpty then
+                s"""${hm.detailedMessage}
+                   |
+                   |${WarningMessages.experimentalSubcommandUsed(name)}""".stripMargin
+              else hm.detailedMessage
+          )
+        )
       )
     else help
 

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommandWithCustomHelp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommandWithCustomHelp.scala
@@ -5,11 +5,11 @@ import caseapp.core.help.{Help, HelpCompanion, RuntimeCommandsHelp}
 import caseapp.core.parser.Parser
 
 import scala.cli.commands.default.{DefaultOptions, LegacyScalaOptions}
-import scala.cli.commands.shared.{HasLoggingOptions, ScalaCliHelp}
+import scala.cli.commands.shared.{HasGlobalOptions, ScalaCliHelp}
 import scala.cli.commands.util.HelpUtils.*
 import scala.cli.launcher.LauncherOptions
 
-abstract class ScalaCommandWithCustomHelp[T <: HasLoggingOptions](
+abstract class ScalaCommandWithCustomHelp[T <: HasGlobalOptions](
   actualHelp: => RuntimeCommandsHelp
 )(
   implicit

--- a/modules/cli/src/main/scala/scala/cli/commands/addpath/AddPathOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/addpath/AddPathOptions.scala
@@ -2,16 +2,14 @@ package scala.cli.commands.addpath
 
 import caseapp.*
 
-import scala.cli.commands.shared.{GlobalSuppressWarningOptions, HasGlobalOptions, LoggingOptions}
+import scala.cli.commands.shared.{GlobalOptions, HasGlobalOptions}
 import scala.cli.commands.tags
 
 // format: off
 @HelpMessage("Add entries to the PATH environment variable.")
 final case class AddPathOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Tag(tags.restricted)
     title: String = ""
 ) extends HasGlobalOptions

--- a/modules/cli/src/main/scala/scala/cli/commands/addpath/AddPathOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/addpath/AddPathOptions.scala
@@ -2,7 +2,7 @@ package scala.cli.commands.addpath
 
 import caseapp.*
 
-import scala.cli.commands.shared.{HasLoggingOptions, LoggingOptions}
+import scala.cli.commands.shared.{GlobalSuppressWarningOptions, HasGlobalOptions, LoggingOptions}
 import scala.cli.commands.tags
 
 // format: off
@@ -10,9 +10,11 @@ import scala.cli.commands.tags
 final case class AddPathOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
+  @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
   @Tag(tags.restricted)
     title: String = ""
-) extends HasLoggingOptions
+) extends HasGlobalOptions
 // format: on
 
 object AddPathOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/Bloop.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/Bloop.scala
@@ -28,12 +28,12 @@ object Bloop extends ScalaCommand[BloopOptions] {
     // directly.
 
     val sharedOptions = SharedOptions(
-      logging = opts.logging,
+      logging = opts.global.logging,
       compilationServer = opts.compilationServer,
       jvm = opts.jvm,
       coursier = opts.coursier
     )
-    val options = sharedOptions.buildOptions(false, None).orExit(opts.logging.logger)
+    val options = sharedOptions.buildOptions(false, None).orExit(opts.global.logging.logger)
     lazy val defaultJvmCmd =
       sharedOptions.downloadJvm(OsLibc.baseDefaultJvm(OsLibc.jvmIndexOs, "17"), options)
     val javaCmd = opts.compilationServer.bloopJvm
@@ -48,9 +48,9 @@ object Bloop extends ScalaCommand[BloopOptions] {
       .getOrElse(defaultJvmCmd)
 
     opts.compilationServer.bloopRifleConfig(
-      opts.logging.logger,
+      opts.global.logging.logger,
       sharedOptions.coursierCache,
-      opts.logging.verbosity,
+      opts.global.logging.verbosity,
       javaCmd,
       Directories.directories,
       Some(17)

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopExit.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopExit.scala
@@ -17,9 +17,9 @@ object BloopExit extends ScalaCommand[BloopExitOptions] {
   private def mkBloopRifleConfig(opts: BloopExitOptions): BloopRifleConfig = {
     import opts.*
     compilationServer.bloopRifleConfig(
-      logging.logger,
-      coursier.coursierCache(logging.logger.coursierLogger("Downloading Bloop")),
-      logging.verbosity,
+      global.logging.logger,
+      coursier.coursierCache(global.logging.logger.coursierLogger("Downloading Bloop")),
+      global.logging.verbosity,
       "java", // shouldn't be used…
       Directories.directories
     )
@@ -36,7 +36,7 @@ object BloopExit extends ScalaCommand[BloopExitOptions] {
       if (ret == 0)
         logger.message("Stopped Bloop server.")
       else {
-        if (options.logging.verbosity >= 0)
+        if (options.global.logging.verbosity >= 0)
           System.err.println(s"Error running bloop exit command (return code $ret)")
         sys.exit(1)
       }

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopExitOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopExitOptions.scala
@@ -2,7 +2,7 @@ package scala.cli.commands.bloop
 
 import caseapp.*
 
-import scala.cli.commands.shared.{CoursierOptions, GlobalSuppressWarningOptions, HasGlobalOptions, HelpMessages, LoggingOptions, SharedCompilationServerOptions}
+import scala.cli.commands.shared.{CoursierOptions, GlobalOptions, HasGlobalOptions, HelpMessages, SharedCompilationServerOptions}
 
 
 // format: off
@@ -12,9 +12,7 @@ import scala.cli.commands.shared.{CoursierOptions, GlobalSuppressWarningOptions,
      |${HelpMessages.bloopInfo}""".stripMargin)
 final case class BloopExitOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Recurse
     compilationServer: SharedCompilationServerOptions = SharedCompilationServerOptions(),
   @Recurse

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopExitOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopExitOptions.scala
@@ -2,7 +2,7 @@ package scala.cli.commands.bloop
 
 import caseapp.*
 
-import scala.cli.commands.shared.{CoursierOptions, HasLoggingOptions, HelpMessages, LoggingOptions, SharedCompilationServerOptions}
+import scala.cli.commands.shared.{CoursierOptions, GlobalSuppressWarningOptions, HasGlobalOptions, HelpMessages, LoggingOptions, SharedCompilationServerOptions}
 
 
 // format: off
@@ -14,10 +14,12 @@ final case class BloopExitOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
   @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+  @Recurse
     compilationServer: SharedCompilationServerOptions = SharedCompilationServerOptions(),
   @Recurse
     coursier: CoursierOptions = CoursierOptions()
-) extends HasLoggingOptions
+) extends HasGlobalOptions
 // format: on
 
 object BloopExitOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOptions.scala
@@ -9,9 +9,7 @@ import scala.cli.commands.tags
 @HelpMessage(BloopOptions.helpMessage, "", BloopOptions.detailedHelpMessage)
 final case class BloopOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Recurse
     compilationServer: SharedCompilationServerOptions = SharedCompilationServerOptions(),
   @Recurse

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOptions.scala
@@ -2,7 +2,7 @@ package scala.cli.commands.bloop
 
 import caseapp.*
 
-import scala.cli.commands.shared.{CoursierOptions, HasLoggingOptions, HelpMessages, LoggingOptions, SharedCompilationServerOptions, SharedJvmOptions}
+import scala.cli.commands.shared._
 import scala.cli.commands.tags
 
 // format: off
@@ -10,6 +10,8 @@ import scala.cli.commands.tags
 final case class BloopOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
+  @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
   @Recurse
     compilationServer: SharedCompilationServerOptions = SharedCompilationServerOptions(),
   @Recurse
@@ -21,7 +23,7 @@ final case class BloopOptions(
   @ExtraName("dir")
   @Tag(tags.restricted)
     workingDirectory: Option[String] = None
-) extends HasLoggingOptions {
+) extends HasGlobalOptions {
   // format: on
 
   def workDirOpt: Option[os.Path] =

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOutput.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOutput.scala
@@ -21,7 +21,7 @@ object BloopOutput extends ScalaCommand[BloopOutputOptions] {
     val bloopRifleConfig = options.compilationServer.bloopRifleConfig(
       logger,
       CoursierOptions().coursierCache(logger.coursierLogger("Downloading Bloop")), // unused here
-      options.logging.verbosity,
+      options.global.logging.verbosity,
       "unused-java", // unused here
       Directories.directories
     )
@@ -31,14 +31,14 @@ object BloopOutput extends ScalaCommand[BloopOutputOptions] {
         logger.debug(s"Bloop server output path: ${s.outputPath}")
         os.Path(s.outputPath, os.pwd)
       case tcp: BloopRifleConfig.Address.Tcp =>
-        if (options.logging.verbosity >= 0)
+        if (options.global.logging.verbosity >= 0)
           System.err.println(
             s"Error: Bloop server is listening on TCP at ${tcp.render}, output not available."
           )
         sys.exit(1)
     }
     if (!os.isFile(outputFile)) {
-      if (options.logging.verbosity >= 0)
+      if (options.global.logging.verbosity >= 0)
         System.err.println(s"Error: $outputFile not found")
       sys.exit(1)
     }

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOutputOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOutputOptions.scala
@@ -2,7 +2,7 @@ package scala.cli.commands.bloop
 
 import caseapp.*
 
-import scala.cli.commands.shared.{HasLoggingOptions, HelpMessages, LoggingOptions, SharedCompilationServerOptions}
+import scala.cli.commands.shared.{GlobalSuppressWarningOptions, HasGlobalOptions, HelpMessages, LoggingOptions, SharedCompilationServerOptions}
 
 // format: off
 @HelpMessage(
@@ -13,8 +13,10 @@ final case class BloopOutputOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
   @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+  @Recurse
     compilationServer: SharedCompilationServerOptions = SharedCompilationServerOptions(),
-) extends HasLoggingOptions
+) extends HasGlobalOptions
 // format: on
 
 object BloopOutputOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOutputOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopOutputOptions.scala
@@ -2,7 +2,7 @@ package scala.cli.commands.bloop
 
 import caseapp.*
 
-import scala.cli.commands.shared.{GlobalSuppressWarningOptions, HasGlobalOptions, HelpMessages, LoggingOptions, SharedCompilationServerOptions}
+import scala.cli.commands.shared.{GlobalOptions, GlobalSuppressWarningOptions, HasGlobalOptions, HelpMessages, LoggingOptions, SharedCompilationServerOptions}
 
 // format: off
 @HelpMessage(
@@ -11,9 +11,7 @@ import scala.cli.commands.shared.{GlobalSuppressWarningOptions, HasGlobalOptions
      |${HelpMessages.bloopInfo}""".stripMargin)
 final case class BloopOutputOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Recurse
     compilationServer: SharedCompilationServerOptions = SharedCompilationServerOptions(),
 ) extends HasGlobalOptions

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopStart.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopStart.scala
@@ -23,16 +23,16 @@ object BloopStart extends ScalaCommand[BloopStartOptions] {
   private def mkBloopRifleConfig(opts: BloopStartOptions): BloopRifleConfig = {
     import opts.*
     val buildOptions = BuildOptions(
-      javaOptions = JvmUtils.javaOptions(jvm).orExit(logging.logger),
+      javaOptions = JvmUtils.javaOptions(jvm).orExit(global.logging.logger),
       internal = InternalOptions(
-        cache = Some(coursier.coursierCache(logging.logger.coursierLogger("")))
+        cache = Some(coursier.coursierCache(global.logging.logger.coursierLogger("")))
       )
     )
 
     compilationServer.bloopRifleConfig(
-      logging.logger,
-      coursier.coursierCache(logging.logger.coursierLogger("Downloading Bloop")),
-      logging.verbosity,
+      global.logging.logger,
+      coursier.coursierCache(global.logging.logger.coursierLogger("Downloading Bloop")),
+      global.logging.verbosity,
       buildOptions.javaHome().value.javaCommand,
       Directories.directories
     )
@@ -51,7 +51,7 @@ object BloopStart extends ScalaCommand[BloopStartOptions] {
       if (ret == 0)
         logger.message("Stopped Bloop server.")
       else {
-        if (options.logging.verbosity >= 0)
+        if (options.global.logging.verbosity >= 0)
           System.err.println(s"Error running bloop exit command (return code $ret)")
         sys.exit(1)
       }

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopStartOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopStartOptions.scala
@@ -12,9 +12,7 @@ import scala.cli.commands.tags
      |${HelpMessages.bloopInfo}""".stripMargin)
 final case class BloopStartOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Recurse
     compilationServer: SharedCompilationServerOptions = SharedCompilationServerOptions(),
   @Recurse

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopStartOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopStartOptions.scala
@@ -2,7 +2,7 @@ package scala.cli.commands.bloop
 
 import caseapp.*
 
-import scala.cli.commands.shared.{CoursierOptions, HasLoggingOptions, HelpMessages, LoggingOptions, SharedCompilationServerOptions, SharedJvmOptions}
+import scala.cli.commands.shared._
 import scala.cli.commands.tags
 
 // format: off
@@ -14,6 +14,8 @@ final case class BloopStartOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
   @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+  @Recurse
     compilationServer: SharedCompilationServerOptions = SharedCompilationServerOptions(),
   @Recurse
     jvm: SharedJvmOptions = SharedJvmOptions(),
@@ -22,7 +24,7 @@ final case class BloopStartOptions(
   @Name("f")
   @Tag(tags.restricted)
     force: Boolean = false
-) extends HasLoggingOptions
+) extends HasGlobalOptions
 // format: on
 
 object BloopStartOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
@@ -59,7 +59,7 @@ object Bsp extends ScalaCommand[BspOptions] {
                 () => buildOptions0.javaHome().value.javaCommand
               ),
               persistentLogger,
-              buildOptions0.suppressWarningOptions.suppressDirectivesInMultipleFilesWarning
+              buildOptions0.suppressWarningOptions
             ).map(_._2).getOrElse(initialInputs)
 
           Build.updateInputs(allInputs, buildOptions(sharedOptions))

--- a/modules/cli/src/main/scala/scala/cli/commands/clean/CleanOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/clean/CleanOptions.scala
@@ -3,22 +3,13 @@ package scala.cli.commands.clean
 import caseapp.*
 
 import scala.cli.ScalaCli.fullRunnerName
-import scala.cli.commands.shared.{
-  GlobalSuppressWarningOptions,
-  HasGlobalOptions,
-  HelpMessages,
-  LoggingOptions,
-  SharedBspFileOptions,
-  SharedWorkspaceOptions
-}
+import scala.cli.commands.shared._
 
 // format: off
 @HelpMessage(CleanOptions.helpMessage, "", CleanOptions.detailedHelpMessage)
 final case class CleanOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Recurse
     bspFile: SharedBspFileOptions = SharedBspFileOptions(),
   @Recurse

--- a/modules/cli/src/main/scala/scala/cli/commands/clean/CleanOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/clean/CleanOptions.scala
@@ -4,7 +4,8 @@ import caseapp.*
 
 import scala.cli.ScalaCli.fullRunnerName
 import scala.cli.commands.shared.{
-  HasLoggingOptions,
+  GlobalSuppressWarningOptions,
+  HasGlobalOptions,
   HelpMessages,
   LoggingOptions,
   SharedBspFileOptions,
@@ -17,10 +18,12 @@ final case class CleanOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
   @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+  @Recurse
     bspFile: SharedBspFileOptions = SharedBspFileOptions(),
   @Recurse
     workspace: SharedWorkspaceOptions = SharedWorkspaceOptions()
-) extends HasLoggingOptions
+) extends HasGlobalOptions
 // format: on
 
 object CleanOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
@@ -13,9 +13,7 @@ import scala.cli.config.{Key, Keys}
 @HelpMessage(ConfigOptions.helpMessage, "", ConfigOptions.detailedHelpMessage)
 final case class ConfigOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Recurse
     coursier: CoursierOptions = CoursierOptions(),
   @Recurse

--- a/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
@@ -5,14 +5,7 @@ import caseapp.*
 import scala.build.internal.util.ConsoleUtils.ScalaCliConsole
 import scala.cli.ScalaCli.{fullRunnerName, progName}
 import scala.cli.commands.pgp.PgpScalaSigningOptions
-import scala.cli.commands.shared.{
-  CoursierOptions,
-  HasLoggingOptions,
-  HelpGroup,
-  HelpMessages,
-  LoggingOptions,
-  SharedJvmOptions
-}
+import scala.cli.commands.shared._
 import scala.cli.commands.tags
 import scala.cli.config.{Key, Keys}
 
@@ -21,6 +14,8 @@ import scala.cli.config.{Key, Keys}
 final case class ConfigOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
+  @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
   @Recurse
     coursier: CoursierOptions = CoursierOptions(),
   @Recurse
@@ -80,7 +75,7 @@ final case class ConfigOptions(
   @Tag(tags.restricted)
   @Tag(tags.inShortHelp)
     passOnRedirect: Option[Boolean] = None
-) extends HasLoggingOptions
+) extends HasGlobalOptions
 // format: on
 
 object ConfigOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/default/Default.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/Default.scala
@@ -47,7 +47,7 @@ class Default(
 
   override def runCommand(options: DefaultOptions, args: RemainingArgs, logger: Logger): Unit =
     // can't fully re-parse and redirect to Version because of --cli-version and --scala-version clashing
-    if options.version then Version.runCommand(VersionOptions(options.shared.logging), args, logger)
+    if options.version then Version.runCommand(VersionOptions(options.shared.global), args, logger)
     else
       {
         val shouldDefaultToRun =

--- a/modules/cli/src/main/scala/scala/cli/commands/default/DefaultFileOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/DefaultFileOptions.scala
@@ -3,7 +3,13 @@ package scala.cli.commands.default
 import caseapp.*
 
 import scala.cli.ScalaCli.fullRunnerName
-import scala.cli.commands.shared.{HasLoggingOptions, HelpGroup, HelpMessages, LoggingOptions}
+import scala.cli.commands.shared.{
+  GlobalSuppressWarningOptions,
+  HasGlobalOptions,
+  HelpGroup,
+  HelpMessages,
+  LoggingOptions
+}
 import scala.cli.commands.tags
 
 // format: off
@@ -14,6 +20,8 @@ import scala.cli.commands.tags
 final case class DefaultFileOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
+  @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
   @Group(HelpGroup.Default.toString)
   @HelpMessage("Write result to files rather than to stdout")
   @Tag(tags.restricted)
@@ -31,7 +39,7 @@ final case class DefaultFileOptions(
   @ExtraName("f")
   @Tag(tags.restricted)
     force: Boolean = false
-) extends HasLoggingOptions
+) extends HasGlobalOptions
 // format: on
 
 object DefaultFileOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/default/DefaultFileOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/DefaultFileOptions.scala
@@ -3,13 +3,7 @@ package scala.cli.commands.default
 import caseapp.*
 
 import scala.cli.ScalaCli.fullRunnerName
-import scala.cli.commands.shared.{
-  GlobalSuppressWarningOptions,
-  HasGlobalOptions,
-  HelpGroup,
-  HelpMessages,
-  LoggingOptions
-}
+import scala.cli.commands.shared.{GlobalOptions, HasGlobalOptions, HelpGroup, HelpMessages}
 import scala.cli.commands.tags
 
 // format: off
@@ -19,9 +13,7 @@ import scala.cli.commands.tags
      |${HelpMessages.commandDocWebsiteReference("misc/default-file")}""".stripMargin)
 final case class DefaultFileOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Group(HelpGroup.Default.toString)
   @HelpMessage("Write result to files rather than to stdout")
   @Tag(tags.restricted)

--- a/modules/cli/src/main/scala/scala/cli/commands/dependencyupdate/DependencyUpdate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/dependencyupdate/DependencyUpdate.scala
@@ -40,7 +40,7 @@ object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
           () => buildOptions.javaHome().value.javaCommand
         ),
         logger,
-        buildOptions.suppressWarningOptions.suppressDirectivesInMultipleFilesWarning
+        buildOptions.suppressWarningOptions
       ).orExit(logger)
 
     val scopedSources = crossSources.scopedSources(buildOptions).orExit(logger)

--- a/modules/cli/src/main/scala/scala/cli/commands/directories/DirectoriesOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/directories/DirectoriesOptions.scala
@@ -3,15 +3,13 @@ package scala.cli.commands.directories
 import caseapp.*
 
 import scala.cli.ScalaCli.fullRunnerName
-import scala.cli.commands.shared.{GlobalSuppressWarningOptions, HasGlobalOptions, LoggingOptions}
+import scala.cli.commands.shared.{GlobalOptions, HasGlobalOptions}
 
 // format: off
 @HelpMessage(s"Prints directories used by $fullRunnerName.")
 final case class DirectoriesOptions(
-  @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions()
+@Recurse
+  global: GlobalOptions = GlobalOptions(),
 ) extends HasGlobalOptions
 // format: on
 

--- a/modules/cli/src/main/scala/scala/cli/commands/directories/DirectoriesOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/directories/DirectoriesOptions.scala
@@ -3,14 +3,16 @@ package scala.cli.commands.directories
 import caseapp.*
 
 import scala.cli.ScalaCli.fullRunnerName
-import scala.cli.commands.shared.{HasLoggingOptions, LoggingOptions}
+import scala.cli.commands.shared.{GlobalSuppressWarningOptions, HasGlobalOptions, LoggingOptions}
 
 // format: off
 @HelpMessage(s"Prints directories used by $fullRunnerName.")
 final case class DirectoriesOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions()
-) extends HasLoggingOptions
+    logging: LoggingOptions = LoggingOptions(),
+  @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions()
+) extends HasGlobalOptions
 // format: on
 
 object DirectoriesOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/export0/Export.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/export0/Export.scala
@@ -50,7 +50,7 @@ object Export extends ScalaCommand[ExportOptions] {
           () => buildOptions.javaHome().value.javaCommand
         ),
         logger,
-        buildOptions.suppressWarningOptions.suppressDirectivesInMultipleFilesWarning
+        buildOptions.suppressWarningOptions
       )
     }
     val scopedSources = value(crossSources.scopedSources(buildOptions))

--- a/modules/cli/src/main/scala/scala/cli/commands/github/HasSharedSecretOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/HasSharedSecretOptions.scala
@@ -1,10 +1,9 @@
 package scala.cli.commands.github
 
-import scala.cli.commands.shared.{GlobalSuppressWarningOptions, HasGlobalOptions, LoggingOptions}
+import scala.cli.commands.shared.{GlobalOptions, HasGlobalOptions}
 
 trait HasSharedSecretOptions extends HasGlobalOptions {
   def shared: SharedSecretOptions
-  override def logging: LoggingOptions = shared.logging
 
-  override def globalSuppressWarning: GlobalSuppressWarningOptions = shared.globalSuppressWarning
+  override def global: GlobalOptions = shared.global
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/github/HasSharedSecretOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/HasSharedSecretOptions.scala
@@ -1,8 +1,10 @@
 package scala.cli.commands.github
 
-import scala.cli.commands.shared.{HasLoggingOptions, LoggingOptions}
+import scala.cli.commands.shared.{GlobalSuppressWarningOptions, HasGlobalOptions, LoggingOptions}
 
-trait HasSharedSecretOptions extends HasLoggingOptions {
+trait HasSharedSecretOptions extends HasGlobalOptions {
   def shared: SharedSecretOptions
   override def logging: LoggingOptions = shared.logging
+
+  override def globalSuppressWarning: GlobalSuppressWarningOptions = shared.globalSuppressWarning
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/github/SharedSecretOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/SharedSecretOptions.scala
@@ -2,7 +2,12 @@ package scala.cli.commands.github
 
 import caseapp.*
 
-import scala.cli.commands.shared.{HasLoggingOptions, HelpGroup, LoggingOptions}
+import scala.cli.commands.shared.{
+  GlobalSuppressWarningOptions,
+  HasGlobalOptions,
+  HelpGroup,
+  LoggingOptions
+}
 import scala.cli.commands.tags
 import scala.cli.signing.shared.{PasswordOption, Secret}
 import scala.cli.signing.util.ArgParsers.*
@@ -11,6 +16,8 @@ import scala.cli.signing.util.ArgParsers.*
 final case class SharedSecretOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
+  @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
   @Group(HelpGroup.Secret.toString)
   @Tag(tags.restricted)
   @Tag(tags.inShortHelp)
@@ -20,7 +27,7 @@ final case class SharedSecretOptions(
   @Tag(tags.restricted)
   @Tag(tags.inShortHelp)
     repository: String = ""
-) extends HasLoggingOptions {
+) extends HasGlobalOptions {
   // format: on
 
   lazy val (repoOrg, repoName) =

--- a/modules/cli/src/main/scala/scala/cli/commands/github/SharedSecretOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/SharedSecretOptions.scala
@@ -2,12 +2,7 @@ package scala.cli.commands.github
 
 import caseapp.*
 
-import scala.cli.commands.shared.{
-  GlobalSuppressWarningOptions,
-  HasGlobalOptions,
-  HelpGroup,
-  LoggingOptions
-}
+import scala.cli.commands.shared.{GlobalOptions, HasGlobalOptions, HelpGroup}
 import scala.cli.commands.tags
 import scala.cli.signing.shared.{PasswordOption, Secret}
 import scala.cli.signing.util.ArgParsers.*
@@ -15,9 +10,7 @@ import scala.cli.signing.util.ArgParsers.*
 // format: off
 final case class SharedSecretOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Group(HelpGroup.Secret.toString)
   @Tag(tags.restricted)
   @Tag(tags.inShortHelp)

--- a/modules/cli/src/main/scala/scala/cli/commands/installcompletions/InstallCompletions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/installcompletions/InstallCompletions.scala
@@ -31,7 +31,7 @@ object InstallCompletions extends ScalaCommand[InstallCompletionsOptions] {
     args: RemainingArgs,
     logger: Logger
   ): Unit = {
-    val interactive = options.logging.verbosityOptions.interactiveInstance()
+    val interactive = options.global.logging.verbosityOptions.interactiveInstance()
     lazy val completionsDir =
       options.output
         .map(os.Path(_, os.pwd))
@@ -92,7 +92,7 @@ object InstallCompletions extends ScalaCommand[InstallCompletionsOptions] {
         Charset.defaultCharset()
       )
 
-      if (options.logging.verbosity >= 0)
+      if (options.global.logging.verbosity >= 0)
         if (updated) {
           System.err.println(s"Updated $rcFile")
           System.err.println(

--- a/modules/cli/src/main/scala/scala/cli/commands/installcompletions/InstallCompletionsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/installcompletions/InstallCompletionsOptions.scala
@@ -3,22 +3,14 @@ package scala.cli.commands.installcompletions
 import caseapp.*
 
 import scala.cli.ScalaCli.fullRunnerName
-import scala.cli.commands.shared.{
-  GlobalSuppressWarningOptions,
-  HasGlobalOptions,
-  HelpGroup,
-  HelpMessages,
-  LoggingOptions
-}
+import scala.cli.commands.shared.{GlobalOptions, HasGlobalOptions, HelpGroup, HelpMessages}
 import scala.cli.commands.tags
 
 // format: off
 @HelpMessage(InstallCompletionsOptions.helpMessage, "", InstallCompletionsOptions.detailedHelpMessage)
 final case class InstallCompletionsOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Group(HelpGroup.Install.toString)
   @Name("shell")
   @Tag(tags.implementation)

--- a/modules/cli/src/main/scala/scala/cli/commands/installcompletions/InstallCompletionsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/installcompletions/InstallCompletionsOptions.scala
@@ -3,7 +3,13 @@ package scala.cli.commands.installcompletions
 import caseapp.*
 
 import scala.cli.ScalaCli.fullRunnerName
-import scala.cli.commands.shared.{HasLoggingOptions, HelpGroup, HelpMessages, LoggingOptions}
+import scala.cli.commands.shared.{
+  GlobalSuppressWarningOptions,
+  HasGlobalOptions,
+  HelpGroup,
+  HelpMessages,
+  LoggingOptions
+}
 import scala.cli.commands.tags
 
 // format: off
@@ -11,6 +17,8 @@ import scala.cli.commands.tags
 final case class InstallCompletionsOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
+  @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
   @Group(HelpGroup.Install.toString)
   @Name("shell")
   @Tag(tags.implementation)
@@ -46,7 +54,7 @@ final case class InstallCompletionsOptions(
   @HelpMessage("Print completions to stdout")
   @Group(HelpGroup.Install.toString)
     env: Boolean = false,
-) extends HasLoggingOptions
+) extends HasGlobalOptions
 // format: on
 
 object InstallCompletionsOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/installhome/InstallHomeOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/installhome/InstallHomeOptions.scala
@@ -3,21 +3,14 @@ package scala.cli.commands.installhome
 import caseapp.*
 
 import scala.cli.ScalaCli.{baseRunnerName, fullRunnerName}
-import scala.cli.commands.shared.{
-  GlobalSuppressWarningOptions,
-  HasGlobalOptions,
-  HelpGroup,
-  LoggingOptions
-}
+import scala.cli.commands.shared.{GlobalOptions, HasGlobalOptions, HelpGroup}
 import scala.cli.commands.tags
 
 // format: off
 @HelpMessage(s"Install $fullRunnerName in a sub-directory of the home directory")
 final case class InstallHomeOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Group(HelpGroup.Install.toString)
   @Tag(tags.implementation)
     scalaCliBinaryPath: String,

--- a/modules/cli/src/main/scala/scala/cli/commands/installhome/InstallHomeOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/installhome/InstallHomeOptions.scala
@@ -3,7 +3,12 @@ package scala.cli.commands.installhome
 import caseapp.*
 
 import scala.cli.ScalaCli.{baseRunnerName, fullRunnerName}
-import scala.cli.commands.shared.{HasLoggingOptions, HelpGroup, LoggingOptions}
+import scala.cli.commands.shared.{
+  GlobalSuppressWarningOptions,
+  HasGlobalOptions,
+  HelpGroup,
+  LoggingOptions
+}
 import scala.cli.commands.tags
 
 // format: off
@@ -11,6 +16,8 @@ import scala.cli.commands.tags
 final case class InstallHomeOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
+  @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
   @Group(HelpGroup.Install.toString)
   @Tag(tags.implementation)
     scalaCliBinaryPath: String,
@@ -33,7 +40,7 @@ final case class InstallHomeOptions(
   @Tag(tags.implementation)
   @HelpMessage("Binary directory")
     binDir: Option[String] = None
-) extends HasLoggingOptions {
+) extends HasGlobalOptions {
   // format: on
   lazy val binDirPath = binDir.map(os.Path(_, os.pwd))
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpCommand.scala
@@ -5,8 +5,10 @@ import caseapp.core.complete.{Completer, CompletionItem}
 import caseapp.core.help.{Help, HelpFormat}
 import caseapp.core.parser.Parser
 
+import scala.build.Logger
 import scala.cli.commands.RestrictableCommand
 import scala.cli.commands.util.CommandHelpers
+import scala.cli.internal.CliLogger
 
 abstract class PgpCommand[T](implicit myParser: Parser[T], help: Help[T])
     extends Command()(myParser, help)
@@ -16,6 +18,8 @@ abstract class PgpCommand[T](implicit myParser: Parser[T], help: Help[T])
 
   override def shouldSuppressExperimentalFeatureWarnings: Boolean =
     false // TODO add handling for scala-cli-signing
+
+  override def logger: Logger = CliLogger.default // TODO add handling for scala-cli-signing
 
   override def hidden = true
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpCommand.scala
@@ -14,5 +14,8 @@ abstract class PgpCommand[T](implicit myParser: Parser[T], help: Help[T])
 
   override def scalaSpecificationLevel = SpecificationLevel.EXPERIMENTAL
 
+  override def shouldSuppressExperimentalFeatureWarnings: Boolean =
+    false // TODO add handling for scala-cli-signing
+
   override def hidden = true
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalCommand.scala
@@ -96,7 +96,7 @@ abstract class PgpExternalCommand extends ExternalCommand {
         case Right((options0, remainingArgs0)) => (options0, remainingArgs0)
       }
 
-    val logger = options.logging.logger
+    val logger = options.global.logging.logger
 
     val cache = options.coursier.coursierCache(logger.coursierLogger(""))
     val retCode = tryRun(

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalOptions.scala
@@ -4,6 +4,7 @@ import caseapp.*
 
 import scala.cli.commands.shared.{
   CoursierOptions,
+  GlobalOptions,
   GlobalSuppressWarningOptions,
   HasGlobalOptions,
   LoggingOptions,
@@ -13,9 +14,7 @@ import scala.cli.commands.shared.{
 // format: off
 final case class PgpExternalOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Recurse
     jvm: SharedJvmOptions = SharedJvmOptions(),
   @Recurse

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalOptions.scala
@@ -4,7 +4,8 @@ import caseapp.*
 
 import scala.cli.commands.shared.{
   CoursierOptions,
-  HasLoggingOptions,
+  GlobalSuppressWarningOptions,
+  HasGlobalOptions,
   LoggingOptions,
   SharedJvmOptions
 }
@@ -14,12 +15,14 @@ final case class PgpExternalOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
   @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+  @Recurse
     jvm: SharedJvmOptions = SharedJvmOptions(),
   @Recurse
     coursier: CoursierOptions = CoursierOptions(),
   @Recurse
     scalaSigning: PgpScalaSigningOptions = PgpScalaSigningOptions()
-) extends HasLoggingOptions
+) extends HasGlobalOptions
 // format: on
 
 object PgpExternalOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPullOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPullOptions.scala
@@ -3,6 +3,7 @@ package scala.cli.commands.pgp
 import caseapp.*
 
 import scala.cli.commands.shared.{
+  GlobalOptions,
   GlobalSuppressWarningOptions,
   HasGlobalOptions,
   HelpGroup,
@@ -12,9 +13,7 @@ import scala.cli.commands.shared.{
 // format: off
 final case class PgpPullOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Recurse
     shared: SharedPgpPushPullOptions = SharedPgpPushPullOptions(),
   @Group(HelpGroup.PGP.toString)

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPullOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPullOptions.scala
@@ -2,18 +2,25 @@ package scala.cli.commands.pgp
 
 import caseapp.*
 
-import scala.cli.commands.shared.{HasLoggingOptions, HelpGroup, LoggingOptions}
+import scala.cli.commands.shared.{
+  GlobalSuppressWarningOptions,
+  HasGlobalOptions,
+  HelpGroup,
+  LoggingOptions
+}
 
 // format: off
 final case class PgpPullOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
   @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+  @Recurse
     shared: SharedPgpPushPullOptions = SharedPgpPushPullOptions(),
   @Group(HelpGroup.PGP.toString)
   @HelpMessage("Whether to exit with code 0 if no key is passed")
     allowEmpty: Boolean = false
-) extends HasLoggingOptions
+) extends HasGlobalOptions
 // format: on
 
 object PgpPullOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPushOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPushOptions.scala
@@ -4,7 +4,8 @@ import caseapp.*
 
 import scala.cli.commands.shared.{
   CoursierOptions,
-  HasLoggingOptions,
+  GlobalSuppressWarningOptions,
+  HasGlobalOptions,
   HelpGroup,
   LoggingOptions,
   SharedJvmOptions
@@ -14,6 +15,8 @@ import scala.cli.commands.shared.{
 final case class PgpPushOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
+  @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
   @Recurse
     shared: SharedPgpPushPullOptions = SharedPgpPushPullOptions(),
   @Recurse
@@ -33,7 +36,7 @@ final case class PgpPushOptions(
   @Group(HelpGroup.PGP.toString)
   @Hidden
     forceSigningBinary: Boolean = false
-) extends HasLoggingOptions
+) extends HasGlobalOptions
 // format: on
 
 object PgpPushOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPushOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPushOptions.scala
@@ -2,21 +2,12 @@ package scala.cli.commands.pgp
 
 import caseapp.*
 
-import scala.cli.commands.shared.{
-  CoursierOptions,
-  GlobalSuppressWarningOptions,
-  HasGlobalOptions,
-  HelpGroup,
-  LoggingOptions,
-  SharedJvmOptions
-}
+import scala.cli.commands.shared._
 
 // format: off
 final case class PgpPushOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Recurse
     shared: SharedPgpPushPullOptions = SharedPgpPushPullOptions(),
   @Recurse

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
@@ -9,7 +9,7 @@ import java.nio.charset.StandardCharsets
 import scala.build.Ops.*
 import scala.build.errors.CompositeBuildException
 import scala.build.internal.CustomCodeWrapper
-import scala.build.options.{BuildOptions, InternalOptions, Scope}
+import scala.build.options.{BuildOptions, InternalOptions, Scope, SuppressWarningOptions}
 import scala.build.{CrossSources, Directories, Logger, Sources}
 import scala.cli.ScalaCli
 import scala.cli.commands.github.{LibSodiumJni, SecretCreate, SecretList}
@@ -91,7 +91,7 @@ object PublishSetup extends ScalaCommand[PublishSetupOptions] {
           () => cliBuildOptions.javaHome().value.javaCommand
         ),
         logger,
-        suppressDirectivesInMultipleFilesWarning = None
+        cliBuildOptions.suppressWarningOptions
       ).orExit(logger)
 
       val crossSourcesSharedOptions = crossSources.sharedOptions(cliBuildOptions)

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetupOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetupOptions.scala
@@ -12,9 +12,7 @@ import scala.cli.signing.util.ArgParsers.*
 @HelpMessage(PublishSetupOptions.helpMessage, "", PublishSetupOptions.detailedHelpMessage)
 final case class PublishSetupOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Recurse
     coursier: CoursierOptions = CoursierOptions(),
   @Recurse

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetupOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetupOptions.scala
@@ -14,6 +14,8 @@ final case class PublishSetupOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
   @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+  @Recurse
     coursier: CoursierOptions = CoursierOptions(),
   @Recurse
     workspace: SharedWorkspaceOptions = SharedWorkspaceOptions(),
@@ -73,7 +75,7 @@ final case class PublishSetupOptions(
   @Tag(tags.implementation)
   @HelpMessage("Dummy mode - don't upload any secret to GitHub")
     dummy: Boolean = false
-) extends HasLoggingOptions
+) extends HasGlobalOptions
 // format: on
 
 object PublishSetupOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/setupide/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/setupide/SetupIde.scala
@@ -40,7 +40,7 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
             () => options.javaHome().value.javaCommand
           ),
           logger,
-          options.suppressWarningOptions.suppressDirectivesInMultipleFilesWarning
+          options.suppressWarningOptions
         )
       }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/GlobalOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/GlobalOptions.scala
@@ -1,0 +1,21 @@
+package scala.cli.commands.shared
+
+import caseapp.*
+
+case class GlobalOptions(
+  @Recurse
+  logging: LoggingOptions = LoggingOptions(),
+  @Recurse
+  globalSuppress: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions()
+)
+
+object GlobalOptions {
+  implicit lazy val parser: Parser[GlobalOptions] = Parser.derive
+  implicit lazy val help: Help[GlobalOptions]     = Help.derive
+
+  def get(args: List[String]): Option[GlobalOptions] =
+    parser
+      .detailedParse(args, stopAtFirstUnrecognized = false, ignoreUnrecognized = true)
+      .toOption
+      .map(_._1)
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/GlobalSuppressWarningOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/GlobalSuppressWarningOptions.scala
@@ -15,10 +15,4 @@ final case class GlobalSuppressWarningOptions(
 object GlobalSuppressWarningOptions {
   implicit lazy val parser: Parser[GlobalSuppressWarningOptions] = Parser.derive
   implicit lazy val help: Help[GlobalSuppressWarningOptions]     = Help.derive
-
-  def shouldSuppressExperimentalFeatureWarning(args: List[String]): Option[Boolean] =
-    parser
-      .detailedParse(args, stopAtFirstUnrecognized = false, ignoreUnrecognized = true)
-      .toOption
-      .flatMap(_._1.suppressExperimentalFeatureWarning)
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/GlobalSuppressWarningOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/GlobalSuppressWarningOptions.scala
@@ -1,0 +1,24 @@
+package scala.cli.commands.shared
+
+import caseapp.*
+
+import scala.cli.commands.tags
+
+final case class GlobalSuppressWarningOptions(
+  @Group(HelpGroup.SuppressWarnings.toString)
+  @Tag(tags.implementation)
+  @HelpMessage("Suppress warnings about using experimental features")
+  @Name("suppressExperimentalWarning")
+  suppressExperimentalFeatureWarning: Boolean = false
+)
+
+object GlobalSuppressWarningOptions {
+  implicit lazy val parser: Parser[GlobalSuppressWarningOptions] = Parser.derive
+  implicit lazy val help: Help[GlobalSuppressWarningOptions]     = Help.derive
+
+  def shouldSuppressExperimentalFeatureWarning(args: List[String]): Boolean =
+    parser
+      .detailedParse(args, stopAtFirstUnrecognized = false, ignoreUnrecognized = true)
+      .map(_._1.suppressExperimentalFeatureWarning.self)
+      .getOrElse(false)
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/GlobalSuppressWarningOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/GlobalSuppressWarningOptions.scala
@@ -9,16 +9,16 @@ final case class GlobalSuppressWarningOptions(
   @Tag(tags.implementation)
   @HelpMessage("Suppress warnings about using experimental features")
   @Name("suppressExperimentalWarning")
-  suppressExperimentalFeatureWarning: Boolean = false
+  suppressExperimentalFeatureWarning: Option[Boolean] = None
 )
 
 object GlobalSuppressWarningOptions {
   implicit lazy val parser: Parser[GlobalSuppressWarningOptions] = Parser.derive
   implicit lazy val help: Help[GlobalSuppressWarningOptions]     = Help.derive
 
-  def shouldSuppressExperimentalFeatureWarning(args: List[String]): Boolean =
+  def shouldSuppressExperimentalFeatureWarning(args: List[String]): Option[Boolean] =
     parser
       .detailedParse(args, stopAtFirstUnrecognized = false, ignoreUnrecognized = true)
-      .map(_._1.suppressExperimentalFeatureWarning.self)
-      .getOrElse(false)
+      .toOption
+      .flatMap(_._1.suppressExperimentalFeatureWarning)
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HasGlobalOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HasGlobalOptions.scala
@@ -1,6 +1,5 @@
 package scala.cli.commands.shared
 
 trait HasGlobalOptions {
-  def logging: LoggingOptions
-  def globalSuppressWarning: GlobalSuppressWarningOptions
+  def global: GlobalOptions
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HasGlobalOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HasGlobalOptions.scala
@@ -1,0 +1,6 @@
+package scala.cli.commands.shared
+
+trait HasGlobalOptions {
+  def logging: LoggingOptions
+  def globalSuppressWarning: GlobalSuppressWarningOptions
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HasLoggingOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HasLoggingOptions.scala
@@ -1,5 +1,0 @@
-package scala.cli.commands.shared
-
-trait HasLoggingOptions {
-  def logging: LoggingOptions
-}

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HasSharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HasSharedOptions.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.shared
 
-trait HasSharedOptions extends HasLoggingOptions {
+trait HasSharedOptions extends HasGlobalOptions {
   def shared: SharedOptions
-  override def logging: LoggingOptions = shared.logging
+  override def logging: LoggingOptions                             = shared.logging
+  override def globalSuppressWarning: GlobalSuppressWarningOptions = shared.suppress.global
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HasSharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HasSharedOptions.scala
@@ -2,6 +2,5 @@ package scala.cli.commands.shared
 
 trait HasSharedOptions extends HasGlobalOptions {
   def shared: SharedOptions
-  override def logging: LoggingOptions                             = shared.logging
-  override def globalSuppressWarning: GlobalSuppressWarningOptions = shared.suppress.global
+  override def global: GlobalOptions = shared.global
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HelpGroups.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HelpGroups.scala
@@ -14,7 +14,7 @@ enum HelpGroup:
     NativeImage,
     Package, PGP, Publishing,
     RedHat, Repl, Run, Runner,
-    Scala, ScalaJs, ScalaNative, Secret, Signing,
+    Scala, ScalaJs, ScalaNative, Secret, Signing, SuppressWarnings,
     Test,
     Uninstall, Update,
     Watch, Windows,
@@ -27,6 +27,7 @@ enum HelpGroup:
     case NativeImage       => "Native image"
     case ScalaJs           => "Scala.js"
     case ScalaNative       => "Scala Native"
+    case SuppressWarnings  => "Suppress warnings"
     case e                 => e.productPrefix
 
 enum HelpCommandGroup:

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HelpOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HelpOptions.scala
@@ -6,8 +6,10 @@ import caseapp.*
 @HelpMessage("Print help message")
 case class HelpOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions()
-) extends HasLoggingOptions
+    logging: LoggingOptions = LoggingOptions(),
+  @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions()
+) extends HasGlobalOptions
 // format: on
 
 object HelpOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HelpOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HelpOptions.scala
@@ -6,9 +6,7 @@ import caseapp.*
 @HelpMessage("Print help message")
 case class HelpOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions()
+     global: GlobalOptions = GlobalOptions(),
 ) extends HasGlobalOptions
 // format: on
 

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -30,7 +30,7 @@ import scala.build.options as bo
 import scala.cli.ScalaCli
 import scala.cli.commands.publish.ConfigUtil.*
 import scala.cli.commands.shared.{
-  HasLoggingOptions,
+  HasGlobalOptions,
   ScalaJsOptions,
   ScalaNativeOptions,
   SharedOptions,
@@ -201,10 +201,12 @@ final case class SharedOptions(
   @Tag(tags.implementation)
   @Tag(tags.inShortHelp)
     withToolkit: Option[String] = None
-) extends HasLoggingOptions {
+) extends HasGlobalOptions {
   // format: on
 
   def logger: Logger = logging.logger
+
+  override def globalSuppressWarning: GlobalSuppressWarningOptions = suppress.global
 
   private def scalaJsOptions(opts: ScalaJsOptions): options.ScalaJsOptions = {
     import opts._
@@ -293,14 +295,16 @@ final case class SharedOptions(
     bo.BuildOptions(
       suppressWarningOptions =
         bo.SuppressWarningOptions(
-          getOptionOrFromConfig(
+          suppressDirectivesInMultipleFilesWarning = getOptionOrFromConfig(
             suppress.suppressDirectivesInMultipleFilesWarning,
             Keys.suppressDirectivesInMultipleFilesWarning
           ),
-          getOptionOrFromConfig(
+          suppressOutdatedDependencyWarning = getOptionOrFromConfig(
             suppress.suppressOutdatedDependencyWarning,
             Keys.suppressOutdatedDependenciessWarning
-          )
+          ),
+          suppressExperimentalFeatureWarning =
+            Some(suppress.global.suppressExperimentalFeatureWarning)
         ),
       scalaOptions = bo.ScalaOptions(
         scalaVersion = scalaVersion

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -205,8 +205,8 @@ final case class SharedOptions(
   // format: on
 
   def logger: Logger = logging.logger
-
-  override def globalSuppressWarning: GlobalSuppressWarningOptions = suppress.global
+  override def global: GlobalOptions =
+    GlobalOptions(logging = logging, globalSuppress = suppress.global)
 
   private def scalaJsOptions(opts: ScalaJsOptions): options.ScalaJsOptions = {
     import opts._

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -303,8 +303,10 @@ final case class SharedOptions(
             suppress.suppressOutdatedDependencyWarning,
             Keys.suppressOutdatedDependenciessWarning
           ),
-          suppressExperimentalFeatureWarning =
-            Some(suppress.global.suppressExperimentalFeatureWarning)
+          suppressExperimentalFeatureWarning = getOptionOrFromConfig(
+            suppress.global.suppressExperimentalFeatureWarning,
+            Keys.suppressExperimentalFeatureWarning
+          )
         ),
       scalaOptions = bo.ScalaOptions(
         scalaVersion = scalaVersion

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SuppressWarningOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SuppressWarningOptions.scala
@@ -6,14 +6,17 @@ import scala.cli.commands.tags
 
 // format: off
 final case class SuppressWarningOptions(
+  @Group(HelpGroup.SuppressWarnings.toString)
   @Tag(tags.implementation)
   @HelpMessage("Suppress warnings about using directives in multiple files")
   @Name("suppressWarningDirectivesInMultipleFiles")
     suppressDirectivesInMultipleFilesWarning: Option[Boolean] = None,
-
+  @Group(HelpGroup.SuppressWarnings.toString)
   @Tag(tags.implementation)
   @HelpMessage("Suppress warnings about outdated dependencies in project")
-    suppressOutdatedDependencyWarning: Option[Boolean]= None
+    suppressOutdatedDependencyWarning: Option[Boolean] = None,
+  @Recurse
+    global: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions()
 )
 // format: on
 

--- a/modules/cli/src/main/scala/scala/cli/commands/uninstall/Uninstall.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/uninstall/Uninstall.scala
@@ -15,7 +15,7 @@ object Uninstall extends ScalaCommand[UninstallOptions] {
 
   override def runCommand(options: UninstallOptions, args: RemainingArgs, logger: Logger): Unit = {
     val interactive =
-      options.bloopExit.logging.verbosityOptions.interactiveInstance(forceEnable = true)
+      options.bloopExit.global.logging.verbosityOptions.interactiveInstance(forceEnable = true)
 
     val binDirPath =
       options.binDirPath.getOrElse(
@@ -44,12 +44,12 @@ object Uninstall extends ScalaCommand[UninstallOptions] {
       // uninstall completions
       logger.debug("Uninstalling completions...")
       UninstallCompletions.run(
-        UninstallCompletionsOptions(options.sharedUninstallCompletions, options.bloopExit.logging),
+        UninstallCompletionsOptions(options.sharedUninstallCompletions, options.bloopExit.global),
         args
       )
       // exit bloop server
       logger.debug("Stopping Bloop server...")
-      BloopExit.runCommand(options.bloopExit, args, options.logging.logger)
+      BloopExit.runCommand(options.bloopExit, args, options.global.logging.logger)
       // remove scala-cli launcher
       logger.debug(s"Removing $baseRunnerName binary...")
       os.remove.all(binDirPath)

--- a/modules/cli/src/main/scala/scala/cli/commands/uninstall/UninstallOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/uninstall/UninstallOptions.scala
@@ -6,13 +6,7 @@ import java.nio.file.Path
 
 import scala.cli.ScalaCli.{baseRunnerName, fullRunnerName}
 import scala.cli.commands.bloop.BloopExitOptions
-import scala.cli.commands.shared.{
-  GlobalSuppressWarningOptions,
-  HasGlobalOptions,
-  HelpGroup,
-  HelpMessages,
-  LoggingOptions
-}
+import scala.cli.commands.shared.{GlobalOptions, HasGlobalOptions, HelpGroup, HelpMessages}
 import scala.cli.commands.tags
 import scala.cli.commands.uninstallcompletions.SharedUninstallCompletionsOptions
 
@@ -47,8 +41,7 @@ final case class UninstallOptions(
   @Tag(tags.implementation)
     binDir: Option[String] = None
 ) extends HasGlobalOptions {
-  override def logging: LoggingOptions = bloopExit.logging
-  override def globalSuppressWarning: GlobalSuppressWarningOptions = bloopExit.globalSuppressWarning
+  override def global: GlobalOptions = bloopExit.global
   // format: on
   lazy val binDirPath: Option[os.Path] = binDir.map(os.Path(_, os.pwd))
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/uninstall/UninstallOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/uninstall/UninstallOptions.scala
@@ -6,7 +6,13 @@ import java.nio.file.Path
 
 import scala.cli.ScalaCli.{baseRunnerName, fullRunnerName}
 import scala.cli.commands.bloop.BloopExitOptions
-import scala.cli.commands.shared.{HasLoggingOptions, HelpGroup, HelpMessages, LoggingOptions}
+import scala.cli.commands.shared.{
+  GlobalSuppressWarningOptions,
+  HasGlobalOptions,
+  HelpGroup,
+  HelpMessages,
+  LoggingOptions
+}
 import scala.cli.commands.tags
 import scala.cli.commands.uninstallcompletions.SharedUninstallCompletionsOptions
 
@@ -40,8 +46,9 @@ final case class UninstallOptions(
   @HelpMessage("Binary directory")
   @Tag(tags.implementation)
     binDir: Option[String] = None
-) extends HasLoggingOptions {
+) extends HasGlobalOptions {
   override def logging: LoggingOptions = bloopExit.logging
+  override def globalSuppressWarning: GlobalSuppressWarningOptions = bloopExit.globalSuppressWarning
   // format: on
   lazy val binDirPath: Option[os.Path] = binDir.map(os.Path(_, os.pwd))
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/UninstallCompletions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/UninstallCompletions.scala
@@ -48,7 +48,7 @@ object UninstallCompletions extends ScalaCommand[UninstallCompletionsOptions] {
         Charset.defaultCharset()
       )
 
-      if (options.logging.verbosity >= 0)
+      if (options.global.logging.verbosity >= 0)
         if (updated) {
           logger.message(s"Updated $rcFile")
           logger.message(s"$baseRunnerName completions uninstalled successfully")

--- a/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/UninstallCompletionsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/UninstallCompletionsOptions.scala
@@ -3,12 +3,7 @@ package scala.cli.commands.uninstallcompletions
 import caseapp.*
 
 import scala.cli.ScalaCli.fullRunnerName
-import scala.cli.commands.shared.{
-  GlobalSuppressWarningOptions,
-  HasGlobalOptions,
-  HelpMessages,
-  LoggingOptions
-}
+import scala.cli.commands.shared.{GlobalOptions, HasGlobalOptions, HelpMessages}
 import scala.cli.commands.uninstallcompletions.SharedUninstallCompletionsOptions
 
 // format: off
@@ -17,9 +12,7 @@ final case class UninstallCompletionsOptions(
   @Recurse
     shared: SharedUninstallCompletionsOptions = SharedUninstallCompletionsOptions(),
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions()
+    global: GlobalOptions = GlobalOptions(),
 ) extends HasGlobalOptions
 // format: on
 

--- a/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/UninstallCompletionsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/UninstallCompletionsOptions.scala
@@ -3,7 +3,12 @@ package scala.cli.commands.uninstallcompletions
 import caseapp.*
 
 import scala.cli.ScalaCli.fullRunnerName
-import scala.cli.commands.shared.{HasLoggingOptions, HelpMessages, LoggingOptions}
+import scala.cli.commands.shared.{
+  GlobalSuppressWarningOptions,
+  HasGlobalOptions,
+  HelpMessages,
+  LoggingOptions
+}
 import scala.cli.commands.uninstallcompletions.SharedUninstallCompletionsOptions
 
 // format: off
@@ -12,8 +17,10 @@ final case class UninstallCompletionsOptions(
   @Recurse
     shared: SharedUninstallCompletionsOptions = SharedUninstallCompletionsOptions(),
   @Recurse
-    logging: LoggingOptions = LoggingOptions()
-) extends HasLoggingOptions
+    logging: LoggingOptions = LoggingOptions(),
+  @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions()
+) extends HasGlobalOptions
 // format: on
 
 object UninstallCompletionsOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/update/Update.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/update/Update.scala
@@ -67,7 +67,8 @@ object Update extends ScalaCommand[UpdateOptions] {
     )
 
   private def updateScalaCli(options: UpdateOptions, newVersion: String, logger: Logger): Unit = {
-    val interactive = options.logging.verbosityOptions.interactiveInstance(forceEnable = true)
+    val interactive =
+      options.global.logging.verbosityOptions.interactiveInstance(forceEnable = true)
     if (!options.force) {
       val fallbackAction = () => {
         logger.error(s"To update $baseRunnerName to $newVersion pass -f or --force")

--- a/modules/cli/src/main/scala/scala/cli/commands/update/UpdateOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/update/UpdateOptions.scala
@@ -3,7 +3,13 @@ package scala.cli.commands.update
 import caseapp.*
 
 import scala.cli.ScalaCli.{baseRunnerName, fullRunnerName}
-import scala.cli.commands.shared.{HasLoggingOptions, HelpGroup, HelpMessages, LoggingOptions}
+import scala.cli.commands.shared.{
+  GlobalSuppressWarningOptions,
+  HasGlobalOptions,
+  HelpGroup,
+  HelpMessages,
+  LoggingOptions
+}
 import scala.cli.commands.tags
 import scala.cli.signing.shared.PasswordOption
 import scala.cli.signing.util.ArgParsers.*
@@ -13,6 +19,8 @@ import scala.cli.signing.util.ArgParsers.*
 final case class UpdateOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
+  @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
   @Hidden
   @Group(HelpGroup.Update.toString)
   @HelpMessage("Binary name")
@@ -36,7 +44,7 @@ final case class UpdateOptions(
   @HelpMessage(HelpMessages.passwordOption)
   @Tag(tags.implementation)
     ghToken: Option[PasswordOption] = None
-) extends HasLoggingOptions
+) extends HasGlobalOptions
 // format: on
 
 object UpdateOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/update/UpdateOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/update/UpdateOptions.scala
@@ -3,13 +3,7 @@ package scala.cli.commands.update
 import caseapp.*
 
 import scala.cli.ScalaCli.{baseRunnerName, fullRunnerName}
-import scala.cli.commands.shared.{
-  GlobalSuppressWarningOptions,
-  HasGlobalOptions,
-  HelpGroup,
-  HelpMessages,
-  LoggingOptions
-}
+import scala.cli.commands.shared.{GlobalOptions, HasGlobalOptions, HelpGroup, HelpMessages}
 import scala.cli.commands.tags
 import scala.cli.signing.shared.PasswordOption
 import scala.cli.signing.util.ArgParsers.*
@@ -18,9 +12,7 @@ import scala.cli.signing.util.ArgParsers.*
 @HelpMessage(UpdateOptions.helpMessage, "", UpdateOptions.detailedHelpMessage)
 final case class UpdateOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Hidden
   @Group(HelpGroup.Update.toString)
   @HelpMessage("Binary name")

--- a/modules/cli/src/main/scala/scala/cli/commands/version/VersionOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/version/VersionOptions.scala
@@ -3,7 +3,13 @@ package scala.cli.commands.version
 import caseapp.*
 
 import scala.cli.ScalaCli.fullRunnerName
-import scala.cli.commands.shared.{HasLoggingOptions, HelpGroup, HelpMessages, LoggingOptions}
+import scala.cli.commands.shared.{
+  GlobalSuppressWarningOptions,
+  HasGlobalOptions,
+  HelpGroup,
+  HelpMessages,
+  LoggingOptions
+}
 import scala.cli.commands.tags
 import scala.cli.signing.shared.PasswordOption
 import scala.cli.signing.util.ArgParsers.*
@@ -13,6 +19,8 @@ import scala.cli.signing.util.ArgParsers.*
 final case class VersionOptions(
   @Recurse
     logging: LoggingOptions = LoggingOptions(),
+  @Recurse
+    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
   @Tag(tags.implementation)
   @Tag(tags.inShortHelp)
   @Group(HelpGroup.Version.toString)
@@ -34,7 +42,7 @@ final case class VersionOptions(
   @Tag(tags.inShortHelp)
   @HelpMessage(s"Don't check for the newest available $fullRunnerName version upstream")
     offline: Boolean = false
-) extends HasLoggingOptions
+) extends HasGlobalOptions
 // format: on
 
 object VersionOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/version/VersionOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/version/VersionOptions.scala
@@ -4,6 +4,7 @@ import caseapp.*
 
 import scala.cli.ScalaCli.fullRunnerName
 import scala.cli.commands.shared.{
+  GlobalOptions,
   GlobalSuppressWarningOptions,
   HasGlobalOptions,
   HelpGroup,
@@ -18,9 +19,7 @@ import scala.cli.signing.util.ArgParsers.*
 @HelpMessage(VersionOptions.helpMessage, "", VersionOptions.detailedHelpMessage)
 final case class VersionOptions(
   @Recurse
-    logging: LoggingOptions = LoggingOptions(),
-  @Recurse
-    globalSuppressWarning: GlobalSuppressWarningOptions = GlobalSuppressWarningOptions(),
+    global: GlobalOptions = GlobalOptions(),
   @Tag(tags.implementation)
   @Tag(tags.inShortHelp)
   @Group(HelpGroup.Version.toString)

--- a/modules/cli/src/main/scala/scala/cli/internal/CliLogger.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/CliLogger.scala
@@ -206,3 +206,7 @@ class CliLogger(
   // Allow to disable that?
   def compilerOutputStream = out
 }
+
+object CliLogger {
+  def default: CliLogger = new CliLogger(0, false, None, System.err)
+}

--- a/modules/cli/src/main/scala/scala/cli/util/ConfigDbUtils.scala
+++ b/modules/cli/src/main/scala/scala/cli/util/ConfigDbUtils.scala
@@ -1,0 +1,36 @@
+package scala.cli.util
+
+import scala.build.errors.BuildException
+import scala.build.{Directories, Logger}
+import scala.cli.commands.publish.ConfigUtil.wrapConfigException
+import scala.cli.config.{ConfigDb, ConfigDbException, Key}
+
+object ConfigDbUtils {
+  lazy val configDb: Either[ConfigDbException, ConfigDb] =
+    ConfigDb.open(Directories.directories.dbPath.toNIO).wrapConfigException
+
+  extension [T](either: Either[Exception, T]) {
+    private def handleConfigDbException(f: BuildException => Unit): Option[T] =
+      either match
+        case Left(e: BuildException) =>
+          f(e)
+          None
+        case Left(e: Exception) =>
+          f(new ConfigDbException(e))
+          None
+        case Right(value) => Some(value)
+  }
+
+  def getConfigDbOpt(logger: Logger): Option[ConfigDb] =
+    configDb.handleConfigDbException(logger.debug)
+
+  extension (db: ConfigDb) {
+    def getOpt[T](configDbKey: Key[T], f: BuildException => Unit): Option[T] =
+      db.get(configDbKey).handleConfigDbException(f).flatten
+    def getOpt[T](configDbKey: Key[T], logger: Logger): Option[T] =
+      getOpt(configDbKey, logger.debug(_))
+    def getOpt[T](configDbKey: Key[T]): Option[T] =
+      getOpt(configDbKey, _.printStackTrace(System.err))
+  }
+
+}

--- a/modules/config/src/main/scala/scala/cli/config/Keys.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Keys.scala
@@ -81,6 +81,12 @@ object Keys {
       name = "outdated-dependencies-files",
       description = "Globally suppresses warnings about outdated dependencies."
     )
+  val suppressExperimentalFeatureWarning =
+    new Key.BooleanEntry(
+      prefix = Seq("suppress-warning"),
+      name = "experimental-features",
+      description = "Globally suppresses warnings about experimental features."
+    )
 
   val proxyAddress = new Key.StringEntry(
     prefix = Seq("httpProxy"),
@@ -135,6 +141,7 @@ object Keys {
     interactive,
     suppressDirectivesInMultipleFilesWarning,
     suppressOutdatedDependenciessWarning,
+    suppressExperimentalFeatureWarning,
     pgpPublicKey,
     pgpSecretKey,
     pgpSecretKeyPassword,

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/StrictDirective.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/StrictDirective.scala
@@ -6,6 +6,10 @@ case class StrictDirective(
   key: String,
   values: Seq[Value[_]]
 ) {
+  override def toString: String = {
+    val suffix = if values.isEmpty then "" else s" \"${values.mkString("\",  \"")}\""
+    s"//> using $key$suffix"
+  }
   def numericalOrStringValuesCount: Int =
     values.count {
       case _: NumericValue => true

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -53,6 +53,23 @@ class SipScalaTests extends ScalaCliSuite {
       expect(res.exitCode == 1)
     }
 
+  def testExportCommandHelp(isPowerMode: Boolean): Unit =
+    TestInputs.empty.fromRoot { root =>
+      val res = os.proc(TestUtil.cli, powerArgs(isPowerMode), "export", "-h").call(
+        cwd = root,
+        stderr = os.Pipe
+      )
+      val output = res.out.trim()
+      if (!isPowerMode)
+        expect(output.contains(
+          "This command is experimental and requires setting the '--power' launcher option to be used"
+        ))
+      else
+        expect(output.contains(
+          "The 'export' sub-command is an experimental feature"
+        ))
+    }
+
   def testPublishDirectives(isPowerMode: Boolean): Unit = TestInputs.empty.fromRoot { root =>
     val code =
       """
@@ -164,6 +181,9 @@ class SipScalaTests extends ScalaCliSuite {
     }
     test(s"test export command when power mode is $powerModeString") {
       testExportCommand(isPowerMode)
+    }
+    test(s"test export command help output when power mode is $powerModeString") {
+      testExportCommandHelp(isPowerMode)
     }
   }
 

--- a/modules/options/src/main/scala/scala/build/options/SuppressWarningOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/SuppressWarningOptions.scala
@@ -2,7 +2,8 @@ package scala.build.options
 
 final case class SuppressWarningOptions(
   suppressDirectivesInMultipleFilesWarning: Option[Boolean] = None,
-  suppressOutdatedDependencyWarning: Option[Boolean] = None
+  suppressOutdatedDependencyWarning: Option[Boolean] = None,
+  suppressExperimentalFeatureWarning: Option[Boolean] = None
 )
 
 object SuppressWarningOptions {

--- a/website/docs/commands/export.md
+++ b/website/docs/commands/export.md
@@ -17,6 +17,14 @@ You can pass it explicitly or set it globally by running:
 scala-cli config power true
 :::
 
+:::caution
+The `export` sub-command is an experimental feature.
+
+Please bear in mind that non-ideal user experience should be expected.
+If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team
+on [GitHub](https://github.com/VirtusLab/scala-cli).
+:::
+
 The project configuration is read both from information specified in source files
 as well as options passed to the `export` sub-command.
 

--- a/website/docs/commands/publishing/publish-local.md
+++ b/website/docs/commands/publishing/publish-local.md
@@ -10,6 +10,14 @@ You can pass it explicitly or set it globally by running:
     scala-cli config power true
 :::
 
+:::caution
+The `publish local` sub-command is an experimental feature.
+
+Please bear in mind that non-ideal user experience should be expected.
+If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team
+on [GitHub](https://github.com/VirtusLab/scala-cli).
+:::
+
 import {ChainedSnippets} from "../../../src/components/MarkdownComponents.js";
 
 The `publish local` sub-command publishes a Scala CLI project in the local Ivy2

--- a/website/docs/commands/publishing/publish-setup.md
+++ b/website/docs/commands/publishing/publish-setup.md
@@ -10,6 +10,14 @@ You can pass it explicitly or set it globally by running:
     scala-cli config power true
 :::
 
+:::caution
+The `publish setup` sub-command is an experimental feature.
+
+Please bear in mind that non-ideal user experience should be expected.
+If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team
+on [GitHub](https://github.com/VirtusLab/scala-cli).
+:::
+
 import {ChainedSnippets} from "../../../src/components/MarkdownComponents.js";
 
 The `publish setup` sub-command configures your project for publishing to Maven repositories,

--- a/website/docs/commands/publishing/publish.md
+++ b/website/docs/commands/publishing/publish.md
@@ -10,6 +10,14 @@ You can pass it explicitly or set it globally by running:
     scala-cli config power true
 :::
 
+:::caution
+The `publish` sub-command is an experimental feature.
+
+Please bear in mind that non-ideal user experience should be expected.
+If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team
+on [GitHub](https://github.com/VirtusLab/scala-cli).
+:::
+
 import {ChainedSnippets} from "../../../src/components/MarkdownComponents.js";
 
 The `publish` sub-command allows to publish Scala CLI projects to Maven repositories.

--- a/website/docs/guides/markdown.md
+++ b/website/docs/guides/markdown.md
@@ -1,7 +1,15 @@
 ---
-title: Markdown (experimental) ⚡️
+title: Markdown ⚡️
 sidebar_position: 60
 ---
+
+:::caution
+Markdown support is an experimental feature.
+
+Please bear in mind that non-ideal user experience should be expected.
+If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team
+on [GitHub](https://github.com/VirtusLab/scala-cli).
+:::
 
 import {ChainedSnippets} from "../../src/components/MarkdownComponents.js";
 

--- a/website/docs/guides/sbt-mill.md
+++ b/website/docs/guides/sbt-mill.md
@@ -3,6 +3,14 @@ title: SBT and Mill ⚡️
 sidebar_position: 50
 ---
 
+:::caution
+The `export` sub-command is an experimental feature.
+
+Please bear in mind that non-ideal user experience should be expected.
+If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team
+on [GitHub](https://github.com/VirtusLab/scala-cli).
+:::
+
 Scala CLI lets you export your current build into sbt or Mill.
 This means that if your project needs something that Scala CLI doesn’t provide — such as a second module — you can export your project to your build tool of choice.
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -402,6 +402,20 @@ Aliases: `--fmt-version`
 
 Pass scalafmt version before running it (3.6.1 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
 
+## Global suppress warning options
+
+Available in commands:
+
+[`add-path`](./commands.md#add-path), [`bloop`](./commands.md#bloop), [`bloop exit`](./commands.md#bloop-exit), [`bloop output`](./commands.md#bloop-output), [`bloop start`](./commands.md#bloop-start), [`bsp`](./commands.md#bsp), [`clean`](./commands.md#clean), [`compile`](./commands.md#compile), [`config`](./commands.md#config), [`default-file`](./commands.md#default-file), [`dependency-update`](./commands.md#dependency-update), [`directories`](./commands.md#directories), [`doc`](./commands.md#doc), [`export`](./commands.md#export), [`fmt` , `format` , `scalafmt`](./commands.md#fmt), [`help`](./commands.md#help), [`install completions` , `install-completions`](./commands.md#install-completions), [`install-home`](./commands.md#install-home), [`package`](./commands.md#package), [`pgp pull`](./commands.md#pgp-pull), [`pgp push`](./commands.md#pgp-push), [`publish`](./commands.md#publish), [`publish local`](./commands.md#publish-local), [`publish setup`](./commands.md#publish-setup), [`repl` , `console`](./commands.md#repl), [`run`](./commands.md#run), [`github secret create` , `gh secret create`](./commands.md#github-secret-create), [`github secret list` , `gh secret list`](./commands.md#github-secret-list), [`setup-ide`](./commands.md#setup-ide), [`shebang`](./commands.md#shebang), [`test`](./commands.md#test), [`uninstall`](./commands.md#uninstall), [`uninstall completions` , `uninstall-completions`](./commands.md#uninstall-completions), [`update`](./commands.md#update), [`version`](./commands.md#version)
+
+<!-- Automatically generated, DO NOT EDIT MANUALLY -->
+
+### `--suppress-experimental-feature-warning`
+
+Aliases: `--suppress-experimental-warning`
+
+Suppress warnings about using experimental features
+
 ## Help options
 
 Available in commands:

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -109,6 +109,10 @@ All supported types of inputs can be mixed with each other.
 
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
+The 'export' sub-command is an experimental feature.
+Please bear in mind that non-ideal user experience should be expected.
+If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
+
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [export](./cli-options.md#export-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
 
 ## fmt
@@ -205,6 +209,10 @@ All supported types of inputs can be mixed with each other.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish
 
+The 'publish' sub-command is an experimental feature.
+Please bear in mind that non-ideal user experience should be expected.
+If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
+
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish](./cli-options.md#publish-options), [publish params](./cli-options.md#publish-params-options), [publish repository](./cli-options.md#publish-repository-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
 ## publish local
@@ -213,6 +221,10 @@ Publishes build artifacts to the local Ivy2 repository.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish-local
 
+The 'publish-local' sub-command is an experimental feature.
+Please bear in mind that non-ideal user experience should be expected.
+If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
+
 Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish](./cli-options.md#publish-options), [publish params](./cli-options.md#publish-params-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
 ## publish setup
@@ -220,6 +232,10 @@ Accepts option groups: [compilation server](./cli-options.md#compilation-server-
 Configures the project for publishing.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish-setup
+
+The 'publish-setup' sub-command is an experimental feature.
+Please bear in mind that non-ideal user experience should be expected.
+If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
 Accepts option groups: [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp push pull](./cli-options.md#pgp-push-pull-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish params](./cli-options.md#publish-params-options), [publish repository](./cli-options.md#publish-repository-options), [publish setup](./cli-options.md#publish-setup-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
 
@@ -258,6 +274,10 @@ Creates or updates a GitHub repository secret.
   scala-cli --power github secret create --repo repo-org/repo-name SECRET_VALUE=value:secret
 ```
 
+The 'secret-create' sub-command is an experimental feature.
+Please bear in mind that non-ideal user experience should be expected.
+If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
+
 Accepts option groups: [coursier](./cli-options.md#coursier-options), [logging](./cli-options.md#logging-options), [secret](./cli-options.md#secret-options), [secret create](./cli-options.md#secret-create-options), [verbosity](./cli-options.md#verbosity-options)
 
 ## github secret list
@@ -265,6 +285,10 @@ Accepts option groups: [coursier](./cli-options.md#coursier-options), [logging](
 Aliases: `gh secret list`
 
 Lists secrets for a given GitHub repository.
+
+The 'secret-list' sub-command is an experimental feature.
+Please bear in mind that non-ideal user experience should be expected.
+If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
 Accepts option groups: [logging](./cli-options.md#logging-options), [secret](./cli-options.md#secret-options), [verbosity](./cli-options.md#verbosity-options)
 

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -14,7 +14,7 @@ Passed inputs will establish the Scala CLI project, for which the workspace will
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/clean
 
-Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
 
 ## compile
 
@@ -32,7 +32,7 @@ All supported types of inputs can be mixed with each other.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/compile
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [compile](./cli-options.md#compile-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [compile](./cli-options.md#compile-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
 ## config
 
@@ -71,13 +71,13 @@ Available keys:
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/config
 
-Accepts option groups: [config](./cli-options.md#config-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [config](./cli-options.md#config-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [verbosity](./cli-options.md#verbosity-options)
 
 ## dependency-update
 
 Update dependency directives in the project
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [dependency update](./cli-options.md#dependency-update-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [dependency update](./cli-options.md#dependency-update-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
 
 ## doc
 
@@ -91,7 +91,7 @@ All supported types of inputs can be mixed with each other.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/doc
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [doc](./cli-options.md#doc-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [doc](./cli-options.md#doc-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
 
 ## export
 
@@ -113,7 +113,7 @@ The 'export' sub-command is an experimental feature.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [export](./cli-options.md#export-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [export](./cli-options.md#export-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
 
 ## fmt
 
@@ -130,13 +130,13 @@ All standard Scala CLI inputs are accepted, but only Scala sources will be forma
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/fmt
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [fmt](./cli-options.md#fmt-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [fmt](./cli-options.md#fmt-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
 
 ## help
 
 Print help message
 
-Accepts option groups: [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 
 ## install completions
 
@@ -146,7 +146,7 @@ Installs Scala CLI completions into your shell
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
-Accepts option groups: [install completions](./cli-options.md#install-completions-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [global suppress warning](./cli-options.md#global-suppress-warning-options), [install completions](./cli-options.md#install-completions-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 
 ## repl
 
@@ -168,7 +168,7 @@ All supported types of inputs can be mixed with each other.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/repl
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [repl](./cli-options.md#repl-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [repl](./cli-options.md#repl-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
 ## package
 
@@ -186,7 +186,7 @@ All supported types of inputs can be mixed with each other.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/package
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [package](./cli-options.md#package-options), [packager](./cli-options.md#packager-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [package](./cli-options.md#package-options), [packager](./cli-options.md#packager-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
 ## publish
 
@@ -213,7 +213,7 @@ The 'publish' sub-command is an experimental feature.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish](./cli-options.md#publish-options), [publish params](./cli-options.md#publish-params-options), [publish repository](./cli-options.md#publish-repository-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish](./cli-options.md#publish-options), [publish params](./cli-options.md#publish-params-options), [publish repository](./cli-options.md#publish-repository-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
 ## publish local
 
@@ -225,7 +225,7 @@ The 'publish-local' sub-command is an experimental feature.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish](./cli-options.md#publish-options), [publish params](./cli-options.md#publish-params-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish](./cli-options.md#publish-options), [publish params](./cli-options.md#publish-params-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
 ## publish setup
 
@@ -237,7 +237,7 @@ The 'publish-setup' sub-command is an experimental feature.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
-Accepts option groups: [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp push pull](./cli-options.md#pgp-push-pull-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish params](./cli-options.md#publish-params-options), [publish repository](./cli-options.md#publish-repository-options), [publish setup](./cli-options.md#publish-setup-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp push pull](./cli-options.md#pgp-push-pull-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [publish params](./cli-options.md#publish-params-options), [publish repository](./cli-options.md#publish-repository-options), [publish setup](./cli-options.md#publish-setup-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
 
 ## run
 
@@ -263,7 +263,7 @@ To pass arguments to the actual application, just add them after `--`, like:
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/run
 
-Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
 ## github secret create
 
@@ -278,7 +278,7 @@ The 'secret-create' sub-command is an experimental feature.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
-Accepts option groups: [coursier](./cli-options.md#coursier-options), [logging](./cli-options.md#logging-options), [secret](./cli-options.md#secret-options), [secret create](./cli-options.md#secret-create-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [coursier](./cli-options.md#coursier-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [secret](./cli-options.md#secret-options), [secret create](./cli-options.md#secret-create-options), [verbosity](./cli-options.md#verbosity-options)
 
 ## github secret list
 
@@ -290,7 +290,7 @@ The 'secret-list' sub-command is an experimental feature.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
-Accepts option groups: [logging](./cli-options.md#logging-options), [secret](./cli-options.md#secret-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [secret](./cli-options.md#secret-options), [verbosity](./cli-options.md#verbosity-options)
 
 ## setup-ide
 
@@ -310,7 +310,7 @@ Using directives can be defined in all supported input source file types.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/setup-ide
 
-Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [setup IDE](./cli-options.md#setup-ide-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [setup IDE](./cli-options.md#setup-ide-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
 
 ## shebang
 
@@ -341,7 +341,7 @@ Using this, it is possible to conveniently set up Unix shebang scripts. For exam
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/shebang
 
-Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
 ## test
 
@@ -365,7 +365,7 @@ All supported types of inputs can be mixed with each other.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/test
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [test](./cli-options.md#test-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [test](./cli-options.md#test-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
 ## uninstall
 
@@ -373,7 +373,7 @@ Uninstalls Scala CLI.
 Works only when installed with the installation script.
 For detailed installation instructions refer to our website: https://scala-cli.virtuslab.org/install
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [logging](./cli-options.md#logging-options), [uninstall](./cli-options.md#uninstall-options), [uninstall completions](./cli-options.md#uninstall-completions-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [uninstall](./cli-options.md#uninstall-options), [uninstall completions](./cli-options.md#uninstall-completions-options), [verbosity](./cli-options.md#verbosity-options)
 
 ## uninstall completions
 
@@ -383,7 +383,7 @@ Uninstalls Scala CLI completions from your shell.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
-Accepts option groups: [logging](./cli-options.md#logging-options), [uninstall completions](./cli-options.md#uninstall-completions-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [uninstall completions](./cli-options.md#uninstall-completions-options), [verbosity](./cli-options.md#verbosity-options)
 
 ## update
 
@@ -393,7 +393,7 @@ If Scala CLI was installed with an external tool, refer to its update methods.
 
 For detailed installation instructions refer to our website: https://scala-cli.virtuslab.org/install
 
-Accepts option groups: [logging](./cli-options.md#logging-options), [update](./cli-options.md#update-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [update](./cli-options.md#update-options), [verbosity](./cli-options.md#verbosity-options)
 
 ## version
 
@@ -407,7 +407,7 @@ Scala version defined by the runner.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/version
 
-Accepts option groups: [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [version](./cli-options.md#version-options)
+Accepts option groups: [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [version](./cli-options.md#version-options)
 
 ## Hidden commands
 
@@ -415,7 +415,7 @@ Accepts option groups: [logging](./cli-options.md#logging-options), [verbosity](
 
 Add entries to the PATH environment variable.
 
-Accepts option groups: [add path](./cli-options.md#add-path-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [add path](./cli-options.md#add-path-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### bloop
 
@@ -427,7 +427,7 @@ If Bloop isn't currently running, it will be started.
 Bloop is the build server used by Scala CLI.
 For more information about Bloop, refer to https://scalacenter.github.io/bloop/
 
-Accepts option groups: [bloop](./cli-options.md#bloop-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [bloop](./cli-options.md#bloop-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### bloop exit
 
@@ -436,7 +436,7 @@ Stop Bloop if an instance is running.
 Bloop is the build server used by Scala CLI.
 For more information about Bloop, refer to https://scalacenter.github.io/bloop/
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### bloop output
 
@@ -445,7 +445,7 @@ Print Bloop output.
 Bloop is the build server used by Scala CLI.
 For more information about Bloop, refer to https://scalacenter.github.io/bloop/
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### bloop start
 
@@ -454,7 +454,7 @@ Starts a Bloop instance, if none is running.
 Bloop is the build server used by Scala CLI.
 For more information about Bloop, refer to https://scalacenter.github.io/bloop/
 
-Accepts option groups: [bloop start](./cli-options.md#bloop-start-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [bloop start](./cli-options.md#bloop-start-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### bsp
 
@@ -468,7 +468,7 @@ It is normally supposed to be invoked by your IDE when a Scala CLI project is im
 
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
-Accepts option groups: [bsp](./cli-options.md#bsp-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [bsp](./cli-options.md#bsp-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
 
 ### default-file
 
@@ -476,27 +476,27 @@ Generates default files for a Scala CLI project (i.e. .gitignore).
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/misc/default-file
 
-Accepts option groups: [default file](./cli-options.md#default-file-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [default file](./cli-options.md#default-file-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### directories
 
 Prints directories used by Scala CLI.
 
-Accepts option groups: [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### install-home
 
 Install Scala CLI in a sub-directory of the home directory
 
-Accepts option groups: [install home](./cli-options.md#install-home-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [global suppress warning](./cli-options.md#global-suppress-warning-options), [install home](./cli-options.md#install-home-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### pgp pull
 
-Accepts option groups: [logging](./cli-options.md#logging-options), [pgp pull](./cli-options.md#pgp-pull-options), [pgp push pull](./cli-options.md#pgp-push-pull-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [pgp pull](./cli-options.md#pgp-pull-options), [pgp push pull](./cli-options.md#pgp-push-pull-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### pgp push
 
-Accepts option groups: [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp push](./cli-options.md#pgp-push-options), [pgp push pull](./cli-options.md#pgp-push-pull-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp push](./cli-options.md#pgp-push-options), [pgp push pull](./cli-options.md#pgp-push-pull-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### pgp create
 

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -67,6 +67,7 @@ Available keys:
   - repositories.default                           Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
   - repositories.mirrors                           Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
+  - suppress-warning.experimental-features         Globally suppresses warnings about experimental features.
   - suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/config

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -354,6 +354,22 @@ Aliases: `--fmt-version`
 
 Pass scalafmt version before running it (3.6.1 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
 
+## Global suppress warning options
+
+Available in commands:
+
+[`bsp`](./commands.md#bsp), [`clean`](./commands.md#clean), [`compile`](./commands.md#compile), [`config`](./commands.md#config), [`doc`](./commands.md#doc), [`fmt` , `format` , `scalafmt`](./commands.md#fmt), [`help`](./commands.md#help), [`install completions` , `install-completions`](./commands.md#install-completions), [`install-home`](./commands.md#install-home), [`repl` , `console`](./commands.md#repl), [`run`](./commands.md#run), [`setup-ide`](./commands.md#setup-ide), [`shebang`](./commands.md#shebang), [`test`](./commands.md#test), [`uninstall`](./commands.md#uninstall), [`uninstall completions` , `uninstall-completions`](./commands.md#uninstall-completions), [`update`](./commands.md#update), [`version`](./commands.md#version)
+
+<!-- Automatically generated, DO NOT EDIT MANUALLY -->
+
+### `--suppress-experimental-feature-warning`
+
+Aliases: `--suppress-experimental-warning`
+
+`IMPLEMENTATION specific` per Scala Runner specification
+
+Suppress warnings about using experimental features
+
 ## Help options
 
 Available in commands:

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -31,7 +31,7 @@ All supported types of inputs can be mixed with each other.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/compile
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [compile](./cli-options.md#compile-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [compile](./cli-options.md#compile-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
 ### config
 
@@ -70,7 +70,7 @@ Available keys:
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/config
 
-Accepts option groups: [config](./cli-options.md#config-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [config](./cli-options.md#config-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [pgp scala signing](./cli-options.md#pgp-scala-signing-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### doc
 
@@ -84,7 +84,7 @@ All supported types of inputs can be mixed with each other.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/doc
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [doc](./cli-options.md#doc-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [doc](./cli-options.md#doc-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
 
 ### repl
 
@@ -106,7 +106,7 @@ All supported types of inputs can be mixed with each other.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/repl
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [repl](./cli-options.md#repl-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [repl](./cli-options.md#repl-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
 ### run
 
@@ -132,7 +132,7 @@ To pass arguments to the actual application, just add them after `--`, like:
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/run
 
-Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
 ### shebang
 
@@ -163,7 +163,7 @@ Using this, it is possible to conveniently set up Unix shebang scripts. For exam
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/shebang
 
-Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [main class](./cli-options.md#main-class-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [run](./cli-options.md#run-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
 ## SHOULD have commands:
 
@@ -182,7 +182,7 @@ All standard Scala CLI inputs are accepted, but only Scala sources will be forma
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/fmt
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [fmt](./cli-options.md#fmt-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [fmt](./cli-options.md#fmt-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
 
 ### test
 
@@ -206,7 +206,7 @@ All supported types of inputs can be mixed with each other.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/test
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [test](./cli-options.md#test-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [cross](./cli-options.md#cross-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [java](./cli-options.md#java-options), [java prop](./cli-options.md#java-prop-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [test](./cli-options.md#test-options), [verbosity](./cli-options.md#verbosity-options), [watch](./cli-options.md#watch-options), [workspace](./cli-options.md#workspace-options)
 
 ### version
 
@@ -220,7 +220,7 @@ Scala version defined by the runner.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/version
 
-Accepts option groups: [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [version](./cli-options.md#version-options)
+Accepts option groups: [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [version](./cli-options.md#version-options)
 
 ## Implementation-specific commands
 
@@ -238,7 +238,7 @@ It is normally supposed to be invoked by your IDE when a Scala CLI project is im
 
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
-Accepts option groups: [bsp](./cli-options.md#bsp-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [bsp](./cli-options.md#bsp-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
 
 ### clean
 
@@ -248,13 +248,13 @@ Passed inputs will establish the Scala CLI project, for which the workspace will
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/clean
 
-Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
 
 ### help
 
 Print help message
 
-Accepts option groups: [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### install completions
 
@@ -264,13 +264,13 @@ Installs Scala CLI completions into your shell
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
-Accepts option groups: [install completions](./cli-options.md#install-completions-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [global suppress warning](./cli-options.md#global-suppress-warning-options), [install completions](./cli-options.md#install-completions-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### install-home
 
 Install Scala CLI in a sub-directory of the home directory
 
-Accepts option groups: [install home](./cli-options.md#install-home-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [global suppress warning](./cli-options.md#global-suppress-warning-options), [install home](./cli-options.md#install-home-options), [logging](./cli-options.md#logging-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### setup-ide
 
@@ -290,7 +290,7 @@ Using directives can be defined in all supported input source file types.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/setup-ide
 
-Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [setup IDE](./cli-options.md#setup-ide-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
+Accepts option groups: [bsp file](./cli-options.md#bsp-file-options), [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [debug](./cli-options.md#debug-options), [dependency](./cli-options.md#dependency-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [help group](./cli-options.md#help-group-options), [input](./cli-options.md#input-options), [jvm](./cli-options.md#jvm-options), [logging](./cli-options.md#logging-options), [markdown](./cli-options.md#markdown-options), [python](./cli-options.md#python-options), [Scala.js](./cli-options.md#scalajs-options), [Scala Native](./cli-options.md#scala-native-options), [scalac](./cli-options.md#scalac-options), [scalac extra](./cli-options.md#scalac-extra-options), [setup IDE](./cli-options.md#setup-ide-options), [shared](./cli-options.md#shared-options), [snippet](./cli-options.md#snippet-options), [suppress warning](./cli-options.md#suppress-warning-options), [verbosity](./cli-options.md#verbosity-options), [workspace](./cli-options.md#workspace-options)
 
 ### uninstall
 
@@ -298,7 +298,7 @@ Uninstalls Scala CLI.
 Works only when installed with the installation script.
 For detailed installation instructions refer to our website: https://scala-cli.virtuslab.org/install
 
-Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [logging](./cli-options.md#logging-options), [uninstall](./cli-options.md#uninstall-options), [uninstall completions](./cli-options.md#uninstall-completions-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [compilation server](./cli-options.md#compilation-server-options), [coursier](./cli-options.md#coursier-options), [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [uninstall](./cli-options.md#uninstall-options), [uninstall completions](./cli-options.md#uninstall-completions-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### uninstall completions
 
@@ -308,7 +308,7 @@ Uninstalls Scala CLI completions from your shell.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/completions
 
-Accepts option groups: [logging](./cli-options.md#logging-options), [uninstall completions](./cli-options.md#uninstall-completions-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [uninstall completions](./cli-options.md#uninstall-completions-options), [verbosity](./cli-options.md#verbosity-options)
 
 ### update
 
@@ -318,5 +318,5 @@ If Scala CLI was installed with an external tool, refer to its update methods.
 
 For detailed installation instructions refer to our website: https://scala-cli.virtuslab.org/install
 
-Accepts option groups: [logging](./cli-options.md#logging-options), [update](./cli-options.md#update-options), [verbosity](./cli-options.md#verbosity-options)
+Accepts option groups: [global suppress warning](./cli-options.md#global-suppress-warning-options), [logging](./cli-options.md#logging-options), [update](./cli-options.md#update-options), [verbosity](./cli-options.md#verbosity-options)
 

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -66,6 +66,7 @@ Available keys:
   - repositories.default                           Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
   - repositories.mirrors                           Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
+  - suppress-warning.experimental-features         Globally suppresses warnings about experimental features.
   - suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/config

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -306,6 +306,12 @@ Aliases: `--suppress-warning-directives-in-multiple-files`
 
 Suppress warnings about outdated dependencies in project
 
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
+
 **--verbose**
 
 Increase verbosity (can be specified multiple times)
@@ -696,6 +702,12 @@ Aliases: `-q`
 
 Use progress bars
 
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
+
 **--ttl**
 
 Specify a TTL for changing dependencies, such as snapshots
@@ -986,6 +998,12 @@ Aliases: `--suppress-warning-directives-in-multiple-files`
 **--suppress-outdated-dependency-warning**
 
 Suppress warnings about outdated dependencies in project
+
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
 
 **--verbose**
 
@@ -1513,6 +1531,12 @@ Aliases: `--suppress-warning-directives-in-multiple-files`
 **--suppress-outdated-dependency-warning**
 
 Suppress warnings about outdated dependencies in project
+
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
 
 **--verbose**
 
@@ -2070,6 +2094,12 @@ Aliases: `--suppress-warning-directives-in-multiple-files`
 **--suppress-outdated-dependency-warning**
 
 Suppress warnings about outdated dependencies in project
+
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
 
 **--verbose**
 
@@ -2637,6 +2667,12 @@ Aliases: `--suppress-warning-directives-in-multiple-files`
 
 Suppress warnings about outdated dependencies in project
 
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
+
 **--verbose**
 
 Increase verbosity (can be specified multiple times)
@@ -3160,6 +3196,12 @@ Aliases: `--suppress-warning-directives-in-multiple-files`
 **--suppress-outdated-dependency-warning**
 
 Suppress warnings about outdated dependencies in project
+
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
 
 **--verbose**
 
@@ -3760,6 +3802,12 @@ Aliases: `--suppress-warning-directives-in-multiple-files`
 
 Suppress warnings about outdated dependencies in project
 
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
+
 **--verbose**
 
 Increase verbosity (can be specified multiple times)
@@ -4091,6 +4139,12 @@ Aliases: `-q`
 
 Use progress bars
 
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
+
 **--cli-version**
 
 Show plain Scala CLI version only
@@ -4353,6 +4407,12 @@ Aliases: `--suppress-warning-directives-in-multiple-files`
 **--suppress-outdated-dependency-warning**
 
 Suppress warnings about outdated dependencies in project
+
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
 
 **--verbose**
 
@@ -4679,6 +4739,12 @@ Aliases: `-q`
 
 Use progress bars
 
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
+
 **--bsp-directory**
 
 Custom BSP configuration location
@@ -4752,6 +4818,12 @@ Aliases: `-q`
 
 Use progress bars
 
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
+
 </details>
 
 ---
@@ -4812,6 +4884,12 @@ Aliases: `-q`
 **--progress**
 
 Use progress bars
+
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
 
 **--format**
 
@@ -4897,6 +4975,12 @@ Aliases: `-q`
 **--progress**
 
 Use progress bars
+
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
 
 **--scala-cli-binary-path**
 
@@ -5166,6 +5250,12 @@ Aliases: `--suppress-warning-directives-in-multiple-files`
 **--suppress-outdated-dependency-warning**
 
 Suppress warnings about outdated dependencies in project
+
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
 
 **--verbose**
 
@@ -5502,6 +5592,12 @@ Aliases: `-q`
 
 Use progress bars
 
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
+
 **--bloop-bsp-protocol**
 
 Protocol to use to open a BSP connection with Bloop
@@ -5677,6 +5773,12 @@ Aliases: `-q`
 
 Use progress bars
 
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
+
 </details>
 
 ---
@@ -5737,6 +5839,12 @@ Aliases: `-q`
 **--progress**
 
 Use progress bars
+
+**--suppress-experimental-feature-warning**
+
+Suppress warnings about using experimental features
+
+Aliases: `--suppress-experimental-warning`
 
 **--binary-name**
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -610,6 +610,7 @@ Available keys:
   - repositories.default                           Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
   - repositories.mirrors                           Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
+  - suppress-warning.experimental-features         Globally suppresses warnings about experimental features.
   - suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/config


### PR DESCRIPTION
Fixes #1281 
Using experimental features will now cause Scala CLI to print an appropriate warning.
The warning can be suppressed with the `--suppress-experimental-warning` option or alternatively with the `suppress-warning.experimental-features` global config key.
```
▶ scala-cli config suppress-warning.experimental-features true
```

Directives:
```bash
▶ scala-cli --power -e '//> using publish.name "my-library"'
# The '//> publish.name "my-library"' directive is an experimental feature.
# Please bear in mind that non-ideal user experience should be expected.
# If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
# Compiling project (Scala 3.2.2, JVM)
# Compiled project (Scala 3.2.2, JVM)
```

Options:
```bash
▶ scala-cli --power -e 'println("Hello")' --markdown
# The '--markdown' option is an experimental feature.
# Please bear in mind that non-ideal user experience should be expected.
# If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
# Compiling project (Scala 3.2.2, JVM)
# Compiled project (Scala 3.2.2, JVM)
# Hello
```
Sub-commands:
```bash
▶ scala-cli --power export 
# The 'export' sub-command is an experimental feature.
# Please bear in mind that non-ideal user experience should be expected.
# If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at # https://github.com/VirtusLab/scala-cli
# Exporting to a sbt project...
# [error]  No inputs provided (expected files with .scala, .sc, .java or .md extensions, and / or directories).
```
Sub-commands' help:
```bash
▶ scala-cli --power publish -h
# Usage: scala-cli publish [options]
# Publishes build artifacts to Maven repositories.
# 
# You are currently viewing the basic help for the publish sub-command. You can view the full help by running: 
#    scala-cli --power publish --help-full
# For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish
# 
# The 'publish' sub-command is an experimental feature.
# Please bear in mind that non-ideal user experience should be expected.
# If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
# 
# Publishing options:
#   --organization string?                         Organization to publish artifacts under
# (...)
```