### PR TITLE
add newline to topWrapper

### DIFF
--- a/modules/core/src/main/scala/scala/build/internals/CodeWrapper.scala
+++ b/modules/core/src/main/scala/scala/build/internals/CodeWrapper.scala
@@ -17,7 +17,7 @@ abstract class CodeWrapper {
     val (topWrapper, bottomWrapper, userCodeNestingLevel) =
       apply(code, pkgName, indexedWrapperName, extraCode0)
     val (topWrapper0, bottomWrapper0) =
-      (topWrapper + "/*<script>*/", "/*</script>*/ /*<generated>*/" + bottomWrapper)
+      (topWrapper + "/*<script>*/\n", "/*</script>*/ /*<generated>*/" + bottomWrapper)
     val importsLen = topWrapper0.length
 
     (topWrapper0 + code + bottomWrapper0, importsLen, userCodeNestingLevel)


### PR DESCRIPTION
fixes #1996

In my testing locally, completions are working for `.sc` files on the first line (and all others)

didn't know if there were tests for this, so I tried building it locally and starting metals in vscode with the local build of scala-cli