### PR TITLE
chore: Remove all deprecated using directive styles

### DIFF
--- a/modules/build/src/main/scala/scala/build/preprocessing/MarkdownCodeBlockProcessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/MarkdownCodeBlockProcessor.scala
@@ -26,7 +26,6 @@ object MarkdownCodeBlockProcessor {
               contentChars = cb.body.toCharArray,
               path = reportingPath,
               logger = logger,
-              supportedDirectives = UsingDirectiveKind.values(),
               cwd = scopePath / os.up,
               maybeRecoverOnError = maybeRecoverOnError
             )

--- a/modules/build/src/main/scala/scala/build/preprocessing/PreprocessingUtil.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/PreprocessingUtil.scala
@@ -32,12 +32,11 @@ object PreprocessingUtil {
     BuildException,
     (DirectivesProcessorOutput[BuildOptions], Option[DirectivesPositions])
   ] = either {
-    val ExtractedDirectives(_, directives0, directivesPositions) =
+    val ExtractedDirectives(directives0, directivesPositions) =
       value(from(
         content.toCharArray,
         path,
         logger,
-        Array(UsingDirectiveKind.PlainComment, UsingDirectiveKind.SpecialComment),
         scopePath,
         maybeRecoverOnError
       ))

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveParsingTest.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveParsingTest.scala
@@ -61,7 +61,6 @@ class DirectiveParsingTest extends munit.FunSuite {
       code,
       Right(path),
       persistentLogger,
-      UsingDirectiveKind.values(),
       ScopePath.fromPath(path),
       maybeRecoverOnError = e => Some(e)
     )
@@ -111,20 +110,18 @@ class DirectiveParsingTest extends munit.FunSuite {
   }
 
   test("Test warnings about mixing syntax") {
-    testDiagnostics(directive, specialCommentDirective)(Warn("ignored", 1, 0))
-    testDiagnostics(directive, commentDirective)(Warn("ignored", 1, 0))
+    testDiagnostics(directive, specialCommentDirective)(Warn("ignored", 0, 0))
+    testDiagnostics(directive, commentDirective)(Warn("ignored", 0, 0))
     testDiagnostics(specialCommentDirective, commentDirective)(Warn("ignored", 1, 0))
     testDiagnostics(commentDirective, specialCommentDirective)(Warn("deprecated", 0, 0))
   }
 
-  test("Plain comment only result in no ignored warning") {
-    testDiagnostics(commentDirective)(NoWarn("ignored"))
+  test("Plain comment result in ignored warning") {
+    testDiagnostics(commentDirective)(Warn("ignored", 0, 0))
   }
 
   test("@using is deprecated") {
     def addAt(s: String) = s.replace("using ", "@using ")
-    testDiagnostics(addAt(commentDirective))(Warn("syntax", 0, 3), Warn("keyword", 0, 3))
-    testDiagnostics(addAt(directive))(Warn("syntax", 0, 0), Warn("keyword", 0, 0))
     testDiagnostics(addAt(specialCommentDirective))(Warn("syntax", 0, 4), Warn("keyword", 0, 4))
   }
 

--- a/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
@@ -245,27 +245,6 @@ class SourcesTests extends munit.FunSuite {
     }
   }
 
-  test("should fail dependencies in .java  with using keyword") {
-    val testInputs = TestInputs(
-      os.rel / "Something.java" ->
-        """using dep "org3:::name3:3.3"
-          |
-          |public class Something {
-          |  public Int a = 1;
-          |}
-          |""".stripMargin
-    )
-    testInputs.withInputs { (_, inputs) =>
-      val crossSources = CrossSources.forInputs(
-        inputs,
-        preprocessors,
-        TestLogger(),
-        SuppressWarningOptions()
-      )
-      expect(crossSources.isLeft)
-    }
-  }
-
   test("should fail for ammonite imports in .sc - $ivy") {
     val testInputs = TestInputs(
       os.rel / "something.sc" ->

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -182,7 +182,7 @@ object Deps {
   def swoval          = ivy"com.swoval:file-tree-views:2.1.9"
   def testInterface   = ivy"org.scala-sbt:test-interface:1.0"
   def toolkit         = ivy"org.virtuslab:toolkit:0.1.0"
-  def usingDirectives = ivy"org.virtuslab:using_directives:0.0.10"
+  def usingDirectives = ivy"org.virtuslab:using_directives:0.1.0"
   // Lives at https://github.com/scala-cli/no-crc32-zip-input-stream, see #865
   // This provides a ZipInputStream that doesn't verify CRC32 checksums, that users
   // can enable by setting SCALA_CLI_VENDORED_ZIS=true in the environment, to workaround


### PR DESCRIPTION
It seems that we still support multiple ways of declaring using directives, which should be removed before 1.0.x.

It's also needed for SIP so that it's clear what can be accepted by the SIP commitee.

