### PR TITLE
Make credential entries respect the --password-value option

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
@@ -186,16 +186,29 @@ object Config extends ScalaCommand[ConfigOptions] {
                         .traverseN
                         .left.map(CompositeBuildException(_))
                         .orExit(logger)
-                      val credentials = RepositoryCredentials(
-                        host,
-                        userOpt,
-                        passwordOpt,
-                        realm = realmOpt,
-                        optional = options.optional,
-                        matchHost = options.matchHost.orElse(Some(true)),
-                        httpsOnly = options.httpsOnly,
-                        passOnRedirect = options.passOnRedirect
-                      )
+                      val credentials =
+                        if (options.passwordValue)
+                          RepositoryCredentials(
+                            host,
+                            userOpt.map(user => PasswordOption.Value(user.get())),
+                            passwordOpt.map(password => PasswordOption.Value(password.get())),
+                            realm = realmOpt,
+                            optional = options.optional,
+                            matchHost = options.matchHost.orElse(Some(true)),
+                            httpsOnly = options.httpsOnly,
+                            passOnRedirect = options.passOnRedirect
+                          )
+                        else
+                          RepositoryCredentials(
+                            host,
+                            userOpt,
+                            passwordOpt,
+                            realm = realmOpt,
+                            optional = options.optional,
+                            matchHost = options.matchHost.orElse(Some(true)),
+                            httpsOnly = options.httpsOnly,
+                            passOnRedirect = options.passOnRedirect
+                          )
                       val previousValueOpt =
                         db.get(Keys.repositoryCredentials).wrapConfigException.orExit(logger)
                       val newValue = credentials :: previousValueOpt.getOrElse(Nil)
@@ -221,7 +234,15 @@ object Config extends ScalaCommand[ConfigOptions] {
                       .left.map(CompositeBuildException(_))
                       .orExit(logger)
                     val credentials =
-                      PublishCredentials(host, userOpt, passwordOpt, realm = realmOpt)
+                      if (options.passwordValue)
+                        PublishCredentials(
+                          host,
+                          userOpt.map(user => PasswordOption.Value(user.get())),
+                          passwordOpt.map(password => PasswordOption.Value(password.get())),
+                          realm = realmOpt
+                        )
+                      else
+                        PublishCredentials(host, userOpt, passwordOpt, realm = realmOpt)
                     val previousValueOpt =
                       db.get(Keys.publishCredentials).wrapConfigException.orExit(logger)
                     val newValue = credentials :: previousValueOpt.getOrElse(Nil)

--- a/modules/config/src/main/scala/scala/cli/config/Keys.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Keys.scala
@@ -216,8 +216,9 @@ object Keys {
 
   val repositoryCredentials: Key[List[RepositoryCredentials]] =
     new Key[List[RepositoryCredentials]] {
-      override val description: String = "Repository credentials, syntax: value:user value:password"
-      override val hidden: Boolean     = true
+      override val description: String =
+        "Repository credentials, syntax: repositoryAddress value:user value:password [realm]"
+      override val hidden: Boolean = true
 
       private def asJson(credentials: RepositoryCredentials): RepositoryCredentialsAsJson =
         RepositoryCredentialsAsJson(
@@ -341,7 +342,7 @@ object Keys {
 
   val publishCredentials: Key[List[PublishCredentials]] = new Key[List[PublishCredentials]] {
     override val description: String =
-      "Publishing credentials, syntax: s1.oss.sonatype.org value:user value:password"
+      "Publishing credentials, syntax: repositoryAddress value:user value:password [realm]"
     override val hidden: Boolean = true
 
     private def asJson(credentials: PublishCredentials): PublishCredentialsAsJson =

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -59,11 +59,11 @@ Available keys:
   - pgp.secret-key                                 The PGP secret key, used for signing.
   - pgp.secret-key-password                        The PGP secret key password, used for signing.
   - power                                          Globally enables power mode (the '--power' launcher flag).
-  - publish.credentials                            Publishing credentials, syntax: s1.oss.sonatype.org value:user value:password
+  - publish.credentials                            Publishing credentials, syntax: repositoryAddress value:user value:password [realm]
   - publish.user.email                             The 'email' user detail, used for publishing.
   - publish.user.name                              The 'name' user detail, used for publishing.
   - publish.user.url                               The 'url' user detail, used for publishing.
-  - repositories.credentials                       Repository credentials, syntax: value:user value:password
+  - repositories.credentials                       Repository credentials, syntax: repositoryAddress value:user value:password [realm]
   - repositories.default                           Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
   - repositories.mirrors                           Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -58,11 +58,11 @@ Available keys:
   - pgp.secret-key                                 The PGP secret key, used for signing.
   - pgp.secret-key-password                        The PGP secret key password, used for signing.
   - power                                          Globally enables power mode (the '--power' launcher flag).
-  - publish.credentials                            Publishing credentials, syntax: s1.oss.sonatype.org value:user value:password
+  - publish.credentials                            Publishing credentials, syntax: repositoryAddress value:user value:password [realm]
   - publish.user.email                             The 'email' user detail, used for publishing.
   - publish.user.name                              The 'name' user detail, used for publishing.
   - publish.user.url                               The 'url' user detail, used for publishing.
-  - repositories.credentials                       Repository credentials, syntax: value:user value:password
+  - repositories.credentials                       Repository credentials, syntax: repositoryAddress value:user value:password [realm]
   - repositories.default                           Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
   - repositories.mirrors                           Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -598,11 +598,11 @@ Available keys:
   - pgp.secret-key                                 The PGP secret key, used for signing.
   - pgp.secret-key-password                        The PGP secret key password, used for signing.
   - power                                          Globally enables power mode (the '--power' launcher flag).
-  - publish.credentials                            Publishing credentials, syntax: s1.oss.sonatype.org value:user value:password
+  - publish.credentials                            Publishing credentials, syntax: repositoryAddress value:user value:password [realm]
   - publish.user.email                             The 'email' user detail, used for publishing.
   - publish.user.name                              The 'name' user detail, used for publishing.
   - publish.user.url                               The 'url' user detail, used for publishing.
-  - repositories.credentials                       Repository credentials, syntax: value:user value:password
+  - repositories.credentials                       Repository credentials, syntax: repositoryAddress value:user value:password [realm]
   - repositories.default                           Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
   - repositories.mirrors                           Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.


### PR DESCRIPTION
Should work like this - mentioned [here](https://scala-cli.virtuslab.org/docs/commands/publishing/publish-setup#sonatype-credentials)
Also documentation for repositories.credentials was wrong - it accepts a format with repository address at the beginning and an optional realm at the end.