### PR TITLE
only hash when boolean is true

### DIFF
--- a/modules/options/src/main/scala/scala/build/options/HasHashData.scala
+++ b/modules/options/src/main/scala/scala/build/options/HasHashData.scala
@@ -49,6 +49,10 @@ object HasHashData:
   given option[T](using hasher: HashedType[T]): HasHashData[Option[T]] =
     (name, opt, update) => opt.foreach(t => update(s"$name=${hasher.hashedValue(t)}"))
 
+  given boolean: HasHashData[Boolean] =
+    (name, bool, update) =>
+      if bool then update(s"$name=true")
+
   given set[T](using hasher: HashedType[T], ordering: Ordering[T]): HasHashData[Set[T]] =
     (name, opt, update) =>
       opt.toVector.sorted(ordering)


### PR DESCRIPTION
This means that vanilla `scala compile foo` with no directives and one source file will compile to `foo/.scala-build/project/main/classes`