### PR TITLE
Add --as-jar option

### DIFF
--- a/modules/build/src/main/scala/scala/build/input/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/input/Inputs.scala
@@ -117,6 +117,8 @@ final case class Inputs(
     workspace / Constants.workspaceDirName / projectName / "native"
   def nativeImageWorkDir: os.Path =
     workspace / Constants.workspaceDirName / projectName / "native-image"
+  def libraryJarWorkDir: os.Path =
+    workspace / Constants.workspaceDirName / projectName / "jar"
   def docJarWorkDir: os.Path =
     workspace / Constants.workspaceDirName / projectName / "doc"
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/compile/Compile.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/compile/Compile.scala
@@ -15,6 +15,7 @@ import scala.cli.commands.update.Update
 import scala.cli.commands.util.BuildCommandHelpers
 import scala.cli.commands.{CommandUtils, ScalaCommand, SpecificationLevel, WatchUtil}
 import scala.cli.config.{ConfigDb, Keys}
+import scala.cli.packaging.Library.fullClassPathMaybeAsJar
 import scala.cli.util.ArgHelpers.*
 import scala.cli.util.ConfigDbUtils
 object Compile extends ScalaCommand[CompileOptions] with BuildCommandHelpers {
@@ -82,7 +83,9 @@ object Compile extends ScalaCommand[CompileOptions] with BuildCommandHelpers {
           } yield s
         if (options.printClassPath)
           for (s <- successulBuildOpt) {
-            val cp = s.fullClassPath.map(_.toString).mkString(File.pathSeparator)
+            val cp = s.fullClassPathMaybeAsJar(options.shared.asJar)
+              .map(_.toString)
+              .mkString(File.pathSeparator)
             println(cp)
           }
         successulBuildOpt.foreach(_.copyOutput(options.shared))

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -540,9 +540,9 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
           case Right(cls) => Some(cls)
         }
       }
-      val content = Library.libraryJar(build, mainClassOpt)
-      val dest    = workingDir / org / s"$moduleName-$ver.jar"
-      os.write.over(dest, content, createFolders = true)
+      val libraryJar = Library.libraryJar(build, mainClassOpt)
+      val dest       = workingDir / org / s"$moduleName-$ver.jar"
+      os.copy.over(libraryJar, dest, createFolders = true)
       dest
     }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
@@ -339,29 +339,6 @@ object Repl extends ScalaCommand[ReplOptions] {
           " These will not be accessible from the REPL."
       )
 
-    def actualBuild: Build.Successful =
-      buildOpt.getOrElse {
-        val ws      = os.temp.dir()
-        val inputs  = Inputs.empty(ws, enableMarkdown = false)
-        val sources = Sources(Nil, Nil, None, Nil, options)
-        val scope   = Scope.Main
-        Build.Successful(
-          inputs = inputs,
-          options = options,
-          scalaParams = Some(scalaParams),
-          scope = scope,
-          sources = Sources(Nil, Nil, None, Nil, options),
-          artifacts = artifacts,
-          project = value(
-            Build.buildProject(inputs, sources, Nil, options, None, scope, logger, artifacts)
-          ),
-          output = classDir.getOrElse(ws),
-          diagnostics = None,
-          generatedSources = Nil,
-          isPartial = false
-        )
-      }
-
     def maybeRunRepl(
       replArtifacts: ReplArtifacts,
       replArgs: Seq[String],

--- a/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
@@ -7,6 +7,8 @@ import coursier.cache.FileCache
 import coursier.error.{FetchError, ResolutionError}
 import dependency.*
 
+import java.util.zip.ZipFile
+
 import scala.build.EitherCps.{either, value}
 import scala.build.*
 import scala.build.errors.{BuildException, CantDownloadAmmoniteError, FetchingDependenciesError}
@@ -24,8 +26,10 @@ import scala.cli.commands.run.RunMode
 import scala.cli.commands.shared.{HelpCommandGroup, HelpGroup, SharedOptions}
 import scala.cli.commands.{ScalaCommand, WatchUtil}
 import scala.cli.config.{ConfigDb, Keys}
+import scala.cli.packaging.Library
 import scala.cli.util.ArgHelpers.*
 import scala.cli.util.ConfigDbUtils
+import scala.jdk.CollectionConverters._
 import scala.util.Properties
 
 object Repl extends ScalaCommand[ReplOptions] {
@@ -127,7 +131,7 @@ object Repl extends ScalaCommand[ReplOptions] {
     def doRunRepl(
       buildOptions: BuildOptions,
       artifacts: Artifacts,
-      classDir: Option[os.Path],
+      mainJarOrClassDir: Option[os.Path],
       allowExit: Boolean,
       runMode: RunMode.HasRepl,
       buildOpt: Option[Build.Successful]
@@ -136,7 +140,7 @@ object Repl extends ScalaCommand[ReplOptions] {
         buildOptions,
         programArgs,
         artifacts,
-        classDir,
+        mainJarOrClassDir,
         directories,
         logger,
         allowExit = allowExit,
@@ -154,12 +158,13 @@ object Repl extends ScalaCommand[ReplOptions] {
     def doRunReplFromBuild(
       build: Build.Successful,
       allowExit: Boolean,
-      runMode: RunMode.HasRepl
+      runMode: RunMode.HasRepl,
+      asJar: Boolean
     ): Unit =
       doRunRepl(
         build.options,
         build.artifacts,
-        build.outputOpt,
+        Some(if (asJar) Library.libraryJar(build) else build.output),
         allowExit,
         runMode,
         Some(build)
@@ -210,7 +215,12 @@ object Repl extends ScalaCommand[ReplOptions] {
         for (builds <- res.orReport(logger))
           builds.main match {
             case s: Build.Successful =>
-              doRunReplFromBuild(s, allowExit = false, runMode = runMode(options))
+              doRunReplFromBuild(
+                s,
+                allowExit = false,
+                runMode = runMode(options),
+                asJar = options.shared.asJar
+              )
             case _: Build.Failed    => buildFailed(allowExit = false)
             case _: Build.Cancelled => buildCancelled(allowExit = false)
           }
@@ -234,7 +244,12 @@ object Repl extends ScalaCommand[ReplOptions] {
           .orExit(logger)
       builds.main match {
         case s: Build.Successful =>
-          doRunReplFromBuild(s, allowExit = true, runMode = runMode(options))
+          doRunReplFromBuild(
+            s,
+            allowExit = true,
+            runMode = runMode(options),
+            asJar = options.shared.asJar
+          )
         case _: Build.Failed    => buildFailed(allowExit = true)
         case _: Build.Cancelled => buildCancelled(allowExit = true)
       }
@@ -254,7 +269,7 @@ object Repl extends ScalaCommand[ReplOptions] {
     options: BuildOptions,
     programArgs: Seq[String],
     artifacts: Artifacts,
-    classDir: Option[os.Path],
+    mainJarOrClassDir: Option[os.Path],
     directories: scala.build.Directories,
     logger: Logger,
     allowExit: Boolean,
@@ -324,13 +339,31 @@ object Repl extends ScalaCommand[ReplOptions] {
 
     // TODO Allow to disable printing the welcome banner and the "Loading..." message in Ammonite.
 
-    val rootClasses = classDir
-      .toSeq
-      .flatMap(os.list(_))
-      .filter(_.last.endsWith(".class"))
-      .filter(os.isFile(_)) // just in case
-      .map(_.last.stripSuffix(".class"))
-      .sorted
+    val rootClasses = mainJarOrClassDir match {
+      case None => Nil
+      case Some(dir) if os.isDir(dir) =>
+        os.list(dir)
+          .filter(_.last.endsWith(".class"))
+          .filter(os.isFile(_)) // just in case
+          .map(_.last.stripSuffix(".class"))
+          .sorted
+      case Some(jar) =>
+        var zf: ZipFile = null
+        try {
+          zf = new ZipFile(jar.toIO)
+          zf.entries()
+            .asScala
+            .map(_.getName)
+            .filter(!_.contains("/"))
+            .filter(_.endsWith(".class"))
+            .map(_.stripSuffix(".class"))
+            .toVector
+            .sorted
+        }
+        finally
+          if (zf != null)
+            zf.close()
+    }
     val warnRootClasses = rootClasses.nonEmpty &&
       options.notForBloopOptions.replOptions.useAmmoniteOpt.contains(true)
     if (warnRootClasses)
@@ -354,7 +387,7 @@ object Repl extends ScalaCommand[ReplOptions] {
             replArtifacts.replJavaOpts ++
             options.javaOptions.javaOpts.toSeq.map(_.value.value) ++
             extraProps.toVector.sorted.map { case (k, v) => s"-D$k=$v" },
-          classDir.toSeq ++ replArtifacts.replClassPath,
+          mainJarOrClassDir.toSeq ++ replArtifacts.replClassPath,
           replArtifacts.replMainClass,
           maybeAdaptForWindows(replArgs),
           logger,

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -140,6 +140,12 @@ final case class SharedOptions(
   @Tag(tags.must)
     resourceDirs: List[String] = Nil,
 
+  @Hidden
+  @Group(HelpGroup.Java.toString)
+  @HelpMessage("Put project in class paths as a JAR rather than as a byte code directory")
+  @Tag(tags.experimental)
+    asJar: Boolean = false,
+
   @Group(HelpGroup.Scala.toString)
   @HelpMessage("Specify platform")
   @ValueDescription("scala-js|scala-native|jvm")

--- a/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
@@ -21,6 +21,7 @@ import scala.cli.commands.shared.{HelpCommandGroup, HelpGroup, SharedOptions}
 import scala.cli.commands.update.Update
 import scala.cli.commands.{CommandUtils, ScalaCommand, SpecificationLevel, WatchUtil}
 import scala.cli.config.{ConfigDb, Keys}
+import scala.cli.packaging.Library.fullClassPathMaybeAsJar
 import scala.cli.util.ArgHelpers.*
 import scala.cli.util.ConfigDbUtils
 
@@ -109,7 +110,8 @@ object Test extends ScalaCommand[TestOptions] {
               options.requireTests,
               args.unparsed,
               logger,
-              allowExecve = allowExit && buildsLen <= 1
+              allowExecve = allowExit && buildsLen <= 1,
+              asJar = options.shared.asJar
             )
             if (printBeforeAfterMessages && idx < buildsLen - 1)
               System.err.println()
@@ -180,6 +182,7 @@ object Test extends ScalaCommand[TestOptions] {
     requireTests: Boolean,
     args: Seq[String],
     logger: Logger,
+    asJar: Boolean,
     allowExecve: Boolean
   ): Either[BuildException, Int] = either {
 
@@ -231,7 +234,7 @@ object Test extends ScalaCommand[TestOptions] {
           }.flatten
         }
       case Platform.JVM =>
-        val classPath = build.fullClassPath
+        val classPath = build.fullClassPathMaybeAsJar(asJar)
 
         val testFrameworkOpt0 = testFrameworkOpt.orElse {
           findTestFramework(classPath.map(_.toNIO), logger)

--- a/modules/cli/src/main/scala/scala/cli/commands/util/RunSpark.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/RunSpark.scala
@@ -43,13 +43,7 @@ object RunSpark {
       else Seq("--jars", depCp.mkString(","))
 
     scratchDirOpt.foreach(os.makeDir.all(_))
-    val library = os.temp(
-      Library.libraryJar(build),
-      dir = scratchDirOpt.orNull,
-      deleteOnExit = scratchDirOpt.isEmpty,
-      prefix = "spark-job",
-      suffix = ".jar"
-    )
+    val library = Library.libraryJar(build)
 
     val finalCommand =
       Seq(submitCommand, "--class", mainClass) ++
@@ -91,13 +85,7 @@ object RunSpark {
     val sparkClassPath  = value(PackageCmd.providedFiles(build, providedModules, logger))
 
     scratchDirOpt.foreach(os.makeDir.all(_))
-    val library = os.temp(
-      Library.libraryJar(build),
-      dir = scratchDirOpt.orNull,
-      deleteOnExit = scratchDirOpt.isEmpty,
-      prefix = "spark-job",
-      suffix = ".jar"
-    )
+    val library = Library.libraryJar(build)
 
     val finalMainClass = "org.apache.spark.deploy.SparkSubmit"
     val depCp          = build.dependencyClassPath.filterNot(sparkClassPath.toSet)

--- a/modules/cli/src/main/scala/scala/cli/packaging/Library.scala
+++ b/modules/cli/src/main/scala/scala/cli/packaging/Library.scala
@@ -82,4 +82,11 @@ object Library {
     finally if (zos != null) zos.close()
   }
 
+  extension (build: Build.Successful) {
+    def fullClassPathAsJar: Seq[os.Path] =
+      Seq(libraryJar(build)) ++ build.dependencyClassPath
+    def fullClassPathMaybeAsJar(asJar: Boolean): Seq[os.Path] =
+      if (asJar) fullClassPathAsJar else build.fullClassPath
+  }
+
 }

--- a/modules/cli/src/main/scala/scala/cli/packaging/NativeImage.scala
+++ b/modules/cli/src/main/scala/scala/cli/packaging/NativeImage.scala
@@ -186,10 +186,10 @@ object NativeImage {
       nativeImageWorkDir
     )
 
-    if (cacheData.changed)
-      Library.withLibraryJar(build, dest.last.stripSuffix(".jar")) { mainJar =>
-
+    if (cacheData.changed) {
+      val mainJar           = Library.libraryJar(build)
       val originalClassPath = mainJar +: build.dependencyClassPath
+
       ManifestJar.maybeWithManifestClassPath(
         createManifest = Properties.isWin,
         classPath = originalClassPath,
@@ -266,7 +266,7 @@ object NativeImage {
         }
         finally util.Try(toClean.foreach(os.remove.all))
       }
-      }
+    }
     else
       logger.message("Found cached native image binary.")
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestsDefault.scala
@@ -1,7 +1,63 @@
 package scala.cli.integration
 
+import com.eed3si9n.expecty.Expecty.expect
+
+import scala.util.Properties
+
 // format: off
 class ReplTestsDefault extends ReplTestDefinitions(
   scalaVersionOpt = None
-)
-// format: on
+) {
+  // format: on
+
+  test("as jar") {
+    val inputs = TestInputs(
+      os.rel / "CheckCp.scala" ->
+        """//> using lib "com.lihaoyi::os-lib:0.9.1"
+          |package checkcp
+          |object CheckCp {
+          |  def hasDir: Boolean =
+          |    sys.props("java.class.path")
+          |      .split(java.io.File.pathSeparator)
+          |      .toVector
+          |      .map(os.Path(_, os.pwd))
+          |      .exists(os.isDir(_))
+          |}
+          |""".stripMargin
+    )
+
+    inputs.fromRoot { root =>
+      val ammArgs = Seq(
+        "-c",
+        """println("hasDir=" + checkcp.CheckCp.hasDir)"""
+      )
+        .map {
+          if (Properties.isWin)
+            a => if (a.contains(" ")) "\"" + a.replace("\"", "\\\"") + "\"" else a
+          else
+            identity
+        }
+        .flatMap(arg => Seq("--ammonite-arg", arg))
+
+      val output =
+        os.proc(TestUtil.cli, "--power", "repl", ".", TestUtil.extraOptions, "--ammonite", ammArgs)
+          .call(cwd = root)
+          .out.trim()
+      expect(output == "hasDir=true")
+
+      val asJarOutput = os.proc(
+        TestUtil.cli,
+        "--power",
+        "repl",
+        ".",
+        TestUtil.extraOptions,
+        "--ammonite",
+        ammArgs,
+        "--as-jar"
+      )
+        .call(cwd = root)
+        .out.trim()
+      expect(asJarOutput == "hasDir=false")
+    }
+  }
+}

--- a/website/docs/commands/compile.md
+++ b/website/docs/commands/compile.md
@@ -437,6 +437,17 @@ Hello
 Note that you should favor the [`run`](./run.md) command to run your code, rather than running `java -cp`.
 The class path obtained this way is only meant for scenarios where Scala CLI doesn't offer a more convenient option.
 
+If you need the class path to consist only of JAR files, pass `--as-jar`. This packages the Scala CLI project
+byte code in a JAR file, rather than leaving it in a directory:
+
+```bash ignore
+scala-cli compile --print-class-path Hello.scala --as-jar
+```
+
+```text
+/work/.scala-build/project_103be31561-475e1607f5/jar/library.jar:~/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.2.2/scala3-library_3-3.2.2.jar:~/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.10/scala-library-2.13.10.jar
+```
+
 ### JVM options
 
 `--javac-opt` lets you add `javac` options which will be passed when compiling sources.

--- a/website/docs/commands/compile.md
+++ b/website/docs/commands/compile.md
@@ -442,7 +442,7 @@ The class path obtained this way is only meant for scenarios where Scala CLI doe
 `--javac-opt` lets you add `javac` options which will be passed when compiling sources.
 
 ```bash
-scala-cli Hello.scala --javac-opt source --javac-opt 1.8 --javac-opt target --javac-opt 1.8 
+scala-cli Hello.scala --javac-opt source --javac-opt 1.8 --javac-opt target --javac-opt 1.8
 ```
 
 You can also add javac options with the using directive `//> using javacOpt`:

--- a/website/docs/commands/repl.md
+++ b/website/docs/commands/repl.md
@@ -72,3 +72,12 @@ scala> :quit
 ```
 
 </ChainedSnippets>
+
+## Inject code as JAR file in class path
+
+If your application inspects its class path, and requires only JAR files in it, use `--as-jar` to
+put the Scala CLI project in the class path as a JAR file rather than as a directory:
+
+```bash ignore
+scala-cli repl Foo.scala --as-jar
+```

--- a/website/docs/commands/run.md
+++ b/website/docs/commands/run.md
@@ -345,3 +345,12 @@ Example debugging with scala-cli:
 ```bash ignore
 scala-cli Foo.scala --debug --debug-mode l --debug-port 5006
 ```
+
+## Inject code as JAR file in class path
+
+If your application inspects its class path, and requires only JAR files in it, use `--as-jar` to
+put the Scala CLI project in the class path as a JAR file rather than as a directory:
+
+```bash ignore
+scala-cli Foo.scala --as-jar
+```

--- a/website/docs/commands/run.md
+++ b/website/docs/commands/run.md
@@ -135,7 +135,7 @@ When you provide a JAR file as input to Scala CLI, it will be added to the `clas
 You can also add source files with the using directive `//> using file`:
 
 ```scala title=Main.scala
-//> using file "Utils.scala" 
+//> using file "Utils.scala"
 
 object Main extends App {
   println(Utils.message)

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1449,6 +1449,11 @@ Aliases: `--resource-dir`
 
 Add a resource directory
 
+### `--as-jar`
+
+[Internal]
+Put project in class paths as a JAR rather than as a byte code directory
+
 ### `--platform`
 
 Specify platform


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/2016

This adds an `--as-jar` option to the `compile` / `run` / `test` / `repl` commands, that puts the project byte code as a JAR in the class path, rather than as a directory, which is useful in contexts where JARs are required.