### PR TITLE
Clean up build

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -57,7 +57,6 @@ object `specification-level` extends Cross[SpecificationLevel](Scala.all: _*)
 object `build-macros`        extends BuildMacros
 object config                extends Cross[Config](Scala.all: _*)
 object options               extends Options
-object scalaparse            extends ScalaParse
 object directives            extends Directives
 object core                  extends Core
 object `build-module`        extends Build
@@ -460,7 +459,6 @@ trait Directives extends ScalaCliSbtModule with ScalaCliPublishModule with HasTe
     Deps.jsoniterCore213,
     Deps.pprint,
     Deps.scalametaTrees,
-    Deps.scalaparse,
     Deps.usingDirectives
   )
 
@@ -559,11 +557,6 @@ trait Options extends ScalaCliSbtModule with ScalaCliPublishModule with HasTests
   }
 }
 
-trait ScalaParse extends SbtModule with ScalaCliPublishModule {
-  def ivyDeps      = super.ivyDeps() ++ Agg(Deps.scalaparse)
-  def scalaVersion = Scala.scala213
-}
-
 trait Scala3Runtime extends SbtModule with ScalaCliPublishModule {
   def ivyDeps      = super.ivyDeps()
   def scalaVersion = Scala.scala3
@@ -602,7 +595,6 @@ trait Build extends ScalaCliSbtModule with ScalaCliPublishModule with HasTests
   def millSourcePath   = super.millSourcePath / os.up / "build"
   def moduleDeps = Seq(
     options,
-    scalaparse,
     directives,
     `scala-cli-bsp`,
     `test-runner`(Scala.scala213), // Depending on version compiled with Scala 3 pulls older stdlib

--- a/build.sc
+++ b/build.sc
@@ -42,7 +42,15 @@ object cli extends Cli
 
 // Publish a bootstrapped, executable jar for a restricted environments
 object cliBootstrapped extends ScalaCliPublishModule {
-  override def jar = cli.assembly()
+  override def unmanagedClasspath = T { cli.nativeImageClassPath() }
+  override def jar = assembly()
+  
+  import mill.modules.Assembly
+
+  override def assemblyRules = Seq(
+    Assembly.Rule.ExcludePattern(".*\\.tasty"),
+    Assembly.Rule.ExcludePattern(".*\\.semanticdb")
+  ) ++ super.assemblyRules
 }
 
 object `specification-level` extends Cross[SpecificationLevel](Scala.all: _*)

--- a/build.sc
+++ b/build.sc
@@ -6,7 +6,6 @@ import $file.project.publish, publish.{ghOrg, ghName, ScalaCliPublishModule, org
 import $file.project.settings, settings.{
   CliLaunchers,
   FormatNativeImageConf,
-  HasMacroAnnotations,
   HasTests,
   LocalRepo,
   PublishLocalNoFluff,
@@ -42,9 +41,9 @@ object cli extends Cli
 
 // Publish a bootstrapped, executable jar for a restricted environments
 object cliBootstrapped extends ScalaCliPublishModule {
-  override def unmanagedClasspath = T { cli.nativeImageClassPath() }
-  override def jar = assembly()
-  
+  override def unmanagedClasspath = T(cli.nativeImageClassPath())
+  override def jar                = assembly()
+
   import mill.modules.Assembly
 
   override def assemblyRules = Seq(
@@ -456,9 +455,8 @@ trait Directives extends ScalaCliSbtModule with ScalaCliPublishModule with HasTe
   def ivyDeps = super.ivyDeps() ++ Agg(
     // Deps.asm,
     Deps.bloopConfig,
-    Deps.jsoniterCore213,
+    Deps.jsoniterCore,
     Deps.pprint,
-    Deps.scalametaTrees,
     Deps.usingDirectives
   )
 
@@ -612,16 +610,16 @@ trait Build extends ScalaCliSbtModule with ScalaCliPublishModule with HasTests
     Deps.asm,
     Deps.collectionCompat,
     Deps.javaClassName,
-    Deps.jsoniterCore213,
+    Deps.jsoniterCore,
+    Deps.scalametaTrees,
     Deps.nativeTestRunner,
     Deps.osLib,
     Deps.pprint,
     Deps.scalaJsEnvNodeJs,
     Deps.scalaJsTestAdapter,
-    Deps.scalametaTrees,
     Deps.swoval,
     Deps.zipInputStream
-  ) ++ (if (scalaVersion().startsWith("3")) Agg() else Agg(Deps.shapeless))
+  )
 
   def repositoriesTask =
     T.task(super.repositoriesTask() ++ deps.customRepositories)
@@ -672,7 +670,7 @@ class SpecificationLevel(val crossScalaVersion: String) extends ScalaCliCrossSbt
 }
 
 trait Cli extends SbtModule with ProtoBuildModule with CliLaunchers
-    with HasMacroAnnotations with FormatNativeImageConf {
+    with FormatNativeImageConf {
 
   def constantsFile = T.persistent {
     val dir  = T.dest / "constants"
@@ -775,7 +773,7 @@ trait Cli extends SbtModule with ProtoBuildModule with CliLaunchers
     Deps.coursierPublish.exclude((organization, "config_2.13")),
     Deps.jimfs, // scalaJsEnvNodeJs pulls jimfs:1.1, whose class path seems borked (bin compat issue with the guava version it depends on)
     Deps.jniUtils,
-    Deps.jsoniterCore213,
+    Deps.jsoniterCore,
     Deps.libsodiumjni,
     Deps.metaconfigTypesafe,
     Deps.pythonNativeLibs,
@@ -856,7 +854,7 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
       Deps.coursier
         .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-macros")),
       Deps.dockerClient,
-      Deps.jsoniterCore213,
+      Deps.jsoniterCore,
       Deps.libsodiumjni,
       Deps.pprint,
       Deps.scalaAsync,

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -117,8 +117,6 @@ object Deps {
   def jgit          = ivy"org.eclipse.jgit:org.eclipse.jgit:6.4.0.202211300538-r"
   def jimfs         = ivy"com.google.jimfs:jimfs:1.2"
   def jniUtils      = ivy"io.get-coursier.jniutils:windows-jni-utils:0.3.3"
-  def jsoniterCore213 =
-    ivy"com.github.plokhotnyuk.jsoniter-scala:jsoniter-scala-core_2.13:${Versions.jsoniterScala}"
   def jsoniterCore =
     ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:${Versions.jsoniterScala}"
   def jsoniterCoreJava8 =
@@ -156,11 +154,10 @@ object Deps {
   def scalametaTrees   = ivy"org.scalameta:trees_2.13:${Versions.scalaMeta}"
   def scalaPackager    = ivy"org.virtuslab:scala-packager_2.13:${Versions.scalaPackager}"
   def scalaPackagerCli = ivy"org.virtuslab:scala-packager-cli_2.13:${Versions.scalaPackager}"
-  def scalaPy                  = ivy"dev.scalapy::scalapy-core::0.5.3"
+  def scalaPy          = ivy"dev.scalapy::scalapy-core::0.5.3"
   def scalaReflect(sv: String) = ivy"org.scala-lang:scala-reflect:$sv"
   def semanticDbJavac          = ivy"com.sourcegraph:semanticdb-javac:0.7.4"
   def semanticDbScalac         = ivy"org.scalameta:::semanticdb-scalac:${Versions.scalaMeta}"
-  def shapeless                = ivy"com.chuusai::shapeless:2.3.9"
   def signingCliShared =
     ivy"org.virtuslab.scala-cli-signing::shared:${Versions.signingCli}"
       // to prevent collisions with scala-cli's case-app version

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -156,8 +156,6 @@ object Deps {
   def scalametaTrees   = ivy"org.scalameta:trees_2.13:${Versions.scalaMeta}"
   def scalaPackager    = ivy"org.virtuslab:scala-packager_2.13:${Versions.scalaPackager}"
   def scalaPackagerCli = ivy"org.virtuslab:scala-packager-cli_2.13:${Versions.scalaPackager}"
-  // Force using of 2.13 - is there a better way?
-  def scalaparse               = ivy"com.lihaoyi:scalaparse_2.13:2.3.3"
   def scalaPy                  = ivy"dev.scalapy::scalapy-core::0.5.3"
   def scalaReflect(sv: String) = ivy"org.scala-lang:scala-reflect:$sv"
   def semanticDbJavac          = ivy"com.sourcegraph:semanticdb-javac:0.7.4"

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -689,25 +689,6 @@ trait LocalRepo extends Module {
 
 }
 
-trait HasMacroAnnotations extends ScalaModule {
-  def scalacOptions = T {
-    val sv = scalaVersion()
-    val extra =
-      if (sv.startsWith("2."))
-        if (sv.startsWith("2.13.")) Seq("-Ymacro-annotations")
-        else Nil
-      else Nil
-    super.scalacOptions() ++ extra
-  }
-  def scalacPluginIvyDeps = T {
-    val sv = scalaVersion()
-    val extra =
-      if (sv.startsWith("2.") && !sv.startsWith("2.13.")) Agg(Deps.macroParadise)
-      else Agg.empty[Dep]
-    super.scalacPluginIvyDeps() ++ extra
-  }
-}
-
 private def doFormatNativeImageConf(dir: os.Path, format: Boolean): List[os.Path] = {
   val sortByName = Set("jni-config.json", "reflect-config.json")
   val files = Seq(


### PR DESCRIPTION
- Remove migration leftovers (e.g. use jsoniter compiled in Scala 3)
- remove not needed scala parse
- Exclude .tasty and .semanticb files as well from the assembly (cliBootstrapped)