### PR TITLE
Fix - uses show cli.nativeImage command to generate native image

### DIFF
--- a/.github/scripts/build-linux-aarch64-from-docker.sh
+++ b/.github/scripts/build-linux-aarch64-from-docker.sh
@@ -11,8 +11,7 @@ eval "$(cs java --env --jvm 11 --jvm-index https://github.com/coursier/jvm-index
 
 git config --global --add safe.directory "$(pwd)"
 
-./mill -i "cli.base-image.writeNativeImageScript" generate.sh ""
-./generate.sh
+./mill -i show cli.nativeImage
 ./mill -i copyDefaultLauncher ./artifacts
 if "true" == $(./mill -i ci.shouldPublish); then
   .github/scripts/generate-os-packages.sh


### PR DESCRIPTION
Fixes #1972.

I was able to successfully build a native image on Ubuntu for the `aarch64` using command:

```
./mill -i show cli.nativeImage
```

This fixed this error:
```
Exception in thread "main" java.lang.NoClassDefFoundError: com.oracle.svm.core.JavaMainWrapper
        at scala.cli.internal.Argv0.get(Argv0.scala:16)
        at scala.cli.ScalaCli$.<clinit>(ScalaCli.scala:28)
        at scala.cli.ScalaCli.main(ScalaCli.scala)
``` 