### PR TITLE
Totally offline mode

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
+++ b/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
@@ -101,4 +101,7 @@ object WarningMessages {
 
   val offlineModeBloopNotFound =
     "Offline mode is ON and Bloop could not be fetched from the local cache, using scalac as fallback"
+
+  val offlineModeBloopJvmNotFound =
+    "Offline mode is ON and a JVM for Bloop could not be fetched from the local cache, using scalac as fallback"
 }

--- a/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
+++ b/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
@@ -98,4 +98,7 @@ object WarningMessages {
 
   val chainingUsingFileDirective: String =
     "Chaining the 'using file' directive is not supported, the source won't be included in the build."
+
+  val offlineModeBloopNotFound =
+    "Offline mode is ON and Bloop could not be fetched from the local cache, using scalac as fallback"
 }

--- a/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
@@ -86,7 +86,12 @@ final case class TestInputs(
     withCustomInputs(fromDirectory, None, skipCreatingSources) { (root, inputs) =>
       val compilerMaker = bloopConfigOpt match {
         case Some(bloopConfig) =>
-          new BloopCompilerMaker(bloopConfig, buildThreads.bloop, strictBloopJsonCheck = true)
+          new BloopCompilerMaker(
+            bloopConfig,
+            buildThreads.bloop,
+            strictBloopJsonCheck = true,
+            offline = false
+          )
         case None =>
           SimpleScalaCompilerMaker("java", Nil)
       }

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/Bloop.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/Bloop.scala
@@ -39,7 +39,7 @@ object Bloop extends ScalaCommand[BloopOptions] {
       .map(JvmUtils.downloadJvm(_, options))
       .getOrElse {
         JvmUtils.getJavaCmdVersionOrHigher(17, options)
-      }
+      }.orExit(logger)
 
     opts.compilationServer.bloopRifleConfig(
       opts.global.logging.logger,

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalCommand.scala
@@ -159,7 +159,7 @@ object PgpExternalCommand {
       JvmUtils.getJavaCmdVersionOrHigher(
         scalaCliSigningJvmVersion,
         buildOptions
-      )
+      ).orThrow
 
     launcher(
       cache,

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/CoursierOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/CoursierOptions.scala
@@ -47,11 +47,15 @@ final case class CoursierOptions(
       baseCache = baseCache.withTtl(ttl0)
     for (loc <- cache.filter(_.trim.nonEmpty))
       baseCache = baseCache.withLocation(loc)
-    for (isOffline <- offline if isOffline)
+    for (isOffline <- getOffline() if isOffline)
       baseCache = baseCache.withCachePolicies(Seq(CachePolicy.LocalOnly))
 
     baseCache
   }
+
+  def getOffline(): Option[Boolean] = offline
+    .orElse(Option(System.getenv("COURSIER_MODE")).map(_ == "offline"))
+    .orElse(Option(System.getProperty("coursier.mode")).map(_ == "offline"))
 }
 
 object CoursierOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/CoursierOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/CoursierOptions.scala
@@ -3,7 +3,7 @@ package scala.cli.commands.shared
 import caseapp.*
 import com.github.plokhotnyuk.jsoniter_scala.core.*
 import com.github.plokhotnyuk.jsoniter_scala.macros.*
-import coursier.cache.{CacheLogger, FileCache}
+import coursier.cache.{CacheLogger, CachePolicy, FileCache}
 
 import scala.cli.commands.tags
 import scala.concurrent.duration.Duration
@@ -26,7 +26,12 @@ final case class CoursierOptions(
   @HelpMessage("Enable checksum validation of artifacts downloaded by coursier")
   @Tag(tags.implementation)
   @Hidden
-    coursierValidateChecksums: Option[Boolean] = None
+    coursierValidateChecksums: Option[Boolean] = None,
+
+  @Group(HelpGroup.Dependency.toString)
+  @HelpMessage("Disable using the network to download artifacts, use the local cache only")
+  @Tag(tags.experimental)
+    offline: Option[Boolean] = None
 ) {
   // format: on
 
@@ -42,6 +47,9 @@ final case class CoursierOptions(
       baseCache = baseCache.withTtl(ttl0)
     for (loc <- cache.filter(_.trim.nonEmpty))
       baseCache = baseCache.withLocation(loc)
+    for (isOffline <- offline if isOffline)
+      baseCache = baseCache.withCachePolicies(Seq(CachePolicy.LocalOnly))
+
     baseCache
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -401,7 +401,8 @@ final case class SharedOptions(
         verbosity = Some(logging.verbosity),
         strictBloopJsonCheck = strictBloopJsonCheck,
         interactive = Some(() => interactive),
-        exclude = exclude.map(Positioned.commandLine)
+        exclude = exclude.map(Positioned.commandLine),
+        offline = coursier.offline
       ),
       notForBloopOptions = bo.PostBuildOptions(
         scalaJsLinkerOptions = linkerOptions(js),
@@ -543,7 +544,8 @@ final case class SharedOptions(
       new BloopCompilerMaker(
         value(bloopRifleConfig()),
         threads.bloop,
-        strictBloopJsonCheckOrDefault
+        strictBloopJsonCheckOrDefault,
+        coursier.offline.getOrElse(false)
       )
     else
       SimpleScalaCompilerMaker("java", Nil)

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -403,7 +403,7 @@ final case class SharedOptions(
         strictBloopJsonCheck = strictBloopJsonCheck,
         interactive = Some(() => interactive),
         exclude = exclude.map(Positioned.commandLine),
-        offline = coursier.offline
+        offline = coursier.getOffline()
       ),
       notForBloopOptions = bo.PostBuildOptions(
         scalaJsLinkerOptions = linkerOptions(js),
@@ -552,9 +552,9 @@ final case class SharedOptions(
             config,
             threads.bloop,
             strictBloopJsonCheckOrDefault,
-            coursier.offline.getOrElse(false)
+            coursier.getOffline().getOrElse(false)
           ))
-        case Left(ex) if coursier.offline.contains(true) =>
+        case Left(ex) if coursier.getOffline().contains(true) =>
           logger.diagnostic(WarningMessages.offlineModeBloopJvmNotFound, Severity.Warning)
           Right(SimpleScalaCompilerMaker("java", Nil))
         case Left(ex) => Left(ex)

--- a/modules/cli/src/main/scala/scala/cli/internal/ProcUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/ProcUtil.scala
@@ -35,43 +35,6 @@ object ProcUtil {
     usesSh
   }
 
-  // from https://github.com/coursier/coursier/blob/7b7c2c312aea26e850f0cd2cf15e688d0777f819/modules/cache/jvm/src/main/scala/coursier/cache/CacheUrl.scala#L489-L497
-  private def closeConn(conn: URLConnection): Unit = {
-    Try(conn.getInputStream).toOption.filter(_ != null).foreach(_.close())
-    conn match {
-      case conn0: HttpURLConnection =>
-        Try(conn0.getErrorStream).toOption.filter(_ != null).foreach(_.close())
-        conn0.disconnect()
-      case _ =>
-    }
-  }
-
-  def download(
-    url: String,
-    headers: (String, String)*
-  ): Array[Byte] = {
-    var conn: URLConnection = null
-    val url0                = new URL(url)
-    try {
-      conn = url0.openConnection()
-      for ((k, v) <- headers)
-        conn.setRequestProperty(k, v)
-      conn.getInputStream.readAllBytes()
-    }
-    catch {
-      case NonFatal(ex) =>
-        throw new RuntimeException(s"Error downloading $url: $ex", ex)
-    }
-    finally
-      if (conn != null)
-        closeConn(conn)
-  }
-
-  def downloadFile(url: String): String = {
-    val data = download(url)
-    new String(data, StandardCharsets.UTF_8)
-  }
-
   def forceKillProcess(process: Process, logger: Logger): Unit = {
     if (process.isAlive) {
       process.destroyForcibly()

--- a/modules/cli/src/test/scala/cli/tests/ScalafmtTest.scala
+++ b/modules/cli/src/test/scala/cli/tests/ScalafmtTest.scala
@@ -51,7 +51,7 @@ class ScalafmtTests extends munit.FunSuite {
       "scalafmt-x86_64-pc-win32.zip"
     )
     val errorMsg =
-      s"""scalafmt native images missing for v$scalaFmtVersion, make a release at https://github.com/VirtusLab/scalafmt-native-image.
+      s"""scalafmt native images missing for v$scalaFmtVersion, make a release at https://github.com/VirtusLab/scalafmt-native-image
          |Ensure that all expected assets are available in the release:
          |  ${expectedAssets.mkString(", ")}
          |for scalafmt-native-image under tag v$scalaFmtVersion.""".stripMargin
@@ -68,7 +68,7 @@ class ScalafmtTests extends munit.FunSuite {
     catch {
       case e: JsonReaderException => throw new Exception(s"Error reading $url", e)
       case e: Throwable => throw new Exception(
-          s"""Failed to check for the ScalaFmt native launcher assets: ${e.getMessage}.
+          s"""Failed to check for the ScalaFmt native launcher assets: ${e.getMessage}
              |
              |$errorMsg
              |""".stripMargin,

--- a/modules/core/src/main/scala/scala/build/errors/JvmDownloadError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/JvmDownloadError.scala
@@ -1,0 +1,9 @@
+package scala.build.errors
+
+import scala.build.Position
+
+final class JvmDownloadError(jvmId: String, cause: Throwable)
+    extends BuildException(
+      s"Cannot download JVM: $jvmId",
+      cause = cause
+    )

--- a/modules/core/src/main/scala/scala/build/internals/OsLibc.scala
+++ b/modules/core/src/main/scala/scala/build/internals/OsLibc.scala
@@ -100,16 +100,7 @@ object OsLibc {
     val ext     = if (Properties.isWin) ".exe" else ""
     val javaCmd = (javaHome / "bin" / s"java$ext").toString
 
-    val javaVersionOutput = os.proc(javaCmd, "-version").call(
-      cwd = os.pwd,
-      stdout = os.Pipe,
-      stderr = os.Pipe,
-      mergeErrIntoOut = true
-    ).out.trim()
-    val javaVersion = parseJavaVersion(javaVersionOutput).getOrElse {
-      throw new Exception(s"Could not parse java version from output: $javaVersionOutput")
-    }
-    (javaVersion, javaCmd)
+    (javaVersion(javaCmd), javaCmd)
   }
 
 }

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -1,7 +1,7 @@
 package scala.build.options
 
 import com.github.plokhotnyuk.jsoniter_scala.core.*
-import coursier.cache.{ArchiveCache, FileCache}
+import coursier.cache.{ArchiveCache, FileCache, UnArchiver}
 import coursier.core.{Repository, Version}
 import coursier.parse.RepositoryParser
 import coursier.util.{Artifact, Task}
@@ -305,6 +305,8 @@ final case class BuildOptions(
     val svOpt: Option[String] = scalaOptions.scalaVersion match {
       case Some(MaybeScalaVersion(None)) =>
         None
+      case Some(MaybeScalaVersion(Some(svInput))) if internal.offline.getOrElse(false) =>
+        Some(svInput)
       case Some(MaybeScalaVersion(Some(svInput))) =>
         val sv = value {
           svInput match {

--- a/modules/options/src/main/scala/scala/build/options/InternalOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/InternalOptions.scala
@@ -25,7 +25,8 @@ final case class InternalOptions(
     */
   keepResolution: Boolean = false,
   extraSourceFiles: Seq[Positioned[os.Path]] = Nil,
-  exclude: Seq[Positioned[String]] = Nil
+  exclude: Seq[Positioned[String]] = Nil,
+  offline: Option[Boolean] = None
 ) {
   def verbosityOrDefault: Int = verbosity.getOrElse(0)
   def strictBloopJsonCheckOrDefault: Boolean =

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -213,6 +213,33 @@ Aliases: `-f`
 
 Force overwriting values for key
 
+## Coursier options
+
+Available in commands:
+
+[`bloop`](./commands.md#bloop), [`bloop exit`](./commands.md#bloop-exit), [`bloop start`](./commands.md#bloop-start), [`bsp`](./commands.md#bsp), [`compile`](./commands.md#compile), [`config`](./commands.md#config), [`dependency-update`](./commands.md#dependency-update), [`doc`](./commands.md#doc), [`export`](./commands.md#export), [`fix`](./commands.md#fix), [`fmt` , `format` , `scalafmt`](./commands.md#fmt), [`package`](./commands.md#package), [`pgp push`](./commands.md#pgp-push), [`publish`](./commands.md#publish), [`publish local`](./commands.md#publish-local), [`publish setup`](./commands.md#publish-setup), [`repl` , `console`](./commands.md#repl), [`run`](./commands.md#run), [`github secret create` , `gh secret create`](./commands.md#github-secret-create), [`setup-ide`](./commands.md#setup-ide), [`shebang`](./commands.md#shebang), [`test`](./commands.md#test), [`uninstall`](./commands.md#uninstall)
+
+<!-- Automatically generated, DO NOT EDIT MANUALLY -->
+
+### `--ttl`
+
+[Internal]
+Specify a TTL for changing dependencies, such as snapshots
+
+### `--cache`
+
+[Internal]
+Set the coursier cache location
+
+### `--coursier-validate-checksums`
+
+[Internal]
+Enable checksum validation of artifacts downloaded by coursier
+
+### `--offline`
+
+Disable using the network to download artifacts, use the local cache only
+
 ## Cross options
 
 Available in commands:
@@ -1847,29 +1874,6 @@ Aliases: `--name`
 
 [Internal]
 Name of BSP
-
-### Coursier options
-
-Available in commands:
-
-[`bloop`](./commands.md#bloop), [`bloop exit`](./commands.md#bloop-exit), [`bloop start`](./commands.md#bloop-start), [`bsp`](./commands.md#bsp), [`compile`](./commands.md#compile), [`config`](./commands.md#config), [`dependency-update`](./commands.md#dependency-update), [`doc`](./commands.md#doc), [`export`](./commands.md#export), [`fix`](./commands.md#fix), [`fmt` , `format` , `scalafmt`](./commands.md#fmt), [`package`](./commands.md#package), [`pgp push`](./commands.md#pgp-push), [`publish`](./commands.md#publish), [`publish local`](./commands.md#publish-local), [`publish setup`](./commands.md#publish-setup), [`repl` , `console`](./commands.md#repl), [`run`](./commands.md#run), [`github secret create` , `gh secret create`](./commands.md#github-secret-create), [`setup-ide`](./commands.md#setup-ide), [`shebang`](./commands.md#shebang), [`test`](./commands.md#test), [`uninstall`](./commands.md#uninstall)
-
-<!-- Automatically generated, DO NOT EDIT MANUALLY -->
-
-### `--ttl`
-
-[Internal]
-Specify a TTL for changing dependencies, such as snapshots
-
-### `--cache`
-
-[Internal]
-Set the coursier cache location
-
-### `--coursier-validate-checksums`
-
-[Internal]
-Enable checksum validation of artifacts downloaded by coursier
 
 ### Default file options
 


### PR DESCRIPTION
Introduce `--offline` flag, which changes Coursier's cache policy to LocalOnly. This way Scala CLI won't download anything, but instead will fail with a message similiar to:
```
[error] ./WithDeps.scala:2:15
[error] Error downloading com.lihaoyi:os-lib_3:0.9.1
[error]   not found: .../ivys/ivy.xml
[error]   not found: ...cache/https/repo1.maven.org/maven2/com/lihaoyi/os-lib_3/0.9.1/os-lib_3-0.9.1.pom
[error]   not found: ...Caches/ScalaCli/local-repo/1.0.4-27-7b90be-DIRTY9091f1a9/com.lihaoyi/os-lib_3/0.9.1/ivys/ivy.xml
[error]   No fallback URL found
[error] //> using dep com.lihaoyi::os-lib:0.9.1
[error]               ^^^^^^^^^^^^^^^^^^^^^^^^^
```


Added support for `COURSIER_MODE=offline` env var and `coursier.mode=offline` java prop (https://github.com/coursier/coursier/issues/688)