### PR TITLE
NIT Remove dead `BuildDeps`

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -180,10 +180,6 @@ object Deps {
   def zipInputStream = ivy"io.github.alexarchambault.scala-cli.tmp:zip-input-stream:0.1.1"
 }
 
-object BuildDeps {
-  def scalaCliVersion = "0.1.9"
-}
-
 def graalVmVersion     = "22.3.0"
 def graalVmJavaVersion = 17
 def graalVmJvmId       = s"graalvm-java$graalVmJavaVersion:$graalVmVersion"

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -2,7 +2,7 @@ import $ivy.`com.goyeau::mill-scalafix::0.2.8`
 import $ivy.`io.github.alexarchambault.mill::mill-native-image::0.1.23`
 
 import $file.deps,
-deps.{BuildDeps, Deps, Docker, alpineVersion, buildCsVersion, buildCsM1Version, libsodiumVersion}
+deps.{Deps, Docker, alpineVersion, buildCsVersion, buildCsM1Version, libsodiumVersion}
 import $file.utils, utils.isArmArchitecture
 
 import com.goyeau.mill.scalafix.ScalafixModule


### PR DESCRIPTION
Seems like this part of code isn't used anywhere... and it refers to an ancient Scala CLI version as well...