### PR TITLE
Fix test watch infinite loop

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -722,9 +722,12 @@ object Build {
         .map { builds =>
           def artifacts(build: Build): Seq[os.Path] =
             build.successfulOpt.toSeq.flatMap(_.artifacts.classPath)
-          val main = artifacts(builds.main)
-          val test = builds.get(Scope.Test).map(artifacts).getOrElse(Nil)
-          (main ++ test).distinct
+          val main               = artifacts(builds.main)
+          val test               = builds.get(Scope.Test).map(artifacts).getOrElse(Nil)
+          val allScopesArtifacts = (main ++ test).distinct
+
+          allScopesArtifacts
+            .filterNot(_.segments.contains(Constants.workspaceDirName))
         }
         .getOrElse(Nil)
       for (artifact <- artifacts) {

--- a/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
@@ -81,6 +81,12 @@ object Test extends ScalaCommand[TestOptions] {
         configDb.get(Keys.actions).getOrElse(None)
       )
 
+    /** Runs the tests via [[testOnce]] if build was successful
+      * @param builds
+      *   build results, checked for failures
+      * @param allowExit
+      *   false in watchMode
+      */
     def maybeTest(builds: Builds, allowExit: Boolean): Unit =
       if (builds.anyFailed) {
         System.err.println("Compilation failed")

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
@@ -2,6 +2,7 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
+import scala.cli.integration.TestUtil.normalizeConsoleOutput
 import scala.util.Properties
 
 trait RunScriptTestDefinitions { _: RunTestDefinitions =>
@@ -21,13 +22,6 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
         expect(output == message)
     }
   }
-
-  def normalizeConsoleOutput(text: String) =
-    text.replace(Console.RED, "")
-      .replace(Console.YELLOW, "")
-      .replace(Console.CYAN, "")
-      .replace(Console.MAGENTA, "")
-      .replace(Console.RESET, "")
 
   test("simple script") {
     simpleScriptTest()
@@ -446,7 +440,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
     test("user readable error when @main is used") {
       val inputs = TestInputs(
         os.rel / "script.sc" ->
-          """using dep "com.lihaoyi::os-lib:0.9.1"
+          """//> using dep "com.lihaoyi::os-lib:0.9.1"
             |/*ignore this while regexing*/ @main def main(args: Strings*): Unit = println("Hello")
             |""".stripMargin
       )

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -6,6 +6,7 @@ import java.util.Locale
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{ExecutorService, Executors, ScheduledExecutorService, ThreadFactory}
 
+import scala.Console._
 import scala.annotation.tailrec
 import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -290,5 +291,13 @@ object TestUtil {
       stream.readLine()
     }
     Await.result(readLineF, timeout)
+  }
+
+  def normalizeConsoleOutput(text: String) = {
+    val allColors =
+      Set(BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE, /* GREY */ "\u001b[90m")
+    allColors.+(Console.RESET).fold(text) { (textAcc, colorStr) =>
+      textAcc.replace(colorStr, "")
+    }
   }
 }


### PR DESCRIPTION
Fixes #2056
Bug introduced in #1727

File-change watcher gets registered for path `.../.scala-build/project_XXX/classes/main` which causes perpetual sheduling of operations since the files change during building.