### PR TITLE
Accumulate exp warnings with logger

### DIFF
--- a/modules/build/src/main/scala/scala/build/CrossSources.scala
+++ b/modules/build/src/main/scala/scala/build/CrossSources.scala
@@ -235,6 +235,8 @@ object CrossSources {
           distinctSources
         }
 
+    logger.flushExperimentalWarnings
+
     val scopedRequirements       = preprocessedSources.flatMap(_.scopedRequirements)
     val scopedRequirementsByRoot = scopedRequirements.groupBy(_.path.root)
     def baseReqs(path: ScopePath): BuildRequirements = {

--- a/modules/build/src/main/scala/scala/build/PersistentDiagnosticLogger.scala
+++ b/modules/build/src/main/scala/scala/build/PersistentDiagnosticLogger.scala
@@ -1,12 +1,13 @@
 package scala.build
 
 import bloop.rifle.BloopRifleLogger
-import org.scalajs.logging.{Logger => ScalaJsLogger}
+import org.scalajs.logging.Logger as ScalaJsLogger
 
 import java.io.PrintStream
 
 import scala.build.errors.{BuildException, Diagnostic}
-import scala.scalanative.{build => sn}
+import scala.build.internals.FeatureType
+import scala.scalanative.build as sn
 
 class PersistentDiagnosticLogger(parent: Logger) extends Logger {
   private val diagBuilder = List.newBuilder[Diagnostic]
@@ -39,4 +40,9 @@ class PersistentDiagnosticLogger(parent: Logger) extends Logger {
   def compilerOutputStream: PrintStream = parent.compilerOutputStream
 
   def verbosity: Int = parent.verbosity
+
+  def experimentalWarning(featureName: String, featureType: FeatureType): Unit =
+    parent.experimentalWarning(featureName, featureType)
+
+  def flushExperimentalWarnings: Unit = parent.flushExperimentalWarnings
 }

--- a/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
+++ b/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
@@ -2,27 +2,34 @@ package scala.build.internal.util
 
 import scala.build.input.ScalaCliInvokeData
 import scala.build.internal.Constants
+import scala.build.internals.FeatureType
 import scala.build.preprocessing.directives.{DirectiveHandler, ScopedDirective}
 import scala.cli.commands.{SpecificationLevel, tags}
 import scala.cli.config.Key
 
 object WarningMessages {
   private val scalaCliGithubUrl = s"https://github.com/${Constants.ghOrg}/${Constants.ghName}"
-  private def experimentalFeatureUsed(featureName: String): String =
-    s"""$featureName is experimental.
-       |Please bear in mind that non-ideal user experience should be expected.
+
+  private val experimentalNote =
+    s"""Please bear in mind that non-ideal user experience should be expected.
        |If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at $scalaCliGithubUrl""".stripMargin
-  def experimentalDirectiveUsed(name: String): String =
-    experimentalFeatureUsed(s"The `$name` directive")
+  def experimentalFeaturesUsed(namesAndFeatureTypes: Seq[(String, FeatureType)]): String = {
+    val message = namesAndFeatureTypes match {
+      case Seq((name, featureType)) => s"The $name $featureType is experimental"
+      case namesAndTypes =>
+        val nl = System.lineSeparator()
+        val bulletPointList = namesAndTypes.map((name, fType) => s" - `$name` $fType")
+          .mkString(nl)
+        s"""Some utilized features are marked as experimental:
+           |$bulletPointList""".stripMargin
+    }
+    s"""$message
+       |$experimentalNote""".stripMargin
+  }
 
   def experimentalSubcommandUsed(name: String): String =
-    experimentalFeatureUsed(s"The `$name` sub-command")
-
-  def experimentalOptionUsed(name: String): String =
-    experimentalFeatureUsed(s"The `$name` option")
-
-  def experimentalConfigKeyUsed(name: String): String =
-    experimentalFeatureUsed(s"The `$name` configuration key")
+    s"""The `$name` sub-command is experimental.
+       |$experimentalNote""".stripMargin
 
   def rawValueNotWrittenToPublishFile(
     rawValue: String,

--- a/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
+++ b/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
@@ -15,19 +15,31 @@ object WarningMessages {
        |If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at $scalaCliGithubUrl""".stripMargin
   def experimentalFeaturesUsed(namesAndFeatureTypes: Seq[(String, FeatureType)]): String = {
     val message = namesAndFeatureTypes match {
-      case Seq((name, featureType)) => s"The $name $featureType is experimental"
+      case Seq((name, featureType)) => s"The `$name` $featureType is experimental"
       case namesAndTypes =>
-        val nl = System.lineSeparator()
-        val bulletPointList = namesAndTypes.map((name, fType) => s" - `$name` $fType")
-          .mkString(nl)
-        s"""Some utilized features are marked as experimental:
+        val nl                   = System.lineSeparator()
+        val distinctFeatureTypes = namesAndTypes.map(_._2).distinct
+        val (bulletPointList, featureNameToPrint) = if (distinctFeatureTypes.size == 1)
+          (
+            namesAndTypes.map((name, fType) => s" - `$name`")
+              .mkString(nl),
+            s"${distinctFeatureTypes.head}s" // plural form
+          )
+        else
+          (
+            namesAndTypes.map((name, fType) => s" - `$name` $fType")
+              .mkString(nl),
+            "features"
+          )
+
+        s"""Some utilized $featureNameToPrint are marked as experimental:
            |$bulletPointList""".stripMargin
     }
     s"""$message
        |$experimentalNote""".stripMargin
   }
 
-  def experimentalSubcommandUsed(name: String): String =
+  def experimentalSubcommandWarning(name: String): String =
     s"""The `$name` sub-command is experimental.
        |$experimentalNote""".stripMargin
 

--- a/modules/build/src/main/scala/scala/build/preprocessing/DirectivesPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/DirectivesPreprocessor.scala
@@ -15,7 +15,7 @@ import scala.build.errors.{
 }
 import scala.build.input.ScalaCliInvokeData
 import scala.build.internal.util.WarningMessages
-import scala.build.internal.util.WarningMessages.experimentalDirectiveUsed
+import scala.build.internals.FeatureType
 import scala.build.options.{
   BuildOptions,
   BuildRequirements,
@@ -123,11 +123,12 @@ case class DirectivesPreprocessor(
       if !allowRestrictedFeatures && (handler.isRestricted || handler.isExperimental) then
         Left(DirectiveErrors(
           ::(WarningMessages.powerDirectiveUsedInSip(scopedDirective, handler), Nil),
+          // TODO: use positions from ExtractedDirectives to get the full directive underlined
           DirectiveUtil.positions(scopedDirective.directive.values, path)
         ))
       else
         if handler.isExperimental && !shouldSuppressExperimentalFeatures then
-          logger.message(experimentalDirectiveUsed(scopedDirective.directive.toString))
+          logger.experimentalWarning(scopedDirective.directive.toString, FeatureType.Directive)
         handler.handleValues(scopedDirective, logger)
 
     val handlersMap = handlers

--- a/modules/build/src/main/scala/scala/build/preprocessing/JavaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/JavaPreprocessor.scala
@@ -47,8 +47,7 @@ final case class JavaPreprocessor(
           val content: String = value(PreprocessingUtil.maybeRead(j.path))
           val scopePath       = ScopePath.fromPath(j.path)
           val preprocessedDirectives: PreprocessedDirectives = value {
-            DirectivesPreprocessor.preprocess(
-              content,
+            DirectivesPreprocessor(
               Right(j.path),
               scopePath,
               logger,
@@ -56,6 +55,7 @@ final case class JavaPreprocessor(
               suppressWarningOptions,
               maybeRecoverOnError
             )
+              .preprocess(content)
           }
           Seq(PreprocessedSource.OnDisk(
             path = j.path,
@@ -89,14 +89,15 @@ final case class JavaPreprocessor(
             else v.subPath
           val content = new String(v.content, StandardCharsets.UTF_8)
           val preprocessedDirectives: PreprocessedDirectives = value {
-            DirectivesPreprocessor.preprocess(
-              content,
+            DirectivesPreprocessor(
               Left(relPath.toString),
               v.scopePath,
               logger,
               allowRestrictedFeatures,
               suppressWarningOptions,
               maybeRecoverOnError
+            ).preprocess(
+              content
             )
           }
           val s = PreprocessedSource.InMemory(

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -221,14 +221,15 @@ case object ScalaPreprocessor extends Preprocessor {
   )(using ScalaCliInvokeData): Either[BuildException, Option[ProcessingOutput]] = either {
     val (content0, isSheBang) = SheBang.ignoreSheBangLines(content)
     val preprocessedDirectives: PreprocessedDirectives =
-      value(DirectivesPreprocessor.preprocess(
-        extractedDirectives,
+      value(DirectivesPreprocessor(
         path,
         scopeRoot,
         logger,
         allowRestrictedFeatures,
         suppressWarningOptions,
         maybeRecoverOnError
+      ).preprocess(
+        extractedDirectives
       ))
 
     if (preprocessedDirectives.isEmpty) None

--- a/modules/build/src/test/scala/scala/build/tests/BuildProjectTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildProjectTests.scala
@@ -3,19 +3,19 @@ package scala.build.tests
 import bloop.rifle.BloopRifleLogger
 import com.eed3si9n.expecty.Expecty.expect
 import coursier.cache.CacheLogger
-import org.scalajs.logging.{Logger => ScalaJsLogger, NullLogger}
+import org.scalajs.logging.{NullLogger, Logger as ScalaJsLogger}
 
 import java.io.PrintStream
-
-import scala.build.Ops._
+import scala.build.Ops.*
 import scala.build.errors.{BuildException, Diagnostic, Severity}
 import scala.build.input.Inputs
+import scala.build.internals.FeatureType
 import scala.build.options.{
   BuildOptions,
   InternalOptions,
   JavaOptions,
-  ScalacOpt,
   ScalaOptions,
+  ScalacOpt,
   Scope,
   ShadowingSeq
 }
@@ -61,6 +61,8 @@ class BuildProjectTests extends munit.FunSuite {
 
     override def verbosity = ???
 
+    override def experimentalWarning(featureName: String, featureType: FeatureType): Unit = ???
+    override def flushExperimentalWarnings: Unit                                          = ???
   }
 
   val bloopJavaPath = Position.Bloop("/home/empty/jvm/8/")

--- a/modules/build/src/test/scala/scala/build/tests/TestLogger.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestLogger.scala
@@ -3,12 +3,13 @@ package scala.build.tests
 import bloop.rifle.BloopRifleLogger
 import coursier.cache.CacheLogger
 import coursier.cache.loggers.{FallbackRefreshDisplay, RefreshLogger}
-import org.scalajs.logging.{Logger => ScalaJsLogger, NullLogger}
+import org.scalajs.logging.{NullLogger, Logger as ScalaJsLogger}
 
 import scala.build.errors.BuildException
 import scala.build.Logger
-import scala.scalanative.{build => sn}
+import scala.scalanative.build as sn
 import scala.build.errors.Diagnostic
+import scala.build.internals.FeatureType
 
 case class TestLogger(info: Boolean = true, debug: Boolean = false) extends Logger {
 
@@ -83,4 +84,9 @@ case class TestLogger(info: Boolean = true, debug: Boolean = false) extends Logg
     if (debug) 2
     else if (info) 0
     else -1
+
+  override def experimentalWarning(featureName: String, featureType: FeatureType): Unit =
+    System.err.println(s"Experimental $featureType `$featureName` used")
+
+  override def flushExperimentalWarnings: Unit = ()
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
@@ -9,6 +9,7 @@ import caseapp.core.{Arg, Error}
 import scala.build.Logger
 import scala.build.input.ScalaCliInvokeData
 import scala.build.internal.util.WarningMessages
+import scala.build.internals.FeatureType
 import scala.cli.ScalaCli
 import scala.cli.util.ArgHelpers.*
 
@@ -54,7 +55,7 @@ object RestrictedCommandsParser {
             ))
           case (r @ Right(Some(_, arg: Arg, _)), passedOption :: _)
               if arg.isExperimental && !shouldSuppressExperimentalWarnings =>
-            logger.message(WarningMessages.experimentalOptionUsed(passedOption))
+            logger.experimentalWarning(passedOption, FeatureType.Option)
             r
           case (other, _) =>
             other

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -289,12 +289,12 @@ abstract class ScalaCommand[T <: HasGlobalOptions](implicit myParser: Parser[T],
             message =
               s"""${hm.message}
                  |
-                 |${WarningMessages.experimentalSubcommandUsed(name)}""".stripMargin,
+                 |${WarningMessages.experimentalSubcommandWarning(name)}""".stripMargin,
             detailedMessage =
               if hm.detailedMessage.nonEmpty then
                 s"""${hm.detailedMessage}
                    |
-                   |${WarningMessages.experimentalSubcommandUsed(name)}""".stripMargin
+                   |${WarningMessages.experimentalSubcommandWarning(name)}""".stripMargin
               else hm.detailedMessage
           )
         )
@@ -347,8 +347,6 @@ abstract class ScalaCommand[T <: HasGlobalOptions](implicit myParser: Parser[T],
     * start of running every [[ScalaCommand]].
     */
   final override def run(options: T, remainingArgs: RemainingArgs): Unit = {
-    logger.flushExperimentalWarnings
-
     CurrentParams.verbosity = options.global.logging.verbosity
     if shouldExcludeInSip then
       logger.error(WarningMessages.powerCommandUsedInSip(
@@ -357,13 +355,15 @@ abstract class ScalaCommand[T <: HasGlobalOptions](implicit myParser: Parser[T],
       ))
       sys.exit(1)
     else if isExperimental && !shouldSuppressExperimentalFeatureWarnings then
-      logger.message(WarningMessages.experimentalSubcommandUsed(name))
+      logger.experimentalWarning(name, FeatureType.Subcommand)
+
     maybePrintWarnings(options)
     maybePrintGroupHelp(options)
     buildOptions(options).foreach { bo =>
       maybePrintSimpleScalacOutput(options, bo)
       maybePrintToolsHelp(options, bo)
     }
+    logger.flushExperimentalWarnings
     runCommand(options, remainingArgs, options.global.logging.logger)
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -19,6 +19,7 @@ import scala.build.errors.BuildException
 import scala.build.input.{ScalaCliInvokeData, SubCommand}
 import scala.build.internal.util.WarningMessages
 import scala.build.internal.{Constants, Runner}
+import scala.build.internals.FeatureType
 import scala.build.options.{BuildOptions, ScalacOpt, Scope}
 import scala.build.{Artifacts, Directories, Logger, Positioned, ReplArtifacts}
 import scala.cli.commands.default.LegacyScalaOptions
@@ -346,6 +347,8 @@ abstract class ScalaCommand[T <: HasGlobalOptions](implicit myParser: Parser[T],
     * start of running every [[ScalaCommand]].
     */
   final override def run(options: T, remainingArgs: RemainingArgs): Unit = {
+    logger.flushExperimentalWarnings
+
     CurrentParams.verbosity = options.global.logging.verbosity
     if shouldExcludeInSip then
       logger.error(WarningMessages.powerCommandUsedInSip(

--- a/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
@@ -9,6 +9,7 @@ import java.util.Base64
 import scala.build.Ops.*
 import scala.build.errors.{BuildException, CompositeBuildException, MalformedCliInputError}
 import scala.build.internal.util.WarningMessages
+import scala.build.internals.FeatureType
 import scala.build.{Directories, Logger}
 import scala.cli.ScalaCli.allowRestrictedFeatures
 import scala.cli.commands.pgp.PgpScalaSigningOptions
@@ -115,7 +116,7 @@ object Config extends ScalaCommand[ConfigOptions] {
               sys.exit(1)
             case Some(entry) =>
               if entry.isExperimental && !shouldSuppressExperimentalFeatureWarnings then
-                logger.message(WarningMessages.experimentalConfigKeyUsed(entry.fullName))
+                logger.experimentalWarning(entry.fullName, FeatureType.ConfigKey)
               if (values.isEmpty)
                 if (options.unset) {
                   db.remove(entry)
@@ -292,6 +293,8 @@ object Config extends ScalaCommand[ConfigOptions] {
           }
       }
     }
+
+    logger.flushExperimentalWarnings
   }
 
   /** Check whether to ask for an update depending on the provided key.

--- a/modules/core/src/main/scala/scala/build/Logger.scala
+++ b/modules/core/src/main/scala/scala/build/Logger.scala
@@ -6,6 +6,7 @@ import org.scalajs.logging.{Logger => ScalaJsLogger, NullLogger}
 import java.io.{OutputStream, PrintStream}
 
 import scala.build.errors.{BuildException, Diagnostic, Severity}
+import scala.build.internals.FeatureType
 import scala.scalanative.{build => sn}
 
 trait Logger {
@@ -37,6 +38,12 @@ trait Logger {
   def compilerOutputStream: PrintStream
 
   def verbosity: Int
+
+  /** Since we have a lot of experimental warnings all over the build process, this method can be
+    * used to accumulate them for a better UX
+    */
+  def experimentalWarning(featureName: String, featureType: FeatureType): Unit
+  def flushExperimentalWarnings: Unit
 }
 
 object Logger {
@@ -73,6 +80,9 @@ object Logger {
       )
 
     def verbosity: Int = -1
+
+    def experimentalWarning(featureUsed: String, featureType: FeatureType): Unit = ()
+    def flushExperimentalWarnings: Unit                                          = ()
   }
   def nop: Logger = new Nop
 }

--- a/modules/core/src/main/scala/scala/build/internals/FeatureType.scala
+++ b/modules/core/src/main/scala/scala/build/internals/FeatureType.scala
@@ -8,3 +8,14 @@ enum FeatureType(stringRepr: String) {
   case Subcommand extends FeatureType("sub-command")
   case ConfigKey  extends FeatureType("configuration key")
 }
+
+object FeatureType {
+  private val ordering = Map(
+    FeatureType.Subcommand -> 0,
+    FeatureType.Option     -> 1,
+    FeatureType.Directive  -> 2,
+    FeatureType.ConfigKey  -> 3
+  )
+
+  given Ordering[FeatureType] = Ordering.by(ordering)
+}

--- a/modules/core/src/main/scala/scala/build/internals/FeatureType.scala
+++ b/modules/core/src/main/scala/scala/build/internals/FeatureType.scala
@@ -1,0 +1,10 @@
+package scala.build.internals
+
+enum FeatureType(stringRepr: String) {
+  override def toString: String = stringRepr
+
+  case Option     extends FeatureType("option")
+  case Directive  extends FeatureType("directive")
+  case Subcommand extends FeatureType("sub-command")
+  case ConfigKey  extends FeatureType("configuration key")
+}


### PR DESCRIPTION
Closes #2294 

Replacement for #2358 that uses a mutable logger instead of return values.
Also handles experimental sub-commands, options, directives and config keys instead of just directives.