### PR TITLE
Bump Bleep to `1.5.6-sc-4`

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -95,7 +95,7 @@ object Deps {
   // that Scala CLI supports.
   def ammonite = ivy"com.lihaoyi:::ammonite:2.5.6-1-f8bff243"
   def asm      = ivy"org.ow2.asm:asm:9.4"
-  def bloop    = ivy"io.github.alexarchambault.bleep:bloop-frontend_2.12:1.5.6-sc-3"
+  def bloop    = ivy"io.github.alexarchambault.bleep:bloop-frontend_2.12:1.5.6-sc-4"
   // Force using of 2.13 - is there a better way?
   def bloopConfig      = ivy"ch.epfl.scala:bloop-config_2.13:1.5.5"
   def bsp4j            = ivy"ch.epfl.scala:bsp4j:2.1.0-M3"


### PR DESCRIPTION
https://github.com/scala-cli/bloop-core/releases/tag/v1.5.6-sc-4