### PR TITLE
Downgrade GraalVM to `22.3.1` to fix M1

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -181,7 +181,7 @@ object Deps {
   def zipInputStream = ivy"io.github.alexarchambault.scala-cli.tmp:zip-input-stream:0.1.1"
 }
 
-def graalVmVersion     = "22.3.2"
+def graalVmVersion     = "22.3.1"
 def graalVmJavaVersion = 17
 def graalVmJvmId       = s"graalvm-java$graalVmJavaVersion:$graalVmVersion"
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -867,7 +867,7 @@ GraalVM Java major version to use to build GraalVM native images (17 by default)
 
 ### `--graalvm-version`
 
-GraalVM version to use to build GraalVM native images (22.3.2 by default)
+GraalVM version to use to build GraalVM native images (22.3.1 by default)
 
 ### `--graalvm-jvm-id`
 


### PR DESCRIPTION
https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-22.3.2
It seems like `22.3.2` didn't release a launcher for M1, so we need to downgrade to the previous version for now.