### PR TITLE
Assign `SpecificationLevel` for each configuration key and handle them accordingly

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -40,7 +40,7 @@ implicit def millModuleBasePath: define.BasePath =
 
 object cli extends Cli
 
-object `specification-level` extends SpecificationLevel
+object `specification-level` extends Cross[SpecificationLevel](Scala.all: _*)
 object `build-macros`        extends BuildMacros
 object config                extends Cross[Config](Scala.all: _*)
 object options               extends Options
@@ -439,7 +439,7 @@ trait Directives extends ScalaCliSbtModule with ScalaCliPublishModule with HasTe
     options,
     core,
     `build-macros`,
-    `specification-level`
+    `specification-level`(Scala.scala3)
   )
   def scalacOptions = T {
     super.scalacOptions() ++ asyncScalacOptions(scalaVersion())
@@ -662,16 +662,15 @@ trait Build extends ScalaCliSbtModule with ScalaCliPublishModule with HasTests
   }
 }
 
-trait SpecificationLevel extends SbtModule with ScalaCliPublishModule {
+class SpecificationLevel(val crossScalaVersion: String) extends ScalaCliCrossSbtModule
+    with ScalaCliPublishModule {
   def scalacOptions = T {
-    val sv         = scalaVersion()
-    val isScala213 = sv.startsWith("2.13.")
+    val isScala213 = crossScalaVersion.startsWith("2.13.")
     val extraOptions =
       if (isScala213) Seq("-Xsource:3")
       else Nil
-    super.scalacOptions() ++ extraOptions
+    super.scalacOptions() ++ extraOptions ++ Seq("-release", "8")
   }
-  def scalaVersion = Scala.defaultInternal
 }
 
 trait Cli extends SbtModule with ProtoBuildModule with CliLaunchers
@@ -766,7 +765,7 @@ trait Cli extends SbtModule with ProtoBuildModule with CliLaunchers
     `build-module`,
     config(Scala.scala3),
     `scala3-graal`(Scala.scala3),
-    `specification-level`
+    `specification-level`(Scala.scala3)
   )
 
   def repositories = super.repositories ++ customRepositories

--- a/build.sc
+++ b/build.sc
@@ -498,6 +498,7 @@ trait Directives extends ScalaCliSbtModule with ScalaCliPublishModule with HasTe
 class Config(val crossScalaVersion: String) extends ScalaCliCrossSbtModule
     with ScalaCliPublishModule
     with ScalaCliScalafixModule {
+  def moduleDeps = Seq(`specification-level`(crossScalaVersion))
   def ivyDeps = {
     val maybeCollectionCompat =
       if (crossScalaVersion.startsWith("2.12.")) Seq(Deps.collectionCompat)

--- a/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
+++ b/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
@@ -16,4 +16,7 @@ object WarningMessages {
 
   def experimentalOptionUsed(name: String): String =
     experimentalFeatureUsed(s"The '$name' option")
+
+  def experimentalConfigKeyUsed(name: String): String =
+    experimentalFeatureUsed(s"The '$name' configuration key")
 }

--- a/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
+++ b/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
@@ -5,7 +5,7 @@ import scala.build.internal.Constants
 object WarningMessages {
   private val scalaCliGithubUrl = s"https://github.com/${Constants.ghOrg}/${Constants.ghName}"
   def experimentalFeatureUsed(featureName: String): String =
-    s"""$featureName is an experimental feature.
+    s"""$featureName is experimental.
        |Please bear in mind that non-ideal user experience should be expected.
        |If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at $scalaCliGithubUrl""".stripMargin
   def experimentalDirectiveUsed(name: String): String =

--- a/modules/build/src/main/scala/scala/build/preprocessing/DirectivesProcessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/DirectivesProcessor.scala
@@ -39,9 +39,10 @@ object DirectivesProcessor {
     ) =
       if !allowRestrictedFeatures && (handler.isRestricted || handler.isExperimental) then
         val powerDirectiveType = if handler.isExperimental then "experimental" else "restricted"
-        val msg =
-          s"""This directive is $powerDirectiveType.
-             |Please run it with the '--power' flag or turn this flag on globally by running 'config power true'""".stripMargin
+        val msg = // TODO pass the called progName here to print the full config command
+          s"""The '${scopedDirective.directive.toString}' directive is $powerDirectiveType.
+             |Please run it with the '--power' flag or turn or turn power mode on globally by running:
+             |  ${Console.BOLD}config power true${Console.RESET}""".stripMargin
         Left(DirectiveErrors(
           ::(msg, Nil),
           DirectiveUtil.positions(scopedDirective.directive.values, path)

--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
@@ -9,6 +9,7 @@ import caseapp.core.{Arg, Error}
 import scala.build.Logger
 import scala.build.internal.util.WarningMessages
 import scala.cli.ScalaCli
+import scala.cli.commands.shared.HelpMessages
 import scala.cli.util.ArgHelpers.*
 
 object RestrictedCommandsParser {
@@ -46,13 +47,8 @@ object RestrictedCommandsParser {
       ): Either[(Error, Arg, List[String]), Option[(D, Arg, List[String])]] =
         (parser.step(args, index, d, nameFormatter), args) match {
           case (Right(Some(_, arg: Arg, _)), passedOption :: _) if !arg.isSupported =>
-            val powerOptionType = if arg.isExperimental then "experimental" else "restricted"
             Left((
-              Error.UnrecognizedArgument(
-                s"""The '$passedOption' option is $powerOptionType.
-                   |You can run it with the '--power' flag or turn the power mode on globally by running:
-                   |  ${Console.BOLD}${ScalaCli.progName} config power true${Console.RESET}.""".stripMargin
-              ),
+              Error.UnrecognizedArgument(HelpMessages.powerOptionUsedInSip(passedOption, arg)),
               arg,
               Nil
             ))

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -276,7 +276,10 @@ abstract class ScalaCommand[T <: HasGlobalOptions](implicit myParser: Parser[T],
   override val messages: Help[T] =
     if shouldExcludeInSip then
       Help[T](helpMessage =
-        Some(HelpMessage(HelpMessages.powerCommandUsedInSip(scalaSpecificationLevel)))
+        Some(HelpMessage(HelpMessages.powerCommandUsedInSip(
+          actualCommandName,
+          scalaSpecificationLevel
+        )))
       )
     else if isExperimental then
       help.copy(helpMessage =
@@ -349,7 +352,7 @@ abstract class ScalaCommand[T <: HasGlobalOptions](implicit myParser: Parser[T],
   final override def run(options: T, remainingArgs: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.global.logging.verbosity
     if shouldExcludeInSip then
-      logger.error(HelpMessages.powerCommandUsedInSip(scalaSpecificationLevel))
+      logger.error(HelpMessages.powerCommandUsedInSip(actualCommandName, scalaSpecificationLevel))
       sys.exit(1)
     else if isExperimental && !shouldSuppressExperimentalFeatureWarnings then
       logger.message(WarningMessages.experimentalSubcommandUsed(name))

--- a/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
@@ -19,7 +19,6 @@ final case class ConfigOptions(
   @Recurse
     jvm: SharedJvmOptions = SharedJvmOptions(),
   @Recurse
-  @Tag(tags.restricted)
     scalaSigning: PgpScalaSigningOptions = PgpScalaSigningOptions(),
   @Group(HelpGroup.Config.toString)
   @HelpMessage("Dump config DB as JSON")
@@ -29,13 +28,11 @@ final case class ConfigOptions(
     dump: Boolean = false,
   @Group(HelpGroup.Config.toString)
   @HelpMessage("Create PGP key in config")
-  @Tag(tags.inShortHelp)
-  @Tag(tags.restricted)
+  @Tag(tags.experimental)
     createPgpKey: Boolean = false,
   @Group(HelpGroup.Config.toString)
   @HelpMessage("Email to use to create PGP key in config")
-  @Tag(tags.restricted)
-  @Tag(tags.inShortHelp)
+  @Tag(tags.experimental)
     email: Option[String] = None,
   @Group(HelpGroup.Config.toString)
   @HelpMessage("If the entry is a password, print the password value rather than how to get the password")

--- a/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/ConfigOptions.scala
@@ -3,9 +3,9 @@ package scala.cli.commands.config
 import caseapp.*
 
 import scala.build.internal.util.ConsoleUtils.ScalaCliConsole
-import scala.cli.ScalaCli.{fullRunnerName, progName}
+import scala.cli.ScalaCli.{allowRestrictedFeatures, fullRunnerName, progName}
 import scala.cli.commands.pgp.PgpScalaSigningOptions
-import scala.cli.commands.shared._
+import scala.cli.commands.shared.*
 import scala.cli.commands.tags
 import scala.cli.config.{Key, Keys}
 
@@ -91,16 +91,24 @@ object ConfigOptions {
        |${HelpMessages.commandDocWebsiteReference(cmdName)}""".stripMargin
   private def configKeyMessages(includeHidden: Boolean): Seq[String] = {
     val allKeys: Seq[Key[_]] = Keys.map.values.toSeq
-    val keys: Seq[Key[_]]    = if includeHidden then allKeys else allKeys.filterNot(_.hidden)
-    val maxFullNameLength    = keys.map(_.fullName.length).max
+    val allowedKeys: Seq[Key[_]] =
+      if allowRestrictedFeatures then allKeys
+      else allKeys.filterNot(k => k.isRestricted || k.isExperimental)
+    val keys: Seq[Key[_]] =
+      if includeHidden then allowedKeys
+      else allowedKeys.filterNot(k => k.hidden || k.isExperimental)
+    val maxFullNameLength = keys.map(_.fullName.length).max
     keys.sortBy(_.fullName)
       .map { key =>
         val currentKeyFullNameLength = maxFullNameLength - key.fullName.length
         val extraSpaces =
           if currentKeyFullNameLength > 0 then " " * currentKeyFullNameLength else ""
-        val hiddenString =
-          if key.hidden then s"${ScalaCliConsole.GRAY}(hidden)${Console.RESET} " else ""
-        s"${Console.YELLOW}${key.fullName}${Console.RESET}$extraSpaces  $hiddenString${key.description}"
+        val hiddenOrExperimentalString =
+          if key.hidden then s"${ScalaCliConsole.GRAY}(hidden)${Console.RESET} "
+          else if key.isRestricted then s"${ScalaCliConsole.GRAY}(power)${Console.RESET} "
+          else if key.isExperimental then s"${ScalaCliConsole.GRAY}(experimental)${Console.RESET} "
+          else ""
+        s"${Console.YELLOW}${key.fullName}${Console.RESET}$extraSpaces  $hiddenOrExperimentalString${key.description}"
       }
   }
   val detailedHelpMessage: String =

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
@@ -2,6 +2,7 @@ package scala.cli.commands.shared
 
 import scala.cli.ScalaCli
 import scala.cli.commands.SpecificationLevel
+import scala.cli.config.Key
 
 object HelpMessages {
   lazy val PowerString: String = if ScalaCli.allowRestrictedFeatures then "" else "--power "
@@ -48,6 +49,18 @@ object HelpMessages {
     s"""Specific $cmdName configurations can be specified with both command line options and using directives defined in sources.
        |Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
        |Using directives can be defined in all supported input source file types.""".stripMargin
+
+  private def powerFeatureUsedInSip(
+    featureName: String,
+    featureType: String,
+    specificationLevel: SpecificationLevel
+  ): String = {
+    val powerType =
+      if specificationLevel == SpecificationLevel.EXPERIMENTAL then "experimental" else "restricted"
+    s"""The '$featureName' $featureType is $powerType.
+       |You can run it with the '--power' flag or turn power mode on globally by running:
+       |  ${Console.BOLD}${ScalaCli.progName} config power true${Console.RESET}.""".stripMargin
+  }
   def powerCommandUsedInSip(specificationLevel: SpecificationLevel): String = {
     val powerCommandType =
       if specificationLevel == SpecificationLevel.EXPERIMENTAL then "experimental" else "restricted"
@@ -55,4 +68,7 @@ object HelpMessages {
        |You can pass it explicitly or set it globally by running:
        |   ${Console.BOLD}${ScalaCli.progName} config power true${Console.RESET}""".stripMargin
   }
+
+  def powerConfigKeyUsedInSip(key: Key[_]): String =
+    powerFeatureUsedInSip(key.fullName, "configuration key", key.specificationLevel)
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
@@ -1,8 +1,11 @@
 package scala.cli.commands.shared
 
+import caseapp.core.Arg
+
 import scala.cli.ScalaCli
-import scala.cli.commands.SpecificationLevel
+import scala.cli.commands.{SpecificationLevel, tags}
 import scala.cli.config.Key
+import scala.cli.util.ArgHelpers.*
 
 object HelpMessages {
   lazy val PowerString: String = if ScalaCli.allowRestrictedFeatures then "" else "--power "
@@ -61,12 +64,18 @@ object HelpMessages {
        |You can run it with the '--power' flag or turn power mode on globally by running:
        |  ${Console.BOLD}${ScalaCli.progName} config power true${Console.RESET}.""".stripMargin
   }
-  def powerCommandUsedInSip(specificationLevel: SpecificationLevel): String = {
-    val powerCommandType =
-      if specificationLevel == SpecificationLevel.EXPERIMENTAL then "experimental" else "restricted"
-    s"""This command is $powerCommandType and requires setting the '--power' launcher option to be used.
-       |You can pass it explicitly or set it globally by running:
-       |   ${Console.BOLD}${ScalaCli.progName} config power true${Console.RESET}""".stripMargin
+  def powerCommandUsedInSip(commandName: String, specificationLevel: SpecificationLevel): String =
+    powerFeatureUsedInSip(commandName, "sub-command", specificationLevel)
+  def powerOptionUsedInSip(optionName: String, arg: Arg): String = {
+    val specificationLevel =
+      if arg.isExperimental then SpecificationLevel.EXPERIMENTAL
+      else if arg.isRestricted then SpecificationLevel.RESTRICTED
+      else
+        arg.tags
+          .flatMap(t => tags.levelFor(t.name))
+          .headOption
+          .getOrElse(SpecificationLevel.EXPERIMENTAL)
+    powerFeatureUsedInSip(optionName, "option", specificationLevel)
   }
 
   def powerConfigKeyUsedInSip(key: Key[_]): String =

--- a/modules/cli/src/main/scala/scala/cli/util/ConfigPasswordOptionHelpers.scala
+++ b/modules/cli/src/main/scala/scala/cli/util/ConfigPasswordOptionHelpers.scala
@@ -2,6 +2,7 @@ package scala.cli.util
 
 import scala.build.errors.BuildException
 import scala.build.options.publish.ConfigPasswordOption
+import scala.cli.commands.SpecificationLevel
 import scala.cli.commands.publish.ConfigUtil._
 import scala.cli.config.{ConfigDb, Key, PasswordOption}
 import scala.cli.errors.MissingConfigEntryError
@@ -16,7 +17,7 @@ object ConfigPasswordOptionHelpers {
         case a: ConfigPasswordOption.ActualOption =>
           Right(a.option.toConfig)
         case c: ConfigPasswordOption.ConfigOption =>
-          val key = new Key.PasswordEntry(c.prefix, c.name)
+          val key = new Key.PasswordEntry(c.prefix, c.name, SpecificationLevel.IMPLEMENTATION)
           configDb.get(key).wrapConfigException.flatMap {
             case None        => Left(new MissingConfigEntryError(c.fullName))
             case Some(value) => Right(value)

--- a/modules/config/src/main/scala/scala/cli/config/Key.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Key.scala
@@ -3,6 +3,7 @@ package scala.cli.config
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.github.plokhotnyuk.jsoniter_scala.macros._
 
+import scala.cli.commands.SpecificationLevel
 import scala.cli.config.Util._ // only used in 2.12, unused import in 2.13
 
 /** A configuration key
@@ -46,6 +47,11 @@ abstract class Key[T] {
 
   /** Whether this key corresponds to a password (see [[Key.PasswordEntry]]) */
   def isPasswordOption: Boolean = false
+
+  /** The [[SpecificationLevel]] of the key. [[SpecificationLevel.RESTRICTED]] &&
+    * [[SpecificationLevel.EXPERIMENTAL]] keys are only available in `power` mode.
+    */
+  def specificationLevel: SpecificationLevel
 }
 
 object Key {
@@ -83,6 +89,7 @@ object Key {
   final class StringEntry(
     val prefix: Seq[String],
     val name: String,
+    override val specificationLevel: SpecificationLevel,
     val description: String = "",
     override val hidden: Boolean = false
   ) extends Key[String] {
@@ -106,6 +113,7 @@ object Key {
   final class BooleanEntry(
     val prefix: Seq[String],
     val name: String,
+    override val specificationLevel: SpecificationLevel,
     val description: String = "",
     override val hidden: Boolean = false
   ) extends Key[Boolean] {
@@ -129,6 +137,7 @@ object Key {
   final class PasswordEntry(
     val prefix: Seq[String],
     val name: String,
+    override val specificationLevel: SpecificationLevel,
     val description: String = "",
     override val hidden: Boolean = false
   ) extends Key[PasswordOption] {
@@ -163,6 +172,7 @@ object Key {
   final class StringListEntry(
     val prefix: Seq[String],
     val name: String,
+    override val specificationLevel: SpecificationLevel,
     val description: String = "",
     override val hidden: Boolean = false
   ) extends Key[List[String]] {

--- a/modules/config/src/main/scala/scala/cli/config/Key.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Key.scala
@@ -52,6 +52,9 @@ abstract class Key[T] {
     * [[SpecificationLevel.EXPERIMENTAL]] keys are only available in `power` mode.
     */
   def specificationLevel: SpecificationLevel
+
+  def isExperimental: Boolean = specificationLevel == SpecificationLevel.EXPERIMENTAL
+  def isRestricted: Boolean   = specificationLevel == SpecificationLevel.RESTRICTED
 }
 
 object Key {

--- a/modules/config/src/main/scala/scala/cli/config/Keys.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Keys.scala
@@ -12,45 +12,39 @@ object Keys {
     prefix = Seq("publish", "user"),
     name = "name",
     specificationLevel = SpecificationLevel.EXPERIMENTAL,
-    description = "The 'name' user detail, used for publishing.",
-    hidden = true
+    description = "The 'name' user detail, used for publishing."
   )
   val userEmail = new Key.StringEntry(
     prefix = Seq("publish", "user"),
     name = "email",
     specificationLevel = SpecificationLevel.EXPERIMENTAL,
-    description = "The 'email' user detail, used for publishing.",
-    hidden = true
+    description = "The 'email' user detail, used for publishing."
   )
   val userUrl = new Key.StringEntry(
     prefix = Seq("publish", "user"),
     name = "url",
     specificationLevel = SpecificationLevel.EXPERIMENTAL,
-    description = "The 'url' user detail, used for publishing.",
-    hidden = true
+    description = "The 'url' user detail, used for publishing."
   )
 
   val ghToken = new Key.PasswordEntry(
     prefix = Seq("github"),
     name = "token",
     specificationLevel = SpecificationLevel.EXPERIMENTAL,
-    description = "GitHub token.",
-    hidden = true
+    description = "GitHub token."
   )
 
   val pgpSecretKey = new Key.PasswordEntry(
     prefix = Seq("pgp"),
     name = "secret-key",
     specificationLevel = SpecificationLevel.EXPERIMENTAL,
-    description = "The PGP secret key, used for signing.",
-    hidden = true
+    description = "The PGP secret key, used for signing."
   )
   val pgpSecretKeyPassword = new Key.PasswordEntry(
     prefix = Seq("pgp"),
     name = "secret-key-password",
     specificationLevel = SpecificationLevel.EXPERIMENTAL,
-    description = "The PGP secret key password, used for signing.",
-    hidden = true
+    description = "The PGP secret key password, used for signing."
   )
   val pgpPublicKey = new Key.PasswordEntry(
     prefix = Seq("pgp"),
@@ -106,22 +100,19 @@ object Keys {
     prefix = Seq("httpProxy"),
     name = "address",
     specificationLevel = SpecificationLevel.RESTRICTED,
-    description = "HTTP proxy address.",
-    hidden = true
+    description = "HTTP proxy address."
   )
   val proxyUser = new Key.PasswordEntry(
     prefix = Seq("httpProxy"),
     name = "user",
     specificationLevel = SpecificationLevel.RESTRICTED,
-    description = "HTTP proxy user (used for authentication).",
-    hidden = true
+    description = "HTTP proxy user (used for authentication)."
   )
   val proxyPassword = new Key.PasswordEntry(
     prefix = Seq("httpProxy"),
     name = "password",
     specificationLevel = SpecificationLevel.RESTRICTED,
-    description = "HTTP proxy password (used for authentication).",
-    hidden = true
+    description = "HTTP proxy password (used for authentication)."
   )
 
   val repositoryMirrors = new Key.StringListEntry(
@@ -129,16 +120,14 @@ object Keys {
     name = "mirrors",
     description =
       s"Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven",
-    specificationLevel = SpecificationLevel.RESTRICTED,
-    hidden = true
+    specificationLevel = SpecificationLevel.RESTRICTED
   )
   val defaultRepositories = new Key.StringListEntry(
     prefix = Seq("repositories"),
     name = "default",
     description =
       "Default repository, syntax: https://first-repo.company.com https://second-repo.company.com",
-    specificationLevel = SpecificationLevel.RESTRICTED,
-    hidden = true
+    specificationLevel = SpecificationLevel.RESTRICTED
   )
 
   // Kept for binary compatibility
@@ -238,7 +227,6 @@ object Keys {
     new Key[List[RepositoryCredentials]] {
       override val description: String =
         "Repository credentials, syntax: repositoryAddress value:user value:password [realm]"
-      override val hidden: Boolean = true
 
       override def specificationLevel: SpecificationLevel = SpecificationLevel.RESTRICTED
 
@@ -365,7 +353,6 @@ object Keys {
   val publishCredentials: Key[List[PublishCredentials]] = new Key[List[PublishCredentials]] {
     override val description: String =
       "Publishing credentials, syntax: repositoryAddress value:user value:password [realm]"
-    override val hidden: Boolean = true
 
     override def specificationLevel: SpecificationLevel = SpecificationLevel.EXPERIMENTAL
 

--- a/modules/config/src/main/scala/scala/cli/config/Keys.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Keys.scala
@@ -3,6 +3,7 @@ package scala.cli.config
 import com.github.plokhotnyuk.jsoniter_scala.core.{Key => _, _}
 import com.github.plokhotnyuk.jsoniter_scala.macros._
 
+import scala.cli.commands.SpecificationLevel
 import scala.collection.mutable.ListBuffer
 
 object Keys {
@@ -10,18 +11,21 @@ object Keys {
   val userName = new Key.StringEntry(
     prefix = Seq("publish", "user"),
     name = "name",
+    specificationLevel = SpecificationLevel.EXPERIMENTAL,
     description = "The 'name' user detail, used for publishing.",
     hidden = true
   )
   val userEmail = new Key.StringEntry(
     prefix = Seq("publish", "user"),
     name = "email",
+    specificationLevel = SpecificationLevel.EXPERIMENTAL,
     description = "The 'email' user detail, used for publishing.",
     hidden = true
   )
   val userUrl = new Key.StringEntry(
     prefix = Seq("publish", "user"),
     name = "url",
+    specificationLevel = SpecificationLevel.EXPERIMENTAL,
     description = "The 'url' user detail, used for publishing.",
     hidden = true
   )
@@ -29,6 +33,7 @@ object Keys {
   val ghToken = new Key.PasswordEntry(
     prefix = Seq("github"),
     name = "token",
+    specificationLevel = SpecificationLevel.EXPERIMENTAL,
     description = "GitHub token.",
     hidden = true
   )
@@ -36,18 +41,21 @@ object Keys {
   val pgpSecretKey = new Key.PasswordEntry(
     prefix = Seq("pgp"),
     name = "secret-key",
+    specificationLevel = SpecificationLevel.EXPERIMENTAL,
     description = "The PGP secret key, used for signing.",
     hidden = true
   )
   val pgpSecretKeyPassword = new Key.PasswordEntry(
     prefix = Seq("pgp"),
     name = "secret-key-password",
+    specificationLevel = SpecificationLevel.EXPERIMENTAL,
     description = "The PGP secret key password, used for signing.",
     hidden = true
   )
   val pgpPublicKey = new Key.PasswordEntry(
     prefix = Seq("pgp"),
     name = "public-key",
+    specificationLevel = SpecificationLevel.EXPERIMENTAL,
     description = "The PGP public key, used for signing.",
     hidden = true
   )
@@ -55,16 +63,19 @@ object Keys {
   val actions = new Key.BooleanEntry(
     prefix = Seq.empty,
     name = "actions",
+    specificationLevel = SpecificationLevel.IMPLEMENTATION,
     description = "Globally enables actionable diagnostics. Enabled by default."
   )
   val interactive = new Key.BooleanEntry(
     prefix = Seq.empty,
     name = "interactive",
+    specificationLevel = SpecificationLevel.IMPLEMENTATION,
     description = "Globally enables interactive mode (the '--interactive' flag)."
   )
   val power = new Key.BooleanEntry(
     prefix = Seq.empty,
     name = "power",
+    specificationLevel = SpecificationLevel.MUST,
     description = "Globally enables power mode (the '--power' launcher flag)."
   )
 
@@ -72,6 +83,7 @@ object Keys {
     new Key.BooleanEntry(
       prefix = Seq("suppress-warning"),
       name = "directives-in-multiple-files",
+      specificationLevel = SpecificationLevel.IMPLEMENTATION,
       description =
         "Globally suppresses warnings about directives declared in multiple source files."
     )
@@ -79,30 +91,35 @@ object Keys {
     new Key.BooleanEntry(
       prefix = Seq("suppress-warning"),
       name = "outdated-dependencies-files",
+      specificationLevel = SpecificationLevel.IMPLEMENTATION,
       description = "Globally suppresses warnings about outdated dependencies."
     )
   val suppressExperimentalFeatureWarning =
     new Key.BooleanEntry(
       prefix = Seq("suppress-warning"),
       name = "experimental-features",
+      specificationLevel = SpecificationLevel.IMPLEMENTATION,
       description = "Globally suppresses warnings about experimental features."
     )
 
   val proxyAddress = new Key.StringEntry(
     prefix = Seq("httpProxy"),
     name = "address",
+    specificationLevel = SpecificationLevel.RESTRICTED,
     description = "HTTP proxy address.",
     hidden = true
   )
   val proxyUser = new Key.PasswordEntry(
     prefix = Seq("httpProxy"),
     name = "user",
+    specificationLevel = SpecificationLevel.RESTRICTED,
     description = "HTTP proxy user (used for authentication).",
     hidden = true
   )
   val proxyPassword = new Key.PasswordEntry(
     prefix = Seq("httpProxy"),
     name = "password",
+    specificationLevel = SpecificationLevel.RESTRICTED,
     description = "HTTP proxy password (used for authentication).",
     hidden = true
   )
@@ -112,6 +129,7 @@ object Keys {
     name = "mirrors",
     description =
       s"Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven",
+    specificationLevel = SpecificationLevel.RESTRICTED,
     hidden = true
   )
   val defaultRepositories = new Key.StringListEntry(
@@ -119,6 +137,7 @@ object Keys {
     name = "default",
     description =
       "Default repository, syntax: https://first-repo.company.com https://second-repo.company.com",
+    specificationLevel = SpecificationLevel.RESTRICTED,
     hidden = true
   )
 
@@ -129,6 +148,7 @@ object Keys {
   val globalInteractiveWasSuggested = new Key.BooleanEntry(
     prefix = Seq.empty,
     name = "interactive-was-suggested",
+    specificationLevel = SpecificationLevel.IMPLEMENTATION,
     description = "Setting indicating if the global interactive mode was already suggested.",
     hidden = true
   )
@@ -219,6 +239,8 @@ object Keys {
       override val description: String =
         "Repository credentials, syntax: repositoryAddress value:user value:password [realm]"
       override val hidden: Boolean = true
+
+      override def specificationLevel: SpecificationLevel = SpecificationLevel.RESTRICTED
 
       private def asJson(credentials: RepositoryCredentials): RepositoryCredentialsAsJson =
         RepositoryCredentialsAsJson(
@@ -344,6 +366,8 @@ object Keys {
     override val description: String =
       "Publishing credentials, syntax: repositoryAddress value:user value:password [realm]"
     override val hidden: Boolean = true
+
+    override def specificationLevel: SpecificationLevel = SpecificationLevel.EXPERIMENTAL
 
     private def asJson(credentials: PublishCredentials): PublishCredentialsAsJson =
       PublishCredentialsAsJson(

--- a/modules/config/src/main/scala/scala/cli/config/internal/JavaHelper.scala
+++ b/modules/config/src/main/scala/scala/cli/config/internal/JavaHelper.scala
@@ -3,6 +3,7 @@ package scala.cli.config.internal
 import java.lang.{Boolean => JBoolean}
 import java.nio.file.Path
 
+import scala.cli.commands.SpecificationLevel
 import scala.cli.config._
 
 object JavaHelper {
@@ -30,7 +31,7 @@ object JavaHelper {
   def getString(key: String): String = {
     val db             = dbOpt.getOrElse(sys.error("DB not open"))
     val (prefix, name) = split(key)
-    val key0           = new Key.StringEntry(prefix, name)
+    val key0           = new Key.StringEntry(prefix, name, SpecificationLevel.IMPLEMENTATION)
     db.get(key0) match {
       case Left(ex)         => throw new Exception(ex)
       case Right(None)      => null
@@ -41,7 +42,7 @@ object JavaHelper {
   def getBoolean(key: String): JBoolean = {
     val db             = dbOpt.getOrElse(sys.error("DB not open"))
     val (prefix, name) = split(key)
-    val key0           = new Key.BooleanEntry(prefix, name)
+    val key0           = new Key.BooleanEntry(prefix, name, SpecificationLevel.IMPLEMENTATION)
     db.get(key0) match {
       case Left(ex)           => throw new Exception(ex)
       case Right(None)        => null
@@ -52,7 +53,7 @@ object JavaHelper {
   def getStringList(key: String): Array[String] = {
     val db             = dbOpt.getOrElse(sys.error("DB not open"))
     val (prefix, name) = split(key)
-    val key0           = new Key.StringListEntry(prefix, name)
+    val key0           = new Key.StringListEntry(prefix, name, SpecificationLevel.IMPLEMENTATION)
     db.get(key0) match {
       case Left(ex)           => throw new Exception(ex)
       case Right(None)        => null
@@ -63,7 +64,7 @@ object JavaHelper {
   def getPassword(key: String): String = {
     val db             = dbOpt.getOrElse(sys.error("DB not open"))
     val (prefix, name) = split(key)
-    val key0           = new Key.PasswordEntry(prefix, name)
+    val key0           = new Key.PasswordEntry(prefix, name, SpecificationLevel.IMPLEMENTATION)
     db.get(key0) match {
       case Left(ex)         => throw new Exception(ex)
       case Right(None)      => null
@@ -74,7 +75,7 @@ object JavaHelper {
   def getPasswordBytes(key: String): Array[Byte] = {
     val db             = dbOpt.getOrElse(sys.error("DB not open"))
     val (prefix, name) = split(key)
-    val key0           = new Key.PasswordEntry(prefix, name)
+    val key0           = new Key.PasswordEntry(prefix, name, SpecificationLevel.IMPLEMENTATION)
     db.get(key0) match {
       case Left(ex)         => throw new Exception(ex)
       case Right(None)      => null

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/ReferenceDocUtils.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/ReferenceDocUtils.scala
@@ -44,7 +44,10 @@ object ReferenceDocUtils {
       consoleToFenceRec(s.linesIterator.toSeq)
     }
     def filterOutHiddenStrings: String =
-      s.replace(s"${ScalaCliConsole.GRAY}(hidden)${Console.RESET} ", "")
+      s
+        .replace(s"${ScalaCliConsole.GRAY}(hidden)${Console.RESET} ", "")
+        .replace(s"${ScalaCliConsole.GRAY}(experimental)${Console.RESET} ", "")
+        .replace(s"${ScalaCliConsole.GRAY}(power)${Console.RESET} ", "")
     def consoleYellowToMdBullets: String = s.replace(Console.YELLOW, "- ")
     def consoleToMarkdown: String = s.filterOutHiddenStrings.consoleYellowToMdBullets.consoleToFence
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
@@ -14,20 +14,32 @@ class ConfigTests extends ScalaCliSuite {
     val name       = "Alex"
     TestInputs.empty.fromRoot { root =>
       val before =
-        os.proc(TestUtil.cli, "config", "publish.user.name").call(cwd = root, env = configEnv)
+        os.proc(TestUtil.cli, "--power", "config", "publish.user.name").call(
+          cwd = root,
+          env = configEnv
+        )
       expect(before.out.trim().isEmpty)
 
-      os.proc(TestUtil.cli, "config", "publish.user.name", name).call(cwd = root, env = configEnv)
+      os.proc(TestUtil.cli, "--power", "config", "publish.user.name", name).call(
+        cwd = root,
+        env = configEnv
+      )
       val res =
-        os.proc(TestUtil.cli, "config", "publish.user.name").call(cwd = root, env = configEnv)
+        os.proc(TestUtil.cli, "--power", "config", "publish.user.name").call(
+          cwd = root,
+          env = configEnv
+        )
       expect(res.out.trim() == name)
 
-      os.proc(TestUtil.cli, "config", "publish.user.name", "--unset").call(
+      os.proc(TestUtil.cli, "--power", "config", "publish.user.name", "--unset").call(
         cwd = root,
         env = configEnv
       )
       val after =
-        os.proc(TestUtil.cli, "config", "publish.user.name").call(cwd = root, env = configEnv)
+        os.proc(TestUtil.cli, "--power", "config", "publish.user.name").call(
+          cwd = root,
+          env = configEnv
+        )
       expect(after.out.trim().isEmpty)
     }
   }
@@ -40,17 +52,17 @@ class ConfigTests extends ScalaCliSuite {
     TestInputs.empty.fromRoot { root =>
 
       def emptyCheck(): Unit = {
-        val value = os.proc(TestUtil.cli, "config", key)
+        val value = os.proc(TestUtil.cli, "--power", "config", key)
           .call(cwd = root, env = configEnv)
         expect(value.out.trim().isEmpty)
       }
 
       def unset(): Unit =
-        os.proc(TestUtil.cli, "config", key, "--unset")
+        os.proc(TestUtil.cli, "--power", "config", key, "--unset")
           .call(cwd = root, env = configEnv)
 
       def read(): String = {
-        val res = os.proc(TestUtil.cli, "config", key)
+        val res = os.proc(TestUtil.cli, "--power", "config", key)
           .call(cwd = root, env = configEnv)
         res.out.trim()
       }
@@ -62,14 +74,14 @@ class ConfigTests extends ScalaCliSuite {
 
       emptyCheck()
 
-      os.proc(TestUtil.cli, "config", key, s"value:$password")
+      os.proc(TestUtil.cli, "--power", "config", key, s"value:$password")
         .call(cwd = root, env = configEnv)
       expect(read() == s"value:$password")
       expect(readDecoded() == password)
       unset()
       emptyCheck()
 
-      os.proc(TestUtil.cli, "config", key, "env:MY_PASSWORD")
+      os.proc(TestUtil.cli, "--power", "config", key, "env:MY_PASSWORD")
         .call(cwd = root, env = configEnv)
       expect(read() == "env:MY_PASSWORD")
       expect(readDecoded(env = Map("MY_PASSWORD" -> password)) == password)
@@ -111,7 +123,7 @@ class ConfigTests extends ScalaCliSuite {
         Map("SCALA_CLI_CONFIG" -> confFile.toString) ++
           TestUtil.putCsInPathViaEnv(root / "bin")
 
-      val res = os.proc(TestUtil.cli, "config", "httpProxy.address")
+      val res = os.proc(TestUtil.cli, "--power", "config", "httpProxy.address")
         .call(cwd = root, env = extraEnv)
       val value = res.out.trim()
       expect(value == proxyAddr)
@@ -146,7 +158,7 @@ class ConfigTests extends ScalaCliSuite {
       val confFile = confDir / "test-config.json"
       val extraEnv = Map("SCALA_CLI_CONFIG" -> confFile.toString)
 
-      val res = os.proc(TestUtil.cli, "config", "httpProxy.address", proxyAddr)
+      val res = os.proc(TestUtil.cli, "--power", "config", "httpProxy.address", proxyAddr)
         .call(cwd = root, env = extraEnv, check = false, mergeErrIntoOut = true)
       val output = res.out.trim()
       expect(output.contains(" has wrong permissions"))
@@ -174,10 +186,10 @@ class ConfigTests extends ScalaCliSuite {
       os.proc(TestUtil.cli, "--power", "config", "--create-pgp-key", "--email", "alex@alex.me")
         .call(cwd = root, env = extraEnv, stdin = os.Inherit, stdout = os.Inherit)
 
-      val password = os.proc(TestUtil.cli, "config", "pgp.secret-key-password")
+      val password = os.proc(TestUtil.cli, "--power", "config", "pgp.secret-key-password")
         .call(cwd = root, env = extraEnv)
         .out.trim()
-      val secretKey = os.proc(TestUtil.cli, "config", "pgp.secret-key")
+      val secretKey = os.proc(TestUtil.cli, "--power", "config", "pgp.secret-key")
         .call(cwd = root, env = extraEnv)
         .out.trim()
       val rawPublicKey = os.proc(TestUtil.cli, "--power", "config", "pgp.public-key", "--password")
@@ -266,6 +278,7 @@ class ConfigTests extends ScalaCliSuite {
       TestUtil.serveFilesInHttpServer(repoPath, user, password, realm) { (host, port) =>
         os.proc(
           TestUtil.cli,
+          "--power",
           "config",
           "repositories.credentials",
           host,
@@ -316,7 +329,7 @@ class ConfigTests extends ScalaCliSuite {
           "--password-value"
         )
           .call(cwd = root, env = configEnv ++ envVars)
-        val credsFromConfig = os.proc(TestUtil.cli, "config", key)
+        val credsFromConfig = os.proc(TestUtil.cli, "--power", "config", key)
           .call(cwd = root, env = configEnv)
           .out.trim()
         expect(credsFromConfig.contains(password))

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -854,11 +854,11 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
       user: String,
       password: String
     ): Unit = {
-      os.proc(TestUtil.cli, "config", "httpProxy.address", s"http://$host:$port")
+      os.proc(TestUtil.cli, "--power", "config", "httpProxy.address", s"http://$host:$port")
         .call(cwd = cwd, env = env)
-      os.proc(TestUtil.cli, "config", "httpProxy.user", s"value:$user")
+      os.proc(TestUtil.cli, "--power", "config", "httpProxy.user", s"value:$user")
         .call(cwd = cwd, env = env)
-      os.proc(TestUtil.cli, "config", "httpProxy.password", s"value:$password")
+      os.proc(TestUtil.cli, "--power", "config", "httpProxy.password", s"value:$password")
         .call(cwd = cwd, env = env)
     }
     val image = Constants.authProxyTestImage

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -48,9 +48,7 @@ class SipScalaTests extends ScalaCliSuite {
       if (!isPowerMode) {
         expect(res.exitCode == 1)
         val output = res.out.text()
-        expect(output.contains(
-          """This command is restricted and requires setting the '--power' launcher option to be used"""
-        ))
+        expect(output.contains("The 'directories' sub-command is restricted."))
       }
       else expect(res.exitCode == 0)
     }
@@ -71,17 +69,11 @@ class SipScalaTests extends ScalaCliSuite {
       expect(res.exitCode == 1)
       isPowerMode -> areWarningsSuppressed match {
         case (false, _) =>
-          expect(errOutput.contains(
-            "This command is experimental and requires setting the '--power' launcher option to be used"
-          ))
+          expect(errOutput.contains("The 'export' sub-command is experimental."))
         case (true, false) =>
-          expect(errOutput.contains(
-            "The 'export' sub-command is an experimental feature"
-          ))
+          expect(errOutput.contains("The 'export' sub-command is experimental."))
         case (true, true) =>
-          expect(!errOutput.contains(
-            "The 'export' sub-command is an experimental feature"
-          ))
+          expect(!errOutput.contains("The 'export' sub-command is experimental."))
       }
     }
 
@@ -119,7 +111,7 @@ class SipScalaTests extends ScalaCliSuite {
           ))
           expect(configPublishUserResult.exitCode == 0)
           expect(configPublishUserErrOutput.contains(
-            "The 'publish.user.name' configuration key is an experimental feature."
+            "The 'publish.user.name' configuration key is experimental."
           ))
         case (true, true) =>
           expect(configProxyResult.exitCode == 0)
@@ -128,7 +120,7 @@ class SipScalaTests extends ScalaCliSuite {
           ))
           expect(configPublishUserResult.exitCode == 0)
           expect(!configPublishUserErrOutput.contains(
-            "The 'publish.user.name' configuration key is an experimental feature."
+            "The 'publish.user.name' configuration key is experimental."
           ))
       }
     }
@@ -140,14 +132,8 @@ class SipScalaTests extends ScalaCliSuite {
         stderr = os.Pipe
       )
       val output = res.out.trim()
-      if (!isPowerMode)
-        expect(output.contains(
-          "This command is experimental and requires setting the '--power' launcher option to be used"
-        ))
-      else
-        expect(output.contains(
-          "The 'export' sub-command is an experimental feature"
-        ))
+      if (!isPowerMode) expect(output.contains("The 'export' sub-command is experimental."))
+      else expect(output.contains("The 'export' sub-command is experimental."))
     }
 
   def testConfigCommandHelp(isPowerMode: Boolean, isFullHelp: Boolean): Unit =
@@ -201,12 +187,12 @@ class SipScalaTests extends ScalaCliSuite {
         case (true, false) =>
           expect(res.exitCode == 0)
           expect(errOutput.contains(
-            """The '//> using publish.name "my-library"' directive is an experimental feature"""
+            """The '//> using publish.name "my-library"' directive is experimental."""
           ))
         case (true, true) =>
           expect(res.exitCode == 0)
           expect(!errOutput.contains(
-            """The '//> using publish.name "my-library"' directive is an experimental feature"""
+            """The '//> using publish.name "my-library"' directive is experimental."""
           ))
       }
     }
@@ -243,10 +229,10 @@ class SipScalaTests extends ScalaCliSuite {
           expect(errOutput.contains("--markdown"))
         case (true, false) =>
           expect(res.exitCode == 0)
-          expect(errOutput.contains("The '--markdown' option is an experimental feature"))
+          expect(errOutput.contains("The '--markdown' option is experimental."))
         case (true, true) =>
           expect(res.exitCode == 0)
-          expect(!errOutput.contains("The '--markdown' option is an experimental feature"))
+          expect(!errOutput.contains("The '--markdown' option is experimental."))
       }
     }
 
@@ -295,11 +281,11 @@ class SipScalaTests extends ScalaCliSuite {
       testWhenDisabled =
         (root, homeEnv) => {
           val errOutput = callExperimentalFeature(root, homeEnv).err.trim()
-          expect(errOutput.contains(s"$featureType is an experimental feature"))
+          expect(errOutput.contains(s"$featureType is experimental."))
         },
       testWhenEnabled = (root, homeEnv) => {
         val errOutput = callExperimentalFeature(root, homeEnv).err.trim()
-        expect(!errOutput.contains(s"$featureType is an experimental feature"))
+        expect(!errOutput.contains(s"$featureType is experimental."))
       }
     )
   }
@@ -393,10 +379,9 @@ class SipScalaTests extends ScalaCliSuite {
         testWhenDisabled = { (root, homeEnv) =>
           val res = os.proc(TestUtil.cli, subCommand)
             .call(cwd = root, check = false, env = homeEnv, stderr = os.Pipe)
+          val errOutput = res.err.trim()
           expect(res.exitCode == 1)
-          expect(res.err.text().trim().contains(
-            s"""This command is $restrictionType and requires setting the '--power' launcher option to be used"""
-          ))
+          expect(errOutput.contains(s"The '$subCommand' sub-command is $restrictionType."))
         },
         testWhenEnabled = { (root, homeEnv) =>
           val res = os.proc(TestUtil.cli, subCommand)

--- a/website/docs/commands/config.md
+++ b/website/docs/commands/config.md
@@ -24,11 +24,20 @@ true
 
 </ChainedSnippets>
 
+:::caution
+Even though the `config` command is not restricted, some available configuration keys may be, and thus may
+require setting the `--power` option to be used.
+You can pass it explicitly or set it globally by running:
+```bash ignore
+scala-cli config power true
+```
+:::
+
 <ChainedSnippets>
 
 ```bash
-scala-cli config publish.user.name "Alex Me"
-scala-cli config publish.user.name
+scala-cli --power config publish.user.name "Alex Me"
+scala-cli --power config publish.user.name
 ```
 
 ```text
@@ -43,6 +52,7 @@ The `--dump` option allows to print all config entries in JSON format:
 ```bash
 scala-cli config --dump | jq .
 ```
+
 ```json
 {
   "github": {
@@ -69,16 +79,19 @@ Use `--password` to get the value of a password entry:
 
 ```bash
 export MY_GITHUB_TOKEN=1234
-scala-cli config github.token "env:MY_GITHUB_TOKEN"
-scala-cli config github.token
+scala-cli --power config github.token "env:MY_GITHUB_TOKEN"
+scala-cli --power config github.token
 ```
+
 ```text
 env:MY_GITHUB_TOKEN
 ```
+
 ```bash
 export MY_GITHUB_TOKEN=1234
 scala-cli --power config --password github.token
 ```
+
 ```text
 1234
 ```
@@ -87,12 +100,16 @@ scala-cli --power config --password github.token
 
 Use `--create-pgp-key` to create a PGP key pair, protected by a randomly-generated password, to
 be used by the `publish setup` sub-command:
+
 ```sh
 scala-cli --power config --create-pgp-key --email "some_email"
 ```
+
 The `--email` option or `publish.user.email` has to be specified for this subcommand to work properly.
 
 Configuration values are stored in a directory under your home directory, with restricted permissions:
+
 - on macOS: `~/Library/Application Support/ScalaCli/secrets/config.json`
 - on Linux: `~/.config/scala-cli/secrets/config.json`
-- on Windows: `%LOCALAPPDATA%\ScalaCli\secrets\config.json` (typically `C:\Users\username\AppData\Local\ScalaCli\secrets\config.json`)
+- on Windows: `%LOCALAPPDATA%\ScalaCli\secrets\config.json` (
+  typically `C:\Users\username\AppData\Local\ScalaCli\secrets\config.json`)

--- a/website/docs/commands/publishing/publish-setup.md
+++ b/website/docs/commands/publishing/publish-setup.md
@@ -47,32 +47,42 @@ In particular, one can configure:
 User-wide configuration in Scala CLI is handled by the [`config` command](/docs/commands/config.md), and
 the sections below show how to use it to configure things for `publish setup`.
 
+:::caution
+Even though the `config` command is not restricted, some available configuration keys may be, and thus may
+require setting the `--power` option to be used.
+That includes configuration keys tied to publishing, like `publish.user.name` and others.
+You can pass the `--power` option explicitly or set it globally by running:
+```bash ignore
+scala-cli config power true
+```
+:::
+
 ### User details
 
 Set details with
-```bash ignore
-scala-cli config publish.user.name "Alex Me"
-scala-cli config publish.user.email "alex@alex.me"
-scala-cli config publish.user.url "https://alex.me"
+```bash
+scala-cli --power config publish.user.name "Alex Me"
+scala-cli --power config publish.user.email "alex@alex.me"
+scala-cli --power config publish.user.url "https://alex.me"
 ```
 
 The email can be left empty if you'd rather not put your email in POM files:
-```bash ignore
-scala-cli config publish.user.email ""
+```bash
+scala-cli --power config publish.user.email ""
 ```
 
 ### PGP key pair
 
 Generate a PGP key pair for publishing with
-```bash ignore
-scala-cli config --create-pgp-key
+```bash
+scala-cli --power config --create-pgp-key
 ```
 
 This sets 3 entries in the Scala CLI configuration, that you can print with
-```bash ignore
-scala-cli config pgp.public-key
-scala-cli config pgp.secret-key
-scala-cli config pgp.secret-key-password
+```bash
+scala-cli --power config pgp.public-key
+scala-cli --power config pgp.secret-key
+scala-cli --power config pgp.secret-key-password
 ```
 
 ### Sonatype credentials
@@ -101,7 +111,7 @@ ask the `config` sub-command to read environment variables and persist the passw
 If you'd rather persist the environment variable names in the Scala CLI configuration, rather than
 their values, you can do
 ```bash ignore
-scala-cli config publish.credentials s01.oss.sonatype.org env:SONATYPE_USER env:SONATYPE_PASSWORD
+scala-cli --power config publish.credentials s01.oss.sonatype.org env:SONATYPE_USER env:SONATYPE_PASSWORD
 ```
 
 Note that in this case, both `SONATYPE_USER` and `SONATYPE_PASSWORD` will need to be available
@@ -259,5 +269,5 @@ prefix), or create a release with a tag with the same name from the GitHub UI.
 In order to setup publishing to GitHub packages, pass `--publish-repository github` to the
 `publish setup` commands above, like
 ```bash ignore
-scala-cli publish setup . --publish-repository github
+scala-cli --power publish setup . --publish-repository github
 ```

--- a/website/docs/guides/proxies.md
+++ b/website/docs/guides/proxies.md
@@ -5,11 +5,21 @@ sidebar_position: 51
 
 ## HTTP proxies
 
+:::caution
+Even though the `config` command is not restricted, some available configuration keys may be, and thus may
+require setting the `--power` option to be used.
+That includes configuration keys tied to setting up proxies, like `httpProxy.address` and others.
+You can pass the `--power` option explicitly or set it globally by running:
+```bash ignore
+scala-cli config power true
+```
+:::
+
 ### Configuration
 
 If you can only download artifacts through a proxy, you need to configure it beforehand, like
-```text
-scala-cli config httpProxy.address http://proxy.company.com
+```bash ignore
+scala-cli --power config httpProxy.address http://proxy.company.com
 ```
 
 Replace `proxy.company.com` by the address of your proxy.
@@ -19,9 +29,9 @@ Change `http://` to `https://` if your proxy is accessible via HTTPS.
 ### Authentication
 
 If your proxy requires authentication, set your user and password with
-```text
-scala-cli config httpProxy.user _encoded_user_
-scala-cli config httpProxy.password _encoded_password_
+```bash ignore
+scala-cli --power config httpProxy.user value:_encoded_user_
+scala-cli --power config httpProxy.password value:_encoded_password_
 ```
 
 Replace `_encoded_user_` and `_encoded_password_` by your actual user and password, following
@@ -32,19 +42,19 @@ the [password option format](/docs/reference/password-options.md). They should t
 
 If you don't rely on proxies, but rather download artifacts through different Maven repositories,
 set those repositories like:
-```text
-scala-cli config repositories.default https://first-repo.company.com https://second-repo.company.com
+```bash ignore
+scala-cli --power config repositories.default https://first-repo.company.com https://second-repo.company.com
 ```
 
 ## Mirrors
 
 If you're fine directly downloading artifacts from the internet, but would rather have some
 repositories requests go through a repository of yours, configure mirror repositories, like
-```text
-scala-cli config repositories.mirrors https://repo1.maven.org/maven2=https://repository.company.com/maven
+```bash ignore
+scala-cli --power config repositories.mirrors https://repo1.maven.org/maven2=https://repository.company.com/maven
 ```
 
 To have all requests to a Maven repository go through a repository of yours, do
-```text
-scala-cli config repositories.mirrors maven:*=https://repository.company.com/maven
+```bash ignore
+scala-cli --power config repositories.mirrors maven:*=https://repository.company.com/maven
 ```

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -110,7 +110,7 @@ All supported types of inputs can be mixed with each other.
 
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
-The 'export' sub-command is an experimental feature.
+The 'export' sub-command is experimental.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
@@ -210,7 +210,7 @@ All supported types of inputs can be mixed with each other.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish
 
-The 'publish' sub-command is an experimental feature.
+The 'publish' sub-command is experimental.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
@@ -222,7 +222,7 @@ Publishes build artifacts to the local Ivy2 repository.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish-local
 
-The 'publish-local' sub-command is an experimental feature.
+The 'publish-local' sub-command is experimental.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
@@ -234,7 +234,7 @@ Configures the project for publishing.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish-setup
 
-The 'publish-setup' sub-command is an experimental feature.
+The 'publish-setup' sub-command is experimental.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
@@ -275,7 +275,7 @@ Creates or updates a GitHub repository secret.
   scala-cli --power github secret create --repo repo-org/repo-name SECRET_VALUE=value:secret
 ```
 
-The 'secret-create' sub-command is an experimental feature.
+The 'secret-create' sub-command is experimental.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
@@ -287,7 +287,7 @@ Aliases: `gh secret list`
 
 Lists secrets for a given GitHub repository.
 
-The 'secret-list' sub-command is an experimental feature.
+The 'secret-list' sub-command is experimental.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 


### PR DESCRIPTION
The `config` sub-command's configuration keys will now have specification levels assigned.
This in turn means that some of them will now be `restricted` or `experimental` and using them will require enabling `--power` mode.
```bash
scala-cli config publish.user.name
# The 'publish.user.name' configuration key is experimental.
# You can run it with the '--power' flag or turn power mode on globally by running:
#   scala-cli config power true.
scala-cli config httpProxy.address
# The 'httpProxy.address' configuration key is restricted.
# You can run it with the '--power' flag or turn power mode on globally by running:
#   scala-cli config power true.
```
Appropriate warnings will also be printed for `experimental` keys.
```bash
scala-cli --power config publish.user.name
# The 'publish.user.name' configuration key is experimental.
# Please bear in mind that non-ideal user experience should be expected.
# If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
```
`--power` mode will now also influence which keys are mentioned in the `config` sub-command's help outputs.
```bash
scala-cli config -h                       
# Usage: scala-cli config [options]
# Configure global settings for Scala CLI.
# 
# Available keys:
#   actions                                        Globally enables actionable diagnostics. Enabled by default.
#   interactive                                    Globally enables interactive mode (the '--interactive' flag).
#   power                                          Globally enables power mode (the '--power' launcher flag).
#   suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
#   suppress-warning.experimental-features         Globally suppresses warnings about experimental features.
#   suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
# 
# You are currently viewing the basic help for the config sub-command. You can view the full help by running: 
#    scala-cli config --help-full
# For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/config
# 
# Config options:
#   --unset, --remove  Remove an entry from config
scala-cli --power config -h
# Usage: scala-cli config [options]
# Configure global settings for Scala CLI.
# 
# Available keys:
#   actions                                        Globally enables actionable diagnostics. Enabled by default.
#   httpProxy.address                              (power) HTTP proxy address.
#   httpProxy.password                             (power) HTTP proxy password (used for authentication).
#   httpProxy.user                                 (power) HTTP proxy user (used for authentication).
#   interactive                                    Globally enables interactive mode (the '--interactive' flag).
#   power                                          Globally enables power mode (the '--power' launcher flag).
#   repositories.credentials                       (power) Repository credentials, syntax: repositoryAddress value:user value:password [realm]
#   repositories.default                           (power) Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
#   repositories.mirrors                           (power) Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
#   suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
#   suppress-warning.experimental-features         Globally suppresses warnings about experimental features.
#   suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
# 
# You are currently viewing the basic help for the config sub-command. You can view the full help by running: 
#    scala-cli config --help-full
# For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/config
# 
# Config options:
#   --password          If the entry is a password, print the password value rather than how to get the password
# (...)
scala-cli --power config --full-help
# Usage: scala-cli config [options]
# Configure global settings for Scala CLI.
# 
# Syntax:
#   scala-cli config key value
# For example, to globally set the interactive mode:
#   scala-cli config interactive true
#   
# Available keys:
#   actions                                        Globally enables actionable diagnostics. Enabled by default.
#   github.token                                   (experimental) GitHub token.
#   httpProxy.address                              (power) HTTP proxy address.
#   httpProxy.password                             (power) HTTP proxy password (used for authentication).
#   httpProxy.user                                 (power) HTTP proxy user (used for authentication).
#   interactive                                    Globally enables interactive mode (the '--interactive' flag).
#   interactive-was-suggested                      (hidden) Setting indicating if the global interactive mode was already suggested.
#   pgp.public-key                                 (hidden) The PGP public key, used for signing.
#   pgp.secret-key                                 (experimental) The PGP secret key, used for signing.
#   pgp.secret-key-password                        (experimental) The PGP secret key password, used for signing.
#   power                                          Globally enables power mode (the '--power' launcher flag).
#   publish.credentials                            (experimental) Publishing credentials, syntax: repositoryAddress value:user value:password [realm]
#   publish.user.email                             (experimental) The 'email' user detail, used for publishing.
#   publish.user.name                              (experimental) The 'name' user detail, used for publishing.
#   publish.user.url                               (experimental) The 'url' user detail, used for publishing.
#   repositories.credentials                       (power) Repository credentials, syntax: repositoryAddress value:user value:password [realm]
#   repositories.default                           (power) Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
#   repositories.mirrors                           (power) Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
#   suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
#   suppress-warning.experimental-features         Globally suppresses warnings about experimental features.
#   suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
#   
#   For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/config
#   
#   Config options:
#     --dump              (hidden) Dump config DB as JSON
#   (...)
```

`--power` mode error messages and `experimental`  warning messages have also been partially standardised, where appropriate.