### PR TITLE
Default to a Scala version for REPL if there are no Scala artifacts.

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
@@ -283,11 +283,10 @@ object Repl extends ScalaCommand[ReplOptions] {
     val cache             = options.internal.cache.getOrElse(FileCache())
     val shouldUseAmmonite = options.notForBloopOptions.replOptions.useAmmonite
 
-    val scalaParams = artifacts.scalaOpt
-      .getOrElse {
-        sys.error("Expected Scala artifacts to be fetched")
-      }
-      .params
+    val scalaParams = artifacts.scalaOpt match {
+      case Some(artifacts) => artifacts.params
+      case None            => ScalaParameters(Constants.defaultScalaVersion)
+    }
 
     val (scalapyJavaOpts, scalapyExtraEnv) =
       if (setupPython) {

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTests.scala
@@ -17,4 +17,21 @@ class ReplTests extends ScalaCliSuite {
     expect(output.contains("parser") && output.contains("typer"))
   }
 
+  test("calling repl with a directory with no scala artifacts") {
+    val inputs = TestInputs(
+      os.rel / "Testing.java" -> "public class Testing {}"
+    )
+    val cmd = Seq[os.Shellable](
+      TestUtil.cli,
+      "repl",
+      "--repl-dry-run",
+      "."
+    )
+    inputs.fromRoot { root =>
+      val res = os.proc(cmd)
+        .call(cwd = root)
+      expect(res.exitCode == 0)
+    }
+  }
+
 }


### PR DESCRIPTION
Solves #2430 

Currently if there's only non-scala artifacts available when launching the REPL, it throws an error because the underlying logic relied on there being at least one Scala artifact available. This commit resolves the latest version available if we're unable to infer a version from a Scala artifact.

This is my first commit to the project, I've had a look at the contributing document as best as I could but do let me know if I'm missing something!