### PR TITLE
Bump typelevel-toolkit to 0.0.11, configure toolkit-test

### DIFF
--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Toolkit.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Toolkit.scala
@@ -59,7 +59,7 @@ object Toolkit {
           case Some(org)         => org
           case None              => Constants.toolkitOrganization
         }
-        if org == Constants.toolkitOrganization then
+        if org == Constants.toolkitOrganization || org == Constants.typelevelOrganization then
           List(
             Positioned(positions, dep"$org::${Constants.toolkitName}::$v,toolkit")
               .withEmptyRequirements,

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -1142,10 +1142,30 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
             |}""".stripMargin
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, ".", "--toolkit", "typelevel:0.0.1")
+      val output = os.proc(TestUtil.cli, ".", "--toolkit", "typelevel:0.0.11")
         .call(cwd = root).out.trim()
 
       expect(output == root.toString())
+    }
+  }
+
+  test("should add typelevel toolkit-test to classpath") {
+    val inputs = TestInputs(
+      os.rel / "Hello.test.scala" ->
+        s"""|import cats.effect.*
+            |import munit.CatsEffectSuite
+            |class HelloSuite extends CatsEffectSuite {
+            |  // IO should be added to classpath by typelevel toolkit-test
+            |  test("warm hello from the sun is coming") {
+            |    (IO("i love to live in the") *> IO("sun")).assertEquals("sun")
+            |  }
+            |}""".stripMargin
+    )
+    inputs.fromRoot { root =>
+      val output = os.proc(TestUtil.cli, "test", ".", "--toolkit", "typelevel:0.0.11")
+        .call(cwd = root).out.text()
+
+      expect(output.contains("+")) // test succeeded
     }
   }
 

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -167,18 +167,18 @@ object Deps {
     ivy"org.virtuslab.scala-cli-signing::cli:${Versions.signingCli}"
       // to prevent collisions with scala-cli's case-app version
       .exclude(("com.github.alexarchambault", "case-app_3"))
-  def slf4jNop         = ivy"org.slf4j:slf4j-nop:2.0.7"
-  def sttp             = ivy"com.softwaremill.sttp.client3:core_2.13:3.8.15"
-  def svm              = ivy"org.graalvm.nativeimage:svm:$graalVmVersion"
-  def swoval           = ivy"com.swoval:file-tree-views:2.1.10"
-  def testInterface    = ivy"org.scala-sbt:test-interface:1.0"
-  val toolkitVersion   = "0.1.7"
-  def toolkit          = ivy"org.scala-lang:toolkit:$toolkitVersion"
-  def toolkitTest      = ivy"org.scala-lang:toolkit-test:$toolkitVersion"
+  def slf4jNop                = ivy"org.slf4j:slf4j-nop:2.0.7"
+  def sttp                    = ivy"com.softwaremill.sttp.client3:core_2.13:3.8.15"
+  def svm                     = ivy"org.graalvm.nativeimage:svm:$graalVmVersion"
+  def swoval                  = ivy"com.swoval:file-tree-views:2.1.10"
+  def testInterface           = ivy"org.scala-sbt:test-interface:1.0"
+  val toolkitVersion          = "0.1.7"
+  def toolkit                 = ivy"org.scala-lang:toolkit:$toolkitVersion"
+  def toolkitTest             = ivy"org.scala-lang:toolkit-test:$toolkitVersion"
   val typelevelToolkitVersion = "0.0.11"
-  def typelevelToolkit = ivy"org.typelevel:toolkit:$typelevelToolkitVersion"
-  def typelevelToolkitTest = ivy"org.typelevel:toolkit-test:$typelevelToolkitVersion"
-  def usingDirectives  = ivy"org.virtuslab:using_directives:1.0.0"
+  def typelevelToolkit        = ivy"org.typelevel:toolkit:$typelevelToolkitVersion"
+  def typelevelToolkitTest    = ivy"org.typelevel:toolkit-test:$typelevelToolkitVersion"
+  def usingDirectives         = ivy"org.virtuslab:using_directives:1.0.0"
   // Lives at https://github.com/scala-cli/no-crc32-zip-input-stream, see #865
   // This provides a ZipInputStream that doesn't verify CRC32 checksums, that users
   // can enable by setting SCALA_CLI_VENDORED_ZIS=true in the environment, to workaround

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -175,7 +175,9 @@ object Deps {
   val toolkitVersion   = "0.1.7"
   def toolkit          = ivy"org.scala-lang:toolkit:$toolkitVersion"
   def toolkitTest      = ivy"org.scala-lang:toolkit-test:$toolkitVersion"
-  def typelevelToolkit = ivy"org.typelevel:toolkit:0.0.10"
+  val typelevelToolkitVersion = "0.0.11"
+  def typelevelToolkit = ivy"org.typelevel:toolkit:$typelevelToolkitVersion"
+  def typelevelToolkitTest = ivy"org.typelevel:toolkit-test:$typelevelToolkitVersion"
   def usingDirectives  = ivy"org.virtuslab:using_directives:1.0.0"
   // Lives at https://github.com/scala-cli/no-crc32-zip-input-stream, see #865
   // This provides a ZipInputStream that doesn't verify CRC32 checksums, that users


### PR DESCRIPTION
Follow-up to https://github.com/VirtusLab/scala-cli/pull/2127 with same changes for typelevel-toolkit. cc @toniogela