### PR TITLE
Add the .exe suffix to output provided by user for graalvm-native-image

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
@@ -268,9 +268,16 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
         case _ if Properties.isWin                              => "app.bat"
         case _                                                  => "app"
       }
+      val output = outputOpt.map {
+        case path
+            if packageType == PackageType.GraalVMNativeImage
+            && Properties.isWin && !path.endsWith(".exe") =>
+          s"$path.exe" // graalvm-native-image requires .exe extension on Windows
+        case path => path
+      }
 
       val packageOutput = build.options.notForBloopOptions.packageOptions.output
-      val dest = outputOpt.orElse(packageOutput)
+      val dest = output.orElse(packageOutput)
         .orElse {
           build.sources.defaultMainClass
             .map(n => n.drop(n.lastIndexOf('.') + 1))

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -808,7 +808,8 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("native image") {
     val message = "Hello from native-image"
-    val dest =
+    val dest    = "hello"
+    val actualDest =
       if (Properties.isWin) "hello.exe"
       else "hello"
     val inputs = TestInputs(
@@ -837,11 +838,11 @@ abstract class PackageTestDefinitions(val scalaVersionOpt: Option[String])
         stdout = os.Inherit
       )
 
-      expect(os.isFile(root / dest))
+      expect(os.isFile(root / actualDest))
 
       // FIXME Check that dest is indeed a binary?
 
-      val res    = os.proc(root / dest).call(cwd = root)
+      val res    = os.proc(root / actualDest).call(cwd = root)
       val output = res.out.trim()
       expect(output == message)
     }


### PR DESCRIPTION
Fixes #2009 