### PR TITLE
Resolve semanticDB for older scala version

### DIFF
--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -360,4 +360,12 @@ class BuildOptionsTests extends munit.FunSuite {
     }
   }
 
+  test("resolve semanticDB for older scala version") {
+    val buildOptions = BuildOptions()
+    val scalaVersion = "2.13.3"
+
+    val semanticDbVersion = buildOptions.findSemanticDbVersion(scalaVersion)
+    expect(semanticDbVersion == "4.8.4")
+  }
+
 }

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -129,7 +129,7 @@ final case class BuildOptions(
       case Some(sv) if sv.startsWith("2.") && generateSemDbs =>
         val semanticDbVersion = findSemanticDbVersion(sv)
         Seq(
-          dep"$semanticDbPluginOrganization:::$semanticDbPluginModuleName:$semanticDbPluginVersion"
+          dep"$semanticDbPluginOrganization:::$semanticDbPluginModuleName:$semanticDbVersion"
         )
       case _ => Nil
     }

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -88,7 +88,7 @@ object Deps {
     def coursierM1Cli        = coursierDefault
     def jsoniterScala        = "2.23.2"
     def jsoniterScalaJava8   = "2.13.5.2"
-    def scalaMeta            = "4.8.4"
+    def scalaMeta            = "4.8.6"
     def scalaNative          = "0.4.14"
     def scalaPackager        = "0.1.29"
     def signingCli           = "0.2.2"


### PR DESCRIPTION
As `semanticdb-scalac` is published only for the latest four patch versions of Scala `2.12` and `2.13`, we need a mechanism to find the recent supported `semanticdb-scalac` version for older Scala version. This would apply when users are trying to generate a semanticDb for  `2.13.4` Scala  version.

A similar implementation was done in Bloop, which you can see here: https://github.com/scalacenter/bloop/pull/2097.