### PR TITLE
Fix `export` failing on input duplicates

### DIFF
--- a/modules/build/src/main/scala/scala/build/CollectionOps.scala
+++ b/modules/build/src/main/scala/scala/build/CollectionOps.scala
@@ -1,0 +1,29 @@
+package scala.build
+import scala.collection.mutable
+object CollectionOps {
+  extension [T](items: Seq[T]) {
+
+    /** Works the same standard lib's `distinct`, but only differentiates based on the key extracted
+      * by the passed function. If more than one value exists for the same key, only the first one
+      * is kept, the rest is filtered out.
+      *
+      * @param f
+      *   function to extract the key used for distinction
+      * @tparam K
+      *   type of the key used for distinction
+      * @return
+      *   the sequence of items with distinct [[items]].map(f)
+      */
+    def distinctBy[K](f: T => K): Seq[T] =
+      if items.length == 1 then items
+      else
+        val seen = mutable.HashSet.empty[K]
+        items.filter { item =>
+          val key = f(item)
+          if seen(key) then false
+          else
+            seen += key
+            true
+        }
+  }
+}

--- a/modules/build/src/main/scala/scala/build/preprocessing/PreprocessedSource.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/PreprocessedSource.scala
@@ -9,10 +9,15 @@ sealed abstract class PreprocessedSource extends Product with Serializable {
   def optionsWithTargetRequirements: List[WithBuildRequirements[BuildOptions]]
   def requirements: Option[BuildRequirements]
   def mainClassOpt: Option[String]
-
   def scopedRequirements: Seq[Scoped[BuildRequirements]]
   def scopePath: ScopePath
   def directivesPositions: Option[Position.File]
+  def distinctPathOrSource: String = this match {
+    case PreprocessedSource.OnDisk(p, _, _, _, _, _, _)                   => p.toString
+    case PreprocessedSource.InMemory(op, rp, _, _, _, _, _, _, _, _, _)   => s"$op; $rp"
+    case PreprocessedSource.UnwrappedScript(p, _, _, _, _, _, _, _, _, _) => p.toString
+    case PreprocessedSource.NoSourceCode(_, _, _, _, p)                   => p.toString
+  }
 }
 
 object PreprocessedSource {

--- a/modules/build/src/test/scala/scala/build/tests/DistinctByTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DistinctByTests.scala
@@ -1,0 +1,45 @@
+package scala.build.tests
+
+import com.eed3si9n.expecty.Expecty.expect
+
+import scala.build.CollectionOps.distinctBy
+class DistinctByTests extends munit.FunSuite {
+  case class Message(a: String, b: Int)
+  val distinctData = Seq(
+    Message(a = "1", b = 4),
+    Message(a = "2", b = 3),
+    Message(a = "3", b = 2),
+    Message(a = "4", b = 1)
+  )
+  val repeatingData = Seq(
+    Message(a = "1", b = 4),
+    Message(a = "1", b = 44),
+    Message(a = "2", b = 3),
+    Message(a = "22", b = 3),
+    Message(a = "3", b = 22),
+    Message(a = "33", b = 2),
+    Message(a = "4", b = 1),
+    Message(a = "4", b = 11)
+  )
+
+  test("distinctBy where data is already distinct") {
+    val distinctByA     = distinctData.distinctBy(_.a)
+    val distinctByB     = distinctData.distinctBy(_.b)
+    val generalDistinct = distinctData.distinct
+    expect(distinctData == generalDistinct)
+    expect(distinctData == distinctByA)
+    expect(distinctData == distinctByB)
+  }
+
+  test("distinctBy doesn't change data order") {
+    val expectedData = Seq(
+      Message(a = "1", b = 4),
+      Message(a = "2", b = 3),
+      Message(a = "22", b = 3),
+      Message(a = "3", b = 22),
+      Message(a = "33", b = 2),
+      Message(a = "4", b = 1)
+    )
+    expect(repeatingData.distinctBy(_.a) == expectedData)
+  }
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/export0/Export.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/export0/Export.scala
@@ -40,7 +40,7 @@ object Export extends ScalaCommand[ExportOptions] {
 
     logger.log("Preparing build")
 
-    val (crossSources, _) = value {
+    val (crossSources: UnwrappedCrossSources, _) = value {
       CrossSources.forInputs(
         inputs,
         Sources.defaultPreprocessors(
@@ -56,8 +56,9 @@ object Export extends ScalaCommand[ExportOptions] {
 
     val wrappedScriptsSources = crossSources.withWrappedScripts(buildOptions)
 
-    val scopedSources = value(wrappedScriptsSources.scopedSources(buildOptions))
-    val sources = scopedSources.sources(scope, wrappedScriptsSources.sharedOptions(buildOptions))
+    val scopedSources: ScopedSources = value(wrappedScriptsSources.scopedSources(buildOptions))
+    val sources: Sources =
+      scopedSources.sources(scope, wrappedScriptsSources.sharedOptions(buildOptions))
 
     if (verbosity >= 3)
       pprint.err.log(sources)

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportCommonTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportCommonTestDefinitions.scala
@@ -7,7 +7,8 @@ import java.nio.charset.Charset
 import scala.util.Properties
 
 trait ExportCommonTestDefinitions { _: ScalaCliSuite & TestScalaVersionArgs =>
-  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
+  protected lazy val extraOptions: Seq[String] =
+    scalaVersionArgs ++ TestUtil.extraOptions ++ Seq("--suppress-experimental-warning")
 
   protected def runExportTests: Boolean = Properties.isLinux
 

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportCommonTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportCommonTestDefinitions.scala
@@ -61,6 +61,17 @@ trait ExportCommonTestDefinitions { _: ScalaCliSuite & TestScalaVersionArgs =>
       expect(output.contains("Hello"))
     }
 
+  def extraSourceFromDirectiveWithExtraDependency(inputs: String*): Unit =
+    prepareTestInputs(
+      ExportTestProjects.extraSourceFromDirectiveWithExtraDependency(actualScalaVersion)
+    ).fromRoot { root =>
+      exportCommand(inputs*).call(cwd = root, stdout = os.Inherit)
+      val res = buildToolCommand(root, runMainArgs*)
+        .call(cwd = root / outputDir)
+      val output = res.out.trim(Charset.defaultCharset())
+      expect(output.contains(root.toString))
+    }
+
   if (runExportTests) {
     test("JVM") {
       jvmTest()
@@ -73,6 +84,12 @@ trait ExportCommonTestDefinitions { _: ScalaCliSuite & TestScalaVersionArgs =>
     }
     test("Ensure test framework NPE is not thrown when depending on logback") {
       logbackBugCase()
+    }
+    test("extra source from a directive introducing a dependency") {
+      extraSourceFromDirectiveWithExtraDependency("Main.scala")
+    }
+    test("extra source passed both via directive and from command line") {
+      extraSourceFromDirectiveWithExtraDependency(".")
     }
   }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportTestProjects.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportTestProjects.scala
@@ -279,4 +279,19 @@ object ExportTestProjects {
          |//> using lib "ch.qos.logback:logback-classic:1.4.5"
          |println("Hello")
          |""".stripMargin)
+
+  def extraSourceFromDirectiveWithExtraDependency(scalaVersion: String): TestInputs =
+    TestInputs(
+      os.rel / "Main.scala" ->
+        s"""//> using scala "$scalaVersion"
+           |//> using file "Message.scala"
+           |object Main extends App {
+           |  println(Message(value = os.pwd.toString).value)
+           |}
+           |""".stripMargin,
+      os.rel / "Message.scala" ->
+        s"""//> using dep "com.lihaoyi::os-lib:0.9.1"
+           |case class Message(value: String)
+           |""".stripMargin
+    )
 }


### PR DESCRIPTION
Fixes #2015

It's possible to pass duplicate inputs with a combination of the `using file` directive and explicit passing from the command line, which results with a `java.nio.file.FileAlreadyExistsException`.
While it's not advisable to even pass inputs like this, it still shouldn't fail.