### PR TITLE
Fix conflicts when watch and interactive try to read StdIn

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/WatchUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/WatchUtil.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands
 
 import scala.annotation.tailrec
+import scala.build.internal.StdInConcurrentReader
 import scala.build.internal.util.ConsoleUtils.ScalaCliConsole
 
 object WatchUtil {
@@ -35,7 +36,7 @@ object WatchUtil {
     @tailrec
     def readNextChar(): Int =
       if (shouldReadInput())
-        try System.in.read()
+        try StdInConcurrentReader.waitForLine().map(s => (s + '\n').head.toInt).getOrElse(-1)
         catch {
           case _: InterruptedException =>
             // Actually never called, as System.in.read isn't interruptible…

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -6,6 +6,8 @@ import java.io.{ByteArrayOutputStream, File}
 import java.nio.charset.Charset
 
 import scala.cli.integration.util.DockerServer
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.Duration
 import scala.io.Codec
 import scala.jdk.CollectionConverters.*
 import scala.util.Properties
@@ -1393,4 +1395,99 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
       expect(output == message)
     }
   }
+
+  test("watch with interactive, with multiple main classes") {
+    val fileName = "watch.scala"
+
+    val inputs = TestInputs(
+      os.rel / fileName ->
+        """object Run1 extends App {println("Run1 launched")}
+          |object Run2 extends App {println("Run2 launched")}
+          |""".stripMargin
+    )
+    inputs.fromRoot { root =>
+      val confDir  = root / "config"
+      val confFile = confDir / "test-config.json"
+
+      os.write(confFile, "{}", createFolders = true)
+
+      if (!Properties.isWin)
+        os.perms.set(confDir, "rwx------")
+
+      val configEnv = Map("SCALA_CLI_CONFIG" -> confFile.toString)
+
+      val proc = os.proc(TestUtil.cli, "run", "--watch", "--interactive", fileName)
+        .spawn(
+          cwd = root,
+          mergeErrIntoOut = true,
+          stdout = os.Pipe,
+          stdin = os.Pipe,
+          env = Map("SCALA_CLI_INTERACTIVE" -> "true") ++ configEnv
+        )
+
+      try
+        TestUtil.withThreadPool("run-watch-interactive-multi-main-class-test", 2) { pool =>
+          val timeout     = Duration("60 seconds")
+          implicit val ec = ExecutionContext.fromExecutorService(pool)
+
+          def lineReaderIter = Iterator.continually(TestUtil.readLine(proc.stdout, ec, timeout))
+
+          def checkLinesForError(lines: Seq[String]) = munit.Assertions.assert(
+            !lines.exists { line =>
+              TestUtil.removeAnsiColors(line).contains("[error]")
+            },
+            clues(lines.toSeq)
+          )
+
+          def answerInteractivePrompt(id: Int) = {
+            val interactivePromptLines = lineReaderIter
+              .takeWhile(!_.startsWith("[1]" /* probably [1] Run2  or [1] No*/ ))
+              .toList
+            expect(interactivePromptLines.nonEmpty)
+            checkLinesForError(interactivePromptLines)
+            proc.stdin.write(s"$id\n")
+            proc.stdin.flush()
+          }
+
+          def analyzeRunOutput(restart: Boolean) = {
+            val runResultLines = lineReaderIter
+              .takeWhile(!_.contains("press Enter to re-run"))
+              .toList
+            expect(runResultLines.nonEmpty)
+            checkLinesForError(runResultLines)
+            if (restart)
+              proc.stdin.write("\n")
+              proc.stdin.flush()
+          }
+
+          // You have run the current scala-cli command with the --interactive mode turned on.
+          // Would you like to leave it on permanently?
+          answerInteractivePrompt(0)
+
+          // Found several main classes. Which would you like to run?
+          answerInteractivePrompt(0)
+          expect(TestUtil.readLine(proc.stdout, ec, timeout) == "Run1 launched")
+
+          analyzeRunOutput( /* restart */ true)
+
+          answerInteractivePrompt(1)
+          expect(TestUtil.readLine(proc.stdout, ec, timeout) == "Run2 launched")
+
+          analyzeRunOutput( /* restart */ false)
+          os.write.append(root / fileName, "\n//comment")
+
+          answerInteractivePrompt(0)
+          expect(TestUtil.readLine(proc.stdout, ec, timeout) == "Run1 launched")
+          analyzeRunOutput( /* restart */ false)
+        }
+      finally
+        if (proc.isAlive()) {
+          proc.destroy()
+          Thread.sleep(200L)
+          if (proc.isAlive())
+            proc.destroyForcibly()
+        }
+    }
+  }
+
 }

--- a/modules/options/src/main/scala/scala/build/internal/StdInConcurrentReader.scala
+++ b/modules/options/src/main/scala/scala/build/internal/StdInConcurrentReader.scala
@@ -1,0 +1,28 @@
+package scala.build.internal
+
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.io.StdIn
+
+object StdInConcurrentReader {
+  private implicit val ec: ExecutionContext = ExecutionContext.global
+  private val readLineFuture: AtomicReference[Future[Option[String]]] =
+    new AtomicReference(Future.successful(None))
+
+  /** Wait for a line to be read from StdIn
+    *
+    * @param atMost
+    *   duration to wait before timeout
+    * @return
+    *   a line from StdIn wrapped in Some or None if end of stream was reached
+    */
+  def waitForLine(atMost: Duration = Duration.Inf): Option[String] = {
+    val updatedFuture = readLineFuture.updateAndGet { f =>
+      if f.isCompleted then Future(Option(StdIn.readLine())) else f
+    }
+
+    Await.result(updatedFuture, atMost)
+  }
+}

--- a/modules/options/src/main/scala/scala/build/internal/StdInConcurrentReader.scala
+++ b/modules/options/src/main/scala/scala/build/internal/StdInConcurrentReader.scala
@@ -6,6 +6,19 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.io.StdIn
 
+/** Allows for reading StdIn concurrently, in a way that it can be interrupted. It was introduced in
+  * [[https://github.com/VirtusLab/scala-cli/pull/2168 #2168]] to fix input conflicts when watch and
+  * interactive modes are used together. <br>
+  *
+  * Two scenarios are possible when a new process uses [[waitforLine]] to read StdIn:
+  *   - if there is no ongoing reads taking place a future reading StdIn is started and the process
+  *     waits until there's a new input line or until it is interrupted
+  *   - if there is an ongoing read, the process waits for the result of the ongoing future or until
+  *     it is interrupted. <br>
+  *
+  * __Effectively, if used in parallel, the potential input is copied and distributed among the
+  * callers of [[waitForLine]]__
+  */
 object StdInConcurrentReader {
   private implicit val ec: ExecutionContext = ExecutionContext.global
   private val readLineFuture: AtomicReference[Future[Option[String]]] =


### PR DESCRIPTION
Fixes #2121

The original problem was caused by watch mode reading StdIn for `ENTER` and then immediately doing `StdIn.read` again, which stole the first character from what interactive mode should have read.

However there's another issue with watch-interactive interaction, sometimes the watch mode reruns when sources change and should no longer read `StdIn`, but the `StdIn.read` is not interruptible, so again it will steal first character from interactive mode.

The solution from this PR fixes both problems.