### PR TITLE
Improve error messages for malformed `config` values

### DIFF
--- a/modules/config/src/main/scala/scala/cli/config/CredentialsValue.scala
+++ b/modules/config/src/main/scala/scala/cli/config/CredentialsValue.scala
@@ -1,0 +1,48 @@
+package scala.cli.config
+
+trait CredentialsValue {
+  def host: String
+  def user: Option[PasswordOption]
+  def password: Option[PasswordOption]
+  def realm: Option[String]
+  def httpsOnly: Option[Boolean]
+  def asString: String
+}
+
+abstract class CredentialsAsJson[T <: CredentialsValue] {
+  def user: Option[String]
+  def password: Option[String]
+  def toCredentialsValue(userOpt: Option[PasswordOption], passwordOpt: Option[PasswordOption]): T
+  def credentialsType: String
+  private def malformedMessage(valueType: String): String =
+    s"Malformed $credentialsType credentials $valueType value (expected 'value:…', or 'file:/path', or 'env:ENV_VAR_NAME')"
+  def credentials: Either[::[String], T] = {
+    val maybeUser = user
+      .map { u =>
+        PasswordOption.parse(u) match {
+          case Left(error)  => Left(s"${malformedMessage("user")}: $error")
+          case Right(value) => Right(Some(value))
+        }
+      }
+      .getOrElse(Right(None))
+    val maybePassword = password
+      .filter(_.nonEmpty)
+      .map { p =>
+        PasswordOption.parse(p) match {
+          case Left(error)  => Left(s"${malformedMessage("password")}: $error")
+          case Right(value) => Right(Some(value))
+        }
+      }
+      .getOrElse(Right(None))
+    (maybeUser, maybePassword) match {
+      case (Right(userOpt), Right(passwordOpt)) => Right(toCredentialsValue(userOpt, passwordOpt))
+      case _ =>
+        val errors =
+          maybeUser.left.toOption.toList ::: maybePassword.left.toOption.toList match {
+            case Nil    => sys.error("Cannot happen")
+            case h :: t => ::(h, t)
+          }
+        Left(errors)
+    }
+  }
+}

--- a/modules/config/src/main/scala/scala/cli/config/ErrorMessages.scala
+++ b/modules/config/src/main/scala/scala/cli/config/ErrorMessages.scala
@@ -1,0 +1,7 @@
+package scala.cli.config
+
+object ErrorMessages {
+  val inlineCredentialsError =
+    "Inline credentials not accepted, please edit the config file manually."
+
+}

--- a/modules/config/src/main/scala/scala/cli/config/Key.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Key.scala
@@ -4,6 +4,8 @@ import com.github.plokhotnyuk.jsoniter_scala.core._
 import com.github.plokhotnyuk.jsoniter_scala.macros._
 
 import scala.cli.commands.SpecificationLevel
+import scala.cli.config.PublishCredentialsAsJson._
+import scala.cli.config.RepositoryCredentialsAsJson._
 import scala.cli.config.Util._ // only used in 2.12, unused import in 2.13
 
 /** A configuration key
@@ -58,13 +60,16 @@ abstract class Key[T] {
 }
 
 object Key {
+  private implicit lazy val stringJsonCodec: JsonValueCodec[String]           = JsonCodecMaker.make
+  private implicit lazy val stringListJsonCodec: JsonValueCodec[List[String]] = JsonCodecMaker.make
+  private implicit lazy val booleanJsonCodec: JsonValueCodec[Boolean]         = JsonCodecMaker.make
 
   abstract class EntryError(
     message: String,
     causeOpt: Option[Throwable] = None
   ) extends Exception(message, causeOpt.orNull)
 
-  final class JsonReaderError(cause: JsonReaderException)
+  private final class JsonReaderError(cause: JsonReaderException)
       extends EntryError("Error parsing config JSON", Some(cause))
 
   final class MalformedValue(
@@ -83,7 +88,7 @@ object Key {
         cause
       )
 
-  final class MalformedEntry(
+  private final class MalformedEntry(
     entry: Key[_],
     messages: ::[String]
   ) extends EntryError(
@@ -91,8 +96,16 @@ object Key {
           messages.mkString(", ")
       )
 
-  private val stringCodec: JsonValueCodec[String]   = JsonCodecMaker.make
-  private val booleanCodec: JsonValueCodec[Boolean] = JsonCodecMaker.make
+  abstract class KeyWithJsonCodec[T](implicit jsonCodec: JsonValueCodec[T]) extends Key[T] {
+    def parse(json: Array[Byte]): Either[Key.EntryError, T] =
+      try Right(readFromArray(json))
+      catch {
+        case e: JsonReaderException =>
+          Left(new Key.JsonReaderError(e))
+      }
+
+    def write(value: T): Array[Byte] = writeToArray(value)
+  }
 
   final class StringEntry(
     val prefix: Seq[String],
@@ -100,15 +113,7 @@ object Key {
     override val specificationLevel: SpecificationLevel,
     val description: String = "",
     override val hidden: Boolean = false
-  ) extends Key[String] {
-    def parse(json: Array[Byte]): Either[EntryError, String] =
-      try Right(readFromArray(json)(stringCodec))
-      catch {
-        case e: JsonReaderException =>
-          Left(new JsonReaderError(e))
-      }
-    def write(value: String): Array[Byte] =
-      writeToArray(value)(stringCodec)
+  ) extends KeyWithJsonCodec[String] {
     def asString(value: String): Seq[String] =
       Seq(value)
     def fromString(values: Seq[String]): Either[MalformedValue, String] =
@@ -124,17 +129,9 @@ object Key {
     override val specificationLevel: SpecificationLevel,
     val description: String = "",
     override val hidden: Boolean = false
-  ) extends Key[Boolean] {
-    def parse(json: Array[Byte]): Either[EntryError, Boolean] =
-      try Right(readFromArray(json)(booleanCodec))
-      catch {
-        case e: JsonReaderException =>
-          Left(new JsonReaderError(e))
-      }
-    def write(value: Boolean): Array[Byte] =
-      writeToArray(value)(booleanCodec)
+  ) extends KeyWithJsonCodec[Boolean] {
     def asString(value: Boolean): Seq[String] =
-      Seq(value.toString())
+      Seq(value.toString)
     def fromString(values: Seq[String]): Either[MalformedValue, Boolean] =
       values match {
         case Seq(value) if value.toBooleanOption.isDefined => Right(value.toBoolean)
@@ -156,7 +153,7 @@ object Key {
   ) extends Key[PasswordOption] {
     def parse(json: Array[Byte]): Either[EntryError, PasswordOption] =
       try {
-        val str = readFromArray(json)(stringCodec)
+        val str = readFromArray(json)(stringJsonCodec)
         PasswordOption.parse(str).left.map { e =>
           new MalformedValue(this, Seq(str), Right(e))
         }
@@ -166,7 +163,7 @@ object Key {
           Left(new JsonReaderError(e))
       }
     def write(value: PasswordOption): Array[Byte] =
-      writeToArray(value.asString.value)(stringCodec)
+      writeToArray(value.asString.value)(stringJsonCodec)
     def asString(value: PasswordOption): Seq[String] = Seq(value.asString.value)
     def fromString(values: Seq[String]): Either[MalformedValue, PasswordOption] =
       values match {
@@ -184,26 +181,85 @@ object Key {
     override def isPasswordOption: Boolean = true
   }
 
-  private val stringListCodec: JsonValueCodec[List[String]] = JsonCodecMaker.make
-
   final class StringListEntry(
     val prefix: Seq[String],
     val name: String,
     override val specificationLevel: SpecificationLevel,
     val description: String = "",
     override val hidden: Boolean = false
-  ) extends Key[List[String]] {
-    def parse(json: Array[Byte]): Either[EntryError, List[String]] =
-      try Right(readFromArray(json)(stringListCodec))
-      catch {
-        case e: JsonReaderException =>
-          Left(new JsonReaderError(e))
-      }
-    def write(value: List[String]): Array[Byte] =
-      writeToArray(value)(stringListCodec)
+  ) extends KeyWithJsonCodec[List[String]] {
     def asString(value: List[String]): Seq[String] = value
     def fromString(values: Seq[String]): Either[MalformedValue, List[String]] =
       Right(values.toList)
   }
+  abstract class CredentialsEntry[T <: CredentialsValue, U <: CredentialsAsJson[T]](implicit
+    jsonCodec: JsonValueCodec[List[U]]
+  ) extends Key[List[T]] {
+    protected def asJson(credentials: T): U
+    def parse(json: Array[Byte]): Either[Key.EntryError, List[T]] =
+      try {
+        val list   = readFromArray(json).map(_.credentials)
+        val errors = list.collect { case Left(errors) => errors }.flatten
+        errors match {
+          case Nil =>
+            Right(list.collect { case Right(v) => v })
+          case h :: t =>
+            Left(new Key.MalformedEntry(this, ::(h, t)))
+        }
+      }
+      catch {
+        case e: JsonReaderException =>
+          Left(new Key.JsonReaderError(e))
+      }
+    def write(value: List[T]): Array[Byte] = writeToArray(value.map(asJson))
+    def fromString(values: Seq[String]): Either[MalformedValue, List[T]] =
+      Left(new Key.MalformedValue(this, values, Right(ErrorMessages.inlineCredentialsError)))
+    def asString(value: List[T]): Seq[String] = value.map(_.asString)
+  }
 
+  final class RepositoryCredentialsEntry(
+    val prefix: Seq[String],
+    val name: String,
+    override val specificationLevel: SpecificationLevel,
+    val description: String = "",
+    override val hidden: Boolean = false
+  ) extends CredentialsEntry[RepositoryCredentials, RepositoryCredentialsAsJson] {
+    def asJson(credentials: RepositoryCredentials): RepositoryCredentialsAsJson =
+      RepositoryCredentialsAsJson(
+        credentials.host,
+        credentials.user.map(_.asString.value),
+        credentials.password.map(_.asString.value),
+        credentials.realm,
+        credentials.optional,
+        credentials.matchHost,
+        credentials.httpsOnly,
+        credentials.passOnRedirect
+      )
+
+    override def asString(value: List[RepositoryCredentials]): Seq[String] =
+      value
+        .zipWithIndex
+        .map {
+          case (cred, idx) =>
+            val prefix = s"configRepo$idx."
+            cred.asString.linesWithSeparators.map(prefix + _).mkString
+        }
+  }
+
+  class PublishCredentialsEntry(
+    val prefix: Seq[String],
+    val name: String,
+    override val specificationLevel: SpecificationLevel,
+    val description: String = "",
+    override val hidden: Boolean = false
+  ) extends CredentialsEntry[PublishCredentials, PublishCredentialsAsJson] {
+    def asJson(credentials: PublishCredentials): PublishCredentialsAsJson =
+      PublishCredentialsAsJson(
+        credentials.host,
+        credentials.user.map(_.asString.value),
+        credentials.password.map(_.asString.value),
+        credentials.realm,
+        credentials.httpsOnly
+      )
+  }
 }

--- a/modules/config/src/main/scala/scala/cli/config/Keys.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Keys.scala
@@ -1,13 +1,10 @@
 package scala.cli.config
 
-import com.github.plokhotnyuk.jsoniter_scala.core.{Key => _, _}
-import com.github.plokhotnyuk.jsoniter_scala.macros._
+import com.github.plokhotnyuk.jsoniter_scala.core.{Key => _}
 
 import scala.cli.commands.SpecificationLevel
-import scala.collection.mutable.ListBuffer
 
 object Keys {
-
   val userName = new Key.StringEntry(
     prefix = Seq("publish", "user"),
     name = "name",
@@ -142,6 +139,22 @@ object Keys {
     hidden = true
   )
 
+  val repositoryCredentials: Key.RepositoryCredentialsEntry = new Key.RepositoryCredentialsEntry(
+    prefix = Seq("repositories"),
+    name = "credentials",
+    specificationLevel = SpecificationLevel.RESTRICTED,
+    description =
+      "Repository credentials, syntax: repositoryAddress value:user value:password [realm]"
+  )
+
+  val publishCredentials: Key.PublishCredentialsEntry = new Key.PublishCredentialsEntry(
+    prefix = Seq("publish"),
+    name = "credentials",
+    specificationLevel = SpecificationLevel.EXPERIMENTAL,
+    description =
+      "Publishing credentials, syntax: repositoryAddress value:user value:password [realm]"
+  )
+
   def all: Seq[Key[_]] = Seq[Key[_]](
     actions,
     defaultRepositories,
@@ -165,246 +178,5 @@ object Keys {
     userName,
     userUrl
   )
-
   lazy val map: Map[String, Key[_]] = all.map(e => e.fullName -> e).toMap
-
-  private final case class RepositoryCredentialsAsJson(
-    host: String,
-    user: Option[String] = None,
-    password: Option[String] = None,
-    realm: Option[String] = None,
-    optional: Option[Boolean] = None,
-    matchHost: Option[Boolean] = None,
-    httpsOnly: Option[Boolean] = None,
-    passOnRedirect: Option[Boolean] = None
-  ) {
-    def credentials: Either[::[String], RepositoryCredentials] = {
-      def malformedMessage(valueType: String) =
-        s"Malformed repository credentials $valueType value (expected 'value:…', or 'file:/path', or 'env:ENV_VAR_NAME')"
-      val maybeUser = user
-        .map { u =>
-          PasswordOption.parse(u) match {
-            case Left(error)  => Left(s"${malformedMessage("user")}: $error")
-            case Right(value) => Right(Some(value))
-          }
-        }
-        .getOrElse(Right(None))
-      val maybePassword = password
-        .filter(_.nonEmpty)
-        .map { p =>
-          PasswordOption.parse(p) match {
-            case Left(error)  => Left(s"${malformedMessage("password")}: $error")
-            case Right(value) => Right(Some(value))
-          }
-        }
-        .getOrElse(Right(None))
-      (maybeUser, maybePassword) match {
-        case (Right(userOpt), Right(passwordOpt)) =>
-          Right(
-            RepositoryCredentials(
-              host = host,
-              user = userOpt,
-              password = passwordOpt,
-              realm = realm,
-              optional = optional,
-              matchHost = matchHost,
-              httpsOnly = httpsOnly,
-              passOnRedirect = passOnRedirect
-            )
-          )
-        case _ =>
-          val errors =
-            (maybeUser.left.toOption.toList ::: maybePassword.left.toOption.toList) match {
-              case Nil    => sys.error("Cannot happen")
-              case h :: t => ::(h, t)
-            }
-          Left(errors)
-      }
-    }
-  }
-
-  val repositoryCredentials: Key[List[RepositoryCredentials]] =
-    new Key[List[RepositoryCredentials]] {
-      override val description: String =
-        "Repository credentials, syntax: repositoryAddress value:user value:password [realm]"
-
-      override def specificationLevel: SpecificationLevel = SpecificationLevel.RESTRICTED
-
-      private def asJson(credentials: RepositoryCredentials): RepositoryCredentialsAsJson =
-        RepositoryCredentialsAsJson(
-          credentials.host,
-          credentials.user.map(_.asString.value),
-          credentials.password.map(_.asString.value),
-          credentials.realm,
-          credentials.optional,
-          credentials.matchHost,
-          credentials.httpsOnly,
-          credentials.passOnRedirect
-        )
-      private val codec: JsonValueCodec[List[RepositoryCredentialsAsJson]] =
-        JsonCodecMaker.make
-
-      def prefix = Seq("repositories")
-      def name   = "credentials"
-
-      def parse(json: Array[Byte]): Either[Key.EntryError, List[RepositoryCredentials]] =
-        try {
-          val list   = readFromArray(json)(codec).map(_.credentials)
-          val errors = list.collect { case Left(errors) => errors }.flatten
-          errors match {
-            case Nil =>
-              Right(list.collect { case Right(v) => v })
-            case h :: t =>
-              Left(new Key.MalformedEntry(this, ::(h, t)))
-          }
-        }
-        catch {
-          case e: JsonReaderException =>
-            Left(new Key.JsonReaderError(e))
-        }
-      def write(value: List[RepositoryCredentials]): Array[Byte] =
-        writeToArray(value.map(asJson))(codec)
-
-      def asString(value: List[RepositoryCredentials]): Seq[String] =
-        value
-          .zipWithIndex
-          .map {
-            case (cred, idx) =>
-              val prefix = s"configRepo$idx"
-              val lines  = new ListBuffer[String]
-              if (cred.host.nonEmpty)
-                lines += s"$prefix.host=${cred.host}"
-              for (u <- cred.user)
-                lines += s"$prefix.username=${u.asString.value}"
-              for (p <- cred.password)
-                lines += s"$prefix.password=${p.asString.value}"
-              for (r <- cred.realm)
-                lines += s"$prefix.realm=$r"
-              for (b <- cred.httpsOnly)
-                lines += s"$prefix.https-only=$b"
-              for (b <- cred.matchHost)
-                lines += s"$prefix.auto=$b"
-              for (b <- cred.passOnRedirect)
-                lines += s"$prefix.pass-on-redirect=$b"
-              // seems cred.optional can't be changed from properties…
-              lines.map(_ + System.lineSeparator()).mkString
-          }
-      def fromString(values: Seq[String]): Either[Key.MalformedValue, List[RepositoryCredentials]] =
-        Left(new Key.MalformedValue(this, values, Right(ErrorMessages.inlineCredentialsError)))
-    }
-
-  private final case class PublishCredentialsAsJson(
-    host: String,
-    user: Option[String] = None,
-    password: Option[String] = None,
-    realm: Option[String] = None,
-    httpsOnly: Option[Boolean] = None
-  ) {
-    def credentials: Either[::[String], PublishCredentials] = {
-      val maybeUser = user
-        .map { u =>
-          PasswordOption.parse(u) match {
-            case Left(error) =>
-              Left(
-                s"Malformed publish credentials user value (expected 'value:…', or 'file:/path', or 'env:ENV_VAR_NAME'): $error"
-              )
-            case Right(value) => Right(Some(value))
-          }
-        }
-        .getOrElse(Right(None))
-      val maybePassword = password
-        .filter(_.nonEmpty)
-        .map { p =>
-          PasswordOption.parse(p) match {
-            case Left(error) =>
-              Left(
-                s"Malformed publish credentials password value (expected 'value:…', or 'file:/path', or 'env:ENV_VAR_NAME'): $error"
-              )
-            case Right(value) => Right(Some(value))
-          }
-        }
-        .getOrElse(Right(None))
-      (maybeUser, maybePassword) match {
-        case (Right(userOpt), Right(passwordOpt)) =>
-          Right(
-            PublishCredentials(
-              host = host,
-              user = userOpt,
-              password = passwordOpt,
-              realm = realm,
-              httpsOnly = httpsOnly
-            )
-          )
-        case _ =>
-          val errors =
-            (maybeUser.left.toOption.toList ::: maybePassword.left.toOption.toList) match {
-              case Nil    => sys.error("Cannot happen")
-              case h :: t => ::(h, t)
-            }
-          Left(errors)
-      }
-    }
-  }
-
-  val publishCredentials: Key[List[PublishCredentials]] = new Key[List[PublishCredentials]] {
-    override val description: String =
-      "Publishing credentials, syntax: repositoryAddress value:user value:password [realm]"
-
-    override def specificationLevel: SpecificationLevel = SpecificationLevel.EXPERIMENTAL
-
-    private def asJson(credentials: PublishCredentials): PublishCredentialsAsJson =
-      PublishCredentialsAsJson(
-        credentials.host,
-        credentials.user.map(_.asString.value),
-        credentials.password.map(_.asString.value),
-        credentials.realm,
-        credentials.httpsOnly
-      )
-    private val codec: JsonValueCodec[List[PublishCredentialsAsJson]] =
-      JsonCodecMaker.make
-
-    def prefix = Seq("publish")
-    def name   = "credentials"
-
-    def parse(json: Array[Byte]): Either[Key.EntryError, List[PublishCredentials]] =
-      try {
-        val list   = readFromArray(json)(codec).map(_.credentials)
-        val errors = list.collect { case Left(errors) => errors }.flatten
-        errors match {
-          case Nil =>
-            Right(list.collect { case Right(v) => v })
-          case h :: t =>
-            Left(new Key.MalformedEntry(this, ::(h, t)))
-        }
-      }
-      catch {
-        case e: JsonReaderException =>
-          Left(new Key.JsonReaderError(e))
-      }
-    def write(value: List[PublishCredentials]): Array[Byte] =
-      writeToArray(value.map(asJson))(codec)
-
-    def asString(value: List[PublishCredentials]): Seq[String] =
-      value.map { cred =>
-        val prefix = cred.httpsOnly match {
-          case Some(true)  => "https://"
-          case Some(false) => "http://"
-          case None        => "//"
-        }
-        // FIXME We're getting secrets and putting them in a non-Secret guarded string here
-        val credentialsPart = {
-          val realmPart    = cred.realm.map("(" + _ + ")").getOrElse("")
-          val userPart     = cred.user.map(_.get().value).getOrElse("")
-          val passwordPart = cred.password.map(":" + _.get().value).getOrElse("")
-          if (realmPart.nonEmpty || userPart.nonEmpty || passwordPart.nonEmpty)
-            realmPart + userPart + passwordPart + "@"
-          else
-            ""
-        }
-        prefix + credentialsPart + cred.host
-      }
-    def fromString(values: Seq[String]): Either[Key.MalformedValue, List[PublishCredentials]] =
-      Left(new Key.MalformedValue(this, values, Right(ErrorMessages.inlineCredentialsError)))
-  }
-
 }

--- a/modules/config/src/main/scala/scala/cli/config/Keys.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Keys.scala
@@ -290,11 +290,7 @@ object Keys {
               lines.map(_ + System.lineSeparator()).mkString
           }
       def fromString(values: Seq[String]): Either[Key.MalformedValue, List[RepositoryCredentials]] =
-        Left(new Key.MalformedValue(
-          this,
-          values,
-          Right("Inline credentials not accepted, please manually edit the config file")
-        ))
+        Left(new Key.MalformedValue(this, values, Right(ErrorMessages.inlineCredentialsError)))
     }
 
   private final case class PublishCredentialsAsJson(
@@ -408,11 +404,7 @@ object Keys {
         prefix + credentialsPart + cred.host
       }
     def fromString(values: Seq[String]): Either[Key.MalformedValue, List[PublishCredentials]] =
-      Left(new Key.MalformedValue(
-        this,
-        values,
-        Right("Inline credentials not accepted, please manually edit the config file")
-      ))
+      Left(new Key.MalformedValue(this, values, Right(ErrorMessages.inlineCredentialsError)))
   }
 
 }

--- a/modules/config/src/main/scala/scala/cli/config/PasswordOption.scala
+++ b/modules/config/src/main/scala/scala/cli/config/PasswordOption.scala
@@ -39,7 +39,7 @@ abstract class LowPriorityPasswordOption {
       Right(PasswordOption.Command(command))
     }
     else
-      Left("Malformed password value (expected \"value:...\")")
+      Left("Malformed password value (expected \"value:password\")")
 
 }
 

--- a/modules/config/src/main/scala/scala/cli/config/PublishCredentials.scala
+++ b/modules/config/src/main/scala/scala/cli/config/PublishCredentials.scala
@@ -1,9 +1,57 @@
 package scala.cli.config
 
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+
 final case class PublishCredentials(
   host: String = "",
   user: Option[PasswordOption] = None,
   password: Option[PasswordOption] = None,
   realm: Option[String] = None,
   httpsOnly: Option[Boolean] = None
-)
+) extends CredentialsValue {
+  override def asString: String = {
+    val prefix = httpsOnly match {
+      case Some(true)  => "https://"
+      case Some(false) => "http://"
+      case None        => "//"
+    }
+    // FIXME We're getting secrets and putting them in a non-Secret guarded string here
+    val credentialsPart = {
+      val realmPart    = realm.map("(" + _ + ")").getOrElse("")
+      val userPart     = user.map(_.get().value).getOrElse("")
+      val passwordPart = password.map(":" + _.get().value).getOrElse("")
+      if (realmPart.nonEmpty || userPart.nonEmpty || passwordPart.nonEmpty)
+        realmPart + userPart + passwordPart + "@"
+      else
+        ""
+    }
+    prefix + credentialsPart + host
+  }
+}
+
+final case class PublishCredentialsAsJson(
+  host: String,
+  user: Option[String] = None,
+  password: Option[String] = None,
+  realm: Option[String] = None,
+  httpsOnly: Option[Boolean] = None
+) extends CredentialsAsJson[PublishCredentials] {
+  def credentialsType: String = "publish"
+  def toCredentialsValue(
+    userOpt: Option[PasswordOption],
+    passwordOpt: Option[PasswordOption]
+  ): PublishCredentials =
+    PublishCredentials(
+      host = host,
+      user = userOpt,
+      password = passwordOpt,
+      realm = realm,
+      httpsOnly = httpsOnly
+    )
+}
+
+object PublishCredentialsAsJson {
+  implicit lazy val listJsonCodec: JsonValueCodec[List[PublishCredentialsAsJson]] =
+    JsonCodecMaker.make
+}

--- a/modules/config/src/main/scala/scala/cli/config/RepositoryCredentials.scala
+++ b/modules/config/src/main/scala/scala/cli/config/RepositoryCredentials.scala
@@ -1,5 +1,10 @@
 package scala.cli.config
 
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+
+import scala.collection.mutable.ListBuffer
+
 final case class RepositoryCredentials(
   host: String = "",
   user: Option[PasswordOption] = None,
@@ -9,4 +14,56 @@ final case class RepositoryCredentials(
   matchHost: Option[Boolean] = None,
   httpsOnly: Option[Boolean] = None,
   passOnRedirect: Option[Boolean] = None
-)
+) extends CredentialsValue {
+  def asString: String = {
+    val lines = new ListBuffer[String]
+    if (host.nonEmpty)
+      lines += s"host=$host"
+    for (u <- user)
+      lines += s"username=${u.asString.value}"
+    for (p <- password)
+      lines += s"password=${p.asString.value}"
+    for (r <- realm)
+      lines += s"realm=$r"
+    for (b <- httpsOnly)
+      lines += s"https-only=$b"
+    for (b <- matchHost)
+      lines += s"auto=$b"
+    for (b <- passOnRedirect)
+      lines += s"pass-on-redirect=$b"
+    // seems cred.optional can't be changed from properties…
+    lines.map(_ + System.lineSeparator()).mkString
+  }
+}
+
+final case class RepositoryCredentialsAsJson(
+  host: String,
+  user: Option[String] = None,
+  password: Option[String] = None,
+  realm: Option[String] = None,
+  optional: Option[Boolean] = None,
+  matchHost: Option[Boolean] = None,
+  httpsOnly: Option[Boolean] = None,
+  passOnRedirect: Option[Boolean] = None
+) extends CredentialsAsJson[RepositoryCredentials] {
+  def credentialsType: String = "repository"
+  def toCredentialsValue(
+    userOpt: Option[PasswordOption],
+    passwordOpt: Option[PasswordOption]
+  ): RepositoryCredentials =
+    RepositoryCredentials(
+      host = host,
+      user = userOpt,
+      password = passwordOpt,
+      realm = realm,
+      optional = optional,
+      matchHost = matchHost,
+      httpsOnly = httpsOnly,
+      passOnRedirect = passOnRedirect
+    )
+}
+
+object RepositoryCredentialsAsJson {
+  implicit lazy val listJsonCodec: JsonValueCodec[List[RepositoryCredentialsAsJson]] =
+    JsonCodecMaker.make
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
@@ -389,4 +389,36 @@ class ConfigTests extends ScalaCliSuite {
     }
   }
 
+  for (
+    (entryType, key, valuesPlural, invalidValue) <- Seq(
+      ("boolean", "power", Seq("true", "false", "true"), "true."),
+      ("string", "publish.user.name", Seq("abc", "def", "xyz"), ""),
+      ("password", "httpProxy.password", Seq("value:pass1", "value:pass2", "value:pass3"), "pass")
+    )
+  ) {
+    test(s"print a meaningful error when multiple values are passed for a $entryType key: $key") {
+      val configFile = os.rel / "config" / "config.json"
+      val env        = Map("SCALA_CLI_CONFIG" -> configFile.toString)
+      TestInputs.empty.fromRoot { root =>
+        val res = os.proc(TestUtil.cli, "--power", "config", key, valuesPlural)
+          .call(cwd = root, env = env, stderr = os.Pipe, check = false)
+        expect(res.exitCode == 1)
+        expect(res.err.trim().contains(s"expected a single $entryType value"))
+      }
+    }
+
+    if (entryType != "string")
+      test(s"print a meaningful error when an invalid value is passed for a $entryType key: $key") {
+        val configFile = os.rel / "config" / "config.json"
+        val env        = Map("SCALA_CLI_CONFIG" -> configFile.toString)
+        TestInputs.empty.fromRoot { root =>
+          val res = os.proc(TestUtil.cli, "--power", "config", key, invalidValue)
+            .call(cwd = root, env = env, stderr = os.Pipe, check = false)
+          expect(res.exitCode == 1)
+          expect(res.err.trim().contains("Malformed"))
+          expect(res.err.trim().contains(invalidValue))
+        }
+      }
+  }
+
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
@@ -338,6 +338,20 @@ class ConfigTests extends ScalaCliSuite {
           realm
         )
           .call(cwd = root, stdin = os.Inherit, stdout = os.Inherit, env = extraEnv)
+        val credentialsAsStringRes = os.proc(
+          TestUtil.cli,
+          "--power",
+          "config",
+          "repositories.credentials"
+        ).call(cwd = root, env = extraEnv)
+        val linePrefix = "configRepo0"
+        val expectedCredentialsAsString =
+          s"""$linePrefix.host=$host
+             |$linePrefix.username=value:$user
+             |$linePrefix.password=value:$password
+             |$linePrefix.realm=$realm
+             |$linePrefix.auto=true""".stripMargin
+        expect(credentialsAsStringRes.out.trim() == expectedCredentialsAsString)
         val res = os.proc(
           TestUtil.cli,
           "run",


### PR DESCRIPTION
Fixes #2000 
Fixed some of the error messages for the `config` subcommand + did a wider refactor.

Before:
```bash
scala-cli config power true.
# [error]  Config DB error: Malformed values true. for power, expected value
scala-cli config power true true false
# [error]  Config DB error: Malformed values true, true, false for power, expected value
```

After the changes:
```bash
scala-cli config power true.          
# [error]  Config DB error: Malformed value 'true.' for the 'power' entry, expected a single boolean value ('true' or 'false').
scala-cli config power true true false
# [error]  Config DB error: Malformed values 'true', 'true', 'false' for the 'power' entry, expected a single boolean value ('true' or 'false').
```