### PR TITLE
Add docs for bootstrapped standalone fat JAR

### DIFF
--- a/website/docs/_advanced_install.mdx
+++ b/website/docs/_advanced_install.mdx
@@ -363,6 +363,22 @@ Script to automatically download and cache standalone `scala-cli` launcher.
 </Tabs>
 </div></div>
 
+<SectionAbout title="Bootstrapped standalone fat JAR" colBigTitle="7"></SectionAbout>
+
+<div className="row"><div className="col col--9 col--offset-1 padding--lg advanced_install_methods">
+
+In certain restricted environments, jar files may only be accessible through Nexus or a specific Artifactory,
+making it cumbersome to manually load each dependency and construct the classpath.
+To simplify this process, run the bootstrapped Scala CLI standalone fat jar using Coursier, follow the command below:
+
+```bash
+cs launch org.virtuslab.scala-cli:cliBootstrapped:latest.release -M scala.cli.ScalaCli
+```
+
+Alternatively, you can directly download it from the Maven repository [here](https://repo1.maven.org/maven2/org/virtuslab/scala-cli/cliBootstrapped).
+
+</div></div>
+
 
 <SectionAbout title="Shell completions">
     <div className="margin--lg"/>

--- a/website/src/components/SectionAbout.js
+++ b/website/src/components/SectionAbout.js
@@ -2,10 +2,11 @@ import React from 'react';
 
 export default function SectionAbout(props){
   const id = props.title.toLowerCase().split(" ").join("-")
+  const colBigTitle = props.colBigTitle || 3
   const link = <a href={"#" + id} >&gt;_</a> 
   return <div className="section-about__wrapper row" id={id}>
         <div className="col col--1 big-title pre-title">{link}</div>
-        <div className="col col--3 big-title">
+        <div className={`col col--${colBigTitle} big-title`}>
             <span className="pre-title-mobile">{link}</span> {props.title}
         </div>
         <div className="col col--8 description">


### PR DESCRIPTION
Add the following section to the advanced installation page:

<img width="845" alt="Screenshot 2023-05-17 at 13 01 31" src="https://github.com/VirtusLab/scala-cli/assets/46607934/19fd328a-c33c-4b2c-88dc-4b010e7432d9">
