### PR TITLE
Fix empty position in DependencyFormatErrors

### DIFF
--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -603,7 +603,7 @@ abstract class BuildTests(server: Boolean) extends munit.FunSuite {
     )
 
     val parsedCliDependency = DependencyParser.parse(cliDependency).getOrElse(
-      throw new DependencyFormatError(cliDependency, "")
+      throw new DependencyFormatError(cliDependency, "", Nil)
     )
 
     // Emulates options derived from cli

--- a/modules/core/src/main/scala/scala/build/errors/DependencyFormatError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/DependencyFormatError.scala
@@ -5,9 +5,8 @@ import scala.build.Position
 final class DependencyFormatError(
   val dependencyString: String,
   val error: String,
-  val originOpt: Option[String] = None,
-  positionOpt: Option[Position] = None
+  positions: Seq[Position]
 ) extends BuildException(
-      s"Error parsing ${originOpt.getOrElse("")}dependency '$dependencyString': $error",
-      positions = positionOpt.toSeq
+      s"Error parsing dependency '$dependencyString': $error",
+      positions = positions
     )

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/DirectiveUtil.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/DirectiveUtil.scala
@@ -62,9 +62,15 @@ object DirectiveUtil {
   extension (deps: List[Positioned[String]]) {
     def asDependencies: Either[BuildException, Seq[Positioned[AnyDependency]]] =
       deps
-        .map {
-          _.map { str =>
-            DependencyParser.parse(str).left.map(new DependencyFormatError(str, _))
+        .map { positionedDep =>
+          positionedDep.map { str =>
+            DependencyParser.parse(str).left.map { error =>
+              new DependencyFormatError(
+                str,
+                error,
+                positions = positionedDep.positions
+              )
+            }
           }.eitherSequence
         }
         .sequence


### PR DESCRIPTION
During BSP operations errors like: `//> using dep not-a-dep` were not get highlighted, turned out their exceptions were not given postions. This PR fixes that.