### PR TITLE
Add class script wrapper

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -18,7 +18,7 @@ import scala.build.errors.*
 import scala.build.input.VirtualScript.VirtualScriptNameRegex
 import scala.build.input.*
 import scala.build.internal.resource.ResourceMapper
-import scala.build.internal.{Constants, CustomCodeWrapper, MainClass, Util}
+import scala.build.internal.{Constants, MainClass, Util}
 import scala.build.options.ScalaVersionUtil.asVersion
 import scala.build.options.*
 import scala.build.options.validation.ValidationException
@@ -227,7 +227,6 @@ object Build {
       CrossSources.forInputs(
         inputs,
         Sources.defaultPreprocessors(
-          options.scriptOptions.codeWrapper.getOrElse(CustomCodeWrapper),
           options.archiveCache,
           options.internal.javaClassNameVersionOpt,
           () => options.javaHome().value.javaCommand
@@ -266,8 +265,11 @@ object Build {
       overrideOptions: BuildOptions
     ): Either[BuildException, NonCrossBuilds] = either {
 
-      val baseOptions   = overrideOptions.orElse(sharedOptions)
-      val scopedSources = value(crossSources.scopedSources(baseOptions))
+      val baseOptions = overrideOptions.orElse(sharedOptions)
+
+      val wrappedScriptsSources = crossSources.withWrappedScripts(baseOptions)
+
+      val scopedSources = value(wrappedScriptsSources.scopedSources(baseOptions))
 
       val mainSources = scopedSources.sources(Scope.Main, baseOptions)
       val mainOptions = mainSources.buildOptions

--- a/modules/build/src/main/scala/scala/build/CrossSources.scala
+++ b/modules/build/src/main/scala/scala/build/CrossSources.scala
@@ -28,13 +28,54 @@ import scala.build.testrunner.DynamicTestRunner.globPattern
 import scala.util.Try
 import scala.util.chaining.*
 
-final case class CrossSources(
+/** CrossSources with unwrapped scripts, use [[withWrappedScripts]] to wrap them and obtain an
+  * instance of CrossSources
+  *
+  * See [[CrossSources]] for more information
+  *
+  * @param paths
+  *   paths and realtive paths to sources on disk, wrapped in their build requirements
+  * @param inMemory
+  *   in memory sources (e.g. snippets) wrapped in their build requirements
+  * @param defaultMainClass
+  * @param resourceDirs
+  * @param buildOptions
+  *   build options from sources
+  * @param unwrappedScripts
+  *   in memory script sources, their code must be wrapped before compiling
+  */
+sealed class UnwrappedCrossSources(
   paths: Seq[WithBuildRequirements[(os.Path, os.RelPath)]],
   inMemory: Seq[WithBuildRequirements[Sources.InMemory]],
   defaultMainClass: Option[String],
   resourceDirs: Seq[WithBuildRequirements[os.Path]],
-  buildOptions: Seq[WithBuildRequirements[BuildOptions]]
+  buildOptions: Seq[WithBuildRequirements[BuildOptions]],
+  unwrappedScripts: Seq[WithBuildRequirements[Sources.UnwrappedScript]]
 ) {
+
+  /** For all unwrapped script sources contained in this object wrap them according to provided
+    * BuildOptions
+    *
+    * @param buildOptions
+    *   options used to choose the script wrapper
+    * @return
+    *   CrossSources with all the scripts wrapped
+    */
+  def withWrappedScripts(buildOptions: BuildOptions): CrossSources = {
+    val codeWrapper = ScriptPreprocessor.getScriptWrapper(buildOptions)
+
+    val wrappedScripts = unwrappedScripts.map { unwrapppedWithRequirements =>
+      unwrapppedWithRequirements.map(_.wrap(codeWrapper))
+    }
+
+    CrossSources(
+      paths,
+      inMemory ++ wrappedScripts,
+      defaultMainClass,
+      resourceDirs,
+      this.buildOptions
+    )
+  }
 
   def sharedOptions(baseOptions: BuildOptions): BuildOptions =
     buildOptions
@@ -42,12 +83,39 @@ final case class CrossSources(
       .map(_.value)
       .foldLeft(baseOptions)(_ orElse _)
 
-  private def needsScalaVersion =
+  protected def needsScalaVersion =
     paths.exists(_.needsScalaVersion) ||
     inMemory.exists(_.needsScalaVersion) ||
     resourceDirs.exists(_.needsScalaVersion) ||
     buildOptions.exists(_.needsScalaVersion)
+}
 
+/** Information gathered from preprocessing command inputs - sources and build options from using
+  * directives
+  *
+  * @param paths
+  *   paths and realtive paths to sources on disk, wrapped in their build requirements
+  * @param inMemory
+  *   in memory sources (e.g. snippets and wrapped scripts) wrapped in their build requirements
+  * @param defaultMainClass
+  * @param resourceDirs
+  * @param buildOptions
+  *   build options from sources
+  */
+final case class CrossSources(
+  paths: Seq[WithBuildRequirements[(os.Path, os.RelPath)]],
+  inMemory: Seq[WithBuildRequirements[Sources.InMemory]],
+  defaultMainClass: Option[String],
+  resourceDirs: Seq[WithBuildRequirements[os.Path]],
+  buildOptions: Seq[WithBuildRequirements[BuildOptions]]
+) extends UnwrappedCrossSources(
+      paths,
+      inMemory,
+      defaultMainClass,
+      resourceDirs,
+      buildOptions,
+      Nil
+    ) {
   def scopedSources(baseOptions: BuildOptions): Either[BuildException, ScopedSources] = either {
 
     val sharedOptions0 = sharedOptions(baseOptions)
@@ -114,34 +182,6 @@ final case class CrossSources(
       crossSources0.buildOptions.map(_.scopedValue(defaultScope))
     )
   }
-
-  /** For all unwrapped script sources contained in this object wrap them according to provided
-    * BuildOptions
-    *
-    * @param buildOptions
-    *   options used to choose the script wrapper
-    * @return
-    *   this with all the script code wrapped
-    */
-  def withWrappedScripts(buildOptions: BuildOptions): CrossSources =
-    copy(
-      inMemory = inMemory.map {
-        case WithBuildRequirements(requirements, source) if source.wrapScriptFunOpt.isDefined =>
-          val wrapScriptFun                = source.wrapScriptFunOpt.get
-          val codeWrapper                  = ScriptPreprocessor.getScriptWrapper(buildOptions)
-          val (wrappedCode, topWrapperLen) = wrapScriptFun(codeWrapper)
-
-          WithBuildRequirements(
-            requirements,
-            source.copy(
-              generatedContent = wrappedCode,
-              topWrapperLen = topWrapperLen,
-              wrapScriptFunOpt = None
-            )
-          )
-        case p => p
-      }
-    )
 }
 
 object CrossSources {
@@ -168,7 +208,7 @@ object CrossSources {
     suppressWarningOptions: SuppressWarningOptions,
     exclude: Seq[Positioned[String]] = Nil,
     maybeRecoverOnError: BuildException => Option[BuildException] = e => Some(e)
-  )(using ScalaCliInvokeData): Either[BuildException, (CrossSources, Inputs)] = either {
+  )(using ScalaCliInvokeData): Either[BuildException, (UnwrappedCrossSources, Inputs)] = either {
 
     def preprocessSources(elems: Seq[SingleElement])
       : Either[BuildException, Seq[PreprocessedSource]] =
@@ -286,7 +326,17 @@ object CrossSources {
           val baseReqs0 = baseReqs(m.scopePath)
           WithBuildRequirements(
             m.requirements.fold(baseReqs0)(_ orElse baseReqs0),
-            Sources.InMemory(m.originalPath, m.relPath, m.code, m.ignoreLen, m.wrapScriptFunOpt)
+            Sources.InMemory(m.originalPath, m.relPath, m.code, m.ignoreLen)
+          ) -> m.directivesPositions
+      }
+    val unwrappedScriptsWithDirectivePositions
+      : Seq[(WithBuildRequirements[Sources.UnwrappedScript], Option[DirectivesPositions])] =
+      preprocessedSources.collect {
+        case m: PreprocessedSource.UnwrappedScript =>
+          val baseReqs0 = baseReqs(m.scopePath)
+          WithBuildRequirements(
+            m.requirements.fold(baseReqs0)(_ orElse baseReqs0),
+            Sources.UnwrappedScript(m.originalPath, m.relPath, m.wrapScriptFun)
           ) -> m.directivesPositions
       }
 
@@ -298,7 +348,9 @@ object CrossSources {
     )
 
     lazy val allPathsWithDirectivesByScope: Map[Scope, Seq[(os.Path, DirectivesPositions)]] =
-      (pathsWithDirectivePositions ++ inMemoryWithDirectivePositions)
+      (pathsWithDirectivePositions ++
+        inMemoryWithDirectivePositions ++
+        unwrappedScriptsWithDirectivePositions)
         .flatMap { (withBuildRequirements, directivesPositions) =>
           val scope = withBuildRequirements.scopedValue(Scope.Main).scope
           val path: os.Path = withBuildRequirements.value match
@@ -306,6 +358,10 @@ object CrossSources {
               im.originalPath match
                 case Right((_, p: os.Path)) => p
                 case _                      => inputs.workspace / im.generatedRelPath
+            case us: Sources.UnwrappedScript =>
+              us.originalPath match
+                case Right((_, p: os.Path)) => p
+                case _                      => inputs.workspace / us.generatedRelPath
             case (p: os.Path, _) => p
           directivesPositions.map((path, scope, _))
         }
@@ -333,9 +389,20 @@ object CrossSources {
         }
     }
 
-    val paths    = pathsWithDirectivePositions.map(_._1)
-    val inMemory = inMemoryWithDirectivePositions.map(_._1)
-    (CrossSources(paths, inMemory, defaultMainClassOpt, resourceDirs, buildOptions), allInputs)
+    val paths            = pathsWithDirectivePositions.map(_._1)
+    val inMemory         = inMemoryWithDirectivePositions.map(_._1)
+    val unwrappedScripts = unwrappedScriptsWithDirectivePositions.map(_._1)
+    (
+      UnwrappedCrossSources(
+        paths,
+        inMemory,
+        defaultMainClassOpt,
+        resourceDirs,
+        buildOptions,
+        unwrappedScripts
+      ),
+      allInputs
+    )
   }
 
   private def resolveInputsFromSources(sources: Seq[Positioned[os.Path]], enableMarkdown: Boolean) =

--- a/modules/build/src/main/scala/scala/build/Sources.scala
+++ b/modules/build/src/main/scala/scala/build/Sources.scala
@@ -70,9 +70,19 @@ object Sources {
     originalPath: Either[String, (os.SubPath, os.Path)],
     generatedRelPath: os.RelPath,
     generatedContent: String,
-    topWrapperLen: Int,
-    wrapScriptFunOpt: Option[CodeWrapper => (String, Int)] = None
+    topWrapperLen: Int
   )
+
+  final case class UnwrappedScript(
+    originalPath: Either[String, (os.SubPath, os.Path)],
+    generatedRelPath: os.RelPath,
+    wrapScriptFun: CodeWrapper => (String, Int)
+  ) {
+    def wrap(wrapper: CodeWrapper): InMemory = {
+      val (content, topWrapperLen) = wrapScriptFun(wrapper)
+      InMemory(originalPath, generatedRelPath, content, topWrapperLen)
+    }
+  }
 
   /** The default preprocessor list.
     *

--- a/modules/build/src/main/scala/scala/build/Sources.scala
+++ b/modules/build/src/main/scala/scala/build/Sources.scala
@@ -70,7 +70,8 @@ object Sources {
     originalPath: Either[String, (os.SubPath, os.Path)],
     generatedRelPath: os.RelPath,
     generatedContent: String,
-    topWrapperLen: Int
+    topWrapperLen: Int,
+    wrapScriptFunOpt: Option[CodeWrapper => (String, Int)] = None
   )
 
   /** The default preprocessor list.
@@ -86,13 +87,12 @@ object Sources {
     * @return
     */
   def defaultPreprocessors(
-    codeWrapper: CodeWrapper,
     archiveCache: ArchiveCache[Task],
     javaClassNameVersionOpt: Option[String],
     javaCommand: () => String
   ): Seq[Preprocessor] =
     Seq(
-      ScriptPreprocessor(codeWrapper),
+      ScriptPreprocessor,
       MarkdownPreprocessor,
       JavaPreprocessor(archiveCache, javaClassNameVersionOpt, javaCommand),
       ScalaPreprocessor,

--- a/modules/build/src/main/scala/scala/build/bsp/BspClient.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspClient.scala
@@ -1,6 +1,6 @@
 package scala.build.bsp
 
-import ch.epfl.scala.{bsp4j => b}
+import ch.epfl.scala.bsp4j as b
 
 import java.lang.Boolean as JBoolean
 import java.net.URI
@@ -10,6 +10,7 @@ import java.util.concurrent.{ConcurrentHashMap, ExecutorService}
 import scala.build.Position.File
 import scala.build.bsp.protocol.TextEdit
 import scala.build.errors.{BuildException, CompositeBuildException, Diagnostic, Severity}
+import scala.build.internal.util.WarningMessages
 import scala.build.postprocessing.LineConversion
 import scala.build.{BloopBuildClient, GeneratedSource, Logger}
 import scala.jdk.CollectionConverters.*
@@ -48,6 +49,16 @@ class BspClient(
                 val diag0 = diag.duplicate()
                 diag0.getRange.getStart.setLine(startLine)
                 diag0.getRange.getEnd.setLine(endLine)
+
+                if (
+                  diag0.getMessage.contains(
+                    "cannot be a main method since it cannot be accessed statically"
+                  )
+                )
+                  diag0.setMessage(
+                    WarningMessages.mainAnnotationNotSupported( /* annotationIgnored */ false)
+                  )
+
                 diag0
               }
               updatedDiagOpt.getOrElse(diag)

--- a/modules/build/src/main/scala/scala/build/internal/ClassCodeWrapper.scala
+++ b/modules/build/src/main/scala/scala/build/internal/ClassCodeWrapper.scala
@@ -6,9 +6,6 @@ package scala.build.internal
   * Scala 3 feature 'export'<br> Incompatible with native JS members - the wrapper is a class
   */
 case object ClassCodeWrapper extends CodeWrapper {
-  def mainClassObject(className: Name): Name =
-    Name(className.raw ++ "_sc")
-
   private val userCodeNestingLevel = 1
   def apply(
     code: String,
@@ -17,7 +14,7 @@ case object ClassCodeWrapper extends CodeWrapper {
     extraCode: String,
     scriptPath: String
   ) = {
-    val name             = mainClassObject(indexedWrapperName).backticked
+    val name             = CodeWrapper.mainClassObject(indexedWrapperName).backticked
     val wrapperClassName = Name(indexedWrapperName.raw ++ "$_").backticked
     val mainObjectCode =
       AmmUtil.normalizeNewlines(s"""|object $name {

--- a/modules/build/src/main/scala/scala/build/internal/ObjectCodeWrapper.scala
+++ b/modules/build/src/main/scala/scala/build/internal/ObjectCodeWrapper.scala
@@ -1,0 +1,73 @@
+package scala.build.internal
+
+/** Script code wrapper compatible with Scala 2 and JS native members <br> <br> When using Scala 3
+  * or/and not using JS native prefer [[ClassCodeWrapper]], since it prevents deadlocks when running
+  * threads from script
+  */
+case object ObjectCodeWrapper extends CodeWrapper {
+  def mainClassObject(className: Name): Name =
+    Name(className.raw ++ "_sc")
+
+  private val userCodeNestingLevel = 1
+  def apply(
+    code: String,
+    pkgName: Seq[Name],
+    indexedWrapperName: Name,
+    extraCode: String,
+    scriptPath: String
+  ) = {
+    val name               = mainClassObject(indexedWrapperName).backticked
+    val aliasedWrapperName = name + "$$alias"
+    val funHashCodeMethod =
+      if (name == "main_sc")
+        s"$aliasedWrapperName.alias.hashCode()" // https://github.com/VirtusLab/scala-cli/issues/314
+      else s"${indexedWrapperName.backticked}.hashCode()"
+    // We need to call hashCode (or any other method so compiler does not report a warning)
+    val mainObjectCode =
+      AmmUtil.normalizeNewlines(s"""|object $name {
+                                    |  private var args$$opt0 = Option.empty[Array[String]]
+                                    |  def args$$set(args: Array[String]): Unit = {
+                                    |    args$$opt0 = Some(args)
+                                    |  }
+                                    |  def args$$opt: Option[Array[String]] = args$$opt0
+                                    |  def args$$: Array[String] = args$$opt.getOrElse {
+                                    |    sys.error("No arguments passed to this script")
+                                    |  }
+                                    |  def main(args: Array[String]): Unit = {
+                                    |    args$$set(args)
+                                    |    $funHashCodeMethod // hasCode to clear scalac warning about pure expression in statement position
+                                    |  }
+                                    |}
+                                    |""".stripMargin)
+
+    val packageDirective =
+      if (pkgName.isEmpty) "" else s"package ${AmmUtil.encodeScalaSourcePath(pkgName)}" + "\n"
+
+    val aliasObject =
+      if (name == "main_sc")
+        s"""object $aliasedWrapperName {
+           |  val alias = ${indexedWrapperName.backticked}
+           |}""".stripMargin
+      else ""
+
+    // indentation is important in the generated code, so we don't want scalafmt to touch that
+    // format: off
+    val top = AmmUtil.normalizeNewlines(s"""
+$packageDirective
+
+
+object ${indexedWrapperName.backticked} {
+def args = $name.args$$
+def scriptPath = \"\"\"$scriptPath\"\"\"
+""")
+    val bottom = AmmUtil.normalizeNewlines(s"""
+$extraCode
+}
+$aliasObject
+$mainObjectCode
+""")
+    // format: on
+
+    (top, bottom, userCodeNestingLevel)
+  }
+}

--- a/modules/build/src/main/scala/scala/build/internal/ObjectCodeWrapper.scala
+++ b/modules/build/src/main/scala/scala/build/internal/ObjectCodeWrapper.scala
@@ -5,9 +5,6 @@ package scala.build.internal
   * threads from script
   */
 case object ObjectCodeWrapper extends CodeWrapper {
-  def mainClassObject(className: Name): Name =
-    Name(className.raw ++ "_sc")
-
   private val userCodeNestingLevel = 1
   def apply(
     code: String,
@@ -16,7 +13,7 @@ case object ObjectCodeWrapper extends CodeWrapper {
     extraCode: String,
     scriptPath: String
   ) = {
-    val name               = mainClassObject(indexedWrapperName).backticked
+    val name               = CodeWrapper.mainClassObject(indexedWrapperName).backticked
     val aliasedWrapperName = name + "$$alias"
     val funHashCodeMethod =
       if (name == "main_sc")

--- a/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
+++ b/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
@@ -34,6 +34,15 @@ object WarningMessages {
        | $directiveName value:$rawValue
        |""".stripMargin
 
+  /** Using @main is impossible in new [[scala.build.internal.ClassCodeWrapper]] since none of the
+    * definitions can be accessed statically, so those errors are swapped with this text
+    * @param annotationIgnored
+    *   will annotation be ignored (or will compilation fail)
+    */
+  def mainAnnotationNotSupported(annotationIgnored: Boolean): String =
+    val consequencesString = if annotationIgnored then s", it will be ignored" else ""
+    s"Annotation @main in .sc scripts is not supported$consequencesString, use .scala format instead"
+
   private def powerFeatureUsedInSip(
     featureName: String,
     featureType: String,

--- a/modules/build/src/main/scala/scala/build/preprocessing/MarkdownPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/MarkdownPreprocessor.scala
@@ -13,7 +13,7 @@ import scala.build.input.{
   VirtualMarkdownFile
 }
 import scala.build.internal.markdown.{MarkdownCodeBlock, MarkdownCodeWrapper}
-import scala.build.internal.{AmmUtil, CodeWrapper, CustomCodeWrapper, Name}
+import scala.build.internal.{AmmUtil, Name}
 import scala.build.options.{BuildOptions, BuildRequirements, SuppressWarningOptions}
 import scala.build.preprocessing.ScalaPreprocessor.ProcessingOutput
 

--- a/modules/build/src/main/scala/scala/build/preprocessing/PreprocessedSource.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/PreprocessedSource.scala
@@ -1,5 +1,6 @@
 package scala.build.preprocessing
 
+import scala.build.internal.CodeWrapper
 import scala.build.options.{BuildOptions, BuildRequirements, WithBuildRequirements}
 
 sealed abstract class PreprocessedSource extends Product with Serializable {
@@ -38,7 +39,8 @@ object PreprocessedSource {
     scopedRequirements: Seq[Scoped[BuildRequirements]],
     mainClassOpt: Option[String],
     scopePath: ScopePath,
-    directivesPositions: Option[DirectivesPositions]
+    directivesPositions: Option[DirectivesPositions],
+    wrapScriptFunOpt: Option[CodeWrapper => (String, Int)] = None
   ) extends PreprocessedSource {
     def reportingPath: Either[String, os.Path] =
       originalPath.map(_._2)

--- a/modules/build/src/main/scala/scala/build/preprocessing/PreprocessedSource.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/PreprocessedSource.scala
@@ -39,12 +39,25 @@ object PreprocessedSource {
     scopedRequirements: Seq[Scoped[BuildRequirements]],
     mainClassOpt: Option[String],
     scopePath: ScopePath,
-    directivesPositions: Option[DirectivesPositions],
-    wrapScriptFunOpt: Option[CodeWrapper => (String, Int)] = None
+    directivesPositions: Option[DirectivesPositions]
   ) extends PreprocessedSource {
     def reportingPath: Either[String, os.Path] =
       originalPath.map(_._2)
   }
+
+  final case class UnwrappedScript(
+    originalPath: Either[String, (os.SubPath, os.Path)],
+    relPath: os.RelPath,
+    options: Option[BuildOptions],
+    optionsWithTargetRequirements: List[WithBuildRequirements[BuildOptions]],
+    requirements: Option[BuildRequirements],
+    scopedRequirements: Seq[Scoped[BuildRequirements]],
+    mainClassOpt: Option[String],
+    scopePath: ScopePath,
+    directivesPositions: Option[DirectivesPositions],
+    wrapScriptFun: CodeWrapper => (String, Int)
+  ) extends PreprocessedSource
+
   final case class NoSourceCode(
     options: Option[BuildOptions],
     optionsWithTargetRequirements: List[WithBuildRequirements[BuildOptions]],

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
@@ -128,7 +128,7 @@ case object ScriptPreprocessor extends Preprocessor {
       optionsWithTargetRequirements = processingOutput.optsWithReqs,
       requirements = Some(processingOutput.globalReqs),
       scopedRequirements = processingOutput.scopedReqs,
-      mainClassOpt = Some(ClassCodeWrapper.mainClassObject(Name(className)).backticked),
+      mainClassOpt = Some(CodeWrapper.mainClassObject(Name(className)).backticked),
       scopePath = scopePath,
       directivesPositions = processingOutput.directivesPositions,
       wrapScriptFunOpt = Some(wrapScriptFun)

--- a/modules/build/src/test/scala/scala/build/tests/ExcludeTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ExcludeTests.scala
@@ -94,7 +94,9 @@ class ExcludeTests extends munit.FunSuite {
           TestLogger(),
           SuppressWarningOptions()
         )(using ScalaCliInvokeData.dummy).orThrow
-      val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
+      val scopedSources = crossSources.withWrappedScripts(BuildOptions())
+        .scopedSources(BuildOptions())
+        .orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.paths.nonEmpty)
@@ -120,7 +122,9 @@ class ExcludeTests extends munit.FunSuite {
           TestLogger(),
           SuppressWarningOptions()
         )(using ScalaCliInvokeData.dummy).orThrow
-      val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
+      val scopedSources = crossSources.withWrappedScripts(BuildOptions())
+        .scopedSources(BuildOptions())
+        .orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.paths.nonEmpty)
@@ -146,7 +150,9 @@ class ExcludeTests extends munit.FunSuite {
           TestLogger(),
           SuppressWarningOptions()
         )(using ScalaCliInvokeData.dummy).orThrow
-      val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
+      val scopedSources = crossSources.withWrappedScripts(BuildOptions())
+        .scopedSources(BuildOptions())
+        .orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.paths.nonEmpty)
@@ -172,7 +178,9 @@ class ExcludeTests extends munit.FunSuite {
           TestLogger(),
           SuppressWarningOptions()
         )(using ScalaCliInvokeData.dummy).orThrow
-      val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
+      val scopedSources = crossSources.withWrappedScripts(BuildOptions())
+        .scopedSources(BuildOptions())
+        .orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.paths.nonEmpty)

--- a/modules/build/src/test/scala/scala/build/tests/ExcludeTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ExcludeTests.scala
@@ -8,7 +8,6 @@ import coursier.util.{Artifact, EitherT, Task}
 import java.io.File
 import scala.build.Ops.*
 import scala.build.Sources
-import scala.build.internal.CustomCodeWrapper
 import scala.build.CrossSources
 import scala.build.errors.ExcludeDefinitionError
 import scala.build.input.ScalaCliInvokeData
@@ -19,7 +18,6 @@ import scala.concurrent.ExecutionContext
 class ExcludeTests extends munit.FunSuite {
 
   val preprocessors: Seq[Preprocessor] = Sources.defaultPreprocessors(
-    codeWrapper = CustomCodeWrapper,
     archiveCache = ArchiveCache().withCache(
       new Cache[Task] {
         def fetch: Fetch[Task] = _ => sys.error("shouldn't be used")

--- a/modules/build/src/test/scala/scala/build/tests/PreprocessingTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/PreprocessingTests.scala
@@ -4,7 +4,6 @@ import scala.build.preprocessing.{MarkdownPreprocessor, ScalaPreprocessor, Scrip
 import com.eed3si9n.expecty.Expecty.expect
 
 import scala.build.input.{Inputs, MarkdownFile, ScalaCliInvokeData, Script, SourceScalaFile}
-import scala.build.internal.CustomCodeWrapper
 import scala.build.options.SuppressWarningOptions
 
 class PreprocessingTests extends munit.FunSuite {
@@ -30,7 +29,7 @@ class PreprocessingTests extends munit.FunSuite {
     val logger      = TestLogger()
     val scalaScript = Script(os.temp.dir(), os.SubPath("NotExists.sc"), None)
 
-    val res = ScriptPreprocessor(CustomCodeWrapper).preprocess(
+    val res = ScriptPreprocessor.preprocess(
       scalaScript,
       logger,
       allowRestrictedFeatures = false,

--- a/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
@@ -64,7 +64,10 @@ class SourcesTests extends munit.FunSuite {
             TestLogger(),
             SuppressWarningOptions()
           ).orThrow
-        val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
+        val wrappedCrossSources =
+          crossSources.withWrappedScripts(crossSources.sharedOptions(BuildOptions()))
+
+        val scopedSources = wrappedCrossSources.scopedSources(BuildOptions()).orThrow
         val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
         val obtainedDeps = sources.buildOptions.classPathOptions.extraDependencies.toSeq.toSeq.map(
@@ -99,7 +102,10 @@ class SourcesTests extends munit.FunSuite {
           TestLogger(),
           SuppressWarningOptions()
         ).orThrow
-      val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
+      val wrappedCrossSources =
+        crossSources.withWrappedScripts(crossSources.sharedOptions(BuildOptions()))
+
+      val scopedSources = wrappedCrossSources.scopedSources(BuildOptions()).orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(
@@ -131,7 +137,10 @@ class SourcesTests extends munit.FunSuite {
           TestLogger(),
           SuppressWarningOptions()
         ).orThrow
-      val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
+      val wrappedCrossSources =
+        crossSources.withWrappedScripts(crossSources.sharedOptions(BuildOptions()))
+
+      val scopedSources = wrappedCrossSources.scopedSources(BuildOptions()).orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(
@@ -163,7 +172,10 @@ class SourcesTests extends munit.FunSuite {
           TestLogger(),
           SuppressWarningOptions()
         ).orThrow
-      val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
+      val wrappedCrossSources =
+        crossSources.withWrappedScripts(crossSources.sharedOptions(BuildOptions()))
+
+      val scopedSources = wrappedCrossSources.scopedSources(BuildOptions()).orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(sources.buildOptions.classPathOptions.extraDependencies.toSeq.map(_.value).isEmpty)
@@ -198,7 +210,10 @@ class SourcesTests extends munit.FunSuite {
           TestLogger(),
           SuppressWarningOptions()
         ).orThrow
-      val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
+      val wrappedCrossSources =
+        crossSources.withWrappedScripts(crossSources.sharedOptions(BuildOptions()))
+
+      val scopedSources = wrappedCrossSources.scopedSources(BuildOptions()).orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(
@@ -235,7 +250,10 @@ class SourcesTests extends munit.FunSuite {
           TestLogger(),
           SuppressWarningOptions()
         ).orThrow
-      val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
+      val wrappedCrossSources =
+        crossSources.withWrappedScripts(crossSources.sharedOptions(BuildOptions()))
+
+      val scopedSources = wrappedCrossSources.scopedSources(BuildOptions()).orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(
@@ -337,7 +355,10 @@ class SourcesTests extends munit.FunSuite {
           TestLogger(),
           SuppressWarningOptions()
         ).orThrow
-      val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
+      val wrappedCrossSources =
+        crossSources.withWrappedScripts(crossSources.sharedOptions(BuildOptions()))
+
+      val scopedSources = wrappedCrossSources.scopedSources(BuildOptions()).orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(
@@ -373,7 +394,10 @@ class SourcesTests extends munit.FunSuite {
           TestLogger(),
           SuppressWarningOptions()
         ).orThrow
-      val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
+      val wrappedCrossSources =
+        crossSources.withWrappedScripts(crossSources.sharedOptions(BuildOptions()))
+
+      val scopedSources = wrappedCrossSources.scopedSources(BuildOptions()).orThrow
       val sources = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
 
       expect(
@@ -400,7 +424,10 @@ class SourcesTests extends munit.FunSuite {
           TestLogger(),
           SuppressWarningOptions()
         ).orThrow
-      val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
+      val wrappedCrossSources =
+        crossSources.withWrappedScripts(crossSources.sharedOptions(BuildOptions()))
+
+      val scopedSources = wrappedCrossSources.scopedSources(BuildOptions()).orThrow
       val sources  = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
       val javaOpts = sources.buildOptions.javaOptions.javaOpts.toSeq.sortBy(_.toString)
 
@@ -438,7 +465,10 @@ class SourcesTests extends munit.FunSuite {
           TestLogger(),
           SuppressWarningOptions()
         ).orThrow
-      val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
+      val wrappedCrossSources =
+        crossSources.withWrappedScripts(crossSources.sharedOptions(BuildOptions()))
+
+      val scopedSources = wrappedCrossSources.scopedSources(BuildOptions()).orThrow
       val sources   = scopedSources.sources(Scope.Main, crossSources.sharedOptions(BuildOptions()))
       val jsOptions = sources.buildOptions.scalaJsOptions
       val jsConfig  = jsOptions.linkerConfig(TestLogger())

--- a/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
@@ -8,7 +8,6 @@ import scala.build.*
 import scala.build.bsp.{BspReloadableOptions, BspThreads}
 import scala.build.errors.BuildException
 import scala.build.input.Inputs
-import scala.build.internal.CustomCodeWrapper
 import scala.build.options.BuildOptions
 import scala.cli.CurrentParams
 import scala.cli.commands.ScalaCommand
@@ -53,7 +52,6 @@ object Bsp extends ScalaCommand[BspOptions] {
             CrossSources.forInputs(
               initialInputs,
               Sources.defaultPreprocessors(
-                buildOptions0.scriptOptions.codeWrapper.getOrElse(CustomCodeWrapper),
                 buildOptions0.archiveCache,
                 buildOptions0.internal.javaClassNameVersionOpt,
                 () => buildOptions0.javaHome().value.javaCommand

--- a/modules/cli/src/main/scala/scala/cli/commands/dependencyupdate/DependencyUpdate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/dependencyupdate/DependencyUpdate.scala
@@ -42,11 +42,13 @@ object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
         buildOptions.internal.exclude
       ).orExit(logger)
 
-    val scopedSources = crossSources.scopedSources(buildOptions).orExit(logger)
+    val sharedOptions       = crossSources.sharedOptions(buildOptions)
+    val wrappedCrossOptions = crossSources.withWrappedScripts(sharedOptions)
+    val scopedSources       = wrappedCrossOptions.scopedSources(buildOptions).orExit(logger)
 
     def generateActionableUpdateDiagnostic(scope: Scope)
       : Seq[ActionableDependencyUpdateDiagnostic] = {
-      val sources = scopedSources.sources(scope, crossSources.sharedOptions(buildOptions))
+      val sources = scopedSources.sources(scope, sharedOptions)
 
       if (verbosity >= 3)
         pprint.err.log(sources)

--- a/modules/cli/src/main/scala/scala/cli/commands/dependencyupdate/DependencyUpdate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/dependencyupdate/DependencyUpdate.scala
@@ -5,7 +5,6 @@ import caseapp.core.help.HelpFormat
 
 import scala.build.actionable.ActionableDependencyHandler
 import scala.build.actionable.ActionableDiagnostic.ActionableDependencyUpdateDiagnostic
-import scala.build.internal.CustomCodeWrapper
 import scala.build.options.{BuildOptions, Scope}
 import scala.build.{CrossSources, Logger, Position, Sources}
 import scala.cli.CurrentParams
@@ -34,7 +33,6 @@ object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
       CrossSources.forInputs(
         inputs,
         Sources.defaultPreprocessors(
-          buildOptions.scriptOptions.codeWrapper.getOrElse(CustomCodeWrapper),
           buildOptions.archiveCache,
           buildOptions.internal.javaClassNameVersionOpt,
           () => buildOptions.javaHome().value.javaCommand

--- a/modules/cli/src/main/scala/scala/cli/commands/export0/Export.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/export0/Export.scala
@@ -15,7 +15,7 @@ import scala.build.EitherCps.{either, value}
 import scala.build.*
 import scala.build.errors.BuildException
 import scala.build.input.Inputs
-import scala.build.internal.{Constants, CustomCodeWrapper}
+import scala.build.internal.Constants
 import scala.build.options.{BuildOptions, Platform, Scope}
 import scala.cli.CurrentParams
 import scala.cli.commands.shared.{HelpGroup, SharedOptions}
@@ -44,7 +44,6 @@ object Export extends ScalaCommand[ExportOptions] {
       CrossSources.forInputs(
         inputs,
         Sources.defaultPreprocessors(
-          buildOptions.scriptOptions.codeWrapper.getOrElse(CustomCodeWrapper),
           buildOptions.archiveCache,
           buildOptions.internal.javaClassNameVersionOpt,
           () => buildOptions.javaHome().value.javaCommand
@@ -54,8 +53,11 @@ object Export extends ScalaCommand[ExportOptions] {
         buildOptions.internal.exclude
       )
     }
-    val scopedSources = value(crossSources.scopedSources(buildOptions))
-    val sources       = scopedSources.sources(scope, crossSources.sharedOptions(buildOptions))
+
+    val wrappedScriptsSources = crossSources.withWrappedScripts(buildOptions)
+
+    val scopedSources = value(wrappedScriptsSources.scopedSources(buildOptions))
+    val sources = scopedSources.sources(scope, wrappedScriptsSources.sharedOptions(buildOptions))
 
     if (verbosity >= 3)
       pprint.err.log(sources)

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
@@ -8,7 +8,6 @@ import java.nio.charset.StandardCharsets
 
 import scala.build.Ops.*
 import scala.build.errors.CompositeBuildException
-import scala.build.internal.CustomCodeWrapper
 import scala.build.options.{BuildOptions, InternalOptions, Scope, SuppressWarningOptions}
 import scala.build.{CrossSources, Directories, Logger, Sources}
 import scala.cli.ScalaCli
@@ -84,7 +83,6 @@ object PublishSetup extends ScalaCommand[PublishSetupOptions] {
       val (crossSources, _) = CrossSources.forInputs(
         inputs,
         Sources.defaultPreprocessors(
-          cliBuildOptions.scriptOptions.codeWrapper.getOrElse(CustomCodeWrapper),
           cliBuildOptions.archiveCache,
           cliBuildOptions.internal.javaClassNameVersionOpt,
           () => cliBuildOptions.javaHome().value.javaCommand

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
@@ -93,8 +93,10 @@ object PublishSetup extends ScalaCommand[PublishSetupOptions] {
       ).orExit(logger)
 
       val crossSourcesSharedOptions = crossSources.sharedOptions(cliBuildOptions)
-      val scopedSources = crossSources.scopedSources(crossSourcesSharedOptions).orExit(logger)
-      val sources       = scopedSources.sources(Scope.Main, crossSourcesSharedOptions)
+      val wrappedCrossSources       = crossSources.withWrappedScripts(crossSourcesSharedOptions)
+      val scopedSources =
+        wrappedCrossSources.scopedSources(crossSourcesSharedOptions).orExit(logger)
+      val sources = scopedSources.sources(Scope.Main, crossSourcesSharedOptions)
 
       val pureJava = sources.hasJava && !sources.hasScala
 

--- a/modules/cli/src/main/scala/scala/cli/commands/setupide/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/setupide/SetupIde.scala
@@ -12,7 +12,7 @@ import scala.build.*
 import scala.build.bsp.IdeInputs
 import scala.build.errors.{BuildException, WorkspaceError}
 import scala.build.input.{Inputs, OnDisk, Virtual, WorkspaceOrigin}
-import scala.build.internal.{Constants, CustomCodeWrapper}
+import scala.build.internal.Constants
 import scala.build.options.{BuildOptions, Scope}
 import scala.cli.CurrentParams
 import scala.cli.commands.shared.{SharedBspFileOptions, SharedOptions}
@@ -34,7 +34,6 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
         CrossSources.forInputs(
           inputs,
           Sources.defaultPreprocessors(
-            CustomCodeWrapper,
             options.archiveCache,
             options.internal.javaClassNameVersionOpt,
             () => options.javaHome().value.javaCommand

--- a/modules/cli/src/main/scala/scala/cli/commands/setupide/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/setupide/SetupIde.scala
@@ -44,7 +44,10 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
         )
       }
 
-      value(crossSources.scopedSources(options))
+      val sharedOptions       = crossSources.sharedOptions(options)
+      val wrappedCrossOptions = crossSources.withWrappedScripts(sharedOptions)
+
+      value(wrappedCrossOptions.scopedSources(options))
         .sources(Scope.Main, crossSources.sharedOptions(options))
         .buildOptions
     }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -22,7 +22,7 @@ import scala.build.input.{Element, Inputs, ResourceDirectory, ScalaCliInvokeData
 import scala.build.interactive.Interactive
 import scala.build.interactive.Interactive.{InteractiveAsk, InteractiveNop}
 import scala.build.internal.CsLoggerUtil.*
-import scala.build.internal.{Constants, FetchExternalBinary, OsLibc, Util}
+import scala.build.internal.{Constants, FetchExternalBinary, ObjectCodeWrapper, OsLibc, Util}
 import scala.build.options.ScalaVersionUtil.fileWithTtl0
 import scala.build.options.{Platform, ScalacOpt, ShadowingSeq}
 import scala.build.preprocessing.directives.Toolkit

--- a/modules/core/src/main/scala/scala/build/internals/CodeWrapper.scala
+++ b/modules/core/src/main/scala/scala/build/internals/CodeWrapper.scala
@@ -15,7 +15,7 @@ abstract class CodeWrapper {
     indexedWrapperName: Name,
     code: String,
     scriptPath: String
-  ) = {
+  ): (String, Int, Int) = {
 
     // we need to normalize topWrapper and bottomWrapper in order to ensure
     // the snippets always use the platform-specific newLine

--- a/modules/core/src/main/scala/scala/build/internals/CodeWrapper.scala
+++ b/modules/core/src/main/scala/scala/build/internals/CodeWrapper.scala
@@ -23,10 +23,18 @@ abstract class CodeWrapper {
     val (topWrapper, bottomWrapper, userCodeNestingLevel) =
       apply(code, pkgName, indexedWrapperName, extraCode0, scriptPath)
     val (topWrapper0, bottomWrapper0) =
-      (topWrapper + "/*<script>*/\n", "/*</script>*/ /*<generated>*/" + bottomWrapper)
+      (
+        topWrapper + "/*<script>*/" + System.lineSeparator(),
+        "/*</script>*/ /*<generated>*/" + bottomWrapper
+      )
     val importsLen = topWrapper0.length
 
     (topWrapper0 + code + bottomWrapper0, importsLen, userCodeNestingLevel)
   }
 
+}
+
+object CodeWrapper {
+  def mainClassObject(className: Name): Name =
+    Name(className.raw ++ "_sc")
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -392,7 +392,11 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
 
         val compileProducts = os.walk(classDir).filter(os.isFile(_)).map(_.relativeTo(classDir))
 
-        expect(compileProducts.contains(os.rel / "simple.class"))
+        if (actualScalaVersion.startsWith("3."))
+          expect(compileProducts.contains(os.rel / "simple$_.class"))
+        else
+          expect(compileProducts.contains(os.rel / "simple$.class"))
+
         expect(
           compileProducts.contains(os.rel / "META-INF" / "semanticdb" / "simple.sc.semanticdb")
         )

--- a/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
@@ -42,7 +42,7 @@ abstract class DocTestDefinitions(val scalaVersionOpt: Option[String])
           Seq(
             "index.html",
             "inkuire-db.json",
-            "_empty_/simple$.html",
+            "_empty_/simple$_.html",
             "lib/Messages$.html"
           )
       val entries =

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -768,7 +768,10 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
 
       val genContent    = readEntry(zf, genSourceEntryName)
       val genContentStr = new String(genContent, StandardCharsets.UTF_8)
-      expect(genContentStr.contains("object simple {"))
+      if (actualScalaVersion.startsWith("2."))
+        expect(genContentStr.contains("object simple"))
+      else
+        expect(genContentStr.contains("class simple$_"))
     }
   }
 
@@ -794,10 +797,11 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
           Seq(
             "index.html",
             "inkuire-db.json",
-            "_empty_/simple$.html",
+            "_empty_/simple$_.html",
             "lib/Messages$.html"
           )
       val entries = zf.entries().asScala.iterator.map(_.getName).toSet
+
       expect(expectedEntries.forall(e => entries.contains(e)))
     }
   }

--- a/website/docs/guides/old-runner-migration.md
+++ b/website/docs/guides/old-runner-migration.md
@@ -358,7 +358,7 @@ println("Args: " + args.mkString(" "))
 
 This in turn is the Scala `3.x` equivalent for its own old `scala` runner.
 
-```scala compile title=old-scala-shebang-3.sc
+```scala title=old-scala-shebang-3.sc
 #!/usr/bin/env scala
 @main def main(args: String*): Unit = println("Args: " + args.mkString(" "))
 ```


### PR DESCRIPTION
This should avoid deadlocks when threads are run from the static initalizer of wrapper object.

Closes #532 and #1933 

The key to this issue is what's visible in the thread dump from [this comment](https://github.com/VirtusLab/scala-cli/issues/532#issuecomment-1236074174)
```
ZScheduler-Worker-1" #15 daemon prio=5 os_prio=0 cpu=109,44ms elapsed=32,71s tid=0x00007f62544c7290 nid=0x22344 in Object.wait()  [0x00007f6214706000]
   java.lang.Thread.State: RUNNABLE
	at issue$minus7301$minusexample$minusko$Photos$$anon$1$$Lambda$481/0x0000000800e2c798.apply(Unknown Source)
	- waiting on the Class initialization monitor for issue$minus7301$minusexample$minusko$
	at zio.ZIO.map$$anonfun$1(ZIO.scala:927)
	at zio.ZIO$$Lambda$87/0x0000000800d3f3e0.apply(Unknown Source)
```

The background thread worker is waiting for object class to be initialized, but the object class initialization process is waiting for the background thread to finish, this introduces a deadlock.

As stated by David Crosson in #532 encapsulating the `wait/join/Await.ready` method into a additonal object fixed this in some cases by making the background thread not dependent on the initialization of the outer wrapper object introduced by Scala CLI.