### PR TITLE
Improve directive parsing errors & special-case `toolkit` directive version parsing

### DIFF
--- a/modules/directives/src/main/scala/scala/build/errors/UsingDirectiveExpectationError.scala
+++ b/modules/directives/src/main/scala/scala/build/errors/UsingDirectiveExpectationError.scala
@@ -28,3 +28,20 @@ final class UsingDirectiveValueNumError(
       s"""Encountered an error when parsing the `$key` using directive$pathString.
          |Expected $expectedValueNum values, but got $providedValueNum values instead.""".stripMargin
     })
+
+final class ToolkitDirectiveMissingVersionError(
+  val maybePath: Either[String, os.Path],
+  val key: String
+) extends UsingDirectiveExpectationError({
+      val pathString = maybePath.map(p => s" at $p").getOrElse("")
+      s"""Encountered an error when parsing the `$key` using directive$pathString.
+         |Expected a version to be passed.
+         |Example: `//> using $key latest`
+         |""".stripMargin
+    })
+object ToolkitDirectiveMissingVersionError {
+  def apply(maybePath: Either[String, os.Path], key: String): ToolkitDirectiveMissingVersionError =
+    new ToolkitDirectiveMissingVersionError(maybePath, key)
+  def unapply(arg: ToolkitDirectiveMissingVersionError): (Either[String, os.Path], String) =
+    arg.maybePath -> arg.key
+}

--- a/modules/directives/src/main/scala/scala/build/errors/UsingDirectiveExpectationError.scala
+++ b/modules/directives/src/main/scala/scala/build/errors/UsingDirectiveExpectationError.scala
@@ -21,10 +21,10 @@ final class UsingDirectiveWrongValueTypeError(
 final class UsingDirectiveValueNumError(
   maybePath: Either[String, os.Path],
   key: String,
-  expectedBounds: String,
+  expectedValueNum: Int,
   providedValueNum: Int
-) extends UsingDirectiveExpectationError(
-      s"expected $expectedBounds for the $key using directive key${maybePath.map(path => s" at $path").getOrElse(
-          ""
-        )}; but got $providedValueNum values, instead."
-    ) {}
+) extends UsingDirectiveExpectationError({
+      val pathString = maybePath.map(p => s" at $p").getOrElse("")
+      s"""Encountered an error when parsing the `$key` using directive$pathString.
+         |Expected $expectedValueNum values, but got $providedValueNum values instead.""".stripMargin
+    })

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/DirectiveHandler.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/DirectiveHandler.scala
@@ -381,6 +381,7 @@ object DirectiveHandler {
                     .map {
                       case (scopeOpt, values) =>
                         $parser.parse(
+                          $scopedDirective.directive.key,
                           $scopedDirective.directive.values,
                           $scopedDirective.cwd,
                           $scopedDirective.maybePath

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -1179,7 +1179,8 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
           checkDiagnostic(
             diagnostic = diagnostics.head,
             expectedMessage =
-              "Expected a string value, got 'true'",
+              """Encountered an error for the scala using directive.
+                |Expected a string value, got 'true'""".stripMargin,
             expectedSeverity = b.DiagnosticSeverity.ERROR,
             expectedStartLine = 0,
             expectedStartCharacter = 16,


### PR DESCRIPTION
Fixes #2129 
~Depends on #2127~

This fixes directive parsing errors to include the actual key of the directive for which the error occurred.
Additionally, the `//> using toolkit` directive is now special-cased to produced a better error message specifically for the Scala Toolkit.

```bash
scala-cli -e '//> using toolkit'
# [error]  Encountered an error when parsing the `toolkit` using directive.
# Expected a version to be passed.
# Example: `//> using toolkit latest`
```