### PR TITLE
Fix markdown - allow running .md files that start with a number

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/markdown/MarkdownCodeWrapper.scala
+++ b/modules/build/src/main/scala/scala/build/internal/markdown/MarkdownCodeWrapper.scala
@@ -37,7 +37,7 @@ object MarkdownCodeWrapper {
     val (pkg, wrapper) = AmmUtil.pathToPackageWrapper(subPath)
     val maybePkgString =
       if pkg.isEmpty then None else Some(s"package ${AmmUtil.encodeScalaSourcePath(pkg)}")
-    val wrapperName = s"${wrapper.raw}_md"
+    val wrapperName = Name(s"${wrapper.raw}_md").backticked
     (
       wrapScalaCode(markdown.scriptCodeBlocks, wrapperName, maybePkgString),
       rawScalaCode(markdown.rawCodeBlocks),

--- a/modules/integration/src/test/scala/scala/cli/integration/MarkdownTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/MarkdownTests.scala
@@ -284,4 +284,21 @@ class MarkdownTests extends ScalaCliSuite {
       expect(result.out.trim() == expectedOutput)
     }
   }
+  test("source file name start with a number") {
+    val fileNameWithNumber = "01-intro.md"
+    TestInputs(
+      os.rel / fileNameWithNumber ->
+        s"""# Introduction
+           |
+           |Welcome to the tutorial!
+           |
+           |```scala
+           |println("Hello")
+           |```
+           |""".stripMargin
+    ).fromRoot { root =>
+      val result = os.proc(TestUtil.cli, fileNameWithNumber).call(cwd = root)
+      expect(result.out.trim() == "Hello")
+    }
+  }
 }


### PR DESCRIPTION
Fixes #2205. @JD557 Thanks for help!