### PR TITLE
Fix the `--source-jar` option & add corresponding `using` directives

### DIFF
--- a/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
@@ -138,6 +138,7 @@ final class BspImpl(
     val generatedSourcesTest = sourcesTest.generateSources(allInputs.generatedSrcRoot(Scope.Test))
 
     bspServer.setExtraDependencySources(options0Main.classPathOptions.extraSourceJars)
+    bspServer.setExtraTestDependencySources(options0Test.classPathOptions.extraSourceJars)
     bspServer.setGeneratedSources(Scope.Main, generatedSourcesMain)
     bspServer.setGeneratedSources(Scope.Test, generatedSourcesTest)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/default/Default.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/Default.scala
@@ -54,7 +54,7 @@ class Default(
           args.remaining.nonEmpty || options.shared.snippet.executeScript.nonEmpty ||
           options.shared.snippet.executeScala.nonEmpty || options.shared.snippet.executeJava.nonEmpty ||
           options.shared.snippet.executeMarkdown.nonEmpty ||
-          (options.shared.extraJarsAndClassPath.nonEmpty && options.sharedRun.mainClass.mainClass.nonEmpty)
+          (options.shared.extraClasspathWasPassed && options.sharedRun.mainClass.mainClass.nonEmpty)
         if shouldDefaultToRun then RunOptions.parser else ReplOptions.parser
       }.parse(options.legacyScala.filterNonDeprecatedArgs(rawArgs, progName, logger)) match
         case Left(e)                              => error(e)

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
@@ -48,6 +48,9 @@ final case class PackageOptions(
     library: Boolean = false,
   @Group(HelpGroup.Package.toString)
   @HelpMessage("Generate a source JAR rather than an executable JAR")
+  @Name("sources")
+  @Name("src")
+  @Name("sourceJar")
   @Tag(tags.restricted)
   @Tag(tags.inShortHelp)
     source: Boolean = false,

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -352,6 +352,7 @@ final case class SharedOptions(
       classPathOptions = bo.ClassPathOptions(
         extraClassPath = extraJarsAndClassPath,
         extraCompileOnlyJars = extraCompileOnlyClassPath,
+        extraSourceJars = extraSourceJars.extractedClassPath,
         extraRepositories = dependencies.repository.map(_.trim).filter(_.nonEmpty),
         extraDependencies = ShadowingSeq.from(
           SharedOptions.parseDependencies(

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ClasspathUtils.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ClasspathUtils.scala
@@ -1,0 +1,7 @@
+package scala.build.preprocessing.directives
+
+object ClasspathUtils {
+  extension (classpathItem: os.Path) {
+    def hasSourceJarSuffix: Boolean = classpathItem.last.endsWith("-sources.jar")
+  }
+}

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/CustomJar.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/CustomJar.scala
@@ -4,6 +4,7 @@ import scala.build.directives.*
 import scala.build.errors.{BuildException, CompositeBuildException, WrongJarPathError}
 import scala.build.options.{BuildOptions, ClassPathOptions, Scope, WithBuildRequirements}
 import scala.build.preprocessing.ScopePath
+import scala.build.preprocessing.directives.ClasspathUtils.*
 import scala.build.preprocessing.directives.CustomJar.JarType
 import scala.build.{Logger, Positioned}
 import scala.cli.commands.SpecificationLevel
@@ -92,7 +93,9 @@ object CustomJar {
       .left.map(CompositeBuildException(_))
       .map { paths =>
         val classPathOptions = jarType match
-          case JarType.Jar        => ClassPathOptions(extraClassPath = paths)
+          case JarType.Jar =>
+            val (sourceJars, regularJars) = paths.partition(_.hasSourceJarSuffix)
+            ClassPathOptions(extraClassPath = regularJars, extraSourceJars = sourceJars)
           case JarType.SourcesJar => ClassPathOptions(extraSourceJars = paths)
         BuildOptions(classPathOptions = classPathOptions)
       }

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -1460,26 +1460,10 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
     testSourceJars(getBspOptions = sourceJarPath => List("--source-jar", sourceJarPath.toString))
   }
 
-  test("source jars handled correctly from a using directive") {
-    testSourceJars(directives =
-      """//> using jar Message.jar
-        |//> using sourceJar Message-sources.jar""".stripMargin
-    )
-  }
-
   test(
     "source jars handled correctly from the command line smartly assuming a *-sources.jar is a source jar"
   ) {
     testSourceJars(getBspOptions = sourceJarPath => List("--extra-jar", sourceJarPath.toString))
-  }
-
-  test(
-    "source jars handled correctly from a using directive smartly assuming a *-sources.jar is a source jar"
-  ) {
-    testSourceJars(directives =
-      """//> using jar Message.jar
-        |//> using jar Message-sources.jar""".stripMargin
-    )
   }
 
   test("source jars handled correctly from a test scope using directive") {

--- a/website/docs/guides/dependencies.md
+++ b/website/docs/guides/dependencies.md
@@ -65,12 +65,7 @@ Repositories can also be resolved from the `COURSIER_REPOSITORIES` environment v
 | ivy2local | Ivy | Local ivy repository, used to publish things locally (e.g. by `publishLocal`). Localized in `<ivy-home>/local`, usually `<user-home>/.ivy/local`.    |
 | m2Local | Maven | Local maven repository, localized in `<user-home>/.m2/repository` |
 
-Scala CLI delegates parsing of predefined repositories to Coursier and full details can be obtains from Coursier source code ([here](https://github.com/coursier/coursier/blob/2444eebcc151e0f6927e269137e8737c1f31cbe2/modules/coursier/jvm/src/main/scala/coursier/LocalRepositories.scala) and [here](https://github.com/coursier/coursier/blob/2444eebcc151e0f6927e269137e8737c1f31cbe2/modules/coursier/shared/src/main/scala/coursier/internal/SharedRepositoryParser.scala))
-
-
-
-
-
+Scala CLI delegates parsing of predefined repositories to Coursier and full details can be obtained from Coursier source code ([here](https://github.com/coursier/coursier/blob/2444eebcc151e0f6927e269137e8737c1f31cbe2/modules/coursier/jvm/src/main/scala/coursier/LocalRepositories.scala) and [here](https://github.com/coursier/coursier/blob/2444eebcc151e0f6927e269137e8737c1f31cbe2/modules/coursier/shared/src/main/scala/coursier/internal/SharedRepositoryParser.scala))
 
 ### Excluding Transitive Dependencies
 
@@ -152,7 +147,7 @@ You can also add a URL fallback for a JAR dependency, if it can't be fetched oth
 
 ```bash ignore
 scala-cli compile Sample.sc \
-  -- dependency "org::name::version,url=https://url-to-the-jar"
+  --dependency "org::name::version,url=https://url-to-the-jar"
 ```
 
 Note that `--dependency` is only meant as a convenience. You should favor adding dependencies in the sources themselves
@@ -172,3 +167,28 @@ Lastly, you can also add simple JAR files as dependencies with `--jar`:
 ```bash ignore
 scala-cli compile Sample.sc --jar /path/to/library.jar
 ```
+
+## Adding local JARs as dependencies
+You can pass local JARs from the command line with the `--extra-jar` option:
+
+```bash ignore
+scala-cli compile Sample.sc \
+  --extra-jar "./path/to/custom.jar"
+```
+
+Local sources JARs can also be passed in a similar manner:
+```bash ignore
+scala-cli compile Sample.sc \
+  --extra-source-jar "./path/to/custom-sources.jar"
+```
+
+Both can be handled with the appropriate `using` directives, too:
+
+```scala
+//> using jar "./path/to/custom.jar"
+//> using sourceJar "./path/to/custom-sources.jar"
+```
+
+:::caution
+Local JARs with the `*-sources.jar` suffix are assumed to be sources JARs and are treated as such.
+:::

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -674,6 +674,8 @@ Generate a library JAR rather than an executable JAR
 
 ### `--source`
 
+Aliases: `--source-jar`, `--sources`, `--src`
+
 Generate a source JAR rather than an executable JAR
 
 ### `--doc`

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -42,6 +42,10 @@ Manually add JAR(s) to the class path
 
 `//> using test.jar /Users/alexandre/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/chuusai/shapeless_2.13/2.3.7/shapeless_2.13-2.3.7.jar`
 
+`//> using sourceJar /path/to/custom-jar-sources.jar`
+
+`//> using sourceJars /path/to/custom-jar-sources.jar /path/to/another-jar-sources.jar`
+
 ### Custom sources
 
 Manually add sources to the project

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -46,6 +46,8 @@ Manually add JAR(s) to the class path
 
 `//> using sourceJars /path/to/custom-jar-sources.jar /path/to/another-jar-sources.jar`
 
+`//> using test.sourceJar /path/to/test-custom-jar-sources.jar`
+
 ### Custom sources
 
 Manually add sources to the project

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -112,6 +112,10 @@ Manually add JAR(s) to the class path
 
 `//> using test.jar /Users/alexandre/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/chuusai/shapeless_2.13/2.3.7/shapeless_2.13-2.3.7.jar`
 
+`//> using sourceJar /path/to/custom-jar-sources.jar`
+
+`//> using sourceJars /path/to/custom-jar-sources.jar /path/to/another-jar-sources.jar`
+
 ### Custom sources
 
 Manually add sources to the project

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -116,6 +116,8 @@ Manually add JAR(s) to the class path
 
 `//> using sourceJars /path/to/custom-jar-sources.jar /path/to/another-jar-sources.jar`
 
+`//> using test.sourceJar /path/to/test-custom-jar-sources.jar`
+
 ### Custom sources
 
 Manually add sources to the project


### PR DESCRIPTION
Fixes #2097 

It turns out the `--source-jar` command line option was implemented, but not at all passed to the build (and thus, non-functioning). 
I fixed it, added corresponding directives and added some tests & docs.

```scala
//> using sourceJar path/to/jar-sources
```

Additionally, the code now assumes any JARs with the `*-sources.jar` name suffix are assumed to be sources JARs, and are treated appropriately (along with a warning).

```bash
scala-cli . --extra-jar '/path/to/custom-sources.jar'
# [warn] Jars with the *-sources.jar name suffix are assumed to be source jars.
# The following jars were assumed to be source jars and will be treated as such: /path/to/custom-sources.jar
```