### PR TITLE
Write PGP keys to publish-conf when doing publish setup

### DIFF
--- a/modules/build-macros/src/main/scala/scala/build/Ops.scala
+++ b/modules/build-macros/src/main/scala/scala/build/Ops.scala
@@ -144,4 +144,47 @@ object Ops {
           Left(errors0)
       }
   }
+
+  implicit class EitherMap6[
+    Ex <: Throwable,
+    ExA <: Ex,
+    ExB <: Ex,
+    ExC <: Ex,
+    ExD <: Ex,
+    ExE <: Ex,
+    ExF <: Ex,
+    A,
+    B,
+    C,
+    D,
+    E,
+    F
+  ](
+    private val eithers: (
+      Either[ExA, A],
+      Either[ExB, B],
+      Either[ExC, C],
+      Either[ExD, D],
+      Either[ExE, E],
+      Either[ExF, F]
+    )
+  ) extends AnyVal {
+    def traverseN: Either[::[Ex], (A, B, C, D, E, F)] =
+      eithers match {
+        case (Right(a), Right(b), Right(c), Right(d), Right(e), Right(f)) =>
+          Right((a, b, c, d, e, f))
+        case _ =>
+          val errors = eithers._1.left.toOption.toSeq ++
+            eithers._2.left.toOption.toSeq ++
+            eithers._3.left.toOption.toSeq ++
+            eithers._4.left.toOption.toSeq ++
+            eithers._5.left.toOption.toSeq ++
+            eithers._6.left.toOption.toSeq
+          val errors0 = errors.toList match {
+            case Nil    => sys.error("Cannot happen")
+            case h :: t => ::(h, t)
+          }
+          Left(errors0)
+      }
+  }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
@@ -259,16 +259,18 @@ object PublishSetup extends ScalaCommand[PublishSetupOptions] {
           inputs.workspace / s"publish-conf$ext"
         }
         val nl = System.lineSeparator() // FIXME Get from dest if it exists?
+
+        def extraDirectivesLines(extraDirectives: Seq[(String, String)]) =
+          extraDirectives.map {
+            case (k, v) =>
+              s"""//> using $k "$v"""" + nl
+          }.mkString
+
         val extraLines = missingFieldsWithDefaultsAndValues.map {
-          case (_, _, None) => ""
+          case (_, default, None) => extraDirectivesLines(default.extraDirectives)
           case (check, default, Some(value)) =>
             s"""//> using ${check.directivePath} "$value"""" + nl +
-              default.extraDirectives
-                .map {
-                  case (k, v) =>
-                    s"""//> using $k "$v"""" + nl
-                }
-                .mkString
+              extraDirectivesLines(default.extraDirectives)
         }
 
         val currentContent =

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
@@ -281,8 +281,10 @@ object PublishSetup extends ScalaCommand[PublishSetupOptions] {
           val updatedContent = currentContent ++
             extraLines.toArray.flatMap(_.getBytes(StandardCharsets.UTF_8))
           os.write.over(dest, updatedContent)
-          logger.message("") // printing an empty line, for readability
-          logger.message(s"Wrote ${CommandUtils.printablePath(dest)}")
+          logger.message(
+            s"""
+               |Wrote ${CommandUtils.printablePath(dest)}""".stripMargin
+          ) // printing an empty line, for readability
           written = written :+ dest
         }
       }

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
@@ -277,12 +277,14 @@ object PublishSetup extends ScalaCommand[PublishSetupOptions] {
           if (os.isFile(dest)) os.read.bytes(dest)
           else if (os.exists(dest)) sys.error(s"Error: $dest already exists and is not a file")
           else Array.emptyByteArray
-        val updatedContent = currentContent ++
-          extraLines.toArray.flatMap(_.getBytes(StandardCharsets.UTF_8))
-        os.write.over(dest, updatedContent)
-        logger.message("") // printing an empty line, for readability
-        logger.message(s"Wrote ${CommandUtils.printablePath(dest)}")
-        written = written :+ dest
+        if (extraLines.nonEmpty) {
+          val updatedContent = currentContent ++
+            extraLines.toArray.flatMap(_.getBytes(StandardCharsets.UTF_8))
+          os.write.over(dest, updatedContent)
+          logger.message("") // printing an empty line, for readability
+          logger.message(s"Wrote ${CommandUtils.printablePath(dest)}")
+          written = written :+ dest
+        }
       }
 
       if (options.checkWorkflow.getOrElse(options.publishParams.setupCi)) {

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/checks/PgpSecretKeyCheck.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/checks/PgpSecretKeyCheck.scala
@@ -279,6 +279,10 @@ final case class PgpSecretKeyCheck(
 
         if (keysFromOptions.secretKeyOpt.isDefined)
           (keysFromOptions, false)
+        else if (
+          keysFromOptions.publicKeyOpt.isDefined || keysFromOptions.secretKeyPasswordOpt.isDefined
+        )
+          throw missingSecretKeyError
         else if (randomSecretKey && options.publishParams.setupCi)
           (getRandomPGPKeys.orThrow, false)
         else {

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/checks/PgpSecretKeyCheck.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/checks/PgpSecretKeyCheck.scala
@@ -90,7 +90,7 @@ final case class PgpSecretKeyCheck(
 
   private lazy val keyServers: Either[BuildException, Seq[Uri]] = {
     val rawKeyServers = options.sharedPgp.keyServer.filter(_.trim.nonEmpty)
-    if (rawKeyServers.filter(_.trim.nonEmpty).isEmpty)
+    if (rawKeyServers.isEmpty)
       Right(KeyServer.allDefaults)
     else
       rawKeyServers
@@ -133,7 +133,7 @@ final case class PgpSecretKeyCheck(
                 )
                 false
               case Left(err) =>
-                logger.debug(s"Error checking $keyId at $keyServer: $err")
+                logger.error(s"Error checking $keyId at $keyServer: $err")
                 false
           }
         case None => false

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/checks/PgpSecretKeyCheck.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/checks/PgpSecretKeyCheck.scala
@@ -2,25 +2,28 @@ package scala.cli.commands.publish.checks
 
 import coursier.cache.{ArchiveCache, FileCache}
 import coursier.util.Task
-import sttp.client3._
+import sttp.client3.*
 import sttp.model.Uri
 
 import java.util.Base64
 
 import scala.build.EitherCps.{either, value}
 import scala.build.Logger
-import scala.build.Ops._
+import scala.build.Ops.*
 import scala.build.errors.{BuildException, CompositeBuildException, MalformedCliInputError}
-import scala.build.options.{PublishOptions => BPublishOptions}
+import scala.build.options.publish.ConfigPasswordOption
+import scala.build.options.publish.ConfigPasswordOption.*
+import scala.build.options.PublishOptions as BPublishOptions
 import scala.cli.commands.config.ThrowawayPgpSecret
 import scala.cli.commands.pgp.{KeyServer, PgpProxyMaker}
-import scala.cli.commands.publish.ConfigUtil._
+import scala.cli.commands.publish.ConfigUtil.*
 import scala.cli.commands.publish.{OptionCheck, PublishSetupOptions, SetSecret}
 import scala.cli.commands.util.JvmUtils
 import scala.cli.config.{ConfigDb, Keys}
 import scala.cli.errors.MissingPublishOptionError
 import scala.cli.signing.shared.PasswordOption
-import scala.cli.util.ConfigPasswordOptionHelpers._
+import scala.cli.util.ConfigPasswordOptionHelpers.*
+import scala.cli.util.MaybeConfigPasswordOption
 
 final case class PgpSecretKeyCheck(
   options: PublishSetupOptions,
@@ -36,14 +39,15 @@ final case class PgpSecretKeyCheck(
   def check(pubOpt: BPublishOptions): Boolean = {
     val opt0 = pubOpt.retained(options.publishParams.setupCi)
 
-    lazy val configSecretKey = for {
-      secretKeyOpt <- configDb().get(Keys.pgpSecretKey).wrapConfigException.toOption
-      secretKey    <- secretKeyOpt
-    } yield secretKey
-
     opt0.repository.orElse(options.publishRepo.publishRepository).contains("github") ||
-    opt0.secretKey.isDefined ||
-    (options.publishParams.ci.contains(false) && configSecretKey.isDefined)
+    (
+      opt0.secretKey.isDefined &&
+      opt0.secretKeyPassword.isDefined &&
+      opt0.publicKey.isDefined &&
+      isKeyUploaded(opt0.publicKey.get.get(configDb()).toOption.map(_.toCliSigning))
+        .getOrElse(false)
+    ) ||
+    opt0.gpgSignatureId.isDefined
   }
 
   private val base64Chars = (('A' to 'Z') ++ ('a' to 'z') ++ ('0' to '9') ++ Seq('+', '/', '='))
@@ -66,97 +70,30 @@ final case class PgpSecretKeyCheck(
       ).value.javaCommand
   }
 
-  def defaultValue(pubOpt: BPublishOptions): Either[BuildException, OptionCheck.DefaultValue] =
-    either {
-      val (pubKeyOpt, secretKey, passwordOpt, isConfigDefault) =
-        options.publishParams.secretKey match {
-          case Some(secretKey) =>
-            val pubKeyOpt = options.publicKey.map(_.get().toConfig)
-            val passwordOpt = value {
-              options.publishParams.secretKeyPassword
-                .map(_.configPasswordOptions())
-                .map(_.get(configDb()))
-                .sequence
-            }
-            (pubKeyOpt, Left(secretKey), passwordOpt, false)
-          case None =>
-            val randomSecretKey = options.randomSecretKey.getOrElse(false)
-            if (randomSecretKey && options.publishParams.setupCi) {
-              val password = {
-                val res = value {
-                  options.publishParams
-                    .secretKeyPassword
-                    .map(_.configPasswordOptions())
-                    .map(_.get(configDb()))
-                    .sequence
-                }
-                res
-                  .map(_.get().toCliSigning)
-                  .getOrElse(ThrowawayPgpSecret.pgpPassPhrase())
-              }
-              val mail = value {
-                options.randomSecretKeyMail
-                  .toRight(
-                    new MissingPublishOptionError(
-                      "the e-mail address to associate to the random key pair",
-                      "--random-secret-key-mail",
-                      ""
-                    )
-                  )
-              }
-              val (pgpPublic, pgpSecret0) = value {
-                ThrowawayPgpSecret.pgpSecret(
-                  mail,
-                  password,
-                  logger,
-                  coursierCache,
-                  value(javaCommand),
-                  options.scalaSigning.cliOptions()
-                )
-              }
-              val pgpSecretBase64 = pgpSecret0.map(Base64.getEncoder.encodeToString)
-              (
-                Some(pgpPublic.toConfig),
-                Right(scala.cli.config.PasswordOption.Value(pgpSecretBase64.toConfig)),
-                Some(scala.cli.config.PasswordOption.Value(password.toConfig)),
-                false
-              )
-            }
-            else
-              value(configDb().get(Keys.pgpSecretKey).wrapConfigException) match {
-                case Some(secretKey) =>
-                  val pubKeyOpt = value(configDb().get(Keys.pgpPublicKey).wrapConfigException)
-                  val passwordOpt =
-                    value(configDb().get(Keys.pgpSecretKeyPassword).wrapConfigException)
-                  (
-                    pubKeyOpt.map(_.get()),
-                    Right(secretKey),
-                    passwordOpt,
-                    true
-                  )
-                case None =>
-                  value {
-                    Left(
-                      new MissingPublishOptionError(
-                        "publish secret key",
-                        "--secret-key",
-                        "publish.secretKey",
-                        configKeys = Seq(Keys.pgpSecretKey.fullName),
-                        extraMessage =
-                          "also specify publish.secretKeyPassword / --secret-key-password if needed." +
-                            (if (options.publishParams.setupCi)
-                               " Alternatively, pass --random-secret-key"
-                             else "")
-                      )
-                    )
-                  }
-              }
+  private lazy val keyServers: Either[BuildException, Seq[Uri]] = {
+    val rawKeyServers = options.sharedPgp.keyServer.filter(_.trim.nonEmpty)
+    if (rawKeyServers.filter(_.trim.nonEmpty).isEmpty)
+      Right(KeyServer.allDefaults)
+    else
+      rawKeyServers
+        .map { keyServerUriStr =>
+          Uri.parse(keyServerUriStr).left.map { err =>
+            new MalformedCliInputError(
+              s"Malformed key server URI '$keyServerUriStr': $err"
+            )
+          }
         }
-      val pushKey: () => Either[BuildException, Unit] = pubKeyOpt match {
+        .sequence
+        .left.map(CompositeBuildException(_))
+  }
+
+  private def isKeyUploaded(pubKeyOpt: Option[PasswordOption]): Either[BuildException, Boolean] =
+    either {
+      pubKeyOpt match {
         case Some(pubKey) =>
           val keyId = value {
             (new PgpProxyMaker).get().keyId(
-              pubKey.value,
+              pubKey.get().value,
               "[generated key]",
               coursierCache,
               logger,
@@ -164,130 +101,296 @@ final case class PgpSecretKeyCheck(
               options.scalaSigning.cliOptions()
             )
           }
-          val keyServers = value {
-            val rawKeyServers = options.sharedPgp.keyServer.filter(_.trim.nonEmpty)
-            if (rawKeyServers.filter(_.trim.nonEmpty).isEmpty)
-              Right(KeyServer.allDefaults)
-            else
-              rawKeyServers
-                .map { keyServerUriStr =>
-                  Uri.parse(keyServerUriStr).left.map { err =>
-                    new MalformedCliInputError(
-                      s"Malformed key server URI '$keyServerUriStr': $err"
-                    )
-                  }
-                }
-                .sequence
-                .left.map(CompositeBuildException(_))
+
+          value(keyServers).forall { keyServer =>
+            KeyServer.check(keyId, keyServer, backend) match
+              case Right(Right(_)) => true
+              case Right(Left(msg)) =>
+                logger.debug(
+                  s"""Response from $keyServer:
+                     |$msg
+                     |""".stripMargin
+                )
+                false
+              case Left(err) =>
+                logger.debug(s"Error checking $keyId at $keyServer: $err")
+                false
           }
-          () =>
-            keyServers
-              .map { keyServer =>
-                if (options.dummy) Right(())
-                else {
-                  val e: Either[BuildException, Unit] = either {
-                    val checkResp = value {
-                      KeyServer.check(keyId, keyServer, backend)
-                        .left.map(msg =>
-                          new PgpSecretKeyCheck.KeyServerError(
-                            s"Error getting key $keyId from $keyServer: $msg"
-                          )
-                        )
-                    }
-                    logger.debug(s"Key server check response: $checkResp")
-                    val check = checkResp.isRight
-                    if (!check) {
-                      val resp = value {
-                        KeyServer.add(pubKey.value, keyServer, backend)
-                          .left.map(msg =>
-                            new PgpSecretKeyCheck.KeyServerError(
-                              s"Error uploading key $keyId to $keyServer: $msg"
-                            )
-                          )
-                      }
-                      logger.debug(s"Key server upload response: $resp")
-                      logger.message("") // printing an empty line, for readability
-                      logger.message(s"Uploaded key 0x${keyId.stripPrefix("0x")} to $keyServer")
-                    }
-                  }
-                  e
-                }
-              }
-              .sequence
-              .left.map(CompositeBuildException(_))
-              .map(_ => ())
+        case None => false
+      }
+    }
+
+  private case class PGPKeys(
+    secretKeyOpt: Option[ConfigPasswordOption],
+    secretKeyPasswordOpt: Option[ConfigPasswordOption],
+    publicKeyOpt: Option[ConfigPasswordOption]
+  )
+
+  val missingSecretKeyError = new MissingPublishOptionError(
+    "publish secret key",
+    "--secret-key",
+    "publish.secretKey",
+    configKeys = Seq(Keys.pgpSecretKey.fullName),
+    extraMessage =
+      "also specify publish.secretKeyPassword / --secret-key-password if needed." +
+        (if (options.publishParams.setupCi)
+           " Alternatively, pass --random-secret-key"
+         else "")
+  )
+
+  private lazy val keysFromOptions: PGPKeys =
+    PGPKeys(
+      options.publishParams.secretKey.map(_.configPasswordOptions()),
+      options.publishParams.secretKeyPassword.map(_.configPasswordOptions()),
+      options.publicKey.map(ConfigPasswordOption.ActualOption.apply)
+    )
+
+  private lazy val maybeKeysFromConfig: Either[BuildException, PGPKeys] =
+    for {
+      secretKeyOpt <- configDb().get(Keys.pgpSecretKey).wrapConfigException
+      pubKeyOpt    <- configDb().get(Keys.pgpPublicKey).wrapConfigException
+      passwordOpt  <- configDb().get(Keys.pgpSecretKeyPassword).wrapConfigException
+    } yield PGPKeys(
+      secretKeyOpt.map(sk => ConfigPasswordOption.ActualOption(sk.toCliSigning)),
+      passwordOpt.map(p => ConfigPasswordOption.ActualOption(p.toCliSigning)),
+      pubKeyOpt.map(pk => ConfigPasswordOption.ActualOption(pk.toCliSigning))
+    )
+
+  private def getRandomPGPKeys: Either[BuildException, PGPKeys] = either {
+    val maybeMail = options.randomSecretKeyMail.toRight(
+      new MissingPublishOptionError(
+        "the e-mail address to associate to the random key pair",
+        "--random-secret-key-mail",
+        ""
+      )
+    )
+
+    val passwordSecret = options.publishParams.secretKeyPassword
+      .map(_.configPasswordOptions())
+      .map { configPasswordOption =>
+        configPasswordOption
+          .get(configDb()).wrapConfigException
+          .map(_.get().toCliSigning)
+          .orThrow
+      }
+      .getOrElse(ThrowawayPgpSecret.pgpPassPhrase())
+
+    val (pgpPublic, pgpSecret0) = value {
+      ThrowawayPgpSecret.pgpSecret(
+        value(maybeMail),
+        passwordSecret,
+        logger,
+        coursierCache,
+        value(javaCommand),
+        options.scalaSigning.cliOptions()
+      )
+    }
+
+    val pgpSecretBase64 = pgpSecret0.map(Base64.getEncoder.encodeToString)
+
+    PGPKeys(
+      Some(ConfigPasswordOption.ActualOption(PasswordOption.Value(pgpSecretBase64))),
+      Some(ConfigPasswordOption.ActualOption(PasswordOption.Value(passwordSecret))),
+      Some(ConfigPasswordOption.ActualOption(PasswordOption.Value(pgpPublic)))
+    )
+  }
+
+  private def uploadKey(keyIdOpt: Option[ConfigPasswordOption]): Either[BuildException, Unit] =
+    either {
+      keyIdOpt match
         case None =>
+          logger.message("") // printing an empty line, for readability
           logger.message(
             "Warning: no public key passed, not checking if the key needs to be uploaded to a key server."
           )
-          () => Right(())
+        case Some(pubKeyConfigPasswordOption) =>
+          val publicKeyString = pubKeyConfigPasswordOption.get(configDb())
+            .orThrow
+            .get()
+            .value
+
+          val keyId = (new PgpProxyMaker).get()
+            .keyId(
+              publicKeyString,
+              "[generated key]",
+              coursierCache,
+              logger,
+              value(javaCommand),
+              options.scalaSigning.cliOptions()
+            ).orThrow
+
+          value(keyServers)
+            .map { keyServer =>
+              if (options.dummy) {
+                logger.message("") // printing an empty line, for readability
+                logger.message(s"Would upload key 0x${keyId.stripPrefix("0x")} to $keyServer")
+                Right(())
+              }
+              else {
+                val e: Either[BuildException, Unit] = either {
+                  val checkResp = value {
+                    KeyServer.check(keyId, keyServer, backend)
+                      .left.map(msg =>
+                        new PgpSecretKeyCheck.KeyServerError(
+                          s"Error getting key $keyId from $keyServer: $msg"
+                        )
+                      )
+                  }
+                  logger.debug(s"Key server check response: $checkResp")
+                  val check = checkResp.isRight
+                  if (!check) {
+                    val resp = value {
+                      KeyServer.add(publicKeyString, keyServer, backend)
+                        .left.map(msg =>
+                          new PgpSecretKeyCheck.KeyServerError(
+                            s"Error uploading key $keyId to $keyServer: $msg"
+                          )
+                        )
+                    }
+                    logger.debug(s"Key server upload response: $resp")
+                    logger.message("") // printing an empty line, for readability
+                    logger.message(s"Uploaded key 0x${keyId.stripPrefix("0x")} to $keyServer")
+                  }
+                }
+                e
+              }
+            }
+            .sequence
+            .left.map(CompositeBuildException(_))
+            .map(_ => ())
+    }
+
+  def defaultValue(pubOpt: BPublishOptions): Either[BuildException, OptionCheck.DefaultValue] =
+    either {
+      val retainedOptions = pubOpt.retained(options.publishParams.setupCi)
+      val (setupKeys, areConfigDefaults) = if (retainedOptions.secretKey.isDefined) {
+        val publicKeySetup = if (retainedOptions.publicKey.isEmpty)
+          keysFromOptions.publicKeyOpt
+        else None
+
+        val passwordSetup = if (retainedOptions.secretKeyPassword.isEmpty)
+          keysFromOptions.secretKeyPasswordOpt
+        else None
+
+        (PGPKeys(None, passwordSetup, publicKeySetup), false)
       }
+      else {
+        val randomSecretKey = options.randomSecretKey.getOrElse(false)
+
+        if (keysFromOptions.secretKeyOpt.isDefined)
+          (keysFromOptions, false)
+        else if (randomSecretKey && options.publishParams.setupCi)
+          (getRandomPGPKeys.orThrow, false)
+        else {
+          val keysFromConfig = maybeKeysFromConfig.orThrow
+          if (keysFromConfig.secretKeyOpt.isDefined)
+            logger.message(s"$fieldName:")
+            logger.message("  found keys in config")
+          else
+            throw missingSecretKeyError
+          if (keysFromConfig.publicKeyOpt.isEmpty)
+            logger.message("  warning: no PGP public key found in config")
+          if (keysFromConfig.secretKeyPasswordOpt.isEmpty)
+            logger.message("  warning: no PGP secret key password found in config")
+
+          (keysFromConfig, true)
+        }
+      }
+
+      val publicKeyOpt = retainedOptions.publicKey.orElse(setupKeys.publicKeyOpt)
+
       if (options.publishParams.setupCi) {
-        val (passwordSetSecret, extraDirectives) = passwordOpt
+        val (passwordSetSecret, passwordDirectives) = setupKeys.secretKeyPasswordOpt
           .map { p =>
-            if (options.publishParams.setupCi) {
-              val dir    = "publish.ci.secretKeyPassword" -> "env:PUBLISH_SECRET_KEY_PASSWORD"
-              val setSec = SetSecret("PUBLISH_SECRET_KEY_PASSWORD", p.get(), force = true)
-              (Seq(setSec), Seq(dir))
-            }
-            else if (isConfigDefault)
-              (Nil, Nil)
-            else {
-              val dir = "publish.secretKeyPassword" -> p.asString.value
-              (Nil, Seq(dir))
-            }
+            val dir    = "publish.ci.secretKeyPassword" -> "env:PUBLISH_SECRET_KEY_PASSWORD"
+            val secret = p.get(configDb()).orThrow.get()
+            val setSec = SetSecret("PUBLISH_SECRET_KEY_PASSWORD", secret, force = true)
+            (Seq(setSec), Seq(dir))
           }
           .getOrElse((Nil, Nil))
 
-        val keySetSecrets =
-          if (options.publishParams.setupCi)
+        val keySetSecrets = setupKeys.secretKeyOpt match
+          case Some(configPasswordOption) =>
+            val secret = configPasswordOption.get(configDb())
+              .orThrow
+              .getBytes()
+
             Seq(SetSecret(
               "PUBLISH_SECRET_KEY",
-              secretKey match {
-                case Left(p) =>
-                  value(p.configPasswordOptions().get(configDb())).getBytes().map(maybeEncodeBase64)
-                case Right(p) => p.getBytes().map(maybeEncodeBase64)
-              },
+              secret.map(maybeEncodeBase64),
               force = true
             ))
-          else
-            Nil
-        val setSecrets = keySetSecrets ++ passwordSetSecret
+          case _ => Nil
+
+        val (publicKeySetSecret, publicKeyDirective) = setupKeys.publicKeyOpt
+          .map { p =>
+            val dir    = "publish.ci.publicKey" -> "env:PUBLISH_PUBLIC_KEY"
+            val secret = p.get(configDb()).orThrow.get()
+            val setSec = SetSecret("PUBLISH_PUBLIC_KEY", secret, force = true)
+            (Seq(setSec), Seq(dir))
+          }
+          .getOrElse((Nil, Nil))
+
+        val secretsToSet    = keySetSecrets ++ passwordSetSecret ++ publicKeySetSecret
+        val extraDirectives = passwordDirectives ++ publicKeyDirective
+
         OptionCheck.DefaultValue(
-          () =>
-            pushKey().map(_ =>
-              if (options.publishParams.setupCi) Some("env:PUBLISH_SECRET_KEY") else None
-            ),
+          () => uploadKey(publicKeyOpt).map(_ => Some("env:PUBLISH_SECRET_KEY")),
           extraDirectives,
-          setSecrets
+          secretsToSet
         )
       }
-      else if (value(configDb().get(Keys.pgpSecretKey).wrapConfigException).isDefined) {
-        val hasPubKey = value(configDb().get(Keys.pgpPublicKey).wrapConfigException).isDefined
-        val hasPassword =
-          value(configDb().get(Keys.pgpSecretKeyPassword).wrapConfigException).isDefined
-        if (!hasPubKey)
-          logger.message("Warning: no PGP public key found in config")
-        if (!hasPassword)
-          logger.message("Warning: no PGP secret key password found in config")
+      else if (areConfigDefaults)
         OptionCheck.DefaultValue(
-          () =>
-            pushKey().map(_ => None),
+          () => uploadKey(publicKeyOpt).map(_ => None),
           Nil,
           Nil
         )
-      }
-      else
-        value {
-          Left(
-            new MissingPublishOptionError(
-              "publish secret key",
-              "",
-              "publish.secretKey",
-              configKeys = Seq(Keys.pgpSecretKey.fullName)
-            )
+      else {
+        def getDirectiveValue(configPasswordOpt: Option[ConfigPasswordOption]): Option[String] =
+          configPasswordOpt.collect {
+            case ActualOption(passwordOption) =>
+              val optionValue = passwordOption.asString.value
+
+              if (optionValue.startsWith("file:")) {
+                val path = os.Path(optionValue.stripPrefix("file:"))
+                scala.util.Try(path.relativeTo(os.pwd))
+                  .map(p => s"file:${p.toString}")
+                  .getOrElse(optionValue)
+
+              }
+              else optionValue
+            case ConfigOption(fullName) => s"config:$fullName"
+          }
+
+        val passwordDirectives = getDirectiveValue(setupKeys.secretKeyPasswordOpt).map {
+          "publish.secretKeyPassword" -> _
+        }.toSeq
+
+        val secretKeyDirValue = getDirectiveValue(setupKeys.secretKeyOpt)
+
+        val publicKeyDirective = getDirectiveValue(setupKeys.publicKeyOpt).map {
+          "publish.publicKey" -> _
+        }.toSeq
+
+        val extraDirectives = passwordDirectives ++ publicKeyDirective
+
+        if (passwordDirectives.exists(_._2.startsWith("value:")))
+          logger.diagnostic(
+            "The secret value of PGP private key password will be written to a potentially public file!"
           )
-        }
+
+        if (secretKeyDirValue.exists(_.startsWith("value:")))
+          logger.diagnostic(
+            "The secret value of PGP private key will be written to a potentially public file!"
+          )
+
+        OptionCheck.DefaultValue(
+          () => uploadKey(publicKeyOpt).map(_ => secretKeyDirValue),
+          extraDirectives,
+          Nil
+        )
+      }
     }
 }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/checks/PgpSecretKeyCheck.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/checks/PgpSecretKeyCheck.scala
@@ -199,10 +199,10 @@ final case class PgpSecretKeyCheck(
     either {
       keyIdOpt match
         case None =>
-          logger.message("") // printing an empty line, for readability
           logger.message(
-            "Warning: no public key passed, not checking if the key needs to be uploaded to a key server."
-          )
+            """
+              |Warning: no public key passed, not checking if the key needs to be uploaded to a key server.""".stripMargin
+          ) // printing an empty line, for readability
         case Some(pubKeyConfigPasswordOption) =>
           val publicKeyString = pubKeyConfigPasswordOption.get(configDb())
             .orThrow
@@ -222,8 +222,10 @@ final case class PgpSecretKeyCheck(
           value(keyServers)
             .map { keyServer =>
               if (options.dummy) {
-                logger.message("") // printing an empty line, for readability
-                logger.message(s"Would upload key 0x${keyId.stripPrefix("0x")} to $keyServer")
+                logger.message(
+                  s"""
+                     |Would upload key 0x${keyId.stripPrefix("0x")} to $keyServer""".stripMargin
+                ) // printing an empty line, for readability
                 Right(())
               }
               else {
@@ -248,8 +250,10 @@ final case class PgpSecretKeyCheck(
                         )
                     }
                     logger.debug(s"Key server upload response: $resp")
-                    logger.message("") // printing an empty line, for readability
-                    logger.message(s"Uploaded key 0x${keyId.stripPrefix("0x")} to $keyServer")
+                    logger.message(
+                      s"""
+                         |Uploaded key 0x${keyId.stripPrefix("0x")} to $keyServer""".stripMargin
+                    ) // printing an empty line, for readability
                   }
                 }
                 e

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/PublishContextual.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/PublishContextual.scala
@@ -24,6 +24,7 @@ trait PublishContextual {
   def gpgOptions: List[String]
   def secretKey: Option[Positioned[String]]
   def secretKeyPassword: Option[Positioned[String]]
+  def publicKey: Option[Positioned[String]]
   def user: Option[Positioned[String]]
   def password: Option[Positioned[String]]
   def realm: Option[String]
@@ -46,6 +47,12 @@ trait PublishContextual {
           .map(ConfigPasswordOption.ActualOption(_))
       }
       .sequence
+    val maybePublicKey = publicKey
+      .map { input =>
+        PublishContextual.parsePasswordOption(input)
+          .map(ConfigPasswordOption.ActualOption(_))
+      }
+      .sequence
 
     val maybeUser = user
       .map(PublishContextual.parsePasswordOption)
@@ -54,8 +61,22 @@ trait PublishContextual {
       .map(PublishContextual.parsePasswordOption)
       .sequence
 
-    val (computeVersionOpt, secretKeyOpt, secretKeyPasswordOpt, userOpt, passwordOpt) = value {
-      (maybeComputeVersion, maybeSecretKey, maybeSecretKeyPassword, maybeUser, maybePassword)
+    val (
+      computeVersionOpt,
+      secretKeyOpt,
+      secretKeyPasswordOpt,
+      publicKeyOpt,
+      userOpt,
+      passwordOpt
+    ) = value {
+      (
+        maybeComputeVersion,
+        maybeSecretKey,
+        maybeSecretKeyPassword,
+        maybePublicKey,
+        maybeUser,
+        maybePassword
+      )
         .traverseN
         .left.map(CompositeBuildException(_))
     }
@@ -67,6 +88,7 @@ trait PublishContextual {
       gpgOptions = gpgOptions,
       secretKey = secretKeyOpt,
       secretKeyPassword = secretKeyPasswordOpt,
+      publicKey = publicKeyOpt,
       repoUser = userOpt,
       repoPassword = passwordOpt,
       repoRealm = realm
@@ -108,6 +130,7 @@ object PublishContextual {
     gpgOptions: List[String] = Nil,
     secretKey: Option[Positioned[String]] = None,
     secretKeyPassword: Option[Positioned[String]] = None,
+    publicKey: Option[Positioned[String]] = None,
     user: Option[Positioned[String]] = None,
     password: Option[Positioned[String]] = None,
     realm: Option[String] = None
@@ -143,6 +166,7 @@ object PublishContextual {
     gpgOptions: List[String] = Nil,
     secretKey: Option[Positioned[String]] = None,
     secretKeyPassword: Option[Positioned[String]] = None,
+    publicKey: Option[Positioned[String]] = None,
     user: Option[Positioned[String]] = None,
     password: Option[Positioned[String]] = None,
     realm: Option[String] = None

--- a/modules/options/src/main/scala/scala/build/options/PublishContextualOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/PublishContextualOptions.scala
@@ -14,6 +14,7 @@ final case class PublishContextualOptions(
   signer: Option[Signer] = None,
   secretKey: Option[ConfigPasswordOption] = None,
   secretKeyPassword: Option[ConfigPasswordOption] = None,
+  publicKey: Option[ConfigPasswordOption] = None,
   repoUser: Option[PasswordOption] = None,
   repoPassword: Option[PasswordOption] = None,
   repoRealm: Option[String] = None,


### PR DESCRIPTION
Make `publish setup` write down PGP keys to publish-conf
Always check if keys are uploaded to a keyserver
