### PR TITLE
Fix - download cs from coursier-m1 as an archive

### DIFF
--- a/.github/scripts/build-linux-aarch64.sh
+++ b/.github/scripts/build-linux-aarch64.sh
@@ -6,7 +6,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
 mkdir -p artifacts
 mkdir -p utils
-cp "$(cs get https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.4/cs-aarch64-pc-linux)" utils/cs
+cp "$(cs get https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.4/cs-aarch64-pc-linux.gz --archive)" utils/cs
 chmod +x utils/cs
 
 cp "$DIR/build-linux-aarch64-from-docker.sh" utils/


### PR DESCRIPTION
Coursier for `aarch64` is published in the `coursier-m1` repository as a `gz` archive, so we need to download it as an archive instead of a binary file.