### PR TITLE
Bump case-app, add names limit to HelpFormat, move some name aliases, add test

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HelpGroupOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HelpGroupOptions.scala
@@ -22,9 +22,9 @@ case class HelpGroupOptions(
   helpNative: Boolean = false,
   @Group(HelpGroup.Help.toString)
   @HelpMessage("Show options for Scaladoc")
+  @Name("helpDoc")
   @Name("scaladocHelp")
   @Name("docHelp")
-  @Name("helpDoc")
   @Tag(tags.implementation)
   @Tag(tags.inShortHelp)
   helpScaladoc: Boolean = false,
@@ -36,9 +36,9 @@ case class HelpGroupOptions(
   helpRepl: Boolean = false,
   @Group(HelpGroup.Help.toString)
   @HelpMessage("Show options for Scalafmt")
+  @Name("helpFmt")
   @Name("scalafmtHelp")
   @Name("fmtHelp")
-  @Name("helpFmt")
   @Tag(tags.implementation)
   @Tag(tags.inShortHelp)
   helpScalafmt: Boolean = false

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaCliHelp.scala
@@ -60,4 +60,5 @@ object ScalaCliHelp {
     .withSortedCommandGroups(sortedCommandGroups)
     .withSortedGroups(sortedHelpGroups)
     .withHiddenGroups(hiddenHelpGroups)
+    .withNamesLimit(2)
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
@@ -15,9 +15,9 @@ final case class ScalacOptions(
   @Group(HelpGroup.Scala.toString)
   @HelpMessage("Add a scalac option")
   @ValueDescription("option")
+  @Name("O")
   @Name("scala-opt")
   @Name("scala-option")
-  @Name("O")
   @Tag(tags.must)
     scalacOption: List[String] = Nil
 )

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedDependencyOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedDependencyOptions.scala
@@ -19,8 +19,8 @@ final case class SharedDependencyOptions(
   @Tag(tags.should)
   @Tag(tags.inShortHelp)
   @HelpMessage(Repository.usageMsg)
-  @Name("repo")
   @Name("r")
+  @Name("repo")
     repository: List[String] = Nil,
   @Group(HelpGroup.Scala.toString)
   @Name("P")

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -76,17 +76,17 @@ final case class SharedOptions(
   @Group(HelpGroup.Scala.toString)
   @HelpMessage(s"Set the Scala version (${Constants.defaultScalaVersion} by default)")
   @ValueDescription("version")
-  @Name("scala")
   @Name("S")
+  @Name("scala")
   @Tag(tags.must)
     scalaVersion: Option[String] = None,
   @Group(HelpGroup.Scala.toString)
   @HelpMessage("Set the Scala binary version")
   @ValueDescription("version")
   @Hidden
+  @Name("B")
   @Name("scalaBinary")
   @Name("scalaBin")
-  @Name("B")
   @Tag(tags.must)
     scalaBinaryVersion: Option[String] = None,
 
@@ -190,8 +190,8 @@ final case class SharedOptions(
     strictBloopJsonCheck: Option[Boolean] = None,
 
   @Group(HelpGroup.Scala.toString)
-  @Name("output-directory")
   @Name("d")
+  @Name("output-directory")
   @Name("destination")
   @Name("compileOutput")
   @Name("compileOut")

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SnippetOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SnippetOptions.scala
@@ -14,9 +14,9 @@ final case class SnippetOptions(
   @Group(HelpGroup.Scala.toString)
   @HelpMessage("A synonym to --script-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly")
   @Hidden
+  @Name("e")
   @Name("executeScalaScript")
   @Name("executeSc")
-  @Name("e")
   @Tag(tags.should)
     executeScript: List[String] = List.empty,
 

--- a/modules/cli/src/main/scala/scala/cli/util/ArgHelpers.scala
+++ b/modules/cli/src/main/scala/scala/cli/util/ArgHelpers.scala
@@ -61,6 +61,7 @@ object ArgHelpers {
       helpFormat.copy(sortedGroups = Some(sortedGroups.map(_.toString)))
     def withSortedCommandGroups(sortedGroups: Seq[HelpCommandGroup]): HelpFormat =
       helpFormat.copy(sortedCommandGroups = Some(sortedGroups.map(_.toString)))
-
+    def withNamesLimit(namesLimit: Int): HelpFormat =
+      helpFormat.copy(namesLimit = Some(namesLimit))
   }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
@@ -46,6 +46,23 @@ class HelpTests extends ScalaCliSuite {
       expect(fullHelpOutput.contains("Legacy Scala runner options"))
     }
   }
+
+  test("name aliases limited for standard help") {
+    val help       = os.proc(TestUtil.cli, "run", "--help").call()
+    val helpOutput = help.out.trim()
+
+    expect(TestUtil.removeAnsiColors(helpOutput).contains(
+      "--jar, --extra-jars paths"
+    ))
+  }
+
+  test("name aliases not limited for full help") {
+    val help       = os.proc(TestUtil.cli, "run", "--full-help").call()
+    val helpOutput = help.out.trim()
+    expect(TestUtil.removeAnsiColors(helpOutput).contains(
+      "-cp, --jar, --jars, --class, --classes, -classpath, --extra-jar, --classpath, --extra-jars, --class-path, --extra-class, --extra-classes, --extra-class-path paths"
+    ))
+  }
 }
 
 object HelpTests {

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -296,7 +296,7 @@ object TestUtil {
 
   def normalizeConsoleOutput(text: String) = {
     val allColors =
-      Set(BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE, /* GREY */ "\u001b[90m")
+      Set(BOLD, BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE, /* GREY */ "\u001b[90m")
     allColors.+(Console.RESET).fold(text) { (textAcc, colorStr) =>
       textAcc.replace(colorStr, "")
     }

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -103,7 +103,7 @@ object Deps {
   def bloopConfig      = ivy"ch.epfl.scala:bloop-config_2.13:1.5.5"
   def bloopRifle       = ivy"io.github.alexarchambault.bleep:bloop-rifle_2.13:1.5.6-sc-8"
   def bsp4j            = ivy"ch.epfl.scala:bsp4j:2.1.0-M5"
-  def caseApp          = ivy"com.github.alexarchambault::case-app:2.1.0-M24"
+  def caseApp          = ivy"com.github.alexarchambault::case-app:2.1.0-M25"
   def collectionCompat = ivy"org.scala-lang.modules::scala-collection-compat:2.11.0"
   // Force using of 2.13 - is there a better way?
   def coursier           = ivy"io.get-coursier:coursier_2.13:${Versions.coursier}"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1428,7 +1428,7 @@ Set the Scala binary version
 
 ### `--extra-jars`
 
-Aliases: `--class`, `--class-path`, `--classes`, `--classpath`, `-classpath`, `-cp`, `--extra-class`, `--extra-class-path`, `--extra-classes`, `--extra-jar`, `--jar`, `--jars`
+Aliases: `--class`, `--class-path`, `--classes`, `-classpath`, `--classpath`, `-cp`, `--extra-class`, `--extra-class-path`, `--extra-classes`, `--extra-jar`, `--jar`, `--jars`
 
 Add extra JARs and compiled classes to the class path
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -924,7 +924,7 @@ Set the Scala binary version
 
 ### `--extra-jars`
 
-Aliases: `--class`, `--class-path`, `--classes`, `--classpath`, `-classpath`, `-cp`, `--extra-class`, `--extra-class-path`, `--extra-classes`, `--extra-jar`, `--jar`, `--jars`
+Aliases: `--class`, `--class-path`, `--classes`, `-classpath`, `--classpath`, `-cp`, `--extra-class`, `--extra-class-path`, `--extra-classes`, `--extra-jar`, `--jar`, `--jars`
 
 `MUST have` per Scala Runner specification
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -72,7 +72,7 @@ Aliases: `--dep`
 
 Add compiler plugin dependencies
 
-Aliases: `--plugin` ,`-P`
+Aliases: `-P` ,`--plugin`
 
 **--scala-version**
 
@@ -84,13 +84,13 @@ Aliases: `-S` ,`--scala`
 
 Set the Scala binary version
 
-Aliases: `-B` ,`--scala-bin` ,`--scala-binary`
+Aliases: `-B` ,`--scala-binary` ,`--scala-bin`
 
 **--extra-jars**
 
 Add extra JARs and compiled classes to the class path
 
-Aliases: `--extra-class-path` ,`--class-path` ,`--classpath` ,`-cp` ,`-classpath` ,`--extra-classes` ,`--classes` ,`--extra-class` ,`--class` ,`--extra-jar` ,`--jars` ,`--jar`
+Aliases: `--jar` ,`--jars` ,`--extra-jar` ,`--class` ,`--extra-class` ,`--classes` ,`--extra-classes` ,`-classpath` ,`-cp` ,`--classpath` ,`--class-path` ,`--extra-class-path`
 
 **--resource-dirs**
 
@@ -102,13 +102,13 @@ Aliases: `--resource-dir`
 
 Allows to include the Scala compiler artifacts on the classpath.
 
-Aliases: `-with-compiler` ,`--with-scala-compiler`
+Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
 Copy compilation results to output directory using either relative or absolute path
 
-Aliases: `--compile-out` ,`--compile-output` ,`--destination` ,`-d` ,`--output-directory`
+Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
 ### SHOULD have options
 
@@ -232,7 +232,7 @@ Allows to execute a passed string as a Scala script
 
 A synonym to --script-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
-Aliases: `-e` ,`--execute-sc` ,`--execute-scala-script`
+Aliases: `-e` ,`--execute-scala-script` ,`--execute-sc`
 
 **--scala-snippet**
 
@@ -242,13 +242,13 @@ Allows to execute a passed string as Scala code
 
 Add extra JARs in the compilaion class path. Mainly using to run code in managed environments like Spark not to include certain depenencies on runtime ClassPath.
 
-Aliases: `--extra-compile-only-jar` ,`--compile-only-jars` ,`--compile-only-jar`
+Aliases: `--compile-only-jar` ,`--compile-only-jars` ,`--extra-compile-only-jar`
 
 **--extra-source-jars**
 
 Add extra source JARs
 
-Aliases: `--extra-source-jar` ,`--source-jars` ,`--source-jar`
+Aliases: `--source-jar` ,`--source-jars` ,`--extra-source-jar`
 
 **--platform**
 
@@ -550,7 +550,7 @@ Show options for ScalaNative
 
 Show options for Scaladoc
 
-Aliases: `--help-doc` ,`--doc-help` ,`--scaladoc-help`
+Aliases: `--help-doc` ,`--scaladoc-help` ,`--doc-help`
 
 **--help-repl**
 
@@ -562,7 +562,7 @@ Aliases: `--repl-help`
 
 Show options for Scalafmt
 
-Aliases: `--help-fmt` ,`--fmt-help` ,`--scalafmt-help`
+Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--strict-bloop-json-check**
 
@@ -776,7 +776,7 @@ Aliases: `--dep`
 
 Add compiler plugin dependencies
 
-Aliases: `--plugin` ,`-P`
+Aliases: `-P` ,`--plugin`
 
 **--scala-version**
 
@@ -788,13 +788,13 @@ Aliases: `-S` ,`--scala`
 
 Set the Scala binary version
 
-Aliases: `-B` ,`--scala-bin` ,`--scala-binary`
+Aliases: `-B` ,`--scala-binary` ,`--scala-bin`
 
 **--extra-jars**
 
 Add extra JARs and compiled classes to the class path
 
-Aliases: `--extra-class-path` ,`--class-path` ,`--classpath` ,`-cp` ,`-classpath` ,`--extra-classes` ,`--classes` ,`--extra-class` ,`--class` ,`--extra-jar` ,`--jars` ,`--jar`
+Aliases: `--jar` ,`--jars` ,`--extra-jar` ,`--class` ,`--extra-class` ,`--classes` ,`--extra-classes` ,`-classpath` ,`-cp` ,`--classpath` ,`--class-path` ,`--extra-class-path`
 
 **--resource-dirs**
 
@@ -806,13 +806,13 @@ Aliases: `--resource-dir`
 
 Allows to include the Scala compiler artifacts on the classpath.
 
-Aliases: `-with-compiler` ,`--with-scala-compiler`
+Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
 Copy compilation results to output directory using either relative or absolute path
 
-Aliases: `--compile-out` ,`--compile-output` ,`--destination` ,`-d` ,`--output-directory`
+Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
 **--output**
 
@@ -948,7 +948,7 @@ Allows to execute a passed string as a Scala script
 
 A synonym to --script-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
-Aliases: `-e` ,`--execute-sc` ,`--execute-scala-script`
+Aliases: `-e` ,`--execute-scala-script` ,`--execute-sc`
 
 **--scala-snippet**
 
@@ -958,13 +958,13 @@ Allows to execute a passed string as Scala code
 
 Add extra JARs in the compilaion class path. Mainly using to run code in managed environments like Spark not to include certain depenencies on runtime ClassPath.
 
-Aliases: `--extra-compile-only-jar` ,`--compile-only-jars` ,`--compile-only-jar`
+Aliases: `--compile-only-jar` ,`--compile-only-jars` ,`--extra-compile-only-jar`
 
 **--extra-source-jars**
 
 Add extra source JARs
 
-Aliases: `--extra-source-jar` ,`--source-jars` ,`--source-jar`
+Aliases: `--source-jar` ,`--source-jars` ,`--extra-source-jar`
 
 **--platform**
 
@@ -1250,7 +1250,7 @@ Show options for ScalaNative
 
 Show options for Scaladoc
 
-Aliases: `--help-doc` ,`--doc-help` ,`--scaladoc-help`
+Aliases: `--help-doc` ,`--scaladoc-help` ,`--doc-help`
 
 **--help-repl**
 
@@ -1262,7 +1262,7 @@ Aliases: `--repl-help`
 
 Show options for Scalafmt
 
-Aliases: `--help-fmt` ,`--fmt-help` ,`--scalafmt-help`
+Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--strict-bloop-json-check**
 
@@ -1315,7 +1315,7 @@ Aliases: `--dep`
 
 Add compiler plugin dependencies
 
-Aliases: `--plugin` ,`-P`
+Aliases: `-P` ,`--plugin`
 
 **--scala-version**
 
@@ -1327,13 +1327,13 @@ Aliases: `-S` ,`--scala`
 
 Set the Scala binary version
 
-Aliases: `-B` ,`--scala-bin` ,`--scala-binary`
+Aliases: `-B` ,`--scala-binary` ,`--scala-bin`
 
 **--extra-jars**
 
 Add extra JARs and compiled classes to the class path
 
-Aliases: `--extra-class-path` ,`--class-path` ,`--classpath` ,`-cp` ,`-classpath` ,`--extra-classes` ,`--classes` ,`--extra-class` ,`--class` ,`--extra-jar` ,`--jars` ,`--jar`
+Aliases: `--jar` ,`--jars` ,`--extra-jar` ,`--class` ,`--extra-class` ,`--classes` ,`--extra-classes` ,`-classpath` ,`-cp` ,`--classpath` ,`--class-path` ,`--extra-class-path`
 
 **--resource-dirs**
 
@@ -1345,13 +1345,13 @@ Aliases: `--resource-dir`
 
 Allows to include the Scala compiler artifacts on the classpath.
 
-Aliases: `-with-compiler` ,`--with-scala-compiler`
+Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
 Copy compilation results to output directory using either relative or absolute path
 
-Aliases: `--compile-out` ,`--compile-output` ,`--destination` ,`-d` ,`--output-directory`
+Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
 **--java-opt**
 
@@ -1481,7 +1481,7 @@ Allows to execute a passed string as a Scala script
 
 A synonym to --script-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
-Aliases: `-e` ,`--execute-sc` ,`--execute-scala-script`
+Aliases: `-e` ,`--execute-scala-script` ,`--execute-sc`
 
 **--scala-snippet**
 
@@ -1491,13 +1491,13 @@ Allows to execute a passed string as Scala code
 
 Add extra JARs in the compilaion class path. Mainly using to run code in managed environments like Spark not to include certain depenencies on runtime ClassPath.
 
-Aliases: `--extra-compile-only-jar` ,`--compile-only-jars` ,`--compile-only-jar`
+Aliases: `--compile-only-jar` ,`--compile-only-jars` ,`--extra-compile-only-jar`
 
 **--extra-source-jars**
 
 Add extra source JARs
 
-Aliases: `--extra-source-jar` ,`--source-jars` ,`--source-jar`
+Aliases: `--source-jar` ,`--source-jars` ,`--extra-source-jar`
 
 **--platform**
 
@@ -1789,7 +1789,7 @@ Show options for ScalaNative
 
 Show options for Scaladoc
 
-Aliases: `--help-doc` ,`--doc-help` ,`--scaladoc-help`
+Aliases: `--help-doc` ,`--scaladoc-help` ,`--doc-help`
 
 **--help-repl**
 
@@ -1801,7 +1801,7 @@ Aliases: `--repl-help`
 
 Show options for Scalafmt
 
-Aliases: `--help-fmt` ,`--fmt-help` ,`--scalafmt-help`
+Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--strict-bloop-json-check**
 
@@ -1868,7 +1868,7 @@ Aliases: `--dep`
 
 Add compiler plugin dependencies
 
-Aliases: `--plugin` ,`-P`
+Aliases: `-P` ,`--plugin`
 
 **--scala-version**
 
@@ -1880,13 +1880,13 @@ Aliases: `-S` ,`--scala`
 
 Set the Scala binary version
 
-Aliases: `-B` ,`--scala-bin` ,`--scala-binary`
+Aliases: `-B` ,`--scala-binary` ,`--scala-bin`
 
 **--extra-jars**
 
 Add extra JARs and compiled classes to the class path
 
-Aliases: `--extra-class-path` ,`--class-path` ,`--classpath` ,`-cp` ,`-classpath` ,`--extra-classes` ,`--classes` ,`--extra-class` ,`--class` ,`--extra-jar` ,`--jars` ,`--jar`
+Aliases: `--jar` ,`--jars` ,`--extra-jar` ,`--class` ,`--extra-class` ,`--classes` ,`--extra-classes` ,`-classpath` ,`-cp` ,`--classpath` ,`--class-path` ,`--extra-class-path`
 
 **--resource-dirs**
 
@@ -1898,13 +1898,13 @@ Aliases: `--resource-dir`
 
 Allows to include the Scala compiler artifacts on the classpath.
 
-Aliases: `-with-compiler` ,`--with-scala-compiler`
+Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
 Copy compilation results to output directory using either relative or absolute path
 
-Aliases: `--compile-out` ,`--compile-output` ,`--destination` ,`-d` ,`--output-directory`
+Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
 **--java-opt**
 
@@ -2040,7 +2040,7 @@ Allows to execute a passed string as a Scala script
 
 A synonym to --script-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
-Aliases: `-e` ,`--execute-sc` ,`--execute-scala-script`
+Aliases: `-e` ,`--execute-scala-script` ,`--execute-sc`
 
 **--scala-snippet**
 
@@ -2050,13 +2050,13 @@ Allows to execute a passed string as Scala code
 
 Add extra JARs in the compilaion class path. Mainly using to run code in managed environments like Spark not to include certain depenencies on runtime ClassPath.
 
-Aliases: `--extra-compile-only-jar` ,`--compile-only-jars` ,`--compile-only-jar`
+Aliases: `--compile-only-jar` ,`--compile-only-jars` ,`--extra-compile-only-jar`
 
 **--extra-source-jars**
 
 Add extra source JARs
 
-Aliases: `--extra-source-jar` ,`--source-jars` ,`--source-jar`
+Aliases: `--source-jar` ,`--source-jars` ,`--extra-source-jar`
 
 **--platform**
 
@@ -2358,7 +2358,7 @@ Show options for ScalaNative
 
 Show options for Scaladoc
 
-Aliases: `--help-doc` ,`--doc-help` ,`--scaladoc-help`
+Aliases: `--help-doc` ,`--scaladoc-help` ,`--doc-help`
 
 **--help-repl**
 
@@ -2370,7 +2370,7 @@ Aliases: `--repl-help`
 
 Show options for Scalafmt
 
-Aliases: `--help-fmt` ,`--fmt-help` ,`--scalafmt-help`
+Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--strict-bloop-json-check**
 
@@ -2446,7 +2446,7 @@ Aliases: `--dep`
 
 Add compiler plugin dependencies
 
-Aliases: `--plugin` ,`-P`
+Aliases: `-P` ,`--plugin`
 
 **--scala-version**
 
@@ -2458,13 +2458,13 @@ Aliases: `-S` ,`--scala`
 
 Set the Scala binary version
 
-Aliases: `-B` ,`--scala-bin` ,`--scala-binary`
+Aliases: `-B` ,`--scala-binary` ,`--scala-bin`
 
 **--extra-jars**
 
 Add extra JARs and compiled classes to the class path
 
-Aliases: `--extra-class-path` ,`--class-path` ,`--classpath` ,`-cp` ,`-classpath` ,`--extra-classes` ,`--classes` ,`--extra-class` ,`--class` ,`--extra-jar` ,`--jars` ,`--jar`
+Aliases: `--jar` ,`--jars` ,`--extra-jar` ,`--class` ,`--extra-class` ,`--classes` ,`--extra-classes` ,`-classpath` ,`-cp` ,`--classpath` ,`--class-path` ,`--extra-class-path`
 
 **--resource-dirs**
 
@@ -2476,13 +2476,13 @@ Aliases: `--resource-dir`
 
 Allows to include the Scala compiler artifacts on the classpath.
 
-Aliases: `-with-compiler` ,`--with-scala-compiler`
+Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
 Copy compilation results to output directory using either relative or absolute path
 
-Aliases: `--compile-out` ,`--compile-output` ,`--destination` ,`-d` ,`--output-directory`
+Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
 **--java-opt**
 
@@ -2618,7 +2618,7 @@ Allows to execute a passed string as a Scala script
 
 A synonym to --script-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
-Aliases: `-e` ,`--execute-sc` ,`--execute-scala-script`
+Aliases: `-e` ,`--execute-scala-script` ,`--execute-sc`
 
 **--scala-snippet**
 
@@ -2628,13 +2628,13 @@ Allows to execute a passed string as Scala code
 
 Add extra JARs in the compilaion class path. Mainly using to run code in managed environments like Spark not to include certain depenencies on runtime ClassPath.
 
-Aliases: `--extra-compile-only-jar` ,`--compile-only-jars` ,`--compile-only-jar`
+Aliases: `--compile-only-jar` ,`--compile-only-jars` ,`--extra-compile-only-jar`
 
 **--extra-source-jars**
 
 Add extra source JARs
 
-Aliases: `--extra-source-jar` ,`--source-jars` ,`--source-jar`
+Aliases: `--source-jar` ,`--source-jars` ,`--extra-source-jar`
 
 **--platform**
 
@@ -2936,7 +2936,7 @@ Show options for ScalaNative
 
 Show options for Scaladoc
 
-Aliases: `--help-doc` ,`--doc-help` ,`--scaladoc-help`
+Aliases: `--help-doc` ,`--scaladoc-help` ,`--doc-help`
 
 **--help-repl**
 
@@ -2948,7 +2948,7 @@ Aliases: `--repl-help`
 
 Show options for Scalafmt
 
-Aliases: `--help-fmt` ,`--fmt-help` ,`--scalafmt-help`
+Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--strict-bloop-json-check**
 
@@ -3012,7 +3012,7 @@ Aliases: `--dep`
 
 Add compiler plugin dependencies
 
-Aliases: `--plugin` ,`-P`
+Aliases: `-P` ,`--plugin`
 
 **--scala-version**
 
@@ -3024,13 +3024,13 @@ Aliases: `-S` ,`--scala`
 
 Set the Scala binary version
 
-Aliases: `-B` ,`--scala-bin` ,`--scala-binary`
+Aliases: `-B` ,`--scala-binary` ,`--scala-bin`
 
 **--extra-jars**
 
 Add extra JARs and compiled classes to the class path
 
-Aliases: `--extra-class-path` ,`--class-path` ,`--classpath` ,`-cp` ,`-classpath` ,`--extra-classes` ,`--classes` ,`--extra-class` ,`--class` ,`--extra-jar` ,`--jars` ,`--jar`
+Aliases: `--jar` ,`--jars` ,`--extra-jar` ,`--class` ,`--extra-class` ,`--classes` ,`--extra-classes` ,`-classpath` ,`-cp` ,`--classpath` ,`--class-path` ,`--extra-class-path`
 
 **--resource-dirs**
 
@@ -3042,13 +3042,13 @@ Aliases: `--resource-dir`
 
 Allows to include the Scala compiler artifacts on the classpath.
 
-Aliases: `-with-compiler` ,`--with-scala-compiler`
+Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
 Copy compilation results to output directory using either relative or absolute path
 
-Aliases: `--compile-out` ,`--compile-output` ,`--destination` ,`-d` ,`--output-directory`
+Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
 ### SHOULD have options
 
@@ -3172,7 +3172,7 @@ Allows to execute a passed string as a Scala script
 
 A synonym to --script-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
-Aliases: `-e` ,`--execute-sc` ,`--execute-scala-script`
+Aliases: `-e` ,`--execute-scala-script` ,`--execute-sc`
 
 **--scala-snippet**
 
@@ -3182,13 +3182,13 @@ Allows to execute a passed string as Scala code
 
 Add extra JARs in the compilaion class path. Mainly using to run code in managed environments like Spark not to include certain depenencies on runtime ClassPath.
 
-Aliases: `--extra-compile-only-jar` ,`--compile-only-jars` ,`--compile-only-jar`
+Aliases: `--compile-only-jar` ,`--compile-only-jars` ,`--extra-compile-only-jar`
 
 **--extra-source-jars**
 
 Add extra source JARs
 
-Aliases: `--extra-source-jar` ,`--source-jars` ,`--source-jar`
+Aliases: `--source-jar` ,`--source-jars` ,`--extra-source-jar`
 
 **--platform**
 
@@ -3472,7 +3472,7 @@ Show options for ScalaNative
 
 Show options for Scaladoc
 
-Aliases: `--help-doc` ,`--doc-help` ,`--scaladoc-help`
+Aliases: `--help-doc` ,`--scaladoc-help` ,`--doc-help`
 
 **--help-repl**
 
@@ -3484,7 +3484,7 @@ Aliases: `--repl-help`
 
 Show options for Scalafmt
 
-Aliases: `--help-fmt` ,`--fmt-help` ,`--scalafmt-help`
+Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--strict-bloop-json-check**
 
@@ -3597,7 +3597,7 @@ Aliases: `--dep`
 
 Add compiler plugin dependencies
 
-Aliases: `--plugin` ,`-P`
+Aliases: `-P` ,`--plugin`
 
 **--scala-version**
 
@@ -3609,13 +3609,13 @@ Aliases: `-S` ,`--scala`
 
 Set the Scala binary version
 
-Aliases: `-B` ,`--scala-bin` ,`--scala-binary`
+Aliases: `-B` ,`--scala-binary` ,`--scala-bin`
 
 **--extra-jars**
 
 Add extra JARs and compiled classes to the class path
 
-Aliases: `--extra-class-path` ,`--class-path` ,`--classpath` ,`-cp` ,`-classpath` ,`--extra-classes` ,`--classes` ,`--extra-class` ,`--class` ,`--extra-jar` ,`--jars` ,`--jar`
+Aliases: `--jar` ,`--jars` ,`--extra-jar` ,`--class` ,`--extra-class` ,`--classes` ,`--extra-classes` ,`-classpath` ,`-cp` ,`--classpath` ,`--class-path` ,`--extra-class-path`
 
 **--resource-dirs**
 
@@ -3627,13 +3627,13 @@ Aliases: `--resource-dir`
 
 Allows to include the Scala compiler artifacts on the classpath.
 
-Aliases: `-with-compiler` ,`--with-scala-compiler`
+Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
 Copy compilation results to output directory using either relative or absolute path
 
-Aliases: `--compile-out` ,`--compile-output` ,`--destination` ,`-d` ,`--output-directory`
+Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
 **--java-opt**
 
@@ -3763,7 +3763,7 @@ Allows to execute a passed string as a Scala script
 
 A synonym to --script-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
-Aliases: `-e` ,`--execute-sc` ,`--execute-scala-script`
+Aliases: `-e` ,`--execute-scala-script` ,`--execute-sc`
 
 **--scala-snippet**
 
@@ -3773,13 +3773,13 @@ Allows to execute a passed string as Scala code
 
 Add extra JARs in the compilaion class path. Mainly using to run code in managed environments like Spark not to include certain depenencies on runtime ClassPath.
 
-Aliases: `--extra-compile-only-jar` ,`--compile-only-jars` ,`--compile-only-jar`
+Aliases: `--compile-only-jar` ,`--compile-only-jars` ,`--extra-compile-only-jar`
 
 **--extra-source-jars**
 
 Add extra source JARs
 
-Aliases: `--extra-source-jar` ,`--source-jars` ,`--source-jar`
+Aliases: `--source-jar` ,`--source-jars` ,`--extra-source-jar`
 
 **--platform**
 
@@ -4083,7 +4083,7 @@ Show options for ScalaNative
 
 Show options for Scaladoc
 
-Aliases: `--help-doc` ,`--doc-help` ,`--scaladoc-help`
+Aliases: `--help-doc` ,`--scaladoc-help` ,`--doc-help`
 
 **--help-repl**
 
@@ -4095,7 +4095,7 @@ Aliases: `--repl-help`
 
 Show options for Scalafmt
 
-Aliases: `--help-fmt` ,`--fmt-help` ,`--scalafmt-help`
+Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--strict-bloop-json-check**
 
@@ -4239,7 +4239,7 @@ Aliases: `--dep`
 
 Add compiler plugin dependencies
 
-Aliases: `--plugin` ,`-P`
+Aliases: `-P` ,`--plugin`
 
 **--scala-version**
 
@@ -4251,13 +4251,13 @@ Aliases: `-S` ,`--scala`
 
 Set the Scala binary version
 
-Aliases: `-B` ,`--scala-bin` ,`--scala-binary`
+Aliases: `-B` ,`--scala-binary` ,`--scala-bin`
 
 **--extra-jars**
 
 Add extra JARs and compiled classes to the class path
 
-Aliases: `--extra-class-path` ,`--class-path` ,`--classpath` ,`-cp` ,`-classpath` ,`--extra-classes` ,`--classes` ,`--extra-class` ,`--class` ,`--extra-jar` ,`--jars` ,`--jar`
+Aliases: `--jar` ,`--jars` ,`--extra-jar` ,`--class` ,`--extra-class` ,`--classes` ,`--extra-classes` ,`-classpath` ,`-cp` ,`--classpath` ,`--class-path` ,`--extra-class-path`
 
 **--resource-dirs**
 
@@ -4269,13 +4269,13 @@ Aliases: `--resource-dir`
 
 Allows to include the Scala compiler artifacts on the classpath.
 
-Aliases: `-with-compiler` ,`--with-scala-compiler`
+Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
 Copy compilation results to output directory using either relative or absolute path
 
-Aliases: `--compile-out` ,`--compile-output` ,`--destination` ,`-d` ,`--output-directory`
+Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
 ### SHOULD have options
 
@@ -4399,7 +4399,7 @@ Allows to execute a passed string as a Scala script
 
 A synonym to --script-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
-Aliases: `-e` ,`--execute-sc` ,`--execute-scala-script`
+Aliases: `-e` ,`--execute-scala-script` ,`--execute-sc`
 
 **--scala-snippet**
 
@@ -4409,13 +4409,13 @@ Allows to execute a passed string as Scala code
 
 Add extra JARs in the compilaion class path. Mainly using to run code in managed environments like Spark not to include certain depenencies on runtime ClassPath.
 
-Aliases: `--extra-compile-only-jar` ,`--compile-only-jars` ,`--compile-only-jar`
+Aliases: `--compile-only-jar` ,`--compile-only-jars` ,`--extra-compile-only-jar`
 
 **--extra-source-jars**
 
 Add extra source JARs
 
-Aliases: `--extra-source-jar` ,`--source-jars` ,`--source-jar`
+Aliases: `--source-jar` ,`--source-jars` ,`--extra-source-jar`
 
 **--platform**
 
@@ -4695,7 +4695,7 @@ Show options for ScalaNative
 
 Show options for Scaladoc
 
-Aliases: `--help-doc` ,`--doc-help` ,`--scaladoc-help`
+Aliases: `--help-doc` ,`--scaladoc-help` ,`--doc-help`
 
 **--help-repl**
 
@@ -4707,7 +4707,7 @@ Aliases: `--repl-help`
 
 Show options for Scalafmt
 
-Aliases: `--help-fmt` ,`--fmt-help` ,`--scalafmt-help`
+Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--strict-bloop-json-check**
 
@@ -5088,7 +5088,7 @@ Aliases: `--dep`
 
 Add compiler plugin dependencies
 
-Aliases: `--plugin` ,`-P`
+Aliases: `-P` ,`--plugin`
 
 **--scala-version**
 
@@ -5100,13 +5100,13 @@ Aliases: `-S` ,`--scala`
 
 Set the Scala binary version
 
-Aliases: `-B` ,`--scala-bin` ,`--scala-binary`
+Aliases: `-B` ,`--scala-binary` ,`--scala-bin`
 
 **--extra-jars**
 
 Add extra JARs and compiled classes to the class path
 
-Aliases: `--extra-class-path` ,`--class-path` ,`--classpath` ,`-cp` ,`-classpath` ,`--extra-classes` ,`--classes` ,`--extra-class` ,`--class` ,`--extra-jar` ,`--jars` ,`--jar`
+Aliases: `--jar` ,`--jars` ,`--extra-jar` ,`--class` ,`--extra-class` ,`--classes` ,`--extra-classes` ,`-classpath` ,`-cp` ,`--classpath` ,`--class-path` ,`--extra-class-path`
 
 **--resource-dirs**
 
@@ -5118,13 +5118,13 @@ Aliases: `--resource-dir`
 
 Allows to include the Scala compiler artifacts on the classpath.
 
-Aliases: `-with-compiler` ,`--with-scala-compiler`
+Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
 Copy compilation results to output directory using either relative or absolute path
 
-Aliases: `--compile-out` ,`--compile-output` ,`--destination` ,`-d` ,`--output-directory`
+Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
 ### SHOULD have options
 
@@ -5248,7 +5248,7 @@ Allows to execute a passed string as a Scala script
 
 A synonym to --script-snippet, which defaults the sub-command to `run` when no sub-command is passed explicitly
 
-Aliases: `-e` ,`--execute-sc` ,`--execute-scala-script`
+Aliases: `-e` ,`--execute-scala-script` ,`--execute-sc`
 
 **--scala-snippet**
 
@@ -5258,13 +5258,13 @@ Allows to execute a passed string as Scala code
 
 Add extra JARs in the compilaion class path. Mainly using to run code in managed environments like Spark not to include certain depenencies on runtime ClassPath.
 
-Aliases: `--extra-compile-only-jar` ,`--compile-only-jars` ,`--compile-only-jar`
+Aliases: `--compile-only-jar` ,`--compile-only-jars` ,`--extra-compile-only-jar`
 
 **--extra-source-jars**
 
 Add extra source JARs
 
-Aliases: `--extra-source-jar` ,`--source-jars` ,`--source-jar`
+Aliases: `--source-jar` ,`--source-jars` ,`--extra-source-jar`
 
 **--platform**
 
@@ -5544,7 +5544,7 @@ Show options for ScalaNative
 
 Show options for Scaladoc
 
-Aliases: `--help-doc` ,`--doc-help` ,`--scaladoc-help`
+Aliases: `--help-doc` ,`--scaladoc-help` ,`--doc-help`
 
 **--help-repl**
 
@@ -5556,7 +5556,7 @@ Aliases: `--repl-help`
 
 Show options for Scalafmt
 
-Aliases: `--help-fmt` ,`--fmt-help` ,`--scalafmt-help`
+Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--strict-bloop-json-check**
 


### PR DESCRIPTION
Fixes #1883
Related to https://github.com/alexarchambault/case-app/pull/480

Some name aliases were moved to the top of the list of `@Name`s so that they are displayed in the short help. In this way we get full option name displayed and possibly a single letter flag for it.

Rules for limiting name aliases are:
Using the `namesLimit = Some(N)` parameter in HelpFormat would pick N-1 first name aliases + the main name.
For example, for option:
```
    @ExtraName("fourOption")
    @ExtraName("f")
    @ExtraName("four")
    @ExtraName("fOpt")
    fourth: Int = 0
```

and `namesLimit = Some(2)` will result in `--fourth, --four-option` getting displayed
and for full help `-f, --four, --f-opt, --fourth, --four-option`
