### PR TITLE
Remove ComputeVersion.Command, make ComputeVersion classes positioned

### DIFF
--- a/modules/build/src/test/scala/scala/build/options/publish/ComputeVersionTests.scala
+++ b/modules/build/src/test/scala/scala/build/options/publish/ComputeVersionTests.scala
@@ -8,20 +8,6 @@ import scala.build.options.ComputeVersion
 import scala.build.tests.{TestInputs, TestUtil}
 
 class ComputeVersionTests extends munit.FunSuite {
-
-  test("command") {
-    val ver = "1.2.3"
-    val inputs = TestInputs(
-      os.rel / "version" -> ver
-    )
-    inputs.fromRoot { root =>
-      val cv = ComputeVersion.Command(Seq("cat", "version"), Nil)
-      val readVersion = cv.get(root)
-        .fold(ex => throw new Exception(ex), identity)
-      expect(readVersion == ver)
-    }
-  }
-
   test("git tag") {
     TestInputs().fromRoot { root =>
       val ghRepo = "scala-cli/compute-version-test"

--- a/modules/build/src/test/scala/scala/build/options/publish/ComputeVersionTests.scala
+++ b/modules/build/src/test/scala/scala/build/options/publish/ComputeVersionTests.scala
@@ -15,7 +15,7 @@ class ComputeVersionTests extends munit.FunSuite {
       os.rel / "version" -> ver
     )
     inputs.fromRoot { root =>
-      val cv = ComputeVersion.Command(Seq("cat", "version"))
+      val cv = ComputeVersion.Command(Seq("cat", "version"), Nil)
       val readVersion = cv.get(root)
         .fold(ex => throw new Exception(ex), identity)
       expect(readVersion == ver)
@@ -31,7 +31,7 @@ class ComputeVersionTests extends munit.FunSuite {
       os.proc("git", "clone", repo)
         .call(cwd = root, stdin = os.Inherit, stdout = os.Inherit)
       val dir = root / "compute-version-test"
-      val cv  = ComputeVersion.GitTag(os.rel, true, "0.0.1-SNAPSHOT")
+      val cv  = ComputeVersion.GitTag(os.rel, true, Nil, "0.0.1-SNAPSHOT")
 
       val commitExpectedVersions = Seq(
         "8ea4e87f202fbcc369bec9615e7ddf2c14b39e9d" -> "0.2.0-1-g8ea4e87-SNAPSHOT",
@@ -56,7 +56,7 @@ class ComputeVersionTests extends munit.FunSuite {
       expect(!hasHead)
 
       val defaultVersion = "0.0.2-SNAPSHOT"
-      val cv             = ComputeVersion.GitTag(os.rel, true, defaultVersion)
+      val cv             = ComputeVersion.GitTag(os.rel, true, Nil, defaultVersion)
 
       val version = cv.get(root)
         .fold(ex => throw new Exception(ex), identity)

--- a/modules/build/src/test/scala/scala/build/tests/SourceGeneratorTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/SourceGeneratorTests.scala
@@ -244,7 +244,6 @@ class SourceGeneratorTests extends munit.FunSuite {
            |//> using platform scala-js
            |//> using jsVersion 1.13.1
            |//> using jsEsVersionStr es2015
-           |//> using computeVersion "command:echo TestVersion"
            |
            |//> using buildInfo
            |
@@ -281,7 +280,7 @@ class SourceGeneratorTests extends munit.FunSuite {
              |  val jsEsVersion = Some("es2015")
              |  val scalaNativeVersion = None
              |  val mainClass = Some("Main")
-             |  val projectVersion = Some("TestVersion")
+             |  val projectVersion = None
              |
              |  object Main {
              |    val sources = Seq("${root / "main.scala"}")
@@ -319,7 +318,6 @@ class SourceGeneratorTests extends munit.FunSuite {
            |//> using mainClass "Main"
            |//> using resourceDir ./resources
            |//> using jar TEST1.jar TEST2.jar
-           |//> using computeVersion "command:echo TestVersion"
            |
            |//> using buildInfo
            |
@@ -356,7 +354,7 @@ class SourceGeneratorTests extends munit.FunSuite {
              |  val jsEsVersion = None
              |  val scalaNativeVersion = None
              |  val mainClass = Some("Main")
-             |  val projectVersion = Some("TestVersion")
+             |  val projectVersion = None
              |
              |  object Main {
              |    val sources = Seq("${root / "main.scala"}")

--- a/modules/build/src/test/scala/scala/build/tests/SourceGeneratorTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/SourceGeneratorTests.scala
@@ -74,7 +74,7 @@ class SourceGeneratorTests extends munit.FunSuite {
     println(s"Git initialized at $cwd")
   }
 
-  test(s"BuildInfo source generated") {
+  test("BuildInfo source generated") {
     val inputs = TestInputs(
       os.rel / "main.scala" ->
         """//> using dep com.lihaoyi::os-lib:0.9.1
@@ -154,7 +154,7 @@ class SourceGeneratorTests extends munit.FunSuite {
 
   }
 
-  test(s"BuildInfo for native") {
+  test("BuildInfo for native") {
     val inputs = TestInputs(
       os.rel / "main.scala" ->
         s"""//> using dep "com.lihaoyi::os-lib:0.9.1"
@@ -230,7 +230,7 @@ class SourceGeneratorTests extends munit.FunSuite {
     }
   }
 
-  test(s"BuildInfo for js") {
+  test("BuildInfo for js") {
     val inputs = TestInputs(
       os.rel / "main.scala" ->
         s"""//> using dep "com.lihaoyi::os-lib:0.9.1"
@@ -308,7 +308,7 @@ class SourceGeneratorTests extends munit.FunSuite {
     }
   }
 
-  test(s"BuildInfo for Scala 2") {
+  test("BuildInfo for Scala 2") {
     val inputs = TestInputs(
       os.rel / "main.scala" ->
         s"""//> using dep "com.lihaoyi::os-lib:0.9.1"

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -370,7 +370,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
     name
   }
   def defaultComputeVersion(mayDefaultToGitTag: Boolean): Option[ComputeVersion] =
-    if (mayDefaultToGitTag) Some(ComputeVersion.GitTag(os.rel, dynVer = false))
+    if (mayDefaultToGitTag) Some(ComputeVersion.GitTag(os.rel, dynVer = false, positions = Nil))
     else None
   def defaultVersionError =
     new MissingPublishOptionError("version", "--version", "publish.version")

--- a/modules/core/src/main/scala/scala/build/errors/BuildInfoGenerationError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/BuildInfoGenerationError.scala
@@ -1,4 +1,10 @@
 package scala.build.errors
 
-final class BuildInfoGenerationError(cause: Exception)
-    extends BuildException(s"BuildInfo generation error: ${cause.getMessage}", cause = cause)
+import scala.build.Position
+
+final class BuildInfoGenerationError(msg: String, positions: Seq[Position], cause: Exception)
+    extends BuildException(
+      s"BuildInfo generation error: $msg",
+      positions = positions,
+      cause = cause
+    )

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
@@ -574,6 +574,28 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
          |```""".stripMargin
     )
 
+    b.section(
+      """## Project version
+        |
+        |A part of the BuildInfo object is the project version. By default, an attempt is made to deduce it using git tags
+        |of the workspace repository. If this fails (e.g. no git repository is present), the version is set to `0.1.0-SNAPSHOT`.
+        |You can override this behaviour by passing the `--project-version` option to Scala CLI or by using a
+        |`//> using projectVersion` directive.
+        |
+        |Please note that only tags that follow the semantic versioning are taken into consideration.
+        |
+        |Values available for project version configuration are:
+        |- `git:tag` or `git`: use the latest stable git tag, if it is older than HEAD then try to increment it
+        |    and add a suffix `-SNAPSHOT`, if no tag is available then use `0.1.0-SNAPSHOT`
+        |- `git:dynver`: use the latest (stable or unstable) git tag, if it is older than HEAD then use the output of
+        |    `-{distance from last tag}-g{shortened version of HEAD commit hash}-SNAPSHOT`, if no tag is available then use `0.1.0-SNAPSHOT`
+        |
+        |The difference between stable and unstable tags are, that the latter can contain letters, e.g. `v0.1.0-RC1`.
+        |It is also possible to specify the path to the repository, e.g. `git:tag:../my-repo`, `git:dynver:../my-repo`.
+        |
+        |""".stripMargin
+    )
+
     b.mkString
   }
 

--- a/website/docs/commands/publishing/publish.md
+++ b/website/docs/commands/publishing/publish.md
@@ -81,6 +81,17 @@ To override this default value, set the `publish.computeVersion` directive, like
 //> using publish.computeVersion git:tag
 ```
 
+Please note that only tags that follow the semantic versioning are taken into consideration.
+
+Values available for project version configuration are:
+- `git:tag` or `git`: use the latest stable git tag, if it is older than HEAD then try to increment it
+  and add a suffix `-SNAPSHOT`, if no tag is available then use `0.1.0-SNAPSHOT`
+- `git:dynver`: use the latest (stable or unstable) git tag, if it is older than HEAD then use the output of
+  `-{distance from last tag}-g{shortened version of HEAD commit hash}-SNAPSHOT`, if no tag is available then use `0.1.0-SNAPSHOT`
+
+The difference between stable and unstable tags are, that the latter can contain letters, e.g. `v0.1.0-RC1`.
+It is also possible to specify the path to the repository, e.g. `git:tag:../my-repo`, `git:dynver:../my-repo`.
+
 ## Repository settings
 
 A repository is required for the `publish` command, and might need other settings to work fine

--- a/website/docs/reference/build-info.md
+++ b/website/docs/reference/build-info.md
@@ -90,3 +90,23 @@ object BuildInfo {
 }
 ```
 
+## Project version
+
+A part of the BuildInfo object is the project version. By default, an attempt is made to deduce it using git tags
+of the workspace repository. If this fails (e.g. no git repository is present), the version is set to `0.1.0-SNAPSHOT`.
+You can override this behaviour by passing the `--project-version` option to Scala CLI or by using a
+`//> using projectVersion` directive.
+
+Please note that only tags that follow the semantic versioning are taken into consideration.
+
+Values available for project version configuration are:
+- `git:tag` or `git`: use the latest stable git tag, if it is older than HEAD then try to increment it
+    and add a suffix `-SNAPSHOT`, if no tag is available then use `0.1.0-SNAPSHOT`
+- `git:dynver`: use the latest (stable or unstable) git tag, if it is older than HEAD then use the output of
+    `-{distance from last tag}-g{shortened version of HEAD commit hash}-SNAPSHOT`, if no tag is available then use `0.1.0-SNAPSHOT`
+
+The difference between stable and unstable tags are, that the latter can contain letters, e.g. `v0.1.0-RC1`.
+It is also possible to specify the path to the repository, e.g. `git:tag:../my-repo`, `git:dynver:../my-repo`.
+
+
+


### PR DESCRIPTION
Remove ComputeVersion.Command since it may be unsafe.
Add positioning to ComputeVersion instances to be able to point out the erroneous directive.
+ Documentation for computing version from #2310 (also for publishing)