### PR TITLE
deps: update mill-scalafix to 0.3.1

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -138,7 +138,6 @@ object Deps {
   def munit                      = ivy"org.scalameta::munit:0.7.29"
   def nativeTestRunner           = ivy"org.scala-native::test-runner:${Versions.scalaNative}"
   def nativeTools                = ivy"org.scala-native::tools:${Versions.scalaNative}"
-  def organizeImports            = ivy"com.github.liancheng::organize-imports:0.6.0"
   def osLib                      = ivy"com.lihaoyi::os-lib:0.9.1"
   def pprint                     = ivy"com.lihaoyi::pprint:0.8.1"
   def pythonInterface            = ivy"io.github.alexarchambault.python:interface:0.1.0"

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -779,13 +779,13 @@ trait FormatNativeImageConf extends JavaModule {
 }
 
 trait ScalaCliScalafixModule extends ScalafixModule {
+
+  override def semanticDbVersion = Deps.Versions.scalaMeta
+
   def scalafixConfig = T {
     if (scalaVersion().startsWith("2.")) super.scalafixConfig()
     else Some(os.pwd / ".scalafix3.conf")
   }
-  def scalafixIvyDeps = super.scalafixIvyDeps() ++ Seq(
-    Deps.organizeImports
-  )
   def scalacPluginIvyDeps = super.scalacPluginIvyDeps() ++ {
     if (scalaVersion().startsWith("2.")) Seq(Deps.semanticDbScalac)
     else Nil


### PR DESCRIPTION
The main reason for this is that you can get rid of the external organize imports rule now that it's inlined.