### PR TITLE
Fix typo in buildInfo directive docs

### DIFF
--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/BuildInfo.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/BuildInfo.scala
@@ -6,7 +6,7 @@ import scala.build.options.{BuildOptions, SourceGeneratorOptions}
 import scala.cli.commands.SpecificationLevel
 
 @DirectiveExamples("//> using buildInfo")
-@DirectiveUsage("//> using buildInfo", "`//> using buildInfo")
+@DirectiveUsage("//> using buildInfo", "`//> using buildInfo`")
 @DirectiveDescription("Generate BuildInfo for project")
 @DirectiveLevel(SpecificationLevel.RESTRICTED)
 final case class BuildInfo(

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -9,7 +9,7 @@ sidebar_position: 2
 
 Generate BuildInfo for project
 
-`//> using buildInfo
+`//> using buildInfo`
 
 #### Examples
 `//> using buildInfo`


### PR DESCRIPTION
Small fix similar to https://github.com/VirtusLab/scala-cli/pull/2233.

I fixed the typo in the `BuildInfo.scala` source and then regenerated the `directives.md` using this command:
```bash
./mill -i generate-reference-doc.run
```