### PR TITLE
Check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,6 +410,14 @@ jobs:
       with:
         name: windows-launchers
         path: artifacts/
+    - name: Check
+      run: ./mill -i integration.test "scala.cli.integration.PackageTestsDefault.native image"
+      env:
+        COURSIER_JNI: force
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 1
+        SCALA_CLI_SODIUM_JNI_ALLOW: false
     - name: Native integration tests
       run: ./mill -i nativeIntegrationTests
       env:
@@ -442,6 +450,14 @@ jobs:
       with:
         name: windows-launchers
         path: artifacts/
+    - name: Check
+      run: ./mill -i integration.test "scala.cli.integration.PackageTestsDefault.native image"
+      env:
+        COURSIER_JNI: force
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 2
+        SCALA_CLI_SODIUM_JNI_ALLOW: false
     - name: Native integration tests
       run: ./mill -i nativeIntegrationTests
       env:
@@ -474,6 +490,14 @@ jobs:
       with:
         name: windows-launchers
         path: artifacts/
+    - name: Check
+      run: ./mill -i integration.test "scala.cli.integration.PackageTestsDefault.native image"
+      env:
+        COURSIER_JNI: force
+        UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
+        SCALA_CLI_IT_GROUP: 3
+        SCALA_CLI_SODIUM_JNI_ALLOW: false
     - name: Native integration tests
       run: ./mill -i nativeIntegrationTests
       env:

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -808,7 +808,8 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("native image") {
     val message = "Hello from native-image"
-    val dest =
+    val dest = "hello"
+    val actualDest =
       if (Properties.isWin) "hello.exe"
       else "hello"
     val inputs = TestInputs(
@@ -837,11 +838,11 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
         stdout = os.Inherit
       )
 
-      expect(os.isFile(root / dest))
+      expect(os.isFile(root / actualDest))
 
       // FIXME Check that dest is indeed a binary?
 
-      val res    = os.proc(root / dest).call(cwd = root)
+      val res    = os.proc(root / actualDest).call(cwd = root)
       val output = res.out.trim()
       expect(output == message)
     }


### PR DESCRIPTION
Just saw the following issue on a Windows job of mine: running something like `scala-cli package --native-image -o foo .` on Windows fails like
```text
…
------------------------------------------------------------------------------------------------------------------------
Produced artifacts:
 .\foo.build_artifacts.txt (txt)
 .\foo.exe (executable)
========================================================================================================================
Finished generating 'run' in 1m 27s.
Wrote .\foo, run it with
  .\foo
Exception in thread "main" java.nio.file.NoSuchFileException: .\foo
	at java.base@17.0.6/sun.nio.fs.WindowsFileAttributeViews$Basic.readAttributes(WindowsFileAttributeViews.java:53)
	at java.base@17.0.6/sun.nio.fs.WindowsFileAttributeViews$Basic.readAttributes(WindowsFileAttributeViews.java:38)
	at java.base@17.0.6/sun.nio.fs.WindowsFileSystemProvider.readAttributes(WindowsFileSystemProvider.java:199)
	at java.base@17.0.6/java.nio.file.Files.readAttributes(Files.java:1851)
	at java.base@17.0.6/java.nio.file.Files.getLastModifiedTime(Files.java:2402)
	at os.mtime$.apply(StatOps.scala:61)
	at scala.cli.commands.package0.Package$.doPackage$$anonfun$1(Package.scala:517)
	at scala.build.EitherCps$Helper.apply(EitherCps.scala:19)
	at scala.cli.commands.package0.Package$.doPackage(Package.scala:521)
	at scala.cli.commands.package0.Package$.runCommand(Package.scala:154)
	at scala.cli.commands.package0.Package$.runCommand(Package.scala:70)
	at scala.cli.commands.ScalaCommand.run(ScalaCommand.scala:364)
	at scala.cli.commands.ScalaCommand.run(ScalaCommand.scala:348)
	at caseapp.core.app.CaseApp.main(CaseApp.scala:150)
	at scala.cli.commands.ScalaCommand.main(ScalaCommand.scala:333)
	at caseapp.core.app.CommandsEntryPoint.main(CommandsEntryPoint.scala:120)
	at scala.cli.ScalaCliCommands.main(ScalaCliCommands.scala:124)
	at scala.cli.ScalaCli$.main0(ScalaCli.scala:203)
	at scala.cli.ScalaCli$.main(ScalaCli.scala:107)
	at scala.cli.ScalaCli.main(ScalaCli.scala)
```

It seems adding a `.exe` extension in the output arg is mandatory, which is kind of surprising.

The native-image ITs seem to add that extension, so this is not caught in ITs.