### PR TITLE
Improve build target names

### DIFF
--- a/modules/build/src/main/scala/scala/build/input/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/input/Inputs.scala
@@ -128,7 +128,6 @@ final case class Inputs(
 object Inputs {
   private def forValidatedElems(
     validElems: Seq[Element],
-    baseProjectName: String,
     workspace: os.Path,
     needsHash: Boolean,
     workspaceOrigin: WorkspaceOrigin,
@@ -152,7 +151,7 @@ object Inputs {
       updatedElems,
       defaultMainClassElemOpt,
       workspace,
-      baseProjectName,
+      workspace.baseName,
       mayAppendHash = needsHash,
       workspaceOrigin = Some(workspaceOrigin),
       enableMarkdown = enableMarkdown,
@@ -318,7 +317,6 @@ object Inputs {
   private def forNonEmptyArgs(
     args: Seq[String],
     cwd: os.Path,
-    baseProjectName: String,
     download: String => Either[String, Array[Byte]],
     stdinOpt: => Option[Array[Byte]],
     scriptSnippetList: List[String],
@@ -407,7 +405,6 @@ object Inputs {
       else
         Right(forValidatedElems(
           validElems,
-          baseProjectName,
           workspace,
           needsHash,
           workspaceOrigin0,
@@ -423,7 +420,6 @@ object Inputs {
   def apply(
     args: Seq[String],
     cwd: os.Path,
-    baseProjectName: String = "project",
     defaultInputs: () => Option[Inputs] = () => None,
     download: String => Either[String, Array[Byte]] = _ => Left("URL not supported"),
     stdinOpt: => Option[Array[Byte]] = None,
@@ -448,7 +444,6 @@ object Inputs {
       forNonEmptyArgs(
         args,
         cwd,
-        baseProjectName,
         download,
         stdinOpt,
         scriptSnippetList,
@@ -469,7 +464,7 @@ object Inputs {
       elements = Nil,
       defaultMainClassElement = None,
       workspace = workspace,
-      baseProjectName = "project",
+      baseProjectName = workspace.baseName,
       mayAppendHash = true,
       workspaceOrigin = None,
       enableMarkdown = enableMarkdown,

--- a/modules/build/src/test/scala/scala/build/tests/InputsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/InputsTests.scala
@@ -37,6 +37,7 @@ class InputsTests extends munit.FunSuite {
     testInputs.withCustomInputs(viaDirectory = false, forcedWorkspaceOpt = Some(forcedWorkspace)) {
       (root, inputs) =>
         expect(inputs.workspace == root / forcedWorkspace)
+        expect(inputs.baseProjectName == "workspace")
     }
   }
 
@@ -65,6 +66,10 @@ class InputsTests extends munit.FunSuite {
         assert(javaOptsCheck)
         assert(os.exists(root / "custom-dir" / Constants.workspaceDirName))
         assert(!os.exists(root / Constants.workspaceDirName))
+
+        val filesUnderScalaBuild = os.list(root / "custom-dir" / Constants.workspaceDirName)
+        assert(filesUnderScalaBuild.exists(_.baseName.startsWith("custom-dir")))
+        assert(!filesUnderScalaBuild.exists(_.baseName.startsWith("project")))
     }
   }
 
@@ -85,6 +90,10 @@ class InputsTests extends munit.FunSuite {
       (root, _, _) =>
         assert(os.exists(root / "custom-dir" / Constants.workspaceDirName))
         assert(!os.exists(root / Constants.workspaceDirName))
+
+        val filesUnderScalaBuild = os.list(root / "custom-dir" / Constants.workspaceDirName)
+        assert(filesUnderScalaBuild.exists(_.baseName.startsWith("custom-dir")))
+        assert(!filesUnderScalaBuild.exists(_.baseName.startsWith("project")))
     }
   }
 
@@ -106,6 +115,10 @@ class InputsTests extends munit.FunSuite {
       (root, inputs, _) =>
         assert(os.exists(root / Constants.workspaceDirName))
         assert(inputs.elements.projectSettingsFiles.length == 1)
+
+        val filesUnderScalaBuild = os.list(root / Constants.workspaceDirName)
+        assert(filesUnderScalaBuild.exists(_.baseName.startsWith(root.baseName)))
+        assert(!filesUnderScalaBuild.exists(_.baseName.startsWith("project")))
     }
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -635,6 +635,7 @@ object SharedOptions {
         path
       }
       .map(ResourceDirectory.apply)
+
     val maybeInputs = Inputs(
       args,
       Os.pwd,

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -182,14 +182,15 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
 
   test("no arg") {
     simpleInputs.fromRoot { root =>
+      val projectFilePrefix = root.baseName + "_"
       os.proc(TestUtil.cli, "compile", extraOptions, ".").call(cwd = root)
       val projDirs = os.list(root / Constants.workspaceDirName)
-        .filter(_.last.startsWith("project_"))
+        .filter(_.last.startsWith(projectFilePrefix))
         .filter(os.isDir(_))
       expect(projDirs.length == 1)
       val projDir     = projDirs.head
       val projDirName = projDir.last
-      val elems       = projDirName.stripPrefix("project_").split("[-_]").toSeq
+      val elems       = projDirName.stripPrefix(projectFilePrefix).split("[-_]").toSeq
       expect(elems.length == 1)
     }
   }
@@ -253,13 +254,15 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
       expect(isDefinedTestPathInClassPath)
       checkIfCompileOutputIsCopied("Tests", tempOutput)
 
+      val projectFilePrefix = root.baseName + "_"
+
       val projDirs = os.list(root / Constants.workspaceDirName)
-        .filter(_.last.startsWith("project_"))
+        .filter(_.last.startsWith(projectFilePrefix))
         .filter(os.isDir(_))
       expect(projDirs.length == 1)
       val projDir     = projDirs.head
       val projDirName = projDir.last
-      val elems       = projDirName.stripPrefix("project_").split("[-_]").toSeq
+      val elems       = projDirName.stripPrefix(projectFilePrefix).split("[-_]").toSeq
       expect(elems.length == 2)
       expect(elems.toSet.size == 2)
     }
@@ -694,6 +697,52 @@ abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
         )
           .call(cwd = root)
         expect(compileWithCompilerRes.out.trim().contains(compilerArtifactName))
+      }
+  }
+
+  test(s"reuse cached project file under .scala-build") {
+    TestInputs(os.rel / "main.scala" ->
+      """object Main extends App {
+        |  println("Hello")
+        |}""".stripMargin)
+      .fromRoot { root =>
+        val firstRes = os.proc(
+          TestUtil.cli,
+          "compile",
+          "main.scala"
+        ).call(cwd = root, mergeErrIntoOut = true)
+
+        expect(os.list(root / Constants.workspaceDirName).count(
+          _.baseName.startsWith(root.baseName)
+        ) == 1)
+        val firstOutput = TestUtil.normalizeConsoleOutput(firstRes.out.text())
+        expect(firstOutput.contains("Compiled project"))
+
+        val differentRes = os.proc(
+          TestUtil.cli,
+          "compile",
+          "main.scala",
+          "--jvm",
+          "8"
+        ).call(cwd = root, mergeErrIntoOut = true)
+
+        expect(os.list(root / Constants.workspaceDirName).count(
+          _.baseName.startsWith(root.baseName)
+        ) == 2)
+        val differentOutput = TestUtil.normalizeConsoleOutput(differentRes.out.text())
+        expect(differentOutput.contains("Compiled project"))
+
+        val secondRes = os.proc(
+          TestUtil.cli,
+          "compile",
+          "main.scala"
+        ).call(cwd = root, mergeErrIntoOut = true)
+
+        expect(os.list(root / Constants.workspaceDirName).count(
+          _.baseName.startsWith(root.baseName)
+        ) == 2)
+        val secondOutput = TestUtil.normalizeConsoleOutput(secondRes.out.text())
+        expect(!secondOutput.contains("Compiled project"))
       }
   }
 }


### PR DESCRIPTION
Fixes #2068

Instead of `project_XYAZXYAX-SXYAYZYS` use the name of the workspace directory to obtain:
`workspace_XYAZXYAX-SXYAYZYS`

E.g.
```
.
├── scripts
│   ├── .scala-build
│   │   └── scripts_59f2159dd5
│   └── one.sc
├── skan
│   ├── .scala-build
│   │   └── skan_88b44a2858
│   └── main.scala
└── skan.code-workspace
```