### PR TITLE
Add support for nativeLto options in command line and using directives

### DIFF
--- a/examples/scala-native/test.sc
+++ b/examples/scala-native/test.sc
@@ -2,5 +2,6 @@ import scala.scalanative.libc._
 import scala.scalanative.unsafe._
 
 Zone { implicit z =>
-  stdio.printf(toCString("Hello from Scala Native\n"))
+  val io = StdioHelpers(stdio)
+  io.printf(c"%s\n", c"Hello from Scala Native")
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaNativeOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaNativeOptions.scala
@@ -23,6 +23,10 @@ final case class ScalaNativeOptions(
   @Tag(tags.should)
     nativeMode: Option[String] = None,
   @Group(HelpGroup.ScalaNative.toString)
+  @HelpMessage("Link-time optimisation mode")
+  @Tag(tags.should)
+    nativeLto: Option[String] = None,
+  @Group(HelpGroup.ScalaNative.toString)
   @HelpMessage("Set the Scala Native garbage collector")
   @Tag(tags.should)
     nativeGc: Option[String] = None,

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -245,6 +245,7 @@ final case class SharedOptions(
     options.ScalaNativeOptions(
       nativeVersion,
       nativeMode,
+      nativeLto,
       nativeGc,
       nativeClang,
       nativeClangpp,

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaNative.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaNative.scala
@@ -14,6 +14,8 @@ import scala.cli.commands.SpecificationLevel
     |
     |`//> using nativeMode` _value_
     |
+    |`//> using nativeLto` _value_
+    |
     |`//> using nativeVersion` _value_
     |
     |`//> using nativeCompile` _value1_, _value2_
@@ -32,6 +34,7 @@ import scala.cli.commands.SpecificationLevel
 final case class ScalaNative(
   nativeGc: Option[String] = None,
   nativeMode: Option[String] = None,
+  nativeLto: Option[String] = None,
   nativeVersion: Option[String] = None,
   nativeCompile: List[String] = Nil,
   nativeLinking: List[String] = Nil,
@@ -45,6 +48,7 @@ final case class ScalaNative(
     val nativeOptions = ScalaNativeOptions(
       gcStr = nativeGc,
       modeStr = nativeMode,
+      ltoStr = nativeLto,
       version = nativeVersion,
       compileOptions = nativeCompile,
       linkingOptions = nativeLinking,

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportJsonTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportJsonTestDefinitions.scala
@@ -98,10 +98,10 @@ abstract class ExportJsonTestDefinitions(val scalaVersionOpt: Option[String])
         )
 
       expect(fileContents ==
-        """{
+        s"""{
           |"scalaVersion":"3.2.2",
           |"platform":"Native",
-          |"scalaNativeVersion":"0.4.9",
+          |"scalaNativeVersion":"${Constants.scalaNativeVersion}",
           |"scopes": {
           | "main": {
           |   "sources": ["Main.scala"],

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportTestProjects.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportTestProjects.scala
@@ -111,7 +111,8 @@ object ExportTestProjects {
            |  def main(args: Array[String]): Unit =
            |    val message = "Hello from " + "exported Scala CLI project" + "$nl"
            |    Zone { implicit z =>
-           |      stdio.printf(toCString(message))
+           |      val io = StdioHelpers(stdio)
+           |      io.printf(c"%s", toCString(message))
            |    }
            |""".stripMargin
       else
@@ -125,7 +126,8 @@ object ExportTestProjects {
            |  def main(args: Array[String]): Unit = {
            |    val message = "Hello from " + "exported Scala CLI project" + "$nl"
            |    Zone { implicit z =>
-           |      stdio.printf(toCString(message))
+           |      val io = StdioHelpers(stdio)
+           |      io.printf(c"%s", toCString(message))
            |    }
            |  }
            |}

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -400,7 +400,8 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
            |import scala.scalanative.unsafe._
            |
            |Zone { implicit z =>
-           |  stdio.printf(toCString("$message$platformNl"))
+           |   val io = StdioHelpers(stdio)
+           |   io.printf(c"%s$platformNl", c"$message")
            |}
            |""".stripMargin
     )

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
@@ -15,7 +15,8 @@ trait RunScalaNativeTestDefinitions { _: RunTestDefinitions =>
            |import scala.scalanative.unsafe._
            |
            |Zone { implicit z =>
-           |  stdio.printf(toCString("$message$platformNl"))
+           |   val io = StdioHelpers(stdio)
+           |   io.printf(c"%s$platformNl", c"$message")
            |}
            |""".stripMargin
     )
@@ -41,7 +42,8 @@ trait RunScalaNativeTestDefinitions { _: RunTestDefinitions =>
            |import scala.scalanative.unsafe._
            |
            |Zone { implicit z =>
-           |  stdio.printf(toCString("$message$platformNl"))
+           |   val io = StdioHelpers(stdio)
+           |   io.printf(c"%s$platformNl", c"$message")
            |}
            |""".stripMargin
     )
@@ -179,7 +181,8 @@ trait RunScalaNativeTestDefinitions { _: RunTestDefinitions =>
            |import scala.scalanative.unsafe._
            |
            |Zone { implicit z =>
-           |  stdio.printf(toCString(messages.msg + "$platformNl"))
+           |   val io = StdioHelpers(stdio)
+           |   io.printf(c"%s$platformNl", toCString(messages.msg))
            |}
            |""".stripMargin
     )
@@ -207,7 +210,8 @@ trait RunScalaNativeTestDefinitions { _: RunTestDefinitions =>
            |import scala.scalanative.unsafe._
            |
            |Zone { implicit z =>
-           |  stdio.printf(toCString(messages.msg + "$platformNl"))
+           |   val io = StdioHelpers(stdio)
+           |   io.printf(c"%s$platformNl", toCString(messages.msg))
            |}
            |""".stripMargin
     )

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
@@ -33,6 +33,29 @@ trait RunScalaNativeTestDefinitions { _: RunTestDefinitions =>
     simpleNativeTests()
   }
 
+  def scalaNativeLtoTests(): Unit = {
+    val fileName = "hello.sc"
+    val message  = "Hello"
+    val inputs = TestInputs(
+      os.rel / fileName ->
+        s"""//> using nativeLto "thin"
+           |println("$message")
+           |""".stripMargin
+    )
+    inputs.fromRoot { root =>
+      val output =
+        os.proc(TestUtil.cli, extraOptions, fileName, "--native")
+          .call(cwd = root)
+          .out.trim()
+      expect(output == message)
+    }
+  }
+
+  if (!Properties.isMac)
+    test("scala native with lto optimisation") {
+      scalaNativeLtoTests()
+    }
+
   test("simple script native command") {
     val fileName = "simple.sc"
     val message  = "Hello"

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -85,7 +85,8 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
         |    test("foo") {
         |      assert(2 + 2 == 4)
         |      Zone { implicit z =>
-        |        stdio.printf(toCString("Hello from " + "tests\n"))
+        |       val io = StdioHelpers(stdio)
+        |       io.printf(c"%s %s\n", c"Hello from", c"tests")
         |      }
         |    }
         |  }

--- a/modules/options/src/main/scala/scala/build/options/ScalaNativeOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaNativeOptions.scala
@@ -6,11 +6,13 @@ import dependency._
 import java.nio.file.Paths
 
 import scala.build.internal.Constants
+import scala.scalanative.build.LTO
 import scala.scalanative.{build => sn}
 
 final case class ScalaNativeOptions(
   version: Option[String] = None,
   modeStr: Option[String] = None,
+  ltoStr: Option[String] = None,
   gcStr: Option[String] = None,
   clang: Option[String] = None,
   clangpp: Option[String] = None,
@@ -65,7 +67,10 @@ final case class ScalaNativeOptions(
 
   private def compileCliOptions(): List[String] =
     finalCompileOptions().flatMap(option => List("--compile-option", option))
-
+  private def ltoOptions(): List[String] =
+    ltoStr.map(_.trim).filter(_.nonEmpty)
+      .map(lto => LTO.apply(lto))
+      .map(lto => List("--lto", lto.name)).getOrElse(Nil)
   private def resourcesCliOptions(resourcesExist: Boolean): List[String] =
     if (embedResources.getOrElse(true))
       (numeralVersion, resourcesExist) match {
@@ -113,6 +118,7 @@ final case class ScalaNativeOptions(
   def configCliOptions(resourcesExist: Boolean): List[String] =
     gcCliOption() ++
       modeCliOption() ++
+      ltoOptions() ++
       clangCliOption() ++
       clangppCliOption() ++
       linkingCliOptions() ++

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -86,7 +86,7 @@ object Deps {
     def jsoniterScala      = "2.20.3"
     def jsoniterScalaJava8 = "2.13.5.2"
     def scalaMeta          = "4.7.1"
-    def scalaNative        = "0.4.9"
+    def scalaNative        = "0.4.12"
     def scalaPackager      = "0.1.29"
     def signingCli         = "0.1.16"
   }

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1291,6 +1291,10 @@ Set the Scala Native version (0.4.12 by default).
 
 Set Scala Native compilation mode
 
+### `--native-lto`
+
+Link-time optimisation mode
+
 ### `--native-gc`
 
 Set the Scala Native garbage collector

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1285,7 +1285,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 ### `--native-version`
 
-Set the Scala Native version (0.4.9 by default).
+Set the Scala Native version (0.4.12 by default).
 
 ### `--native-mode`
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -242,6 +242,8 @@ Add Scala Native options
 
 `//> using nativeMode` _value_
 
+`//> using nativeLto` _value_
+
 `//> using nativeVersion` _value_
 
 `//> using nativeCompile` _value1_, _value2_

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -794,7 +794,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 `SHOULD have` per Scala Runner specification
 
-Set the Scala Native version (0.4.9 by default).
+Set the Scala Native version (0.4.12 by default).
 
 ### `--native-mode`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -802,6 +802,12 @@ Set the Scala Native version (0.4.12 by default).
 
 Set Scala Native compilation mode
 
+### `--native-lto`
+
+`SHOULD have` per Scala Runner specification
+
+Link-time optimisation mode
+
 ### `--native-gc`
 
 `SHOULD have` per Scala Runner specification

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -187,6 +187,8 @@ Add Scala Native options
 
 `//> using nativeMode` _value_
 
+`//> using nativeLto` _value_
+
 `//> using nativeVersion` _value_
 
 `//> using nativeCompile` _value1_, _value2_

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -158,7 +158,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.9 by default).
+Set the Scala Native version (0.4.12 by default).
 
 **--native-mode**
 
@@ -864,7 +864,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.9 by default).
+Set the Scala Native version (0.4.12 by default).
 
 **--native-mode**
 
@@ -1387,7 +1387,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.9 by default).
+Set the Scala Native version (0.4.12 by default).
 
 **--native-mode**
 
@@ -1936,7 +1936,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.9 by default).
+Set the Scala Native version (0.4.12 by default).
 
 **--native-mode**
 
@@ -2504,7 +2504,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.9 by default).
+Set the Scala Native version (0.4.12 by default).
 
 **--native-mode**
 
@@ -3048,7 +3048,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.9 by default).
+Set the Scala Native version (0.4.12 by default).
 
 **--native-mode**
 
@@ -3629,7 +3629,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.9 by default).
+Set the Scala Native version (0.4.12 by default).
 
 **--native-mode**
 
@@ -4255,7 +4255,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.9 by default).
+Set the Scala Native version (0.4.12 by default).
 
 **--native-mode**
 
@@ -5094,7 +5094,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.9 by default).
+Set the Scala Native version (0.4.12 by default).
 
 **--native-mode**
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -164,6 +164,10 @@ Set the Scala Native version (0.4.12 by default).
 
 Set Scala Native compilation mode
 
+**--native-lto**
+
+Link-time optimisation mode
+
 **--native-gc**
 
 Set the Scala Native garbage collector
@@ -870,6 +874,10 @@ Set the Scala Native version (0.4.12 by default).
 
 Set Scala Native compilation mode
 
+**--native-lto**
+
+Link-time optimisation mode
+
 **--native-gc**
 
 Set the Scala Native garbage collector
@@ -1392,6 +1400,10 @@ Set the Scala Native version (0.4.12 by default).
 **--native-mode**
 
 Set Scala Native compilation mode
+
+**--native-lto**
+
+Link-time optimisation mode
 
 **--native-gc**
 
@@ -1941,6 +1953,10 @@ Set the Scala Native version (0.4.12 by default).
 **--native-mode**
 
 Set Scala Native compilation mode
+
+**--native-lto**
+
+Link-time optimisation mode
 
 **--native-gc**
 
@@ -2510,6 +2526,10 @@ Set the Scala Native version (0.4.12 by default).
 
 Set Scala Native compilation mode
 
+**--native-lto**
+
+Link-time optimisation mode
+
 **--native-gc**
 
 Set the Scala Native garbage collector
@@ -3053,6 +3073,10 @@ Set the Scala Native version (0.4.12 by default).
 **--native-mode**
 
 Set Scala Native compilation mode
+
+**--native-lto**
+
+Link-time optimisation mode
 
 **--native-gc**
 
@@ -3634,6 +3658,10 @@ Set the Scala Native version (0.4.12 by default).
 **--native-mode**
 
 Set Scala Native compilation mode
+
+**--native-lto**
+
+Link-time optimisation mode
 
 **--native-gc**
 
@@ -4260,6 +4288,10 @@ Set the Scala Native version (0.4.12 by default).
 **--native-mode**
 
 Set Scala Native compilation mode
+
+**--native-lto**
+
+Link-time optimisation mode
 
 **--native-gc**
 
@@ -5099,6 +5131,10 @@ Set the Scala Native version (0.4.12 by default).
 **--native-mode**
 
 Set Scala Native compilation mode
+
+**--native-lto**
+
+Link-time optimisation mode
 
 **--native-gc**
 


### PR DESCRIPTION
Fixes #1951.

I added support for passing the `--native-lto` option via the command line:
```
scala-cli Hello.scala --native --native-lto thin
```

or via using directives:

```
$ cat Hello.scala
//> using nativeLto "thin"

object Main extends App {
  println("Hello2")
}
```