### PR TITLE
Print a better error when workspace path contains the `File.pathSeparator`

### DIFF
--- a/modules/build/src/main/scala/scala/build/input/ScalaCliInvokeData.scala
+++ b/modules/build/src/main/scala/scala/build/input/ScalaCliInvokeData.scala
@@ -17,7 +17,14 @@ case class ScalaCliInvokeData(
   subCommandName: String,
   subCommand: SubCommand,
   isShebangCapableShell: Boolean
-)
+) {
+
+  /** [[progName]] with [[subCommandName]] if any */
+  def invocationString: String =
+    subCommand match
+      case SubCommand.Default => progName
+      case _                  => s"$progName $subCommandName"
+}
 
 enum SubCommand:
   case Default extends SubCommand


### PR DESCRIPTION
Fixes #1411 

`:` is the `File.pathSeparator` on UNIX systems, used as the separator on classpaths by the compiler. 
Unfortunately, it seems that there is no way of escaping it, even though `:` is a valid character for directory names.
The recommended workaround is to either move your project to a sane path or at the very least override your workspace with one.

```bash
scala-cli run Hello.scala
# [error]  Invalid workspace path: ~/IdeaProjects/scala-cli-tests/weird:directory
# Workspace path cannot contain a : (colon character).
# Consider moving your project to a different path.
# Alternatively, you can force your workspace with the '--workspace' option:
#     scala-cli run --workspace <alternative-workspace-path> Hello.scala
```