### PR TITLE
Pass `invokeData` all the way to pre-processing to give more meaningful error/warning messages

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -221,7 +221,7 @@ object Build {
     buildTests: Boolean,
     partial: Option[Boolean],
     actionableDiagnostics: Option[Boolean]
-  ): Either[BuildException, Builds] = either {
+  )(using ScalaCliInvokeData): Either[BuildException, Builds] = either {
     // allInputs contains elements from using directives
     val (crossSources, allInputs) = value {
       CrossSources.forInputs(
@@ -425,7 +425,7 @@ object Build {
     buildTests: Boolean,
     partial: Option[Boolean],
     actionableDiagnostics: Option[Boolean]
-  ): Either[BuildException, Build] = either {
+  )(using ScalaCliInvokeData): Either[BuildException, Build] = either {
 
     val build0 = value {
       buildOnce(
@@ -547,7 +547,7 @@ object Build {
     buildTests: Boolean,
     partial: Option[Boolean],
     actionableDiagnostics: Option[Boolean]
-  ): Either[BuildException, Builds] = {
+  )(using ScalaCliInvokeData): Either[BuildException, Builds] = {
     val buildClient = BloopBuildClient.create(
       logger,
       keepDiagnostics = options.internal.keepDiagnostics
@@ -621,7 +621,7 @@ object Build {
     partial: Option[Boolean],
     actionableDiagnostics: Option[Boolean],
     postAction: () => Unit = () => ()
-  )(action: Either[BuildException, Builds] => Unit): Watcher = {
+  )(action: Either[BuildException, Builds] => Unit)(using ScalaCliInvokeData): Watcher = {
 
     val buildClient = BloopBuildClient.create(
       logger,
@@ -1212,7 +1212,7 @@ object Build {
     compiler: ScalaCompiler,
     buildTests: Boolean,
     actionableDiagnostics: Option[Boolean]
-  ): Either[BuildException, Option[Build]] = either {
+  )(using ScalaCliInvokeData): Either[BuildException, Option[Build]] = either {
     val jmhProjectName = inputs.projectName + "_jmh"
     val jmhOutputDir   = inputs.workspace / Constants.workspaceDirName / jmhProjectName
     os.remove.all(jmhOutputDir)

--- a/modules/build/src/main/scala/scala/build/CrossSources.scala
+++ b/modules/build/src/main/scala/scala/build/CrossSources.scala
@@ -129,7 +129,7 @@ object CrossSources {
     logger: Logger,
     suppressWarningOptions: SuppressWarningOptions,
     maybeRecoverOnError: BuildException => Option[BuildException] = e => Some(e)
-  ): Either[BuildException, (CrossSources, Inputs)] = either {
+  )(using ScalaCliInvokeData): Either[BuildException, (CrossSources, Inputs)] = either {
 
     def preprocessSources(elems: Seq[SingleElement])
       : Either[BuildException, Seq[PreprocessedSource]] =

--- a/modules/build/src/main/scala/scala/build/bsp/Bsp.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/Bsp.scala
@@ -3,7 +3,7 @@ package scala.build.bsp
 import java.io.{InputStream, OutputStream}
 
 import scala.build.errors.BuildException
-import scala.build.input.Inputs
+import scala.build.input.{Inputs, ScalaCliInvokeData}
 import scala.concurrent.Future
 
 trait Bsp {
@@ -19,7 +19,7 @@ object Bsp {
     in: InputStream,
     out: OutputStream,
     actionableDiagnostics: Option[Boolean]
-  ): Bsp =
+  )(using ScalaCliInvokeData): Bsp =
     new BspImpl(
       argsToInputs,
       bspReloadableOptionsReference,

--- a/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
@@ -21,7 +21,7 @@ import scala.build.errors.{
   Diagnostic,
   ParsingInputsException
 }
-import scala.build.input.Inputs
+import scala.build.input.{Inputs, ScalaCliInvokeData}
 import scala.build.internal.{Constants, CustomCodeWrapper}
 import scala.build.options.{BuildOptions, Scope}
 import scala.collection.mutable.ListBuffer
@@ -50,7 +50,7 @@ final class BspImpl(
   in: InputStream,
   out: OutputStream,
   actionableDiagnostics: Option[Boolean]
-) extends Bsp {
+)(using ScalaCliInvokeData) extends Bsp {
 
   import BspImpl.{PreBuildData, PreBuildProject, buildTargetIdToEvent, responseError}
 

--- a/modules/build/src/main/scala/scala/build/input/ScalaCliInvokeData.scala
+++ b/modules/build/src/main/scala/scala/build/input/ScalaCliInvokeData.scala
@@ -26,6 +26,10 @@ case class ScalaCliInvokeData(
       case _                  => s"$progName $subCommandName"
 }
 
+object ScalaCliInvokeData {
+  def dummy: ScalaCliInvokeData = ScalaCliInvokeData("", "", SubCommand.Other, false)
+}
+
 enum SubCommand:
   case Default extends SubCommand
   case Shebang extends SubCommand

--- a/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
+++ b/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
@@ -1,10 +1,14 @@
 package scala.build.internal.util
 
+import scala.build.input.ScalaCliInvokeData
 import scala.build.internal.Constants
+import scala.build.preprocessing.directives.{DirectiveHandler, ScopedDirective}
+import scala.cli.commands.{SpecificationLevel, tags}
+import scala.cli.config.Key
 
 object WarningMessages {
   private val scalaCliGithubUrl = s"https://github.com/${Constants.ghOrg}/${Constants.ghName}"
-  def experimentalFeatureUsed(featureName: String): String =
+  private def experimentalFeatureUsed(featureName: String): String =
     s"""$featureName is experimental.
        |Please bear in mind that non-ideal user experience should be expected.
        |If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at $scalaCliGithubUrl""".stripMargin
@@ -29,4 +33,38 @@ object WarningMessages {
        |Provide it as an option to the publish subcommand with:
        | $directiveName value:$rawValue
        |""".stripMargin
+
+  private def powerFeatureUsedInSip(
+    featureName: String,
+    featureType: String,
+    specificationLevel: SpecificationLevel
+  )(using invokeData: ScalaCliInvokeData): String = {
+    val powerType =
+      if specificationLevel == SpecificationLevel.EXPERIMENTAL then "experimental" else "restricted"
+    s"""The '$featureName' $featureType is $powerType.
+       |You can run it with the '--power' flag or turn power mode on globally by running:
+       |  ${Console.BOLD}${invokeData.progName} config power true${Console.RESET}.""".stripMargin
+  }
+
+  def powerCommandUsedInSip(commandName: String, specificationLevel: SpecificationLevel)(using
+    ScalaCliInvokeData
+  ): String = powerFeatureUsedInSip(commandName, "sub-command", specificationLevel)
+
+  def powerOptionUsedInSip(optionName: String, specificationLevel: SpecificationLevel)(using
+    ScalaCliInvokeData
+  ): String =
+    powerFeatureUsedInSip(optionName, "option", specificationLevel)
+
+  def powerConfigKeyUsedInSip(key: Key[_])(using ScalaCliInvokeData): String =
+    powerFeatureUsedInSip(key.fullName, "configuration key", key.specificationLevel)
+
+  def powerDirectiveUsedInSip(
+    directive: ScopedDirective,
+    handler: DirectiveHandler[_]
+  )(using ScalaCliInvokeData): String =
+    powerFeatureUsedInSip(
+      directive.directive.toString,
+      "directive",
+      handler.scalaSpecificationLevel
+    )
 }

--- a/modules/build/src/main/scala/scala/build/preprocessing/DataPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/DataPreprocessor.scala
@@ -5,7 +5,7 @@ import java.nio.charset.StandardCharsets
 import scala.build.EitherCps.{either, value}
 import scala.build.Logger
 import scala.build.errors.BuildException
-import scala.build.input.{Inputs, SingleElement, VirtualData}
+import scala.build.input.{Inputs, ScalaCliInvokeData, SingleElement, VirtualData}
 import scala.build.options.{
   BuildOptions,
   BuildRequirements,
@@ -21,7 +21,7 @@ case object DataPreprocessor extends Preprocessor {
     maybeRecoverOnError: BuildException => Option[BuildException] = e => Some(e),
     allowRestrictedFeatures: Boolean,
     suppressWarningOptions: SuppressWarningOptions
-  ): Option[Either[BuildException, Seq[PreprocessedSource]]] =
+  )(using ScalaCliInvokeData): Option[Either[BuildException, Seq[PreprocessedSource]]] =
     input match {
       case file: VirtualData =>
         val res = either {

--- a/modules/build/src/main/scala/scala/build/preprocessing/JarPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/JarPreprocessor.scala
@@ -5,7 +5,7 @@ import java.nio.charset.StandardCharsets
 import scala.build.EitherCps.{either, value}
 import scala.build.Logger
 import scala.build.errors.BuildException
-import scala.build.input.{Inputs, JarFile, SingleElement}
+import scala.build.input.{Inputs, JarFile, ScalaCliInvokeData, SingleElement}
 import scala.build.options.{
   BuildOptions,
   BuildRequirements,
@@ -20,7 +20,7 @@ case object JarPreprocessor extends Preprocessor {
     maybeRecoverOnError: BuildException => Option[BuildException] = e => Some(e),
     allowRestrictedFeatures: Boolean,
     suppressWarningOptions: SuppressWarningOptions
-  ): Option[Either[BuildException, Seq[PreprocessedSource]]] =
+  )(using ScalaCliInvokeData): Option[Either[BuildException, Seq[PreprocessedSource]]] =
     input match {
       case jar: JarFile => Some(either {
           val buildOptions = BuildOptions().copy(

--- a/modules/build/src/main/scala/scala/build/preprocessing/JavaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/JavaPreprocessor.scala
@@ -9,7 +9,7 @@ import java.nio.charset.StandardCharsets
 import scala.build.EitherCps.{either, value}
 import scala.build.Logger
 import scala.build.errors.BuildException
-import scala.build.input.{Inputs, JavaFile, SingleElement, VirtualJavaFile}
+import scala.build.input.{Inputs, JavaFile, ScalaCliInvokeData, SingleElement, VirtualJavaFile}
 import scala.build.internal.JavaParserProxyMaker
 import scala.build.options.{
   BuildOptions,
@@ -42,7 +42,7 @@ final case class JavaPreprocessor(
     maybeRecoverOnError: BuildException => Option[BuildException] = e => Some(e),
     allowRestrictedFeatures: Boolean,
     suppressWarningOptions: SuppressWarningOptions
-  ): Option[Either[BuildException, Seq[PreprocessedSource]]] =
+  )(using ScalaCliInvokeData): Option[Either[BuildException, Seq[PreprocessedSource]]] =
     input match {
       case j: JavaFile => Some(either {
           val content: String = value(PreprocessingUtil.maybeRead(j.path))

--- a/modules/build/src/main/scala/scala/build/preprocessing/MarkdownPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/MarkdownPreprocessor.scala
@@ -5,7 +5,13 @@ import java.nio.charset.StandardCharsets
 import scala.build.EitherCps.{either, value}
 import scala.build.Logger
 import scala.build.errors.BuildException
-import scala.build.input.{Inputs, MarkdownFile, SingleElement, VirtualMarkdownFile}
+import scala.build.input.{
+  Inputs,
+  MarkdownFile,
+  ScalaCliInvokeData,
+  SingleElement,
+  VirtualMarkdownFile
+}
 import scala.build.internal.markdown.{MarkdownCodeBlock, MarkdownCodeWrapper}
 import scala.build.internal.{AmmUtil, CodeWrapper, CustomCodeWrapper, Name}
 import scala.build.options.{BuildOptions, BuildRequirements, SuppressWarningOptions}
@@ -18,7 +24,7 @@ case object MarkdownPreprocessor extends Preprocessor {
     maybeRecoverOnError: BuildException => Option[BuildException],
     allowRestrictedFeatures: Boolean,
     suppressWarningOptions: SuppressWarningOptions
-  ): Option[Either[BuildException, Seq[PreprocessedSource]]] =
+  )(using ScalaCliInvokeData): Option[Either[BuildException, Seq[PreprocessedSource]]] =
     input match {
       case markdown: MarkdownFile =>
         val res = either {
@@ -69,7 +75,7 @@ case object MarkdownPreprocessor extends Preprocessor {
     maybeRecoverOnError: BuildException => Option[BuildException],
     allowRestrictedFeatures: Boolean,
     suppressWarningOptions: SuppressWarningOptions
-  ): Either[BuildException, List[PreprocessedSource.InMemory]] = either {
+  )(using ScalaCliInvokeData): Either[BuildException, List[PreprocessedSource.InMemory]] = either {
     def preprocessSnippets(
       maybeWrapper: Option[MarkdownCodeWrapper.WrappedMarkdownCode],
       generatedSourceNameSuffix: String

--- a/modules/build/src/main/scala/scala/build/preprocessing/Preprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/Preprocessor.scala
@@ -2,7 +2,7 @@ package scala.build.preprocessing
 
 import scala.build.Logger
 import scala.build.errors.BuildException
-import scala.build.input.{Inputs, SingleElement}
+import scala.build.input.{Inputs, ScalaCliInvokeData, SingleElement}
 import scala.build.options.SuppressWarningOptions
 
 trait Preprocessor {
@@ -12,5 +12,5 @@ trait Preprocessor {
     maybeRecoverOnError: BuildException => Option[BuildException] = e => Some(e),
     allowRestrictedFeatures: Boolean,
     suppressWarningOptions: SuppressWarningOptions
-  ): Option[Either[BuildException, Seq[PreprocessedSource]]]
+  )(using ScalaCliInvokeData): Option[Either[BuildException, Seq[PreprocessedSource]]]
 }

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -14,7 +14,7 @@ import scala.build.directives.{
   HasBuildRequirements
 }
 import scala.build.errors.*
-import scala.build.input.{Inputs, ScalaFile, SingleElement, VirtualScalaFile}
+import scala.build.input.{Inputs, ScalaCliInvokeData, ScalaFile, SingleElement, VirtualScalaFile}
 import scala.build.internal.Util
 import scala.build.options.*
 import scala.build.preprocessing.directives
@@ -53,7 +53,7 @@ case object ScalaPreprocessor extends Preprocessor {
     maybeRecoverOnError: BuildException => Option[BuildException] = e => Some(e),
     allowRestrictedFeatures: Boolean,
     suppressWarningOptions: SuppressWarningOptions
-  ): Option[Either[BuildException, Seq[PreprocessedSource]]] =
+  )(using ScalaCliInvokeData): Option[Either[BuildException, Seq[PreprocessedSource]]] =
     input match {
       case f: ScalaFile =>
         val res = either {
@@ -188,7 +188,7 @@ case object ScalaPreprocessor extends Preprocessor {
     maybeRecoverOnError: BuildException => Option[BuildException],
     allowRestrictedFeatures: Boolean,
     suppressWarningOptions: SuppressWarningOptions
-  ): Either[BuildException, Option[ProcessingOutput]] = either {
+  )(using ScalaCliInvokeData): Either[BuildException, Option[ProcessingOutput]] = either {
     val (contentWithNoShebang, _) = SheBang.ignoreSheBangLines(content)
     val extractedDirectives: ExtractedDirectives = value(ExtractedDirectives.from(
       contentWithNoShebang.toCharArray,
@@ -219,7 +219,7 @@ case object ScalaPreprocessor extends Preprocessor {
     allowRestrictedFeatures: Boolean,
     suppressWarningOptions: SuppressWarningOptions,
     maybeRecoverOnError: BuildException => Option[BuildException]
-  ): Either[BuildException, Option[ProcessingOutput]] = either {
+  )(using ScalaCliInvokeData): Either[BuildException, Option[ProcessingOutput]] = either {
     val (content0, isSheBang) = SheBang.ignoreSheBangLines(content)
     val preprocessedDirectives: PreprocessedDirectives =
       value(DirectivesPreprocessor.preprocess(

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
@@ -5,7 +5,7 @@ import java.nio.charset.StandardCharsets
 import scala.build.EitherCps.{either, value}
 import scala.build.Logger
 import scala.build.errors.BuildException
-import scala.build.input.{Inputs, Script, SingleElement, VirtualScript}
+import scala.build.input.{Inputs, ScalaCliInvokeData, Script, SingleElement, VirtualScript}
 import scala.build.internal.{AmmUtil, CodeWrapper, CustomCodeWrapper, Name}
 import scala.build.options.{BuildOptions, BuildRequirements, SuppressWarningOptions}
 import scala.build.preprocessing.ScalaPreprocessor.ProcessingOutput
@@ -17,7 +17,7 @@ final case class ScriptPreprocessor(codeWrapper: CodeWrapper) extends Preprocess
     maybeRecoverOnError: BuildException => Option[BuildException] = e => Some(e),
     allowRestrictedFeatures: Boolean,
     suppressWarningOptions: SuppressWarningOptions
-  ): Option[Either[BuildException, Seq[PreprocessedSource]]] =
+  )(using ScalaCliInvokeData): Option[Either[BuildException, Seq[PreprocessedSource]]] =
     input match {
       case script: Script =>
         val res = either {
@@ -80,7 +80,7 @@ object ScriptPreprocessor {
     maybeRecoverOnError: BuildException => Option[BuildException],
     allowRestrictedFeatures: Boolean,
     suppressWarningOptions: SuppressWarningOptions
-  ): Either[BuildException, List[PreprocessedSource.InMemory]] = either {
+  )(using ScalaCliInvokeData): Either[BuildException, List[PreprocessedSource.InMemory]] = either {
 
     val (contentIgnoredSheBangLines, _) = SheBang.ignoreSheBangLines(content)
 

--- a/modules/build/src/test/scala/scala/build/tests/PreprocessingTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/PreprocessingTests.scala
@@ -3,7 +3,7 @@ package scala.build.tests
 import scala.build.preprocessing.{MarkdownPreprocessor, ScalaPreprocessor, ScriptPreprocessor}
 import com.eed3si9n.expecty.Expecty.expect
 
-import scala.build.input.{Inputs, MarkdownFile, Script, SourceScalaFile}
+import scala.build.input.{Inputs, MarkdownFile, ScalaCliInvokeData, Script, SourceScalaFile}
 import scala.build.internal.CustomCodeWrapper
 import scala.build.options.SuppressWarningOptions
 
@@ -18,7 +18,7 @@ class PreprocessingTests extends munit.FunSuite {
       logger,
       allowRestrictedFeatures = false,
       suppressWarningOptions = SuppressWarningOptions()
-    )
+    )(using ScalaCliInvokeData.dummy)
     val expectedMessage = s"File not found: ${scalaFile.path}"
 
     assert(res.nonEmpty)
@@ -35,7 +35,7 @@ class PreprocessingTests extends munit.FunSuite {
       logger,
       allowRestrictedFeatures = false,
       suppressWarningOptions = SuppressWarningOptions()
-    )
+    )(using ScalaCliInvokeData.dummy)
     val expectedMessage = s"File not found: ${scalaScript.path}"
 
     assert(res.nonEmpty)
@@ -52,7 +52,7 @@ class PreprocessingTests extends munit.FunSuite {
       logger,
       allowRestrictedFeatures = false,
       suppressWarningOptions = SuppressWarningOptions()
-    )
+    )(using ScalaCliInvokeData.dummy)
     val expectedMessage = s"File not found: ${markdownFile.path}"
 
     assert(res.nonEmpty)

--- a/modules/build/src/test/scala/scala/build/tests/ScalaPreprocessorTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ScalaPreprocessorTests.scala
@@ -2,7 +2,7 @@ package scala.build.tests
 
 import com.eed3si9n.expecty.Expecty.expect
 
-import scala.build.input.SourceScalaFile
+import scala.build.input.{ScalaCliInvokeData, SourceScalaFile}
 import scala.build.options.SuppressWarningOptions
 import scala.build.preprocessing.{PreprocessedSource, ScalaPreprocessor}
 
@@ -24,7 +24,7 @@ class ScalaPreprocessorTests extends munit.FunSuite {
         logger = TestLogger(),
         allowRestrictedFeatures = false,
         suppressWarningOptions = SuppressWarningOptions()
-      )
+      )(using ScalaCliInvokeData.dummy)
       expect(result.nonEmpty)
       val Some(directivesPositions) = result.head.directivesPositions
       expect(directivesPositions.specialCommentDirectives.startPos == 0 -> 0)
@@ -44,7 +44,7 @@ class ScalaPreprocessorTests extends munit.FunSuite {
         logger = TestLogger(),
         allowRestrictedFeatures = false,
         suppressWarningOptions = SuppressWarningOptions()
-      )
+      )(using ScalaCliInvokeData.dummy)
       expect(result.nonEmpty)
       val Some(directivesPositions) = result.head.directivesPositions
       expect(directivesPositions.specialCommentDirectives.startPos == 0 -> 0)

--- a/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
@@ -11,6 +11,7 @@ import scala.build.internal.CustomCodeWrapper
 import scala.build.CrossSources
 import scala.build.Position
 import scala.build.errors.{UsingDirectiveValueNumError, UsingDirectiveWrongValueTypeError}
+import scala.build.input.ScalaCliInvokeData
 import scala.build.options.{BuildOptions, Scope, SuppressWarningOptions}
 import scala.build.internal.ScalaJsLinkerConfig
 
@@ -19,6 +20,8 @@ class SourcesTests extends munit.FunSuite {
   def scalaVersion       = "2.13.5"
   def scalaParams        = ScalaParameters(scalaVersion)
   def scalaBinaryVersion = scalaParams.scalaBinaryVersion
+
+  given ScalaCliInvokeData = ScalaCliInvokeData.dummy
 
   val preprocessors = Sources.defaultPreprocessors(
     CustomCodeWrapper,

--- a/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
@@ -46,7 +46,7 @@ final case class TestInputs(
         forcedWorkspace = forcedWorkspaceOpt.map(_.resolveFrom(tmpDir)),
         allowRestrictedFeatures = true,
         extraClasspathWasPassed = false
-      )(using ScalaCliInvokeData("", "", SubCommand.Other, false))
+      )(using ScalaCliInvokeData.dummy)
       res match {
         case Left(err)     => throw new Exception(err)
         case Right(inputs) => f(tmpDir, inputs)
@@ -93,7 +93,7 @@ final case class TestInputs(
           buildTests = buildTests,
           partial = None,
           actionableDiagnostics = Some(actionableDiagnostics)
-        )
+        )(using ScalaCliInvokeData.dummy)
       val res = builds.map(_.get(scope).getOrElse {
         sys.error(s"No ${scope.name} build found")
       })

--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictableCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictableCommand.scala
@@ -4,6 +4,7 @@ import caseapp.core.app.Command
 import caseapp.core.parser.Parser
 
 import scala.build.Logger
+import scala.build.input.ScalaCliInvokeData
 import scala.cli.commands.shared.HasGlobalOptions
 
 trait RestrictableCommand[T](implicit myParser: Parser[T]) {
@@ -11,8 +12,11 @@ trait RestrictableCommand[T](implicit myParser: Parser[T]) {
 
   def shouldSuppressExperimentalFeatureWarnings: Boolean
   def logger: Logger
+  protected def invokeData: ScalaCliInvokeData
   override def parser: Parser[T] =
-    RestrictedCommandsParser(myParser, logger, shouldSuppressExperimentalFeatureWarnings)
+    RestrictedCommandsParser(myParser, logger, shouldSuppressExperimentalFeatureWarnings)(using
+      invokeData
+    )
 
   final def isRestricted: Boolean = scalaSpecificationLevel == SpecificationLevel.RESTRICTED
 

--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
@@ -7,9 +7,9 @@ import caseapp.core.util.Formatter
 import caseapp.core.{Arg, Error}
 
 import scala.build.Logger
+import scala.build.input.ScalaCliInvokeData
 import scala.build.internal.util.WarningMessages
 import scala.cli.ScalaCli
-import scala.cli.commands.shared.HelpMessages
 import scala.cli.util.ArgHelpers.*
 
 object RestrictedCommandsParser {
@@ -17,7 +17,7 @@ object RestrictedCommandsParser {
     parser: Parser[T],
     logger: Logger,
     shouldSuppressExperimentalWarnings: Boolean
-  ): Parser[T] =
+  )(using ScalaCliInvokeData): Parser[T] =
     new Parser[T] {
 
       type D = parser.D
@@ -48,7 +48,7 @@ object RestrictedCommandsParser {
         (parser.step(args, index, d, nameFormatter), args) match {
           case (Right(Some(_, arg: Arg, _)), passedOption :: _) if !arg.isSupported =>
             Left((
-              Error.UnrecognizedArgument(HelpMessages.powerOptionUsedInSip(passedOption, arg)),
+              Error.UnrecognizedArgument(arg.powerOptionUsedInSip(passedOption)),
               arg,
               Nil
             ))

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -276,7 +276,7 @@ abstract class ScalaCommand[T <: HasGlobalOptions](implicit myParser: Parser[T],
   override val messages: Help[T] =
     if shouldExcludeInSip then
       Help[T](helpMessage =
-        Some(HelpMessage(HelpMessages.powerCommandUsedInSip(
+        Some(HelpMessage(WarningMessages.powerCommandUsedInSip(
           actualCommandName,
           scalaSpecificationLevel
         )))
@@ -348,7 +348,10 @@ abstract class ScalaCommand[T <: HasGlobalOptions](implicit myParser: Parser[T],
   final override def run(options: T, remainingArgs: RemainingArgs): Unit = {
     CurrentParams.verbosity = options.global.logging.verbosity
     if shouldExcludeInSip then
-      logger.error(HelpMessages.powerCommandUsedInSip(actualCommandName, scalaSpecificationLevel))
+      logger.error(WarningMessages.powerCommandUsedInSip(
+        actualCommandName,
+        scalaSpecificationLevel
+      ))
       sys.exit(1)
     else if isExperimental && !shouldSuppressExperimentalFeatureWarnings then
       logger.message(WarningMessages.experimentalSubcommandUsed(name))

--- a/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
@@ -13,7 +13,7 @@ import scala.build.{Directories, Logger}
 import scala.cli.ScalaCli.allowRestrictedFeatures
 import scala.cli.commands.pgp.PgpScalaSigningOptions
 import scala.cli.commands.publish.ConfigUtil.*
-import scala.cli.commands.shared.{HelpGroup, HelpMessages}
+import scala.cli.commands.shared.HelpGroup
 import scala.cli.commands.util.JvmUtils
 import scala.cli.commands.{ScalaCommand, SpecificationLevel}
 import scala.cli.config.{
@@ -122,7 +122,7 @@ object Config extends ScalaCommand[ConfigOptions] {
             case None => unrecognizedKey(name)
             case Some(powerEntry)
                 if (powerEntry.isRestricted || powerEntry.isExperimental) && !allowRestrictedFeatures =>
-              logger.error(HelpMessages.powerConfigKeyUsedInSip(powerEntry))
+              logger.error(WarningMessages.powerConfigKeyUsedInSip(powerEntry))
               sys.exit(1)
             case Some(entry) =>
               if entry.isExperimental && !shouldSuppressExperimentalFeatureWarnings then

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpCommand.scala
@@ -6,13 +6,23 @@ import caseapp.core.help.{Help, HelpFormat}
 import caseapp.core.parser.Parser
 
 import scala.build.Logger
+import scala.build.input.{ScalaCliInvokeData, SubCommand}
+import scala.cli.ScalaCli
 import scala.cli.commands.RestrictableCommand
 import scala.cli.commands.util.CommandHelpers
-import scala.cli.internal.CliLogger
+import scala.cli.internal.{CliLogger, ProcUtil}
 
 abstract class PgpCommand[T](implicit myParser: Parser[T], help: Help[T])
     extends Command()(myParser, help)
     with CommandHelpers with RestrictableCommand[T] {
+  override protected def invokeData: ScalaCliInvokeData =
+    ScalaCliInvokeData(
+      progName = ScalaCli.progName,
+      subCommandName =
+        name, // FIXME Should be the actual name that was called from the command line
+      subCommand = SubCommand.Other,
+      isShebangCapableShell = ProcUtil.isShebangCapableShell
+    )
 
   override def scalaSpecificationLevel = SpecificationLevel.EXPERIMENTAL
 

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HelpMessages.scala
@@ -2,6 +2,8 @@ package scala.cli.commands.shared
 
 import caseapp.core.Arg
 
+import scala.build.input.ScalaCliInvokeData
+import scala.build.internal.util.WarningMessages
 import scala.cli.ScalaCli
 import scala.cli.commands.{SpecificationLevel, tags}
 import scala.cli.config.Key
@@ -52,32 +54,4 @@ object HelpMessages {
     s"""Specific $cmdName configurations can be specified with both command line options and using directives defined in sources.
        |Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.
        |Using directives can be defined in all supported input source file types.""".stripMargin
-
-  private def powerFeatureUsedInSip(
-    featureName: String,
-    featureType: String,
-    specificationLevel: SpecificationLevel
-  ): String = {
-    val powerType =
-      if specificationLevel == SpecificationLevel.EXPERIMENTAL then "experimental" else "restricted"
-    s"""The '$featureName' $featureType is $powerType.
-       |You can run it with the '--power' flag or turn power mode on globally by running:
-       |  ${Console.BOLD}${ScalaCli.progName} config power true${Console.RESET}.""".stripMargin
-  }
-  def powerCommandUsedInSip(commandName: String, specificationLevel: SpecificationLevel): String =
-    powerFeatureUsedInSip(commandName, "sub-command", specificationLevel)
-  def powerOptionUsedInSip(optionName: String, arg: Arg): String = {
-    val specificationLevel =
-      if arg.isExperimental then SpecificationLevel.EXPERIMENTAL
-      else if arg.isRestricted then SpecificationLevel.RESTRICTED
-      else
-        arg.tags
-          .flatMap(t => tags.levelFor(t.name))
-          .headOption
-          .getOrElse(SpecificationLevel.EXPERIMENTAL)
-    powerFeatureUsedInSip(optionName, "option", specificationLevel)
-  }
-
-  def powerConfigKeyUsedInSip(key: Key[_]): String =
-    powerFeatureUsedInSip(key.fullName, "configuration key", key.specificationLevel)
 }

--- a/modules/cli/src/main/scala/scala/cli/util/ArgHelpers.scala
+++ b/modules/cli/src/main/scala/scala/cli/util/ArgHelpers.scala
@@ -3,6 +3,8 @@ package scala.cli.util
 import caseapp.core.Arg
 import caseapp.core.help.HelpFormat
 
+import scala.build.input.ScalaCliInvokeData
+import scala.build.internal.util.WarningMessages
 import scala.cli.ScalaCli.allowRestrictedFeatures
 import scala.cli.commands.shared.{HelpCommandGroup, HelpGroup}
 import scala.cli.commands.{SpecificationLevel, tags}
@@ -24,6 +26,17 @@ object ArgHelpers {
       .flatMap(t => tags.levelFor(t.name))
       .headOption
       .getOrElse(SpecificationLevel.IMPLEMENTATION)
+    def powerOptionUsedInSip(optionName: String)(using ScalaCliInvokeData): String = {
+      val specificationLevel =
+        if arg.isExperimental then SpecificationLevel.EXPERIMENTAL
+        else if arg.isRestricted then SpecificationLevel.RESTRICTED
+        else
+          arg.tags
+            .flatMap(t => tags.levelFor(t.name))
+            .headOption
+            .getOrElse(SpecificationLevel.EXPERIMENTAL)
+      WarningMessages.powerOptionUsedInSip(optionName, specificationLevel)
+    }
   }
 
   extension (helpFormat: HelpFormat) {


### PR DESCRIPTION
Because `ScalaCliInvokeData` wasn't passed to pre-processing, we didn't know how the app was called when showing warnings/errors in preprocessors.
As a result, we had stuff like this:
```bash
scala-cli -e '//> using target.scope "test"'    
# [error] snippet:1:24
# [error] Directives errors: The '//> using target.scope "test"' directive is experimental.
# [error] Please run it with the '--power' flag or turn or turn power mode on globally by running:
# [error]   config power true
```

which should now be fixed to:
```bash
scala-cli -e '//> using target.scope "test"'      
# [error] snippet:1:24
# [error] Directives errors: The '//> using target.scope "test"' directive is experimental.
# [error] Please run it with the '--power' flag or turn or turn power mode on globally by running:
# [error]   scala-cli config power true
```
This should also make it easier to avoid stuff like that in the future.