### PR TITLE
Fix snapshot versions calculation when the current version ends with `-RC.`

### DIFF
--- a/project/publish.sc
+++ b/project/publish.sc
@@ -70,7 +70,11 @@ private def computePublishVersion(state: VcsState, simple: Boolean): String =
           if (simple) {
             val idx = tag.lastIndexOf(".")
             if (idx >= 0)
-              Some(tag.take(idx + 1) + (tag.drop(idx + 1).toInt + 1).toString + "-SNAPSHOT")
+              Some(
+                tag.take(idx + 1) +
+                  (tag.drop(idx + 1).replaceAll("-RC.", "").toInt + 1).toString +
+                  "-SNAPSHOT"
+              )
             else
               None
           }


### PR DESCRIPTION
Release candidate versions seem to be breaking the snapshot version calculation, which in turn, among other things, breaks the `scala-cli-src` script.
```bash
▶ scala-cli-src version
# (...)
# 1 targets failed
# show 1 targets failed
# finalPublishVersion java.lang.NumberFormatException: For input string: "0-RC1"
#     java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
#    java.base/java.lang.Integer.parseInt(Integer.java:668)
#     java.base/java.lang.Integer.parseInt(Integer.java:786)
#     scala.collection.StringOps$.toInt$extension(StringOps.scala:908)
#     ammonite.$file.project.publish.$anonfun$computePublishVersion$4(publish.sc:73)
#     scala.Option.flatMap(Option.scala:283)
#     ammonite.$file.project.publish.computePublishVersion(publish.sc:69)
#     ammonite.$file.project.publish.$anonfun$finalPublishVersion$5(publish.sc:113)
#     mill.define.Task$TraverseCtx.evaluate(Task.scala:380)
```

After the fix, seems to work fine.
```bash
▶ scala-cli-src version
# (...)
# Scala CLI version: 1.0.1-SNAPSHOT
# Scala version (default): 3.2.2
```