### PR TITLE
Use ASCII armored secret key

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
@@ -82,7 +82,7 @@ object Config extends ScalaCommand[ConfigOptions] {
             else
               options.pgpPassword.map(scala.cli.signing.shared.Secret.apply)
 
-            val (pgpPublic, pgpSecret0) =
+            val (pgpPublic, pgpSecret) =
               ThrowawayPgpSecret.pgpSecret(
                 mail,
                 passwordOpt,
@@ -96,9 +96,8 @@ object Config extends ScalaCommand[ConfigOptions] {
                   ).value.javaCommand,
                 options.scalaSigning.cliOptions()
               ).orExit(logger)
-            val pgpSecretBase64 = pgpSecret0.map(Base64.getEncoder.encodeToString)
 
-            db.set(secKeyEntry, PasswordOption.Value(pgpSecretBase64.toConfig))
+            db.set(secKeyEntry, PasswordOption.Value(pgpSecret.toConfig))
             db.set(pubKeyEntry, PasswordOption.Value(pgpPublic.toConfig))
             db.save(directories.dbPath.toNIO)
               .wrapConfigException

--- a/modules/cli/src/main/scala/scala/cli/commands/config/ThrowawayPgpSecret.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/ThrowawayPgpSecret.scala
@@ -35,7 +35,7 @@ object ThrowawayPgpSecret {
     cache: FileCache[Task],
     javaCommand: () => String,
     signingCliOptions: bo.ScalaSigningCliOptions
-  ): Either[BuildException, (Secret[String], Secret[Array[Byte]])] = either {
+  ): Either[BuildException, (Secret[String], Secret[String])] = either {
 
     val dir    = os.temp.dir(perms = if (Properties.isWin) null else "rwx------")
     val pubKey = dir / "pub"
@@ -58,7 +58,7 @@ object ThrowawayPgpSecret {
       os.remove.all(dir)
 
     if (retCode == 0)
-      try (Secret(os.read(pubKey)), Secret(os.read.bytes(secKey)))
+      try (Secret(os.read(pubKey)), Secret(os.read(secKey)))
       finally cleanUp()
     else {
       cleanUp()

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
@@ -386,6 +386,17 @@ abstract class PublishTestDefinitions(val scalaVersionOpt: Option[String])
           "none"
         ).call(cwd = root, env = extraEnv)
 
+        val secretKeyConfig = os.proc(
+          TestUtil.cli,
+          "--power",
+          "config",
+          "pgp.secret-key"
+        ).call(cwd = root, env = extraEnv)
+          .out.text()
+
+        expect(secretKeyConfig.contains("value:-----BEGIN PGP PRIVATE KEY BLOCK-----"))
+        expect(secretKeyConfig.contains("-----END PGP PRIVATE KEY BLOCK-----"))
+
         os.proc(
           TestUtil.cli,
           "--power",

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -88,7 +88,7 @@ object Deps {
     def scalaMeta          = "4.7.1"
     def scalaNative        = "0.4.12"
     def scalaPackager      = "0.1.29"
-    def signingCli         = "0.1.17"
+    def signingCli         = "0.2.0"
   }
   // DO NOT hardcode a Scala version in this dependency string
   // This dependency is used to ensure that Ammonite is available for Scala versions


### PR DESCRIPTION
Allignment with propsed scala-cli-signing changes: https://github.com/VirtusLab/scala-cli-signing/pull/30
Simplifies our logic and allows for migration to `gpg` for more complex handling of keychains.