### PR TITLE
Add a guide doc for toolkits & enforce all toolkits to have a separate `toolkit-test`

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -937,6 +937,9 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
            |  def workspaceDirName = "$workspaceDirName"
            |  def libsodiumVersion = "${deps.libsodiumVersion}"
            |  def dockerArchLinuxImage = "${TestDeps.archLinuxImage}"
+           |  
+           |  def toolkitVersion = "${Deps.toolkitVersion}"
+           |  def typelevelToolkitVersion = "${Deps.typelevelToolkitVersion}"
            |
            |  def ghOrg = "$ghOrg"
            |  def ghName = "$ghName"

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
@@ -291,7 +291,7 @@ class DirectiveTests extends munit.FunSuite {
   test("resolve typelevel toolkit dependency") {
     val testInputs = TestInputs(
       os.rel / "simple.sc" ->
-        """//> using toolkit "typelevel:latest"
+        """//> using toolkit typelevel:latest
           |""".stripMargin
     )
     testInputs.withBuild(baseOptions, buildThreads, bloopConfigOpt) {

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Toolkit.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Toolkit.scala
@@ -43,8 +43,7 @@ object Toolkit {
   /** @param toolkitCoords
     *   the toolkit coordinates
     * @return
-    *   the `toolkit` and (potentially) `toolkit-test` dependencies with the appropriate build
-    *   requirements
+    *   the `toolkit` and `toolkit-test` dependencies with the appropriate build requirements
     */
   def resolveDependenciesWithRequirements(toolkitCoords: Positioned[String])
     : List[WithBuildRequirements[Positioned[DependencyLike[NameAttributes, NameAttributes]]]] =
@@ -59,18 +58,12 @@ object Toolkit {
           case Some(org)         => org
           case None              => Constants.toolkitOrganization
         }
-        if org == Constants.toolkitOrganization || org == Constants.typelevelOrganization then
-          List(
-            Positioned(positions, dep"$org::${Constants.toolkitName}::$v,toolkit")
-              .withEmptyRequirements,
-            Positioned(positions, dep"$org::${Constants.toolkitTestName}::$v,toolkit")
-              .withScopeRequirement(Scope.Test)
-          )
-        else
-          List(
-            Positioned(positions, dep"$org::${Constants.toolkitName}::$v,toolkit")
-              .withEmptyRequirements
-          )
+        List(
+          Positioned(positions, dep"$org::${Constants.toolkitName}::$v,toolkit")
+            .withEmptyRequirements,
+          Positioned(positions, dep"$org::${Constants.toolkitTestName}::$v,toolkit")
+            .withScopeRequirement(Scope.Test)
+        )
   val handler: DirectiveHandler[Toolkit] = DirectiveHandler.derive
 
   /** Returns the `toolkit` (and potentially `toolkit-test`) dependency with the appropriate
@@ -89,7 +82,7 @@ object Toolkit {
     *   the scope requirement for the `toolkit` dependency
     * @return
     *   a list of [[Either]] [[BuildException]] [[WithBuildRequirements]] [[BuildOptions]]
-    *   containing the `toolkit` (and potentially `toolkit-test`) dependencies.
+    *   containing the `toolkit` and `toolkit-test` dependencies.
     */
   private def buildOptionsWithScopeRequirement(
     t: Option[Positioned[String]],

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -1122,7 +1122,7 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
            |}""".stripMargin
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, ".", "--toolkit", "0.1.7")
+      val output = os.proc(TestUtil.cli, ".", "--toolkit", Constants.toolkitVersion)
         .call(cwd = root).out.trim()
 
       expect(output == root.toString())
@@ -1142,8 +1142,9 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
             |}""".stripMargin
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, ".", "--toolkit", "typelevel:0.0.11")
-        .call(cwd = root).out.trim()
+      val output =
+        os.proc(TestUtil.cli, ".", "--toolkit", s"typelevel:${Constants.typelevelToolkitVersion}")
+          .call(cwd = root).out.trim()
 
       expect(output == root.toString())
     }
@@ -1162,7 +1163,13 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
             |}""".stripMargin
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, "test", ".", "--toolkit", "typelevel:0.0.11")
+      val output = os.proc(
+        TestUtil.cli,
+        "test",
+        ".",
+        "--toolkit",
+        s"typelevel:${Constants.typelevelToolkitVersion}"
+      )
         .call(cwd = root).out.text()
 
       expect(output.contains("+")) // test succeeded

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -734,7 +734,7 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
   }
 
   test("toolkit") {
-    successfulTestInputs("//> using toolkit latest").fromRoot { root =>
+    successfulTestInputs(s"//> using toolkit ${Constants.toolkitVersion}").fromRoot { root =>
       val output = os.proc(TestUtil.cli, "test", extraOptions, ".").call(cwd = root).out.text()
       expect(output.contains("Hello from tests"))
     }
@@ -743,7 +743,14 @@ abstract class TestTestDefinitions(val scalaVersionOpt: Option[String])
   test("toolkit from command line") {
     successfulTestInputs("").fromRoot { root =>
       val output =
-        os.proc(TestUtil.cli, "test", extraOptions, ".", "--toolkit", "latest").call(cwd =
+        os.proc(
+          TestUtil.cli,
+          "test",
+          extraOptions,
+          ".",
+          "--toolkit",
+          Constants.toolkitVersion
+        ).call(cwd =
           root
         ).out.text()
       expect(output.contains("Hello from tests"))

--- a/website/docs/guides/intro.md
+++ b/website/docs/guides/intro.md
@@ -23,6 +23,7 @@ These few guides are a good starting point when learning how to use Scala CLI.
 - [`using` directives](./using-directives.md) - Scala CLI’s syntax that lets you store configuration information
   directly in source files
 - [IDE support](./ide.md) - how to import and use Scala CLI-based projects in your favorite IDE.
+- [Scala Toolkit](./toolkit.md) - how to use the [Scala Toolkit](https://github.com/scala/toolkit) dependency batch (and other dependency batches) in a Scala CLI project.
 - [Migrating from the old `scala` runner](./old-runner-migration.md) - an in-depth look at all the differences between Scala CLI and the old `scala` script.
 
 ## Scripting guides

--- a/website/docs/guides/toolkit.md
+++ b/website/docs/guides/toolkit.md
@@ -1,0 +1,151 @@
+---
+title: Scala Toolkit
+sidebar_position: 7
+---
+
+import {ChainedSnippets} from "../../src/components/MarkdownComponents.js";
+
+# Scala Toolkit
+
+[Scala Toolkit](https://github.com/scala/toolkit) is an ongoing
+effort by Scala Center and VirtusLab to compose a set of approachable libraries to solve
+everyday problems.
+
+You can easily add it to your Scala CLI project with the `--toolkit` option:
+
+<ChainedSnippets>
+
+```scala title=UseOsLib.sc
+println(os.pwd)
+```
+
+```bash
+scala-cli UseOsLib.sc --toolkit latest
+```
+
+</ChainedSnippets>
+
+Similarly, you can achieve the same with the `using toolkit` directive:
+
+```scala compile
+//> using toolkit latest
+@main def printPwd: Unit = println(os.pwd)
+```
+
+## Scala Toolkit and tests
+
+Adding Scala Toolkit to your project effectively adds 2 dependencies to your classpath:
+
+- `org.scala-lang:toolkit:<version>` for your main scope (usable everywhere in the project);
+- `org.scala-lang:toolkit-test:<version>` for your test scope (usable only in tests).
+
+`toolkit-test` includes a batch of libraries only relevant for testing (like i.e. `munit`), which you probably don't
+want on your main scope
+class path (which is why Scala CLI won't put it there).
+And so, you can use it like this:
+
+<ChainedSnippets>
+
+```scala title=Something.test.scala
+//> using toolkit latest
+class Something extends munit.FunSuite {
+  test("foo") {
+    assert(true)
+  }
+}
+```
+
+```bash
+scala-cli test Something.test.scala
+```
+
+</ChainedSnippets>
+
+Also, in case you only want Scala Toolkit to be added to the test scope (and not for the main scope in any capacity),
+you can always use the `using test.toolkit` directive.
+
+<ChainedSnippets>
+
+```scala title=project.scala
+//> using test.toolkit latest
+```
+
+```scala title=Another.test.scala
+class Another extends munit.FunSuite {
+  test("foo") {
+    assert(os.pwd.last.nonEmpty)
+  }
+}
+```
+
+```bash
+scala-cli test Another.test.scala project.scala
+```
+
+</ChainedSnippets>
+
+More details about test scope directives can be found in
+the [`using` directives guide](./using-directives#directives-with-a-test-scope-equivalent).
+
+## Other toolkits
+
+Scala CLI also supports adding other toolkits to your project in a similar manner. Those have to follow the same
+structure of 2 dependencies with the names `toolkit` and `toolkit-test`.
+To do so, you have to explicitly pass the organisation the toolkit was released under (or an alias if defined).
+
+For example, to add the [Typelevel Toolkit](https://github.com/typelevel/toolkit) to your project, you can pass it with
+the `--toolkit` option:
+
+<ChainedSnippets>
+
+```scala title=UseTypelevel.scala
+import cats.effect.*
+import fs2.io.file.Files
+
+object Hello extends IOApp.Simple {
+  def run = Files[IO].currentWorkingDirectory.flatMap { cwd =>
+    IO.println(cwd.toString)
+  }
+}
+```
+
+```bash
+scala-cli UseTypelevel.scala --toolkit org.typelevel:latest
+scala-cli UseTypelevel.scala --toolkit typelevel:latest # typelevel has a shorter alias defined
+```
+
+</ChainedSnippets>
+
+Similarly, you can achieve the same with the `using toolkit` directive:
+
+```scala compile
+//> using toolkit org.typelevel:latest
+
+import cats.effect.*
+import fs2.io.file.Files
+
+object Hello extends IOApp.Simple {
+  def run = Files[IO].currentWorkingDirectory.flatMap { cwd =>
+    IO.println(cwd.toString)
+  }
+}
+```
+
+Or with the alias:
+
+```scala compile
+//> using toolkit typelevel:latest
+
+import cats.effect.*
+import fs2.io.file.Files
+
+object Hello extends IOApp.Simple {
+  def run = Files[IO].currentWorkingDirectory.flatMap { cwd =>
+    IO.println(cwd.toString)
+  }
+}
+```
+
+
+
+

--- a/website/docs/guides/using-directives.md
+++ b/website/docs/guides/using-directives.md
@@ -132,7 +132,8 @@ Directives with a test scope equivalent:
 
 ```scala compile
 //> using test.dep org.scalameta::munit::0.7.29
-//> using test.jar path/to/jar
+//> using test.jar path/to/dep.jar
+//> using test.sourceJar path/to/some-sources.jar
 //> using test.javaOpt -Dfoo=bar
 //> using test.javacOpt source 1.8 target 1.8
 //> using test.javaProp foo1=bar1


### PR DESCRIPTION
A followup for #2135, #2127 and #2025 

With these changes, we now enforce all toolkits to have the `toolkit` and `toolkit-test` dependency separation. 
Since `Typelevel` supports it now, we might as well treat it as the norm.

I also added some misc refactors and a dedicated guide doc for using toolkits.