### PR TITLE
Fix - install certificates for java

### DIFF
--- a/gifs/Dockerfile
+++ b/gifs/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 
 RUN curl -fsSL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update
-RUN apt-get install openjdk-17-jdk openjdk-17-jre -y
+RUN apt-get install ca-certificates-java openjdk-17-jdk openjdk-17-jre -y
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y pv curl clang rubygems nodejs python3-pip &&\
     rm -rf /var/lib/apt/lists/* &&\
     gem install rouge &&\


### PR DESCRIPTION
This PR fixes the error that started throwing in the `docs-test` job in the main branch.

```
head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory
Exception in thread "main" java.lang.InternalError: Error loading java.security file
        at java.base/java.security.Security.initialize(Security.java:106)
        at java.base/java.security.Security$1.run(Security.java:84)
        at java.base/java.security.Security$1.run(Security.java:82)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
        at java.base/java.security.Security.<clinit>(Security.java:82)
        at java.base/sun.security.jca.ProviderList.<init>(ProviderList.java:178)
        at java.base/sun.security.jca.ProviderList$2.run(ProviderList.java:96)
        at java.base/sun.security.jca.ProviderList$2.run(ProviderList.java:94)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
        at java.base/sun.security.jca.ProviderList.fromSecurityProperties(ProviderList.java:93)
        at java.base/sun.security.jca.Providers.<clinit>(Providers.java:55)
        at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:156)
        at java.base/java.security.cert.CertificateFactory.getInstance(CertificateFactory.java:193)
        at org.debian.security.KeyStoreHandler.<init>(KeyStoreHandler.java:50)
        at org.debian.security.UpdateCertificates.<init>(UpdateCertificates.java:65)
        at org.debian.security.UpdateCertificates.main(UpdateCertificates.java:51)
dpkg: error processing package ca-certificates-java (--configure):
 installed ca-certificates-java package post-installation script subprocess returned error exit status 1
```