### PR TITLE
Allow BSP to start successfully even with unrecognised `using` directives

### DIFF
--- a/modules/build/src/main/scala/scala/build/preprocessing/DataPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/DataPreprocessor.scala
@@ -33,7 +33,8 @@ case object DataPreprocessor extends Preprocessor {
               file.scopePath,
               logger,
               allowRestrictedFeatures,
-              suppressWarningOptions
+              suppressWarningOptions,
+              maybeRecoverOnError
             )
           }
           val inMemory = Seq(

--- a/modules/build/src/main/scala/scala/build/preprocessing/JavaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/JavaPreprocessor.scala
@@ -54,7 +54,8 @@ final case class JavaPreprocessor(
               scopePath,
               logger,
               allowRestrictedFeatures,
-              suppressWarningOptions
+              suppressWarningOptions,
+              maybeRecoverOnError
             )
           }
           Seq(PreprocessedSource.OnDisk(
@@ -95,7 +96,8 @@ final case class JavaPreprocessor(
               v.scopePath,
               logger,
               allowRestrictedFeatures,
-              suppressWarningOptions
+              suppressWarningOptions,
+              maybeRecoverOnError
             )
           }
           val s = PreprocessedSource.InMemory(

--- a/modules/build/src/main/scala/scala/build/preprocessing/MarkdownPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/MarkdownPreprocessor.scala
@@ -86,7 +86,8 @@ case object MarkdownPreprocessor extends Preprocessor {
                   scopeRoot = scopePath / os.up,
                   logger = logger,
                   allowRestrictedFeatures = allowRestrictedFeatures,
-                  suppressWarningOptions = suppressWarningOptions
+                  suppressWarningOptions = suppressWarningOptions,
+                  maybeRecoverOnError = maybeRecoverOnError
                 )
               }.getOrElse(ProcessingOutput.empty)
             val processedCode = processingOutput.updatedContent.getOrElse(wrappedMarkdown.code)

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -196,15 +196,18 @@ case object ScalaPreprocessor extends Preprocessor {
       logger,
       maybeRecoverOnError
     ))
-    value(processSources(
-      content,
-      extractedDirectives,
-      path,
-      scopeRoot,
-      logger,
-      allowRestrictedFeatures,
-      suppressWarningOptions
-    ))
+    value {
+      processSources(
+        content,
+        extractedDirectives,
+        path,
+        scopeRoot,
+        logger,
+        allowRestrictedFeatures,
+        suppressWarningOptions,
+        maybeRecoverOnError
+      )
+    }
   }
 
   def processSources(
@@ -214,7 +217,8 @@ case object ScalaPreprocessor extends Preprocessor {
     scopeRoot: ScopePath,
     logger: Logger,
     allowRestrictedFeatures: Boolean,
-    suppressWarningOptions: SuppressWarningOptions
+    suppressWarningOptions: SuppressWarningOptions,
+    maybeRecoverOnError: BuildException => Option[BuildException]
   ): Either[BuildException, Option[ProcessingOutput]] = either {
     val (content0, isSheBang) = SheBang.ignoreSheBangLines(content)
     val preprocessedDirectives: PreprocessedDirectives =
@@ -224,7 +228,8 @@ case object ScalaPreprocessor extends Preprocessor {
         scopeRoot,
         logger,
         allowRestrictedFeatures,
-        suppressWarningOptions
+        suppressWarningOptions,
+        maybeRecoverOnError
       ))
 
     if (preprocessedDirectives.isEmpty) None

--- a/modules/build/src/main/scala/scala/build/preprocessing/directives/PreprocessedDirectives.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/directives/PreprocessedDirectives.scala
@@ -17,3 +17,15 @@ case class PreprocessedDirectives(
     strippedContent.isEmpty &&
     usingsWithReqs.isEmpty
 }
+
+object PreprocessedDirectives {
+  def empty: PreprocessedDirectives =
+    PreprocessedDirectives(
+      globalReqs = BuildRequirements.monoid.zero,
+      globalUsings = BuildOptions.monoid.zero,
+      usingsWithReqs = Nil,
+      scopedReqs = Nil,
+      strippedContent = None,
+      directivesPositions = None
+    )
+}


### PR DESCRIPTION
~Depends on #2066~
This allows for the BSP server to start successfully on an initial IDE import even when an unrecognised directive is passed.
```scala
//> using invalid.directive "value"
```