### PR TITLE
Add WinGet release step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1062,3 +1062,8 @@ jobs:
       run: ./mill -i ci.updateChocolateyPackage
       env:
         CHOCO_SECRET: ${{ secrets.CHOCO_SECRET_KEY }}
+    - uses: vedantmgoyal2009/winget-releaser@v2
+      with:
+        identifier: VirtusLab.ScalaCLI
+        installers-regex: '\.msi$'
+        token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1066,4 +1066,4 @@ jobs:
       with:
         identifier: VirtusLab.ScalaCLI
         installers-regex: '\.msi$'
-        token: ${{ secrets.WINGET_TOKEN }}
+        token: ${{ secrets.STEWARD_WINGET_TOKEN }}


### PR DESCRIPTION
This pull request was created following [this discussion](https://github.com/VirtusLab/scala-cli/discussions/2215).

The PR adds another step to the CI process that updates the WinGet release using [WinGet Releaser](https://github.com/vedantmgoyal2009/winget-releaser) action.

## Requirements

WinGet Releaser has following requirements, which were better explained in its readme:

- [x] At least one version of the package to be released in the Windows Package Manager Community Repository.
- [ ] A _classic_ Personel Access Token.
- [ ] An up-to-date fork of [winget-pkgs](https://github.com/microsoft/winget-pkgs) under the same account as this repository. WinGet Releaser can automatically update the fork if the Personel Access Token has workflow permission.
- [x] The action will only work when the release is _published_ (not a draft).