### PR TITLE
Increase maximum memory allocation for JVM

### DIFF
--- a/.mill-jvm-opts
+++ b/.mill-jvm-opts
@@ -1,4 +1,4 @@
--Xmx768m
+-Xmx2048m
 -Xms128m
 -Xss8m
 -Dxsbt.skip.cp.lookup=true


### PR DESCRIPTION
Trying to fix [publishSonatype java.lang.OutOfMemoryError: Java heap space](https://github.com/VirtusLab/scala-cli/actions/runs/4627168466/jobs/8185994410#step:6:4740) when uploading fat jar to maven.
