### PR TITLE
Fix - install ps, which is necessary for starting Bloop

### DIFF
--- a/.github/scripts/docker/ScalaCliDockerFile
+++ b/.github/scripts/docker/ScalaCliDockerFile
@@ -1,5 +1,5 @@
 FROM debian:stable-slim
-RUN apt update && apt install build-essential libz-dev clang -y
+RUN apt update && apt install build-essential libz-dev clang procps -y
 ADD scala-cli /usr/bin/
 RUN \
  echo "println(1)" | scala-cli -S 3 - -v -v -v && \

--- a/.github/scripts/docker/ScalaCliDockerFile
+++ b/.github/scripts/docker/ScalaCliDockerFile
@@ -4,7 +4,7 @@ ADD scala-cli /usr/bin/
 RUN \
  echo "println(1)" | scala-cli -S 3 - -v -v -v && \
  echo "println(1)" | scala-cli -S 2.13 - -v -v -v && \
- echo "println(1)" | scala-cli -S 2.12 - -v -v -v \
+ echo "println(1)" | scala-cli -S 2.12 - -v -v -v
 RUN \
  echo "println(1)" | scala-cli --power package --native _.sc --force && \
  echo "println(1)" | scala-cli --power package --native-image _.sc --force

--- a/modules/integration/docker/src/test/scala/scala/cli/integration/RunDockerTests.scala
+++ b/modules/integration/docker/src/test/scala/scala/cli/integration/RunDockerTests.scala
@@ -13,6 +13,12 @@ class RunDockerTests extends munit.FunSuite {
   lazy val termOpt = if (System.console() == null) Nil else Seq("-t")
   lazy val ciOpt   = Option(System.getenv("CI")).map(v => Seq("-e", s"CI=$v")).getOrElse(Nil)
   lazy val slimScalaCliImage = "scala-cli-slim"
+  val extraOptions: List[String] = List(
+    "--bloop-startup-timeout",
+    "2min",
+    "--bloop-bsp-timeout",
+    "1min"
+  )
 
   test("run simple app in in docker") {
     val fileName = "simple.sc"
@@ -28,7 +34,7 @@ class RunDockerTests extends munit.FunSuite {
       val cmd = Seq[os.Shellable](
         // format: off
         "docker", "run", "--rm", termOpt, "-v", s"$root:/data", "-w", "/data", ciOpt,
-        imageName, fileName
+        imageName, fileName, extraOptions
         // format: on
       )
       os.proc(cmd).call(
@@ -54,7 +60,7 @@ class RunDockerTests extends munit.FunSuite {
         val cmdPackage = Seq[os.Shellable](
           // format: off
           "docker", "run", "--rm", termOpt, "-v", s"$root:/data", "-w", "/data", ciOpt,
-          imageName, "--power", "package", "--native", fileName, "-o", "Hello"
+          imageName, "--power", "package", "--native", fileName, "-o", "Hello", extraOptions
           // format: on
         )
         val procPackage = os.proc(cmdPackage).call(cwd = root, check = false)
@@ -70,7 +76,7 @@ class RunDockerTests extends munit.FunSuite {
         val cmdPackage = Seq[os.Shellable](
           // format: off
           "docker", "run", "--rm", termOpt, "-v", s"$root:/data", "-w", "/data", ciOpt,
-          imageName, "--power", "package", "--native-image", fileName, "-o", "Hello"
+          imageName, "--power", "package", "--native-image", fileName, "-o", "Hello", extraOptions
           // format: on
         )
         val procPackage = os.proc(cmdPackage).call(cwd = root, check = false)


### PR DESCRIPTION
The latest docker image version, `debian:stable-slim`, doesn't include `ps`. I added the installation of `ps` to ensure bloop starts correctly; without it, the following [error](https://github.com/VirtusLab/scala-cli/actions/runs/5776298075/job/15655258536#step:4:3202) was thrown during Bloop's initialization:
```
 Exception in thread "main" java.io.IOException: Cannot run program "ps": error=2, No such file or directory
 	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1143)
 	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1073)
 	at scala.sys.process.ProcessBuilderImpl$Simple.run(ProcessBuilderImpl.scala:75)
 	at scala.sys.process.ProcessBuilderImpl$AbstractBuilder.$bang(ProcessBuilderImpl.scala:119)
 	at scala.sys.process.ProcessBuilderImpl$AbstractBuilder.slurp(ProcessBuilderImpl.scala:135)
 	at scala.sys.process.ProcessBuilderImpl$AbstractBuilder.$bang$bang(ProcessBuilderImpl.scala:108)
 	at libdaemonjvm.internal.Processes$.isRunning(Processes.scala:20)
 	at libdaemonjvm.internal.LockProcess$Default.$anonfun$isRunning$2(LockProcess.scala:16)
 	at scala.runtime.java8.JFunction0$mcZ$sp.apply(JFunction0$mcZ$sp.java:23)
 	at scala.Option.getOrElse(Option.scala:189)
 	at libdaemonjvm.internal.LockProcess$Default.isRunning(LockProcess.scala:16)
 	at libdaemonjvm.server.Lock$.$anonfun$tryAcquire$6(Lock.scala:76)
 	at libdaemonjvm.server.Lock$.$anonfun$tryAcquire$6$adapted(Lock.scala:75)
 	at scala.Option.flatMap(Option.scala:271)
 	at libdaemonjvm.server.Lock$.ifFiles$1(Lock.scala:75)
 	at libdaemonjvm.server.Lock$.tryAcquire(Lock.scala:94)
 	at bloop.Bloop$.loop$1(Bloop.scala:95)
 	at bloop.Bloop$.main(Bloop.scala:113)
 	at bloop.Bloop.main(Bloop.scala)
 Caused by: java.io.IOException: error=2, No such file or directory
 	at java.base/java.lang.ProcessImpl.forkAndExec(Native Method)
 	at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:314)
 	at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:244)
 	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1143)
 	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1073)
 	at scala.sys.process.ProcessBuilderImpl$Simple.run(ProcessBuilderImpl.scala:75)
 	at scala.sys.process.ProcessBuilderImpl$AbstractBuilder.$bang(ProcessBuilderImpl.scala:119)
 	at scala.sys.process.ProcessBuilderImpl$AbstractBuilder.slurp(ProcessBuilderImpl.scala:135)
 	at scala.sys.process.ProcessBuilderImpl$AbstractBuilder.$bang$bang(ProcessBuilderImpl.scala:108)
 	at libdaemonjvm.internal.Processes$.isRunning(Processes.scala:20)
 	at libdaemonjvm.internal.LockProcess$Default.$anonfun$isRunning$2(LockProcess.scala:16)
 	at scala.runtime.java8.JFunction0$mcZ$sp.apply(JFunction0$mcZ$sp.java:23)
 	at scala.Option.getOrElse(Option.scala:189)
 	at libdaemonjvm.internal.LockProcess$Default.isRunning(LockProcess.scala:16)
 	at libdaemonjvm.server.Lock$.$anonfun$tryAcquire$6(Lock.scala:76)
 	at libdaemonjvm.server.Lock$.$anonfun$tryAcquire$6$adapted(Lock.scala:75)
 	at scala.Option.flatMap(Option.scala:271)
 	at libdaemonjvm.server.Lock$.ifFiles$1(Lock.scala:75)
 	at libdaemonjvm.server.Lock$.tryAcquire(Lock.scala:94)
 	at bloop.Bloop$.loop$1(Bloop.scala:95)
 	at bloop.Bloop$.main(Bloop.scala:113)
 	at bloop.Bloop.main(Bloop.scala)
 Caused by: java.io.IOException: error=2, No such file or directory
 	at java.base/java.lang.ProcessImpl.forkAndExec(Native Method)
 	at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:314)
 	at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:244)
 	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1110)
```