### PR TITLE
Prevent downloading Java 17 when running a REPL without sources

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
@@ -112,8 +112,8 @@ object Repl extends ScalaCommand[ReplOptions] {
     CurrentParams.workspaceOpt = Some(inputs.workspace)
 
     val threads = BuildThreads.create()
-
-    val compilerMaker = options.shared.compilerMaker(threads).orExit(logger)
+    // compilerMaker should be a lazy val to prevent download a JAVA 17 for bloop when users run the repl without sources
+    lazy val compilerMaker = options.shared.compilerMaker(threads).orExit(logger)
 
     val directories = Directories.directories
 

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestsDefault.scala
@@ -2,6 +2,8 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
+import java.io.File
+
 import scala.util.Properties
 
 // format: off
@@ -60,4 +62,29 @@ class ReplTestsDefault extends ReplTestDefinitions(
       expect(asJarOutput == "hasDir=false")
     }
   }
+
+  if (TestUtil.isNativeCli)
+    test("not download java 17 when run repl without sources") {
+      TestInputs.empty.fromRoot { root =>
+        val java8Home =
+          os.Path(os.proc(TestUtil.cs, "java-home", "--jvm", "zulu:8").call().out.trim(), os.pwd)
+
+        val res =
+          os.proc(TestUtil.cli, "--power", "repl", TestUtil.extraOptions, "--", "-version").call(
+            cwd = root,
+            mergeErrIntoOut = true,
+            env = Map(
+              "JAVA_HOME"              -> java8Home.toString,
+              "COURSIER_ARCHIVE_CACHE" -> (root / "archive-cache").toString(),
+              "COURSIER_CACHE"         -> (root / "cache").toString(),
+              "PATH" -> ((java8Home / "bin").toString + File.pathSeparator + System.getenv("PATH"))
+            )
+          )
+
+        val output = res.out.trim().toLowerCase()
+
+        expect(!output.contains("jdk17"))
+        expect(!output.contains("jvm-index"))
+      }
+    }
 }


### PR DESCRIPTION
Fixes #2268 