### PR TITLE
configuration.md examples "using dep" to current versions

### DIFF
--- a/website/docs/guides/configuration.md
+++ b/website/docs/guides/configuration.md
@@ -46,7 +46,7 @@ Another thing you can do is to specify dependencies:
 <ChainedSnippets>
 
 ```bash
-scala-cli --dependency org.typelevel::cats-core:2.9.0 Test.scala
+scala-cli --dependency org.typelevel::cats-core:2.10.0 Test.scala
 ```
 
 ```text
@@ -81,7 +81,7 @@ The reference documentation lists [all available using directives](/docs/referen
 Also, there are some directives which only target tests, like `using test.dep`. 
 Those can be useful when defining configuration specific to your test runs.
 ```scala compile
-//> using test.dep com.lihaoyi::utest:0.7.10
+//> using test.dep com.lihaoyi::utest::0.8.1
 ```
 
 More details can be found in the [`using` directives guide](./using-directives.md#directives-with-a-test-scope-equivalent).
@@ -91,8 +91,8 @@ More details can be found in the [`using` directives guide](./using-directives.m
 Dependencies can be added right from `.scala` and `.sc` files with [`using` directives](#using-directives):
 
 ```scala compile
-//> using dep com.lihaoyi::upickle:1.4.0
-//> using dep com.lihaoyi::pprint:0.6.6
+//> using dep com.lihaoyi::upickle::3.1.2
+//> using dep com.lihaoyi::pprint::0.8.1
 import ujson._
 ```
 


### PR DESCRIPTION
All scala 3 examples updated to current version of packages, upickle, eg,  was extremely outdated.