### PR TITLE
Add object wrapper flag and directive

### DIFF
--- a/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
@@ -160,16 +160,18 @@ case object ScriptPreprocessor extends Preprocessor {
     * @return
     *   code wrapper compatible with provided BuildOptions
     */
-  def getScriptWrapper(buildOptions: BuildOptions): CodeWrapper = {
-    val scalaVersionOpt = for {
-      maybeScalaVersion <- buildOptions.scalaOptions.scalaVersion
-      scalaVersion      <- maybeScalaVersion.versionOpt
-    } yield scalaVersion
-    buildOptions.scalaOptions.platform.map(_.value) match {
-      case Some(_: Platform.JS.type)                      => ObjectCodeWrapper
-      case _ if scalaVersionOpt.exists(_.startsWith("2")) => ObjectCodeWrapper
-      case _                                              => ClassCodeWrapper
+  def getScriptWrapper(buildOptions: BuildOptions): CodeWrapper =
+    buildOptions.scriptOptions.forceObjectWrapper match {
+      case Some(true) => ObjectCodeWrapper
+      case _ =>
+        val scalaVersionOpt = for {
+          maybeScalaVersion <- buildOptions.scalaOptions.scalaVersion
+          scalaVersion      <- maybeScalaVersion.versionOpt
+        } yield scalaVersion
+        buildOptions.scalaOptions.platform.map(_.value) match {
+          case Some(_: Platform.JS.type)                      => ObjectCodeWrapper
+          case _ if scalaVersionOpt.exists(_.startsWith("2")) => ObjectCodeWrapper
+          case _                                              => ClassCodeWrapper
+        }
     }
-  }
-
 }

--- a/modules/build/src/main/scala/scala/build/preprocessing/directives/DirectivesPreprocessingUtils.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/directives/DirectivesPreprocessingUtils.scala
@@ -16,6 +16,7 @@ object DirectivesPreprocessingUtils {
       directives.JavaHome.handler,
       directives.Jvm.handler,
       directives.MainClass.handler,
+      directives.ObjectWrapper.handler,
       directives.Packaging.handler,
       directives.Platform.handler,
       directives.Plugin.handler,

--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -59,7 +59,7 @@ abstract class BuildTests(server: Boolean) extends munit.FunSuite {
       scalaVersion = Some(MaybeScalaVersion(sv2)),
       scalaBinaryVersion = None
     ),
-    scriptOptions = ScriptOptions(Some(ObjectCodeWrapper))
+    scriptOptions = ScriptOptions(Some(true))
   )
 
   def sv3 = "3.0.0"
@@ -68,7 +68,7 @@ abstract class BuildTests(server: Boolean) extends munit.FunSuite {
       scalaVersion = Some(MaybeScalaVersion(sv3)),
       scalaBinaryVersion = None
     ),
-    scriptOptions = ScriptOptions(Some(ClassCodeWrapper))
+    scriptOptions = ScriptOptions(None)
   )
 
   def simple(checkResults: Boolean = true): Unit = {

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -208,6 +208,9 @@ final case class SharedOptions(
     withToolkit: Option[String] = None,
   @HelpMessage("Exclude sources")
     exclude: List[String] = Nil,
+  @HelpMessage("Force object wrapper for scripts")
+  @Tag(tags.experimental)
+    objectWrapper: Option[Boolean] = None,
 ) extends HasGlobalOptions {
   // format: on
 
@@ -348,7 +351,7 @@ final case class SharedOptions(
         platform = platformOpt.map(o => Positioned(List(Position.CommandLine()), o))
       ),
       scriptOptions = bo.ScriptOptions(
-        codeWrapper = None
+        forceObjectWrapper = objectWrapper
       ),
       scalaJsOptions = scalaJsOptions(js),
       scalaNativeOptions = scalaNativeOptions(native),

--- a/modules/core/src/main/scala/scala/build/internals/Name.scala
+++ b/modules/core/src/main/scala/scala/build/internals/Name.scala
@@ -12,7 +12,7 @@ case class Name(raw: String) {
   assert(raw.charAt(0) != '`', "Cannot create already-backticked identifiers")
   override def toString = s"Name($backticked)"
   def encoded           = NameTransformer.encode(raw)
-  def backticked        = Name.backtickWrap(raw)
+  def backticked        = Name.backtickWrap(encoded)
 }
 
 object Name {

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ObjectWrapper.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ObjectWrapper.scala
@@ -1,0 +1,25 @@
+package scala.build.preprocessing.directives
+
+import scala.build.directives.*
+import scala.build.errors.BuildException
+import scala.build.options.{BuildOptions, ScriptOptions}
+import scala.cli.commands.SpecificationLevel
+
+@DirectiveExamples("//> using objectWrapper")
+@DirectiveUsage("//> using objectWrapper", "`//> using objectWrapper")
+@DirectiveDescription("Set the default code wrapper for scripts to object wrapper")
+@DirectiveLevel(SpecificationLevel.RESTRICTED)
+final case class ObjectWrapper(
+  @DirectiveName("object.wrapper")
+  objectWrapper: Boolean = false
+) extends HasBuildOptions {
+  def buildOptions: Either[BuildException, BuildOptions] =
+    val options = BuildOptions(scriptOptions =
+      ScriptOptions(forceObjectWrapper = Some(true))
+    )
+    Right(options)
+}
+
+object ObjectWrapper {
+  val handler: DirectiveHandler[ObjectWrapper] = DirectiveHandler.derive
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
@@ -535,10 +535,22 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
           """//> using dep "com.lihaoyi::os-lib:0.9.1"
             |//> using object.wrapper
             |@main def main(args: String*): Unit = println("Hello")
-            |""".stripMargin
+            |""".stripMargin,
+        os.rel / "munit.sc" ->
+          """//> using scala  "3.2.2"
+            |//> using dep "org.scalatest::scalatest:3.2.15"
+            |
+            |import org.scalatest.*, flatspec.*, matchers.*
+            |
+            |class PiTest extends AnyFlatSpec with should.Matchers {
+            |  "pi calculus" should "return a precise enough pi value" in {
+            |    math.Pi shouldBe 3.14158d +- 0.001d
+            |  }
+            |}
+            |org.scalatest.tools.Runner.main(Array("-oDF", "-s", classOf[PiTest].getName))""".stripMargin
       )
       inputs.fromRoot { root =>
-        val res = os.proc(TestUtil.cli, "--power", "script.sc", "--object-wrapper")
+        val res = os.proc(TestUtil.cli, "--power", "script.sc", "munit.sc", "--object-wrapper")
           .call(cwd = root, mergeErrIntoOut = true, stdout = os.Pipe)
 
         val outputNormalized: String = normalizeConsoleOutput(res.out.text())
@@ -547,7 +559,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
           "[warn]  Annotation @main in .sc scripts is not supported, it will be ignored, use .scala format instead"
         ))
 
-        val directiveRes = os.proc(TestUtil.cli, "--power", "script-with-directive.sc")
+        val directiveRes = os.proc(TestUtil.cli, "--power", "script-with-directive.sc", "munit.sc")
           .call(cwd = root, mergeErrIntoOut = true, stdout = os.Pipe)
 
         val directiveOutputNormalized: String = normalizeConsoleOutput(directiveRes.out.text())

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
@@ -524,5 +524,29 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
           .contains("Annotation @main in .sc scripts is not supported"))
       }
     }
+
+    test("object-wrapped script forced") {
+      val inputs = TestInputs(
+        os.rel / "script.sc" ->
+          """//> using dep "com.lihaoyi::os-lib:0.9.1"
+            |@main def main(args: String*): Unit = println("Hello")
+            |""".stripMargin,
+        os.rel / "script_with_directive.sc" ->
+          """//> using dep "com.lihaoyi::os-lib:0.9.1"
+            |//> using objectWrapper
+            |@main def main(args: String*): Unit = println("Hello")
+            |""".stripMargin
+      )
+      inputs.fromRoot { root =>
+        val res = os.proc(TestUtil.cli, "--power", "script.sc", "--object-wrapper")
+          .call(cwd = root, mergeErrIntoOut = true, stdout = os.Pipe)
+
+        val outputNormalized: String = normalizeConsoleOutput(res.out.text())
+
+        expect(outputNormalized.contains(
+          "[warn]  Annotation @main in .sc scripts is not supported, it will be ignored, use .scala format instead"
+        ))
+      }
+    }
   }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
@@ -531,7 +531,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
           """//> using dep "com.lihaoyi::os-lib:0.9.1"
             |@main def main(args: String*): Unit = println("Hello")
             |""".stripMargin,
-        os.rel / "script_with_directive.sc" ->
+        os.rel / "script-with-directive.sc" ->
           """//> using dep "com.lihaoyi::os-lib:0.9.1"
             |//> using object.wrapper
             |@main def main(args: String*): Unit = println("Hello")
@@ -547,7 +547,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
           "[warn]  Annotation @main in .sc scripts is not supported, it will be ignored, use .scala format instead"
         ))
 
-        val directiveRes = os.proc(TestUtil.cli, "--power", "script_with_directive.sc")
+        val directiveRes = os.proc(TestUtil.cli, "--power", "script-with-directive.sc")
           .call(cwd = root, mergeErrIntoOut = true, stdout = os.Pipe)
 
         val directiveOutputNormalized: String = normalizeConsoleOutput(directiveRes.out.text())

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
@@ -533,7 +533,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
             |""".stripMargin,
         os.rel / "script_with_directive.sc" ->
           """//> using dep "com.lihaoyi::os-lib:0.9.1"
-            |//> using objectWrapper
+            |//> using object.wrapper
             |@main def main(args: String*): Unit = println("Hello")
             |""".stripMargin
       )
@@ -544,6 +544,15 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
         val outputNormalized: String = normalizeConsoleOutput(res.out.text())
 
         expect(outputNormalized.contains(
+          "[warn]  Annotation @main in .sc scripts is not supported, it will be ignored, use .scala format instead"
+        ))
+
+        val directiveRes = os.proc(TestUtil.cli, "--power", "script_with_directive.sc")
+          .call(cwd = root, mergeErrIntoOut = true, stdout = os.Pipe)
+
+        val directiveOutputNormalized: String = normalizeConsoleOutput(directiveRes.out.text())
+
+        expect(directiveOutputNormalized.contains(
           "[warn]  Annotation @main in .sc scripts is not supported, it will be ignored, use .scala format instead"
         ))
       }

--- a/modules/options/src/main/scala/scala/build/options/ScriptOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScriptOptions.scala
@@ -3,7 +3,7 @@ package scala.build.options
 import scala.build.internal.CodeWrapper
 
 final case class ScriptOptions(
-  codeWrapper: Option[CodeWrapper] = None
+  forceObjectWrapper: Option[Boolean] = None
 )
 
 object ScriptOptions {

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1505,6 +1505,10 @@ Add toolkit to classPath
 
 Exclude sources
 
+### `--object-wrapper`
+
+Force object wrapper for scripts
+
 ## Snippet options
 
 Available in commands:

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -150,6 +150,15 @@ Specify default main class
 #### Examples
 `//> using mainClass helloWorld`
 
+### ObjectWrapper
+
+Set the default code wrapper for scripts to object wrapper
+
+`//> using objectWrapper
+
+#### Examples
+`//> using objectWrapper`
+
 ### Packaging
 
 Set parameters for packaging


### PR DESCRIPTION
Addresses #2128 and #2117

Adds cli flag `--object-wrapper` and `using objectWrapper` for forcing object-wrapping for script.

Additionally fixes wrong mainClass name being passed for scripts when filename contains special characters e.g. `-`