### PR TITLE
Fix flaky completions for `zsh`

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
+++ b/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
@@ -13,16 +13,16 @@ object WarningMessages {
        |Please bear in mind that non-ideal user experience should be expected.
        |If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at $scalaCliGithubUrl""".stripMargin
   def experimentalDirectiveUsed(name: String): String =
-    experimentalFeatureUsed(s"The '$name' directive")
+    experimentalFeatureUsed(s"The `$name` directive")
 
   def experimentalSubcommandUsed(name: String): String =
-    experimentalFeatureUsed(s"The '$name' sub-command")
+    experimentalFeatureUsed(s"The `$name` sub-command")
 
   def experimentalOptionUsed(name: String): String =
-    experimentalFeatureUsed(s"The '$name' option")
+    experimentalFeatureUsed(s"The `$name` option")
 
   def experimentalConfigKeyUsed(name: String): String =
-    experimentalFeatureUsed(s"The '$name' configuration key")
+    experimentalFeatureUsed(s"The `$name` configuration key")
 
   def rawValueNotWrittenToPublishFile(
     rawValue: String,
@@ -50,8 +50,8 @@ object WarningMessages {
   )(using invokeData: ScalaCliInvokeData): String = {
     val powerType =
       if specificationLevel == SpecificationLevel.EXPERIMENTAL then "experimental" else "restricted"
-    s"""The '$featureName' $featureType is $powerType.
-       |You can run it with the '--power' flag or turn power mode on globally by running:
+    s"""The `$featureName` $featureType is $powerType.
+       |You can run it with the `--power` flag or turn power mode on globally by running:
        |  ${Console.BOLD}${invokeData.progName} config power true${Console.RESET}.""".stripMargin
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/CompleteTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompleteTests.scala
@@ -17,7 +17,7 @@ class CompleteTests extends ScalaCliSuite {
   test("zsh bug") {
     // guard against https://github.com/alexarchambault/case-app/issues/475
     TestInputs.empty.fromRoot { root =>
-      val res = os.proc(TestUtil.cli, "complete", "zsh-v1", "2", "scala-cli").call(cwd = root)
+      val res = os.proc(TestUtil.cli, "complete", shellFormat, "2", "scala-cli").call(cwd = root)
       expect(res.exitCode == 0)
       expect(!res.out.text().contains(raw"\'"))
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/CompleteTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompleteTests.scala
@@ -14,6 +14,15 @@ class CompleteTests extends ScalaCliSuite {
     }
   }
 
+  test("zsh bug") {
+    // guard against https://github.com/alexarchambault/case-app/issues/475
+    TestInputs.empty.fromRoot { root =>
+      val res = os.proc(TestUtil.cli, "complete", "zsh-v1", "2", "scala-cli").call(cwd = root)
+      expect(res.exitCode == 0)
+      expect(!res.out.text().contains(raw"\'"))
+    }
+  }
+
   def shellFormat: String =
     if (Properties.isMac) "zsh-v1"
     else "bash-v1"

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -48,7 +48,7 @@ class SipScalaTests extends ScalaCliSuite {
       if (!isPowerMode) {
         expect(res.exitCode == 1)
         val output = res.out.text()
-        expect(output.contains("The 'directories' sub-command is restricted."))
+        expect(output.contains("The `directories` sub-command is restricted."))
       }
       else expect(res.exitCode == 0)
     }
@@ -69,11 +69,11 @@ class SipScalaTests extends ScalaCliSuite {
       expect(res.exitCode == 1)
       isPowerMode -> areWarningsSuppressed match {
         case (false, _) =>
-          expect(errOutput.contains("The 'export' sub-command is experimental."))
+          expect(errOutput.contains("The `export` sub-command is experimental."))
         case (true, false) =>
-          expect(errOutput.contains("The 'export' sub-command is experimental."))
+          expect(errOutput.contains("The `export` sub-command is experimental."))
         case (true, true) =>
-          expect(!errOutput.contains("The 'export' sub-command is experimental."))
+          expect(!errOutput.contains("The `export` sub-command is experimental."))
       }
     }
 
@@ -98,29 +98,29 @@ class SipScalaTests extends ScalaCliSuite {
         case (false, _) =>
           expect(configProxyResult.exitCode == 1)
           expect(configProxyErrOutput.contains(
-            "The 'repositories.default' configuration key is restricted."
+            "The `repositories.default` configuration key is restricted."
           ))
           expect(configPublishUserResult.exitCode == 1)
           expect(configPublishUserErrOutput.contains(
-            "The 'publish.user.name' configuration key is experimental."
+            "The `publish.user.name` configuration key is experimental."
           ))
         case (true, false) =>
           expect(configProxyResult.exitCode == 0)
           expect(!configProxyErrOutput.contains(
-            "The 'repositories.default' configuration key is restricted."
+            "The `repositories.default` configuration key is restricted."
           ))
           expect(configPublishUserResult.exitCode == 0)
           expect(configPublishUserErrOutput.contains(
-            "The 'publish.user.name' configuration key is experimental."
+            "The `publish.user.name` configuration key is experimental."
           ))
         case (true, true) =>
           expect(configProxyResult.exitCode == 0)
           expect(!configProxyErrOutput.contains(
-            "The 'repositories.default' configuration key is restricted."
+            "The `repositories.default` configuration key is restricted."
           ))
           expect(configPublishUserResult.exitCode == 0)
           expect(!configPublishUserErrOutput.contains(
-            "The 'publish.user.name' configuration key is experimental."
+            "The `publish.user.name` configuration key is experimental."
           ))
       }
     }
@@ -132,8 +132,8 @@ class SipScalaTests extends ScalaCliSuite {
         stderr = os.Pipe
       )
       val output = res.out.trim()
-      if (!isPowerMode) expect(output.contains("The 'export' sub-command is experimental."))
-      else expect(output.contains("The 'export' sub-command is experimental."))
+      if (!isPowerMode) expect(output.contains("The `export` sub-command is experimental."))
+      else expect(output.contains("The `export` sub-command is experimental."))
     }
 
   def testConfigCommandHelp(isPowerMode: Boolean, isFullHelp: Boolean): Unit =
@@ -187,12 +187,12 @@ class SipScalaTests extends ScalaCliSuite {
         case (true, false) =>
           expect(res.exitCode == 0)
           expect(errOutput.contains(
-            """The '//> using publish.name "my-library"' directive is experimental."""
+            """The `//> using publish.name "my-library"` directive is experimental."""
           ))
         case (true, true) =>
           expect(res.exitCode == 0)
           expect(!errOutput.contains(
-            """The '//> using publish.name "my-library"' directive is experimental."""
+            """The `//> using publish.name "my-library"` directive is experimental."""
           ))
       }
     }
@@ -229,10 +229,10 @@ class SipScalaTests extends ScalaCliSuite {
           expect(errOutput.contains("--markdown"))
         case (true, false) =>
           expect(res.exitCode == 0)
-          expect(errOutput.contains("The '--markdown' option is experimental."))
+          expect(errOutput.contains("The `--markdown` option is experimental."))
         case (true, true) =>
           expect(res.exitCode == 0)
-          expect(!errOutput.contains("The '--markdown' option is experimental."))
+          expect(!errOutput.contains("The `--markdown` option is experimental."))
       }
     }
 
@@ -381,7 +381,7 @@ class SipScalaTests extends ScalaCliSuite {
             .call(cwd = root, check = false, env = homeEnv, stderr = os.Pipe)
           val errOutput = res.err.trim()
           expect(res.exitCode == 1)
-          expect(errOutput.contains(s"The '$subCommand' sub-command is $restrictionType."))
+          expect(errOutput.contains(s"The `$subCommand` sub-command is $restrictionType."))
         },
         testWhenEnabled = { (root, homeEnv) =>
           val res = os.proc(TestUtil.cli, subCommand)

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -110,7 +110,7 @@ All supported types of inputs can be mixed with each other.
 
 Detailed documentation can be found on our website: https://scala-cli.virtuslab.org
 
-The 'export' sub-command is experimental.
+The `export` sub-command is experimental.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
@@ -210,7 +210,7 @@ All supported types of inputs can be mixed with each other.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish
 
-The 'publish' sub-command is experimental.
+The `publish` sub-command is experimental.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
@@ -222,7 +222,7 @@ Publishes build artifacts to the local Ivy2 repository.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish-local
 
-The 'publish-local' sub-command is experimental.
+The `publish-local` sub-command is experimental.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
@@ -234,7 +234,7 @@ Configures the project for publishing.
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/publishing/publish-setup
 
-The 'publish-setup' sub-command is experimental.
+The `publish-setup` sub-command is experimental.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
@@ -275,7 +275,7 @@ Creates or updates a GitHub repository secret.
   scala-cli --power github secret create --repo repo-org/repo-name SECRET_VALUE=value:secret
 ```
 
-The 'secret-create' sub-command is experimental.
+The `secret-create` sub-command is experimental.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 
@@ -287,7 +287,7 @@ Aliases: `gh secret list`
 
 Lists secrets for a given GitHub repository.
 
-The 'secret-list' sub-command is experimental.
+The `secret-list` sub-command is experimental.
 Please bear in mind that non-ideal user experience should be expected.
 If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
 


### PR DESCRIPTION
Quotes break zsh completions.

Or more specifically, escaped quotes `\'` seem to break completions on zsh.