### PR TITLE
Skip setting release flag when user pass directly -release or -java-o…

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -766,8 +766,9 @@ object Build {
     else if (compilerJvmVersionOpt.exists(_.value == 8))
       None
     else if (
-      options.scalaOptions.scalacOptions.values.exists(
-        _.headOption.exists(_.value.value == "-release")
+      options.scalaOptions.scalacOptions.values.exists(opt =>
+        opt.headOption.exists(_.value.value.startsWith("-release")) ||
+        opt.headOption.exists(_.value.value.startsWith("-java-output-version"))
       )
     )
       None


### PR DESCRIPTION
…utput-version

Fixes #2126 

When users pass `-java-output-version` or `-release` we shouldn't pass by default options `-release` for compiler. 