### PR TITLE
Bump `coursier` to `2.1.3`

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1,5 +1,5 @@
 import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`
-import $ivy.`io.get-coursier::coursier-launcher:2.1.0-M7-34-gf519b50a3`
+import $ivy.`io.get-coursier::coursier-launcher:2.1.3`
 import $ivy.`io.github.alexarchambault.mill::mill-native-image-upload:0.1.23`
 import $file.project.deps, deps.{Deps, Docker, InternalDeps, Scala, TestDeps}
 import $file.project.publish, publish.{ghOrg, ghName, ScalaCliPublishModule, organization}

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -80,9 +80,10 @@ object InternalDeps {
 object Deps {
   object Versions {
     // jni-utils version may need to be sync-ed when bumping the coursier version
-    def coursier           = "2.1.2"
-    def coursierCli        = "2.1.2"
-    def coursierM1Cli      = "2.1.2"
+    def coursierDefault    = "2.1.3"
+    def coursier           = coursierDefault
+    def coursierCli        = coursierDefault
+    def coursierM1Cli      = coursierDefault
     def jsoniterScala      = "2.23.0"
     def jsoniterScalaJava8 = "2.13.5.2"
     def scalaMeta          = "4.7.7"


### PR DESCRIPTION
https://github.com/coursier/coursier/releases/tag/v2.1.3
https://github.com/VirtusLab/coursier-m1/releases/tag/v2.1.3