### PR TITLE
Add --jmx-remote option

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopStart.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/BloopStart.scala
@@ -19,10 +19,10 @@ object BloopStart extends ScalaCommand[BloopStartOptions] {
     List("bloop", "start")
   )
 
-  private def mkBloopRifleConfig(opts: BloopStartOptions): BloopRifleConfig = {
+  private def mkBloopRifleConfig(opts: BloopStartOptions, logger: Logger): BloopRifleConfig = {
     import opts.*
     val buildOptions = BuildOptions(
-      javaOptions = JvmUtils.javaOptions(jvm).orExit(global.logging.logger),
+      javaOptions = JvmUtils.javaOptions(jvm, logger).orExit(global.logging.logger),
       internal = InternalOptions(
         cache = Some(coursier.coursierCache(global.logging.logger.coursierLogger("")))
       )
@@ -39,7 +39,7 @@ object BloopStart extends ScalaCommand[BloopStartOptions] {
 
   override def runCommand(options: BloopStartOptions, args: RemainingArgs, logger: Logger): Unit = {
     val threads          = BloopThreads.create()
-    val bloopRifleConfig = mkBloopRifleConfig(options)
+    val bloopRifleConfig = mkBloopRifleConfig(options, logger)
 
     val isRunning = BloopRifle.check(bloopRifleConfig, logger.bloopRifleLogger)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
@@ -89,7 +89,7 @@ object Config extends ScalaCommand[ConfigOptions] {
                 logger,
                 coursierCache,
                 () =>
-                  JvmUtils.javaOptions(options.jvm).orExit(logger).javaHome(
+                  JvmUtils.javaOptions(options.jvm, logger).orExit(logger).javaHome(
                     ArchiveCache().withCache(coursierCache),
                     coursierCache,
                     logger.verbosity

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalCommand.scala
@@ -106,7 +106,7 @@ abstract class PgpExternalCommand extends ExternalCommand {
       logger,
       allowExecve = true,
       () =>
-        JvmUtils.javaOptions(options.jvm).orExit(logger).javaHome(
+        JvmUtils.javaOptions(options.jvm, logger).orExit(logger).javaHome(
           ArchiveCache().withCache(cache),
           cache,
           logger.verbosity

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPush.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPush.scala
@@ -42,7 +42,7 @@ object PgpPush extends ScalaCommand[PgpPushOptions] {
       val keyContent = os.read(path)
 
       val javaCommand = () =>
-        JvmUtils.javaOptions(options.jvm).orExit(logger).javaHome(
+        JvmUtils.javaOptions(options.jvm, logger).orExit(logger).javaHome(
           ArchiveCache().withCache(coursierCache),
           coursierCache,
           logger.verbosity

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/checks/PgpSecretKeyCheck.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/checks/PgpSecretKeyCheck.scala
@@ -71,7 +71,7 @@ final case class PgpSecretKeyCheck(
 
   def javaCommand: Either[BuildException, () => String] = either {
     () =>
-      value(JvmUtils.javaOptions(options.sharedJvm)).javaHome(
+      value(JvmUtils.javaOptions(options.sharedJvm, logger)).javaHome(
         ArchiveCache().withCache(coursierCache),
         coursierCache,
         logger.verbosity

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedJvmOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedJvmOptions.scala
@@ -61,7 +61,16 @@ final case class SharedJvmOptions(
   @Tag(tags.implementation)
   @HelpMessage("Port for BSP debugging")
   @Hidden
-    bspDebugPort: Option[String] = None
+    bspDebugPort: Option[String] = None,
+
+  @Group(HelpGroup.Debug.toString)
+  @Tag(tags.implementation)
+  @HelpMessage(
+    "Enable JMX remote connections. Pass a port or host:port as argument, like --jmx-remote 9010 or --jmx-remote locahost:9010. Host defaults to localhost. " +
+    "If running on a machine you connect to with 'ssh foo', run 'ssh foo -L port:localhost:port' on your local machine, then open a JMX remote connection to localhost:port in VisualVM running locally."
+  )
+  @Hidden
+    jmxRemote: Option[String] = None
 )
 // format: on
 

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -342,7 +342,7 @@ final case class SharedOptions(
       ),
       scalaJsOptions = scalaJsOptions(js),
       scalaNativeOptions = scalaNativeOptions(native),
-      javaOptions = value(scala.cli.commands.util.JvmUtils.javaOptions(jvm)),
+      javaOptions = value(scala.cli.commands.util.JvmUtils.javaOptions(jvm, logger)),
       jmhOptions = bo.JmhOptions(
         addJmhDependencies =
           if (enableJmh) jmhVersion.orElse(Some(Constants.jmhVersion))

--- a/modules/cli/src/main/scala/scala/cli/commands/util/JvmUtils.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/JvmUtils.scala
@@ -11,55 +11,56 @@ import scala.cli.commands.shared.{SharedJvmOptions, SharedOptions}
 import scala.util.Properties
 
 object JvmUtils {
-  def javaOptions(opts: SharedJvmOptions): Either[BuildException, JavaOptions] = either {
-    import opts._
+  def javaOptions(opts: SharedJvmOptions): Either[BuildException, JavaOptions] =
+    either {
+      import opts._
 
-    val (javacFilePlugins, javacPluginDeps) =
-      javacPlugin
-        .filter(_.trim.nonEmpty)
-        .partition { input =>
-          input.contains(File.separator) ||
-          (Properties.isWin && input.contains("/")) ||
-          input.count(_ == ':') < 2
-        }
-
-    val javaOptsSeq = {
-      val isDebug =
-        opts.sharedDebug.debug ||
-        opts.sharedDebug.debugMode.nonEmpty ||
-        opts.sharedDebug.debugPort.nonEmpty
-      if (isDebug) {
-        val server = value {
-          opts.sharedDebug.debugMode match {
-            case Some("attach") | Some("a") | None => Right("y")
-            case Some("listen") | Some("l")        => Right("n")
-            case Some(m)                           => Left(new UnrecognizedDebugModeError(m))
+      val (javacFilePlugins, javacPluginDeps) =
+        javacPlugin
+          .filter(_.trim.nonEmpty)
+          .partition { input =>
+            input.contains(File.separator) ||
+            (Properties.isWin && input.contains("/")) ||
+            input.count(_ == ':') < 2
           }
-        }
-        val port = opts.sharedDebug.debugPort.getOrElse("5005")
-        Seq(Positioned.none(
-          JavaOpt(s"-agentlib:jdwp=transport=dt_socket,server=$server,suspend=y,address=$port")
-        ))
-      }
-      else
-        Seq.empty
-    }
 
-    JavaOptions(
-      javaHomeOpt = javaHome.filter(_.nonEmpty).map(v =>
-        Positioned(Seq(Position.CommandLine("--java-home")), os.Path(v, Os.pwd))
-      ),
-      jvmIdOpt = jvm.filter(_.nonEmpty).map(Positioned.commandLine),
-      jvmIndexOpt = jvmIndex.filter(_.nonEmpty),
-      jvmIndexOs = jvmIndexOs.map(_.trim).filter(_.nonEmpty),
-      jvmIndexArch = jvmIndexArch.map(_.trim).filter(_.nonEmpty),
-      javaOpts = ShadowingSeq.from(javaOptsSeq),
-      javacPluginDependencies = SharedOptions.parseDependencies(
-        javacPluginDeps.map(Positioned.none(_)),
-        ignoreErrors = false
-      ),
-      javacPlugins = javacFilePlugins.map(s => Positioned.none(os.Path(s, Os.pwd))),
-      javacOptions = javacOption.map(Positioned.commandLine)
-    )
-  }
+      val javaOptsSeq = {
+        val isDebug =
+          opts.sharedDebug.debug ||
+          opts.sharedDebug.debugMode.nonEmpty ||
+          opts.sharedDebug.debugPort.nonEmpty
+        if (isDebug) {
+          val server = value {
+            opts.sharedDebug.debugMode match {
+              case Some("attach") | Some("a") | None => Right("y")
+              case Some("listen") | Some("l")        => Right("n")
+              case Some(m)                           => Left(new UnrecognizedDebugModeError(m))
+            }
+          }
+          val port = opts.sharedDebug.debugPort.getOrElse("5005")
+          Seq(Positioned.none(
+            JavaOpt(s"-agentlib:jdwp=transport=dt_socket,server=$server,suspend=y,address=$port")
+          ))
+        }
+        else
+          Seq.empty
+      }
+
+      JavaOptions(
+        javaHomeOpt = javaHome.filter(_.nonEmpty).map(v =>
+          Positioned(Seq(Position.CommandLine("--java-home")), os.Path(v, Os.pwd))
+        ),
+        jvmIdOpt = jvm.filter(_.nonEmpty).map(Positioned.commandLine),
+        jvmIndexOpt = jvmIndex.filter(_.nonEmpty),
+        jvmIndexOs = jvmIndexOs.map(_.trim).filter(_.nonEmpty),
+        jvmIndexArch = jvmIndexArch.map(_.trim).filter(_.nonEmpty),
+        javaOpts = ShadowingSeq.from(javaOptsSeq),
+        javacPluginDependencies = SharedOptions.parseDependencies(
+          javacPluginDeps.map(Positioned.none(_)),
+          ignoreErrors = false
+        ),
+        javacPlugins = javacFilePlugins.map(s => Positioned.none(os.Path(s, Os.pwd))),
+        javacOptions = javacOption.map(Positioned.commandLine)
+      )
+    }
 }

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -596,6 +596,11 @@ Javac options
 [Internal]
 Port for BSP debugging
 
+### `--jmx-remote`
+
+[Internal]
+Enable JMX remote connections. Pass a port or host:port as argument, like --jmx-remote 9010 or --jmx-remote locahost:9010. Host defaults to localhost. If running on a machine you connect to with 'ssh foo', run 'ssh foo -L port:localhost:port' on your local machine, then open a JMX remote connection to localhost:port in VisualVM running locally.
+
 ## Logging options
 
 Available in commands:

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -586,6 +586,12 @@ Javac options
 
 Port for BSP debugging
 
+### `--jmx-remote`
+
+`IMPLEMENTATION specific` per Scala Runner specification
+
+Enable JMX remote connections. Pass a port or host:port as argument, like --jmx-remote 9010 or --jmx-remote locahost:9010. Host defaults to localhost. If running on a machine you connect to with 'ssh foo', run 'ssh foo -L port:localhost:port' on your local machine, then open a JMX remote connection to localhost:port in VisualVM running locally.
+
 ## Logging options
 
 Available in commands:

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -478,6 +478,10 @@ CPU architecture to use when looking up in the JVM index
 
 Port for BSP debugging
 
+**--jmx-remote**
+
+Enable JMX remote connections. Pass a port or host:port as argument, like --jmx-remote 9010 or --jmx-remote locahost:9010. Host defaults to localhost. If running on a machine you connect to with 'ssh foo', run 'ssh foo -L port:localhost:port' on your local machine, then open a JMX remote connection to localhost:port in VisualVM running locally.
+
 **--ttl**
 
 Specify a TTL for changing dependencies, such as snapshots
@@ -742,6 +746,10 @@ CPU architecture to use when looking up in the JVM index
 **--bsp-debug-port**
 
 Port for BSP debugging
+
+**--jmx-remote**
+
+Enable JMX remote connections. Pass a port or host:port as argument, like --jmx-remote 9010 or --jmx-remote locahost:9010. Host defaults to localhost. If running on a machine you connect to with 'ssh foo', run 'ssh foo -L port:localhost:port' on your local machine, then open a JMX remote connection to localhost:port in VisualVM running locally.
 
 **--dump**
 
@@ -1177,6 +1185,10 @@ CPU architecture to use when looking up in the JVM index
 **--bsp-debug-port**
 
 Port for BSP debugging
+
+**--jmx-remote**
+
+Enable JMX remote connections. Pass a port or host:port as argument, like --jmx-remote 9010 or --jmx-remote locahost:9010. Host defaults to localhost. If running on a machine you connect to with 'ssh foo', run 'ssh foo -L port:localhost:port' on your local machine, then open a JMX remote connection to localhost:port in VisualVM running locally.
 
 **--ttl**
 
@@ -1716,6 +1728,10 @@ CPU architecture to use when looking up in the JVM index
 **--bsp-debug-port**
 
 Port for BSP debugging
+
+**--jmx-remote**
+
+Enable JMX remote connections. Pass a port or host:port as argument, like --jmx-remote 9010 or --jmx-remote locahost:9010. Host defaults to localhost. If running on a machine you connect to with 'ssh foo', run 'ssh foo -L port:localhost:port' on your local machine, then open a JMX remote connection to localhost:port in VisualVM running locally.
 
 **--ttl**
 
@@ -2285,6 +2301,10 @@ CPU architecture to use when looking up in the JVM index
 **--bsp-debug-port**
 
 Port for BSP debugging
+
+**--jmx-remote**
+
+Enable JMX remote connections. Pass a port or host:port as argument, like --jmx-remote 9010 or --jmx-remote locahost:9010. Host defaults to localhost. If running on a machine you connect to with 'ssh foo', run 'ssh foo -L port:localhost:port' on your local machine, then open a JMX remote connection to localhost:port in VisualVM running locally.
 
 **--ttl**
 
@@ -2864,6 +2884,10 @@ CPU architecture to use when looking up in the JVM index
 
 Port for BSP debugging
 
+**--jmx-remote**
+
+Enable JMX remote connections. Pass a port or host:port as argument, like --jmx-remote 9010 or --jmx-remote locahost:9010. Host defaults to localhost. If running on a machine you connect to with 'ssh foo', run 'ssh foo -L port:localhost:port' on your local machine, then open a JMX remote connection to localhost:port in VisualVM running locally.
+
 **--ttl**
 
 Specify a TTL for changing dependencies, such as snapshots
@@ -3399,6 +3423,10 @@ CPU architecture to use when looking up in the JVM index
 **--bsp-debug-port**
 
 Port for BSP debugging
+
+**--jmx-remote**
+
+Enable JMX remote connections. Pass a port or host:port as argument, like --jmx-remote 9010 or --jmx-remote locahost:9010. Host defaults to localhost. If running on a machine you connect to with 'ssh foo', run 'ssh foo -L port:localhost:port' on your local machine, then open a JMX remote connection to localhost:port in VisualVM running locally.
 
 **--ttl**
 
@@ -4011,6 +4039,10 @@ CPU architecture to use when looking up in the JVM index
 
 Port for BSP debugging
 
+**--jmx-remote**
+
+Enable JMX remote connections. Pass a port or host:port as argument, like --jmx-remote 9010 or --jmx-remote locahost:9010. Host defaults to localhost. If running on a machine you connect to with 'ssh foo', run 'ssh foo -L port:localhost:port' on your local machine, then open a JMX remote connection to localhost:port in VisualVM running locally.
+
 **--ttl**
 
 Specify a TTL for changing dependencies, such as snapshots
@@ -4622,6 +4654,10 @@ CPU architecture to use when looking up in the JVM index
 **--bsp-debug-port**
 
 Port for BSP debugging
+
+**--jmx-remote**
+
+Enable JMX remote connections. Pass a port or host:port as argument, like --jmx-remote 9010 or --jmx-remote locahost:9010. Host defaults to localhost. If running on a machine you connect to with 'ssh foo', run 'ssh foo -L port:localhost:port' on your local machine, then open a JMX remote connection to localhost:port in VisualVM running locally.
 
 **--ttl**
 
@@ -5471,6 +5507,10 @@ CPU architecture to use when looking up in the JVM index
 **--bsp-debug-port**
 
 Port for BSP debugging
+
+**--jmx-remote**
+
+Enable JMX remote connections. Pass a port or host:port as argument, like --jmx-remote 9010 or --jmx-remote locahost:9010. Host defaults to localhost. If running on a machine you connect to with 'ssh foo', run 'ssh foo -L port:localhost:port' on your local machine, then open a JMX remote connection to localhost:port in VisualVM running locally.
 
 **--ttl**
 


### PR DESCRIPTION
This adds an option that's been useful to me. Basically, passing `--jmx-remote 4321` allows to connect to the JVM process to be run using JMX from a remote machine, which allows to inspect it in [VisualVM](https://visualvm.github.io) for example. See the help message of the option for more details.