### PR TITLE
Support declaring some test directives from the main scope

### DIFF
--- a/modules/build/src/main/scala/scala/build/CrossSources.scala
+++ b/modules/build/src/main/scala/scala/build/CrossSources.scala
@@ -195,7 +195,7 @@ object CrossSources {
     val buildOptions: Seq[WithBuildRequirements[BuildOptions]] = (for {
       preprocessedSource <- preprocessedSources
       opts               <- preprocessedSource.options.toSeq
-      if opts != BuildOptions()
+      if opts != BuildOptions() || preprocessedSource.optionsWithTargetRequirements.nonEmpty
     } yield {
       val baseReqs0 = baseReqs(preprocessedSource.scopePath)
       preprocessedSource.optionsWithTargetRequirements :+ WithBuildRequirements(

--- a/modules/build/src/main/scala/scala/build/preprocessing/JarPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/JarPreprocessor.scala
@@ -12,7 +12,6 @@ import scala.build.options.{
   ClassPathOptions,
   SuppressWarningOptions
 }
-import scala.build.preprocessing.PreprocessingUtil.optionsAndPositionsFromDirectives
 
 case object JarPreprocessor extends Preprocessor {
   def preprocess(
@@ -30,12 +29,13 @@ case object JarPreprocessor extends Preprocessor {
             )
           )
           Seq(PreprocessedSource.OnDisk(
-            jar.path,
-            Some(buildOptions),
-            Some(BuildRequirements()),
-            Nil,
-            None,
-            None
+            path = jar.path,
+            options = Some(buildOptions),
+            optionsWithTargetRequirements = List.empty,
+            requirements = Some(BuildRequirements()),
+            scopedRequirements = Nil,
+            mainClassOpt = None,
+            directivesPositions = None
           ))
         })
       case _ =>

--- a/modules/build/src/main/scala/scala/build/preprocessing/MarkdownPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/MarkdownPreprocessor.scala
@@ -88,7 +88,7 @@ case object MarkdownPreprocessor extends Preprocessor {
                   allowRestrictedFeatures = allowRestrictedFeatures,
                   suppressWarningOptions = suppressWarningOptions
                 )
-              }.getOrElse(ProcessingOutput(BuildRequirements(), Nil, BuildOptions(), None, None))
+              }.getOrElse(ProcessingOutput.empty)
             val processedCode = processingOutput.updatedContent.getOrElse(wrappedMarkdown.code)
             PreprocessedSource.InMemory(
               originalPath = reportingPath.map(subPath -> _),
@@ -96,6 +96,7 @@ case object MarkdownPreprocessor extends Preprocessor {
               processedCode,
               ignoreLen = 0,
               options = Some(processingOutput.opts),
+              optionsWithTargetRequirements = processingOutput.optsWithReqs,
               requirements = Some(processingOutput.globalReqs),
               processingOutput.scopedReqs,
               mainClassOpt = None,

--- a/modules/build/src/main/scala/scala/build/preprocessing/PreprocessedSource.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/PreprocessedSource.scala
@@ -1,9 +1,10 @@
 package scala.build.preprocessing
 
-import scala.build.options.{BuildOptions, BuildRequirements}
+import scala.build.options.{BuildOptions, BuildRequirements, WithBuildRequirements}
 
 sealed abstract class PreprocessedSource extends Product with Serializable {
   def options: Option[BuildOptions]
+  def optionsWithTargetRequirements: List[WithBuildRequirements[BuildOptions]]
   def requirements: Option[BuildRequirements]
   def mainClassOpt: Option[String]
 
@@ -17,6 +18,7 @@ object PreprocessedSource {
   final case class OnDisk(
     path: os.Path,
     options: Option[BuildOptions],
+    optionsWithTargetRequirements: List[WithBuildRequirements[BuildOptions]],
     requirements: Option[BuildRequirements],
     scopedRequirements: Seq[Scoped[BuildRequirements]],
     mainClassOpt: Option[String],
@@ -31,6 +33,7 @@ object PreprocessedSource {
     code: String,
     ignoreLen: Int,
     options: Option[BuildOptions],
+    optionsWithTargetRequirements: List[WithBuildRequirements[BuildOptions]],
     requirements: Option[BuildRequirements],
     scopedRequirements: Seq[Scoped[BuildRequirements]],
     mainClassOpt: Option[String],
@@ -42,6 +45,7 @@ object PreprocessedSource {
   }
   final case class NoSourceCode(
     options: Option[BuildOptions],
+    optionsWithTargetRequirements: List[WithBuildRequirements[BuildOptions]],
     requirements: Option[BuildRequirements],
     scopedRequirements: Seq[Scoped[BuildRequirements]],
     path: os.Path

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -67,7 +67,6 @@ case object ScalaPreprocessor extends Preprocessor {
   val usingDirectiveHandlers: Seq[DirectiveHandler[BuildOptions]] =
     Seq[DirectiveHandler[_ <: HasBuildOptions]](
       directives.CustomJar.handler,
-      directives.JavacOptions.handler,
       directives.JavaOptions.handler,
       directives.JavaProps.handler,
       directives.JavaHome.handler,
@@ -94,7 +93,8 @@ case object ScalaPreprocessor extends Preprocessor {
   val usingDirectiveWithReqsHandlers
     : Seq[DirectiveHandler[List[WithBuildRequirements[BuildOptions]]]] =
     Seq[DirectiveHandler[_ <: HasBuildOptionsWithRequirements]](
-      directives.Dependency.handler
+      directives.Dependency.handler,
+      directives.JavacOptions.handler
     ).map(_.mapE(_.buildOptionsWithRequirements))
 
   val requireDirectiveHandlers: Seq[DirectiveHandler[BuildRequirements]] =

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -67,7 +67,6 @@ case object ScalaPreprocessor extends Preprocessor {
   val usingDirectiveHandlers: Seq[DirectiveHandler[BuildOptions]] =
     Seq[DirectiveHandler[_ <: HasBuildOptions]](
       directives.CustomJar.handler,
-      directives.JavaOptions.handler,
       directives.JavaProps.handler,
       directives.JavaHome.handler,
       directives.Jvm.handler,
@@ -94,6 +93,7 @@ case object ScalaPreprocessor extends Preprocessor {
     : Seq[DirectiveHandler[List[WithBuildRequirements[BuildOptions]]]] =
     Seq[DirectiveHandler[_ <: HasBuildOptionsWithRequirements]](
       directives.Dependency.handler,
+      directives.JavaOptions.handler,
       directives.JavacOptions.handler
     ).map(_.mapE(_.buildOptionsWithRequirements))
 

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -67,7 +67,6 @@ case object ScalaPreprocessor extends Preprocessor {
 
   val usingDirectiveHandlers: Seq[DirectiveHandler[BuildOptions]] =
     Seq[DirectiveHandler[_ <: HasBuildOptions]](
-      directives.CustomJar.handler,
       directives.JavaHome.handler,
       directives.Jvm.handler,
       directives.MainClass.handler,
@@ -89,6 +88,7 @@ case object ScalaPreprocessor extends Preprocessor {
   val usingDirectiveWithReqsHandlers
     : Seq[DirectiveHandler[List[WithBuildRequirements[BuildOptions]]]] =
     Seq[DirectiveHandler[_ <: HasBuildOptionsWithRequirements]](
+      directives.CustomJar.handler,
       directives.Dependency.handler,
       directives.JavaOptions.handler,
       directives.JavacOptions.handler,

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -35,7 +35,8 @@ case object ScalaPreprocessor extends Preprocessor {
     def isEmpty: Boolean = globalReqs == BuildRequirements.monoid.zero &&
       globalUsings == BuildOptions.monoid.zero &&
       scopedReqs.isEmpty &&
-      strippedContent.isEmpty
+      strippedContent.isEmpty &&
+      usingsWithReqs.isEmpty
   }
 
   private case class SpecialImportsProcessingOutput(
@@ -82,8 +83,7 @@ case object ScalaPreprocessor extends Preprocessor {
       directives.ScalaNative.handler,
       directives.ScalaVersion.handler,
       directives.Sources.handler,
-      directives.Tests.handler,
-      directives.Toolkit.handler
+      directives.Tests.handler
     ).map(_.mapE(_.buildOptions))
 
   val usingDirectiveWithReqsHandlers
@@ -94,7 +94,8 @@ case object ScalaPreprocessor extends Preprocessor {
       directives.JavacOptions.handler,
       directives.JavaProps.handler,
       directives.Resources.handler,
-      directives.ScalacOptions.handler
+      directives.ScalacOptions.handler,
+      directives.Toolkit.handler
     ).map(_.mapE(_.buildOptionsWithRequirements))
 
   val requireDirectiveHandlers: Seq[DirectiveHandler[BuildRequirements]] =

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -78,7 +78,6 @@ case object ScalaPreprocessor extends Preprocessor {
       directives.PublishContextual.CI.handler,
       directives.Python.handler,
       directives.Repository.handler,
-      directives.ScalacOptions.handler,
       directives.ScalaJs.handler,
       directives.ScalaNative.handler,
       directives.ScalaVersion.handler,
@@ -94,7 +93,8 @@ case object ScalaPreprocessor extends Preprocessor {
       directives.JavaOptions.handler,
       directives.JavacOptions.handler,
       directives.JavaProps.handler,
-      directives.Resources.handler
+      directives.Resources.handler,
+      directives.ScalacOptions.handler
     ).map(_.mapE(_.buildOptionsWithRequirements))
 
   val requireDirectiveHandlers: Seq[DirectiveHandler[BuildRequirements]] =

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -67,7 +67,6 @@ case object ScalaPreprocessor extends Preprocessor {
   val usingDirectiveHandlers: Seq[DirectiveHandler[BuildOptions]] =
     Seq[DirectiveHandler[_ <: HasBuildOptions]](
       directives.CustomJar.handler,
-      directives.JavaProps.handler,
       directives.JavaHome.handler,
       directives.Jvm.handler,
       directives.MainClass.handler,
@@ -94,7 +93,8 @@ case object ScalaPreprocessor extends Preprocessor {
     Seq[DirectiveHandler[_ <: HasBuildOptionsWithRequirements]](
       directives.Dependency.handler,
       directives.JavaOptions.handler,
-      directives.JavacOptions.handler
+      directives.JavacOptions.handler,
+      directives.JavaProps.handler
     ).map(_.mapE(_.buildOptionsWithRequirements))
 
   val requireDirectiveHandlers: Seq[DirectiveHandler[BuildRequirements]] =

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -78,7 +78,6 @@ case object ScalaPreprocessor extends Preprocessor {
       directives.PublishContextual.CI.handler,
       directives.Python.handler,
       directives.Repository.handler,
-      directives.Resources.handler,
       directives.ScalacOptions.handler,
       directives.ScalaJs.handler,
       directives.ScalaNative.handler,
@@ -94,7 +93,8 @@ case object ScalaPreprocessor extends Preprocessor {
       directives.Dependency.handler,
       directives.JavaOptions.handler,
       directives.JavacOptions.handler,
-      directives.JavaProps.handler
+      directives.JavaProps.handler,
+      directives.Resources.handler
     ).map(_.mapE(_.buildOptionsWithRequirements))
 
   val requireDirectiveHandlers: Seq[DirectiveHandler[BuildRequirements]] =

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
@@ -86,7 +86,7 @@ object ScriptPreprocessor {
 
     val (pkg, wrapper) = AmmUtil.pathToPackageWrapper(subPath)
 
-    val processingOutput =
+    val processingOutput: ProcessingOutput =
       value(ScalaPreprocessor.process(
         contentIgnoredSheBangLines,
         reportingPath,
@@ -96,7 +96,7 @@ object ScriptPreprocessor {
         allowRestrictedFeatures,
         suppressWarningOptions
       ))
-        .getOrElse(ProcessingOutput(BuildRequirements(), Nil, BuildOptions(), None, None))
+        .getOrElse(ProcessingOutput.empty)
 
     val (code, topWrapperLen, _) = codeWrapper.wrapCode(
       pkg,
@@ -109,16 +109,17 @@ object ScriptPreprocessor {
     val relPath   = os.rel / (subPath / os.up) / s"${subPath.last.stripSuffix(".sc")}.scala"
 
     val file = PreprocessedSource.InMemory(
-      reportingPath.map((subPath, _)),
-      relPath,
-      code,
-      topWrapperLen,
-      Some(processingOutput.opts),
-      Some(processingOutput.globalReqs),
-      processingOutput.scopedReqs,
-      Some(CustomCodeWrapper.mainClassObject(Name(className)).backticked),
-      scopePath,
-      processingOutput.directivesPositions
+      originalPath = reportingPath.map((subPath, _)),
+      relPath = relPath,
+      code = code,
+      ignoreLen = topWrapperLen,
+      options = Some(processingOutput.opts),
+      optionsWithTargetRequirements = processingOutput.optsWithReqs,
+      requirements = Some(processingOutput.globalReqs),
+      scopedRequirements = processingOutput.scopedReqs,
+      mainClassOpt = Some(CustomCodeWrapper.mainClassObject(Name(className)).backticked),
+      scopePath = scopePath,
+      directivesPositions = processingOutput.directivesPositions
     )
     List(file)
   }

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
@@ -174,6 +174,19 @@ class DirectiveTests extends munit.FunSuite {
         expect(if isTestScope then hasTestJavaProps else !hasTestJavaProps)
       }
     }
+    test(s"resolve test scope resourceDir correctly when building for ${scope.name} scope") {
+      withProjectFile(projectFileContent =
+        """//> using resourceDir "./mainResources"
+          |//> using test.resourceDir "./testResources"
+          |//> using test.dep "org.scalameta::munit::0.7.29"
+          |""".stripMargin
+      ) { (build, isTestScope) =>
+        val resourcesDirs = build.options.classPathOptions.resourcesDir
+        expect(resourcesDirs.exists(_.last == "mainResources"))
+        val hasTestResources = resourcesDirs.exists(_.last == "testResources")
+        expect(if isTestScope then hasTestResources else !hasTestResources)
+      }
+    }
   }
 
   test("handling special syntax for path") {

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
@@ -200,6 +200,19 @@ class DirectiveTests extends munit.FunSuite {
         expect(if isTestScope then hasTestResources else !hasTestResources)
       }
     }
+    test(s"resolve test scope toolkit dependency correctly when building for ${scope.name} scope") {
+      withProjectFile(
+        projectFileContent =
+          s"""//> using test.toolkit "latest"
+             |""".stripMargin
+      ) { (build, isTestScope) =>
+        val deps = build.options.classPathOptions.extraDependencies.toSeq.map(_.value)
+        if isTestScope then expect(deps.nonEmpty)
+        val hasToolkitDep =
+          deps.exists(d => d.organization == "org.scala-lang" && d.name == "toolkit")
+        expect(if isTestScope then hasToolkitDep else !hasToolkitDep)
+      }
+    }
   }
 
   test("handling special syntax for path") {

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
@@ -3,11 +3,10 @@ package scala.build.tests
 import com.eed3si9n.expecty.Expecty.expect
 
 import java.io.IOException
-import scala.build.{BuildThreads, Directories, LocalRepo, Position, Positioned}
+import scala.build.{Build, BuildThreads, Directories, LocalRepo, Position, Positioned}
 import scala.build.options.{BuildOptions, InternalOptions, MaybeScalaVersion, ScalacOpt, Scope}
 import scala.build.tests.util.BloopServer
 import build.Ops.EitherThrowOps
-import scala.build.Position
 import dependency.AnyDependency
 
 class DirectiveTests extends munit.FunSuite {
@@ -106,37 +105,50 @@ class DirectiveTests extends munit.FunSuite {
         expect(toolkitDep.version == "latest.release")
     }
   }
-  for (scope <- Scope.all)
-    test(s"resolve test scope directives correctly when building for ${scope.name} scope") {
-      val inputs = TestInputs(
-        os.rel / "project.scala" ->
-          """//> using dep "com.lihaoyi::os-lib:0.9.1"
-            |//> using test.dep "org.scalameta::munit::0.7.29"
-            |""".stripMargin,
-        os.rel / "Tests.test.scala" ->
-          """class Tests extends munit.FunSuite {
-            |  test("foo") {
-            |    println("foo")
-            |  }
-            |}
-            |""".stripMargin
-      )
-      inputs.withBuild(baseOptions, buildThreads, bloopConfigOpt, scope = scope) {
-        (_, _, maybeBuild) =>
-          val isTestScope = scope == Scope.Test
-          val build       = maybeBuild.orThrow
-          val deps        = build.options.classPathOptions.extraDependencies.toSeq.map(_.value)
-          expect(deps.nonEmpty)
-          val hasMainDeps = deps.exists(d =>
-            d.organization == "com.lihaoyi" && d.name == "os-lib" && d.version == "0.9.1"
-          )
-          val hasTestDeps = deps.exists(d =>
-            d.organization == "org.scalameta" && d.name == "munit" && d.version == "0.7.29"
-          )
-          expect(hasMainDeps)
-          expect(if isTestScope then hasTestDeps else !hasTestDeps)
+  for (scope <- Scope.all) {
+    def withProjectFile[T](projectFileContent: String)(f: (Build, Boolean) => T): T = TestInputs(
+      os.rel / "project.scala" -> projectFileContent,
+      os.rel / "Tests.test.scala" ->
+        """class Tests extends munit.FunSuite {
+          |  test("foo") {
+          |    println("foo")
+          |  }
+          |}
+          |""".stripMargin
+    ).withBuild(baseOptions, buildThreads, bloopConfigOpt, scope = scope) { (_, _, maybeBuild) =>
+      f(maybeBuild.orThrow, scope == Scope.Test)
+    }
+
+    test(s"resolve test scope dependencies correctly when building for ${scope.name} scope") {
+      withProjectFile(projectFileContent = """//> using dep "com.lihaoyi::os-lib:0.9.1"
+                                             |//> using test.dep "org.scalameta::munit::0.7.29"
+                                             |""".stripMargin) { (build, isTestScope) =>
+        val deps = build.options.classPathOptions.extraDependencies.toSeq.map(_.value)
+        expect(deps.nonEmpty)
+        val hasMainDeps = deps.exists(d =>
+          d.organization == "com.lihaoyi" && d.name == "os-lib" && d.version == "0.9.1"
+        )
+        val hasTestDeps = deps.exists(d =>
+          d.organization == "org.scalameta" && d.name == "munit" && d.version == "0.7.29"
+        )
+        expect(hasMainDeps)
+        expect(if isTestScope then hasTestDeps else !hasTestDeps)
       }
     }
+    test(s"resolve test scope javacOpts correctly when building for ${scope.name} scope") {
+      withProjectFile(projectFileContent =
+        """//> using javacOpt "source", "1.8"
+          |//> using test.javacOpt "target", "1.8"
+          |//> using test.dep "org.scalameta::munit::0.7.29"
+          |""".stripMargin
+      ) { (build, isTestScope) =>
+        val javacOpts = build.options.javaOptions.javacOptions.map(_.value)
+        expect(javacOpts.contains("source"))
+        val hasTestJavacOpts = javacOpts.contains("target")
+        expect(if isTestScope then hasTestJavacOpts else !hasTestJavacOpts)
+      }
+    }
+  }
 
   test("handling special syntax for path") {
     val filePath = os.rel / "src" / "simple.scala"

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
@@ -161,6 +161,19 @@ class DirectiveTests extends munit.FunSuite {
         expect(if isTestScope then hasTestJavaOpts else !hasTestJavaOpts)
       }
     }
+    test(s"resolve test scope javaProps correctly when building for ${scope.name} scope") {
+      withProjectFile(projectFileContent =
+        """//> using javaProp "foo=1"
+          |//> using test.javaProp "bar=2"
+          |//> using test.dep "org.scalameta::munit::0.7.29"
+          |""".stripMargin
+      ) { (build, isTestScope) =>
+        val javaProps = build.options.javaOptions.javaOpts.toSeq.map(_.value.value)
+        expect(javaProps.contains("-Dfoo=1"))
+        val hasTestJavaProps = javaProps.contains("-Dbar=2")
+        expect(if isTestScope then hasTestJavaProps else !hasTestJavaProps)
+      }
+    }
   }
 
   test("handling special syntax for path") {

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
@@ -148,6 +148,19 @@ class DirectiveTests extends munit.FunSuite {
         expect(if isTestScope then hasTestJavacOpts else !hasTestJavacOpts)
       }
     }
+    test(s"resolve test scope javaOpts correctly when building for ${scope.name} scope") {
+      withProjectFile(projectFileContent =
+        """//> using javaOpt "-Xmx2g"
+          |//> using test.javaOpt "-Dsomething=a"
+          |//> using test.dep "org.scalameta::munit::0.7.29"
+          |""".stripMargin
+      ) { (build, isTestScope) =>
+        val javaOpts = build.options.javaOptions.javaOpts.toSeq.map(_.value.value)
+        expect(javaOpts.contains("-Xmx2g"))
+        val hasTestJavaOpts = javaOpts.contains("-Dsomething=a")
+        expect(if isTestScope then hasTestJavaOpts else !hasTestJavaOpts)
+      }
+    }
   }
 
   test("handling special syntax for path") {

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
@@ -148,6 +148,19 @@ class DirectiveTests extends munit.FunSuite {
         expect(if isTestScope then hasTestJavacOpts else !hasTestJavacOpts)
       }
     }
+    test(s"resolve test scope scalac opts correctly when building for ${scope.name} scope") {
+      withProjectFile(projectFileContent =
+        """//> using option "--explain"
+          |//> using test.option "-deprecation"
+          |//> using test.dep "org.scalameta::munit::0.7.29"
+          |""".stripMargin
+      ) { (build, isTestScope) =>
+        val scalacOpts = build.options.scalaOptions.scalacOptions.toSeq.map(_.value.value)
+        expect(scalacOpts.contains("--explain"))
+        val hasTestScalacOpts = scalacOpts.contains("-deprecation")
+        expect(if isTestScope then hasTestScalacOpts else !hasTestScalacOpts)
+      }
+    }
     test(s"resolve test scope javaOpts correctly when building for ${scope.name} scope") {
       withProjectFile(projectFileContent =
         """//> using javaOpt "-Xmx2g"

--- a/modules/directives/src/main/scala/scala/build/directives/HasBuildOptions.scala
+++ b/modules/directives/src/main/scala/scala/build/directives/HasBuildOptions.scala
@@ -1,9 +1,10 @@
 package scala.build.directives
 
 import scala.build.errors.BuildException
-import scala.build.options.BuildOptions
+import scala.build.options.{BuildOptions, HasScope}
 import scala.build.preprocessing.ScopePath
 
 trait HasBuildOptions {
   def buildOptions: Either[BuildException, BuildOptions]
+  HasScope
 }

--- a/modules/directives/src/main/scala/scala/build/directives/HasBuildOptionsWithRequirements.scala
+++ b/modules/directives/src/main/scala/scala/build/directives/HasBuildOptionsWithRequirements.scala
@@ -1,0 +1,9 @@
+package scala.build.directives
+
+import scala.build.errors.BuildException
+import scala.build.options.{BuildOptions, WithBuildRequirements}
+
+trait HasBuildOptionsWithRequirements {
+  def buildOptionsWithRequirements
+    : Either[BuildException, List[WithBuildRequirements[BuildOptions]]]
+}

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/CustomJar.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/CustomJar.scala
@@ -1,9 +1,10 @@
 package scala.build.preprocessing.directives
-import scala.build.Ops._
+import scala.build.Ops.*
 import scala.build.directives.*
 import scala.build.errors.{BuildException, CompositeBuildException, WrongJarPathError}
-import scala.build.options.{BuildOptions, ClassPathOptions}
+import scala.build.options.{BuildOptions, ClassPathOptions, Scope, WithBuildRequirements}
 import scala.build.preprocessing.ScopePath
+import scala.build.preprocessing.directives.CustomJar.buildOptions
 import scala.build.{Logger, Positioned}
 import scala.cli.commands.SpecificationLevel
 import scala.util.{Failure, Success, Try}
@@ -11,6 +12,8 @@ import scala.util.{Failure, Success, Try}
 @DirectiveGroupName("Custom JAR")
 @DirectiveExamples(
   "//> using jar \"/Users/alexandre/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/chuusai/shapeless_2.13/2.3.7/shapeless_2.13-2.3.7.jar\""
+) @DirectiveExamples(
+  "//> using test.jar \"/Users/alexandre/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/chuusai/shapeless_2.13/2.3.7/shapeless_2.13-2.3.7.jar\""
 )
 @DirectiveUsage(
   "`//> using jar `_path_ | `//> using jars `_path1_, _path2_ …",
@@ -23,9 +26,30 @@ import scala.util.{Failure, Success, Try}
 final case class CustomJar(
   @DirectiveName("jars")
   jar: DirectiveValueParser.WithScopePath[List[Positioned[String]]] =
+    DirectiveValueParser.WithScopePath.empty(Nil),
+  @DirectiveName("test.jar")
+  @DirectiveName("test.jars")
+  testJar: DirectiveValueParser.WithScopePath[List[Positioned[String]]] =
     DirectiveValueParser.WithScopePath.empty(Nil)
-) extends HasBuildOptions {
-  def buildOptions: Either[BuildException, BuildOptions] = {
+) extends HasBuildOptionsWithRequirements {
+  override def buildOptionsWithRequirements
+    : Either[BuildException, List[WithBuildRequirements[BuildOptions]]] =
+    Seq(
+      buildOptions(jar).map(_.withEmptyRequirements),
+      buildOptions(testJar).map(_.withScopeRequirement(Scope.Test))
+    )
+      .sequence
+      .left
+      .map(CompositeBuildException(_))
+      .map(_.toList)
+
+}
+
+object CustomJar {
+  val handler: DirectiveHandler[CustomJar] = DirectiveHandler.derive
+
+  def buildOptions(jar: DirectiveValueParser.WithScopePath[List[Positioned[String]]])
+    : Either[BuildException, BuildOptions] = {
     val cwd = jar.scopePath
     jar.value
       .map { posPathStr =>
@@ -47,8 +71,4 @@ final case class CustomJar(
         )
       }
   }
-}
-
-object CustomJar {
-  val handler: DirectiveHandler[CustomJar] = DirectiveHandler.derive
 }

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavaOptions.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavaOptions.scala
@@ -2,34 +2,38 @@ package scala.build.preprocessing.directives
 
 import scala.build.directives.*
 import scala.build.errors.BuildException
-import scala.build.options.{BuildOptions, JavaOpt, ShadowingSeq}
+import scala.build.options.{BuildOptions, JavaOpt, Scope, ShadowingSeq, WithBuildRequirements}
+import scala.build.preprocessing.directives.JavaOptions.buildOptions
 import scala.build.{Logger, Positioned, options}
 import scala.cli.commands.SpecificationLevel
 
 @DirectiveGroupName("Java options")
 @DirectiveExamples("//> using javaOpt \"-Xmx2g\", \"-Dsomething=a\"")
+@DirectiveExamples("//> using test.javaOpt \"-Dsomething=a\"")
 @DirectiveUsage(
   "//> using javaOpt _options_",
   "`//> using javaOpt `_options_"
 )
 @DirectiveDescription("Add Java options which will be passed when running an application.")
 @DirectiveLevel(SpecificationLevel.MUST)
-// format: off
 final case class JavaOptions(
   @DirectiveName("javaOpt")
-    javaOptions: List[Positioned[String]] = Nil
-) extends HasBuildOptions {
-  // format: on
-  def buildOptions: Either[BuildException, BuildOptions] = {
-    val buildOpt = BuildOptions(
-      javaOptions = options.JavaOptions(
-        javaOpts = ShadowingSeq.from(javaOptions.map(_.map(JavaOpt(_))))
-      )
-    )
-    Right(buildOpt)
-  }
+  javaOptions: List[Positioned[String]] = Nil,
+  @DirectiveName("test.javaOpt")
+  testJavaOptions: List[Positioned[String]] = Nil
+) extends HasBuildOptionsWithRequirements {
+  def buildOptionsWithRequirements
+    : Either[BuildException, List[WithBuildRequirements[BuildOptions]]] =
+    Right(List(
+      buildOptions(javaOptions).withEmptyRequirements,
+      buildOptions(testJavaOptions).withScopeRequirement(Scope.Test)
+    ))
 }
 
 object JavaOptions {
   val handler: DirectiveHandler[JavaOptions] = DirectiveHandler.derive
+  def buildOptions(javaOptions: List[Positioned[String]]): BuildOptions =
+    BuildOptions(javaOptions =
+      options.JavaOptions(javaOpts = ShadowingSeq.from(javaOptions.map(_.map(JavaOpt(_)))))
+    )
 }

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavacOptions.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavacOptions.scala
@@ -2,34 +2,38 @@ package scala.build.preprocessing.directives
 
 import scala.build.directives.*
 import scala.build.errors.BuildException
-import scala.build.options.{BuildOptions, JavaOpt, ShadowingSeq}
+import scala.build.options.{BuildOptions, JavaOpt, Scope, ShadowingSeq, WithBuildRequirements}
+import scala.build.preprocessing.directives.JavacOptions.buildOptions
 import scala.build.{Logger, Positioned, options}
 import scala.cli.commands.SpecificationLevel
 
 @DirectiveGroupName("Javac options")
 @DirectiveExamples("//> using javacOpt \"source\", \"1.8\", \"target\", \"1.8\"")
+@DirectiveExamples("//> using test.javacOpt \"source\", \"1.8\", \"target\", \"1.8\"")
 @DirectiveUsage(
   "//> using javacOpt _options_",
   "`//> using javacOpt `_options_"
 )
 @DirectiveDescription("Add Javac options which will be passed when compiling sources.")
 @DirectiveLevel(SpecificationLevel.SHOULD)
-// format: off
 final case class JavacOptions(
   @DirectiveName("javacOpt")
-    javacOptions: List[Positioned[String]] = Nil
-) extends HasBuildOptions {
-  // format: on
-  def buildOptions: Either[BuildException, BuildOptions] = {
-    val buildOpt = BuildOptions(
-      javaOptions = options.JavaOptions(
-        javacOptions = javacOptions
-      )
-    )
-    Right(buildOpt)
-  }
+  javacOptions: List[Positioned[String]] = Nil,
+  @DirectiveName("test.javacOpt")
+  testJavacOptions: List[Positioned[String]] = Nil
+) extends HasBuildOptionsWithRequirements {
+
+  def buildOptionsWithRequirements
+    : Either[BuildException, List[WithBuildRequirements[BuildOptions]]] =
+    Right(List(
+      buildOptions(javacOptions).withEmptyRequirements,
+      buildOptions(testJavacOptions).withScopeRequirement(Scope.Test)
+    ))
 }
 
 object JavacOptions {
   val handler: DirectiveHandler[JavacOptions] = DirectiveHandler.derive
+
+  def buildOptions(javacOptions: List[Positioned[String]]): BuildOptions =
+    BuildOptions(javaOptions = options.JavaOptions(javacOptions = javacOptions))
 }

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalacOptions.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalacOptions.scala
@@ -2,12 +2,21 @@ package scala.build.preprocessing.directives
 
 import scala.build.directives.*
 import scala.build.errors.BuildException
-import scala.build.options.{BuildOptions, ScalaOptions, ScalacOpt, ShadowingSeq}
+import scala.build.options.{
+  BuildOptions,
+  ScalaOptions,
+  ScalacOpt,
+  Scope,
+  ShadowingSeq,
+  WithBuildRequirements
+}
+import scala.build.preprocessing.directives.ScalacOptions.buildOptions
 import scala.build.{Logger, Positioned}
 import scala.cli.commands.SpecificationLevel
 
 @DirectiveGroupName("Compiler options")
 @DirectiveExamples("//> using option \"-Xasync\"")
+@DirectiveExamples("//> using test.option \"-Xasync\"")
 @DirectiveExamples("//> using options \"-Xasync\", \"-Xfatal-warnings\"")
 @DirectiveUsage(
   "using option _option_ | using options _option1_ _option2_ …",
@@ -17,22 +26,28 @@ import scala.cli.commands.SpecificationLevel
 )
 @DirectiveDescription("Add Scala compiler options")
 @DirectiveLevel(SpecificationLevel.MUST)
-// format: off
 final case class ScalacOptions(
   @DirectiveName("option")
-    options: List[Positioned[String]] = Nil
-) extends HasBuildOptions {
-  // format: on
-  def buildOptions: Either[BuildException, BuildOptions] = {
-    val buildOpt = BuildOptions(
-      scalaOptions = ScalaOptions(
-        scalacOptions = ShadowingSeq.from(options.map(_.map(ScalacOpt(_))))
-      )
-    )
-    Right(buildOpt)
-  }
+  options: List[Positioned[String]] = Nil,
+  @DirectiveName("test.option")
+  @DirectiveName("test.options")
+  @DirectiveName("test.scalacOptions")
+  testOptions: List[Positioned[String]] = Nil
+) extends HasBuildOptionsWithRequirements {
+  def buildOptionsWithRequirements
+    : Either[BuildException, List[WithBuildRequirements[BuildOptions]]] =
+    Right(List(
+      buildOptions(options).withEmptyRequirements,
+      buildOptions(testOptions).withScopeRequirement(Scope.Test)
+    ))
 }
 
 object ScalacOptions {
   val handler: DirectiveHandler[ScalacOptions] = DirectiveHandler.derive
+  def buildOptions(options: List[Positioned[String]]): BuildOptions =
+    BuildOptions(
+      scalaOptions = ScalaOptions(
+        scalacOptions = ShadowingSeq.from(options.map(_.map(ScalacOpt(_))))
+      )
+    )
 }

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Toolkit.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Toolkit.scala
@@ -8,34 +8,42 @@ import scala.build.EitherCps.{either, value}
 import scala.build.directives.*
 import scala.build.errors.BuildException
 import scala.build.internal.Constants
-import scala.build.options.{BuildOptions, ClassPathOptions, JavaOpt, Scope, ShadowingSeq}
+import scala.build.options.{
+  BuildOptions,
+  ClassPathOptions,
+  JavaOpt,
+  Scope,
+  ShadowingSeq,
+  WithBuildRequirements
+}
+import scala.build.preprocessing.directives.Toolkit.buildOptions
 import scala.build.{Artifacts, Logger, Positioned, options}
 import scala.cli.commands.SpecificationLevel
 
 @DirectiveGroupName("Toolkit")
 @DirectiveExamples("//> using toolkit \"0.1.0\"")
 @DirectiveExamples("//> using toolkit \"latest\"")
+@DirectiveExamples("//> using test.toolkit \"latest\"")
 @DirectiveUsage(
   "//> using toolkit _version_",
   "`//> using toolkit` _version_"
 )
 @DirectiveDescription("Use a toolkit as dependency")
 @DirectiveLevel(SpecificationLevel.SHOULD)
-// format: off
 final case class Toolkit(
-  toolkit: Option[Positioned[String]] = None
-) extends HasBuildOptions {
-  // format: on
-  def buildOptions: Either[BuildException, BuildOptions] = {
-    val toolkitDep =
-      toolkit.toList.map(Toolkit.resolveDependency)
-    val buildOpt = BuildOptions(
-      classPathOptions = ClassPathOptions(
-        extraDependencies = ShadowingSeq.from(toolkitDep)
+  toolkit: Option[Positioned[String]] = None,
+  @DirectiveName("test.toolkit")
+  testToolkit: Option[Positioned[String]] = None
+) extends HasBuildOptionsWithRequirements {
+  def buildOptionsWithRequirements
+    : Either[BuildException, List[WithBuildRequirements[BuildOptions]]] =
+    Right {
+      val mainBuildOpts = buildOptions(toolkit)
+      val testBuildOpts = buildOptions(testToolkit)
+      mainBuildOpts.toList.map(_.withEmptyRequirements) ++ testBuildOpts.toList.map(
+        _.withScopeRequirement(Scope.Test)
       )
-    )
-    Right(buildOpt)
-  }
+    }
 }
 
 object Toolkit {
@@ -44,4 +52,12 @@ object Toolkit {
     dep"${Constants.toolkitOrganization}::${Constants.toolkitName}::$v,toolkit"
   )
   val handler: DirectiveHandler[Toolkit] = DirectiveHandler.derive
+
+  def buildOptions(toolkit: Option[Positioned[String]]): Option[BuildOptions] = toolkit.map { t =>
+    BuildOptions(
+      classPathOptions = ClassPathOptions(
+        extraDependencies = ShadowingSeq.from(List(resolveDependency(t)))
+      )
+    )
+  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -1253,4 +1253,78 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
         .call(cwd = root, stderr = os.Pipe)
     }
   }
+  test("declare test scope custom jar from main scope") {
+    val projectFile      = "project.scala"
+    val testMessageFile  = "TestMessage.scala"
+    val mainMessageFile  = "MainMessage.scala"
+    val validMainFile    = "ValidMain.scala"
+    val invalidMainFile  = "InvalidMain.scala"
+    val testFile         = "Tests.test.scala"
+    val expectedMessage1 = "Hello"
+    val expectedMessage2 = " world!"
+    val jarPathsWithFiles @ Seq((mainMessageJar, _), (testMessageJar, _)) =
+      Seq(
+        os.rel / "MainMessage.jar" -> mainMessageFile,
+        os.rel / "TestMessage.jar" -> testMessageFile
+      )
+    TestInputs(
+      os.rel / projectFile ->
+        s"""//> using jar "$mainMessageJar"
+           |//> using test.jar "$testMessageJar"
+           |//> using test.dep "org.scalameta::munit::0.7.29"
+           |""".stripMargin,
+      os.rel / mainMessageFile ->
+        """case class MainMessage(value: String)
+          |""".stripMargin,
+      os.rel / testMessageFile ->
+        """case class TestMessage(value: String)
+          |""".stripMargin,
+      os.rel / invalidMainFile ->
+        s"""object InvalidMain extends App {
+           |  println(TestMessage("$expectedMessage1").value)
+           |}
+           |""".stripMargin,
+      os.rel / validMainFile ->
+        s"""object ValidMain extends App {
+           |  println(MainMessage("$expectedMessage1").value)
+           |}
+           |""".stripMargin,
+      os.rel / testFile ->
+        s"""class Tests extends munit.FunSuite {
+           |  val msg1 = MainMessage("$expectedMessage1").value
+           |  val msg2 = TestMessage("$expectedMessage2").value
+           |  val testName = msg1 + msg2
+           |  test(testName) {
+           |    assert(1 + 1 == 2)
+           |  }
+           |}
+           |""".stripMargin
+    ).fromRoot { root =>
+      // package the MainMessage and TestMessage jars
+      for ((jarPath, sourcePath) <- jarPathsWithFiles)
+        os.proc(
+          TestUtil.cli,
+          "--power",
+          "package",
+          sourcePath,
+          "--library",
+          "-o",
+          jarPath,
+          extraOptions
+        )
+          .call(cwd = root)
+      // running `invalidMainFile` should fail, as it's in the main scope and depends on the test scope jar
+      val res1 = os.proc(TestUtil.cli, "run", projectFile, invalidMainFile, extraOptions)
+        .call(cwd = root, check = false)
+      expect(res1.exitCode == 1)
+      // running `validMainFile` should succeed, since it only depends on the main scope jar
+      val res2 = os.proc(TestUtil.cli, "run", projectFile, validMainFile, extraOptions)
+        .call(cwd = root)
+      expect(res2.out.trim() == expectedMessage1)
+      // test scope should have access to both main and test deps
+      val res3 = os.proc(TestUtil.cli, "test", projectFile, testFile, extraOptions)
+        .call(cwd = root, stderr = os.Pipe)
+      expect(res3.out.trim().contains(s"$expectedMessage1$expectedMessage2"))
+    }
+  }
 }

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -21,6 +21,7 @@ import scala.build.internal.Constants.*
 import scala.build.internal.CsLoggerUtil.*
 import scala.build.internal.Regexes.scala3NightlyNicknameRegex
 import scala.build.internal.{Constants, OsLibc, StableScalaVersion}
+import scala.build.options.BuildRequirements.ScopeRequirement
 import scala.build.options.validation.BuildOptionsRule
 import scala.build.{Artifacts, Logger, Os, Position, Positioned}
 import scala.collection.immutable.Seq
@@ -486,6 +487,16 @@ final case class BuildOptions(
 
   lazy val interactive: Either[BuildException, Interactive] =
     internal.interactive.map(_()).getOrElse(Right(InteractiveNop))
+
+  def withBuildRequirements(buildRequirements: BuildRequirements)
+    : WithBuildRequirements[BuildOptions] =
+    WithBuildRequirements(buildRequirements, this)
+
+  def withEmptyRequirements: WithBuildRequirements[BuildOptions] =
+    withBuildRequirements(BuildRequirements())
+
+  def withScopeRequirement(scope: Scope): WithBuildRequirements[BuildOptions] =
+    withBuildRequirements(BuildRequirements(scope = Some(ScopeRequirement(scope = scope))))
 }
 
 object BuildOptions {

--- a/modules/options/src/main/scala/scala/build/options/BuildRequirements.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildRequirements.scala
@@ -22,6 +22,7 @@ final case class BuildRequirements(
     }
   def isEmpty: Boolean =
     this == BuildRequirements()
+  def nonEmpty: Boolean = !isEmpty
   def orElse(other: BuildRequirements): BuildRequirements =
     BuildRequirements.monoid.orElse(this, other)
 }

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -341,6 +341,8 @@ Use a toolkit as dependency
 
 `//> using toolkit "latest"`
 
+`//> using test.toolkit "latest"`
+
 
 ## target directives
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -56,9 +56,11 @@ Add dependencies
 `//> using dep "`_org_`:`name`:`ver"
 
 #### Examples
-`//> using dep "org.scalatest::scalatest:3.2.10"`
+`//> using dep "com.lihaoyi::os-lib:0.9.1"`
 
-`//> using dep "org.scalameta::munit:0.7.29"`
+`//> using test.dep "org.scalatest::scalatest:3.2.10"`
+
+`//> using test.dep "org.scalameta::munit:0.7.29"`
 
 `//> using dep "tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar"`
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -107,6 +107,8 @@ Add Java properties
 #### Examples
 `//> using javaProp "foo1=bar", "foo2"`
 
+`//> using test.javaProp "foo3=bar", "foo4"`
+
 ### Javac options
 
 Add Javac options which will be passed when compiling sources.

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -40,6 +40,8 @@ Manually add JAR(s) to the class path
 #### Examples
 `//> using jar "/Users/alexandre/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/chuusai/shapeless_2.13/2.3.7/shapeless_2.13-2.3.7.jar"`
 
+`//> using test.jar "/Users/alexandre/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/chuusai/shapeless_2.13/2.3.7/shapeless_2.13-2.3.7.jar"`
+
 ### Custom sources
 
 Manually add sources to the project

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -16,6 +16,8 @@ Add Scala compiler options
 #### Examples
 `//> using option "-Xasync"`
 
+`//> using test.option "-Xasync"`
+
 `//> using options "-Xasync", "-Xfatal-warnings"`
 
 ### Compiler plugins

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -114,6 +114,8 @@ Add Javac options which will be passed when compiling sources.
 #### Examples
 `//> using javacOpt "source", "1.8", "target", "1.8"`
 
+`//> using test.javacOpt "source", "1.8", "target", "1.8"`
+
 ### Main class
 
 Specify default main class

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -242,6 +242,8 @@ Manually add a resource directory to the class path
 #### Examples
 `//> using resourceDir "./resources"`
 
+`//> using test.resourceDir "./resources"`
+
 ### Scala Native options
 
 Add Scala Native options

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -95,6 +95,8 @@ Add Java options which will be passed when running an application.
 #### Examples
 `//> using javaOpt "-Xmx2g", "-Dsomething=a"`
 
+`//> using test.javaOpt "-Dsomething=a"`
+
 ### Java properties
 
 Add Java properties

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -110,6 +110,8 @@ Manually add JAR(s) to the class path
 #### Examples
 `//> using jar "/Users/alexandre/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/chuusai/shapeless_2.13/2.3.7/shapeless_2.13-2.3.7.jar"`
 
+`//> using test.jar "/Users/alexandre/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/chuusai/shapeless_2.13/2.3.7/shapeless_2.13-2.3.7.jar"`
+
 ### Custom sources
 
 Manually add sources to the project

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -146,6 +146,8 @@ Add Javac options which will be passed when compiling sources.
 #### Examples
 `//> using javacOpt "source", "1.8", "target", "1.8"`
 
+`//> using test.javacOpt "source", "1.8", "target", "1.8"`
+
 ### Platform
 
 Set the default platform to Scala.js or Scala Native

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -271,3 +271,5 @@ Use a toolkit as dependency
 
 `//> using toolkit "latest"`
 
+`//> using test.toolkit "latest"`
+

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -40,9 +40,11 @@ Add dependencies
 `//> using dep "`_org_`:`name`:`ver"
 
 #### Examples
-`//> using dep "org.scalatest::scalatest:3.2.10"`
+`//> using dep "com.lihaoyi::os-lib:0.9.1"`
 
-`//> using dep "org.scalameta::munit:0.7.29"`
+`//> using test.dep "org.scalatest::scalatest:3.2.10"`
+
+`//> using test.dep "org.scalameta::munit:0.7.29"`
 
 `//> using dep "tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar"`
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -187,6 +187,8 @@ Manually add a resource directory to the class path
 #### Examples
 `//> using resourceDir "./resources"`
 
+`//> using test.resourceDir "./resources"`
+
 ### Scala Native options
 
 Add Scala Native options

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -22,6 +22,8 @@ Add Scala compiler options
 #### Examples
 `//> using option "-Xasync"`
 
+`//> using test.option "-Xasync"`
+
 `//> using options "-Xasync", "-Xfatal-warnings"`
 
 ### Compiler plugins

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -57,6 +57,8 @@ Add Java options which will be passed when running an application.
 #### Examples
 `//> using javaOpt "-Xmx2g", "-Dsomething=a"`
 
+`//> using test.javaOpt "-Dsomething=a"`
+
 ### Java properties
 
 Add Java properties

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -69,6 +69,8 @@ Add Java properties
 #### Examples
 `//> using javaProp "foo1=bar", "foo2"`
 
+`//> using test.javaProp "foo3=bar", "foo4"`
+
 ### Main class
 
 Specify default main class


### PR DESCRIPTION
Fixes #1729 

Some select directives (and not others) can now be declared for the test scope even in main scope sources. 
Those now support a separate key with the `test.*` prefix, indicating the test scope target.
The recommended location for declaring such directives would be the optional `project.scala` configuration file.

Directives supporting this feature:
```scala
//> using test.jar "<custom jar path>"
//> using test.dep "<dependency>"
//> using test.option "<scalac option>"
//> using test.javacOpt "<javac option>"
//> using test.javaOpt "<java option>"
//> using test.javaProp "<java properties>"
//> using test.toolkit "latest"
//> using test.resourceDir "<resources directory>"
```