### PR TITLE
Fix 'JVM too old' as bsp

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -197,6 +197,9 @@ object Build {
     def diagnostics: None.type   = None
   }
 
+  /** If some options are manually overridden, append a hash of the options to the project name
+    * Using only the command-line options not the ones from the sources.
+    */
   def updateInputs(
     inputs: Inputs,
     options: BuildOptions,

--- a/modules/build/src/main/scala/scala/build/bsp/Bsp.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/Bsp.scala
@@ -7,7 +7,7 @@ import scala.build.input.{Inputs, ScalaCliInvokeData}
 import scala.concurrent.Future
 
 trait Bsp {
-  def run(initialInputs: Inputs): Future[Unit]
+  def run(initialInputs: Inputs, initialBspOptions: BspReloadableOptions): Future[Unit]
   def shutdown(): Unit
 }
 

--- a/modules/build/src/main/scala/scala/build/bsp/BspReloadableOptions.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspReloadableOptions.scala
@@ -29,7 +29,4 @@ object BspReloadableOptions {
     def get: BspReloadableOptions                   = ref
     def reload(): Unit                              = ref = getReloaded()
   }
-  object Reference {
-    def apply(getReloaded: () => BspReloadableOptions): Reference = new Reference(getReloaded)
-  }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/Bloop.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/Bloop.scala
@@ -35,7 +35,7 @@ object Bloop extends ScalaCommand[BloopOptions] {
     )
     val options = sharedOptions.buildOptions(false, None).orExit(opts.global.logging.logger)
 
-    val javaCmd = opts.compilationServer.bloopJvm
+    val javaHomeInfo = opts.compilationServer.bloopJvm
       .map(JvmUtils.downloadJvm(_, options))
       .getOrElse {
         JvmUtils.getJavaCmdVersionOrHigher(17, options)
@@ -45,9 +45,9 @@ object Bloop extends ScalaCommand[BloopOptions] {
       opts.global.logging.logger,
       sharedOptions.coursierCache,
       opts.global.logging.verbosity,
-      javaCmd,
+      javaHomeInfo.javaCommand,
       Directories.directories,
-      Some(17)
+      Some(javaHomeInfo.version)
     )
   }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
@@ -8,7 +8,7 @@ import scala.build.*
 import scala.build.bsp.{BspReloadableOptions, BspThreads}
 import scala.build.errors.BuildException
 import scala.build.input.Inputs
-import scala.build.options.BuildOptions
+import scala.build.options.{BuildOptions, Scope}
 import scala.cli.CurrentParams
 import scala.cli.commands.ScalaCommand
 import scala.cli.commands.publish.ConfigUtil.*
@@ -38,7 +38,7 @@ object Bsp extends ScalaCommand[BspOptions] {
 
     val getSharedOptions: () => SharedOptions = () => latestSharedOptions(options)
 
-    val argsToInputs: Seq[String] => Either[BuildException, Inputs] =
+    val preprocessInputs: Seq[String] => Either[BuildException, (Inputs, BuildOptions)] =
       argsSeq =>
         either {
           val sharedOptions = getSharedOptions()
@@ -47,25 +47,53 @@ object Bsp extends ScalaCommand[BspOptions] {
           if (sharedOptions.logging.verbosity >= 3)
             pprint.err.log(initialInputs)
 
-          val buildOptions0    = buildOptions(sharedOptions)
+          val baseOptions      = buildOptions(sharedOptions)
           val latestLogger     = sharedOptions.logging.logger
           val persistentLogger = new PersistentDiagnosticLogger(latestLogger)
 
-          val allInputs =
-            CrossSources.forInputs(
-              initialInputs,
-              Sources.defaultPreprocessors(
-                buildOptions0.archiveCache,
-                buildOptions0.internal.javaClassNameVersionOpt,
-                () => buildOptions0.javaHome().value.javaCommand
-              ),
-              persistentLogger,
-              buildOptions0.suppressWarningOptions,
-              buildOptions0.internal.exclude
-            ).map(_._2).getOrElse(initialInputs)
+          val crossResult = CrossSources.forInputs(
+            initialInputs,
+            Sources.defaultPreprocessors(
+              baseOptions.archiveCache,
+              baseOptions.internal.javaClassNameVersionOpt,
+              () => baseOptions.javaHome().value.javaCommand
+            ),
+            persistentLogger,
+            baseOptions.suppressWarningOptions,
+            baseOptions.internal.exclude
+          )
 
-          Build.updateInputs(allInputs, buildOptions(sharedOptions))
+          val (allInputs, finalBuildOptions) = {
+            for
+              crossSourcesAndInputs <- crossResult
+              // compiler bug, can't do :
+              // (crossSources, crossInputs) <- crossResult
+              (crossSources, crossInputs) = crossSourcesAndInputs
+              sharedBuildOptions          = crossSources.sharedOptions(baseOptions)
+              scopedSources <- crossSources.scopedSources(sharedBuildOptions)
+              resolvedBuildOptions =
+                scopedSources.buildOptionsFor(Scope.Main).foldRight(sharedBuildOptions)(_ orElse _)
+            yield (crossInputs, resolvedBuildOptions)
+          }.getOrElse(initialInputs -> baseOptions)
+
+          Build.updateInputs(allInputs, baseOptions) -> finalBuildOptions
         }
+
+    val (inputs, finalBuildOptions) = preprocessInputs(args.all).orExit(logger)
+
+    /** values used for lauching the bsp, especially for launching a bloop server, they include
+      * options extracted from sources
+      */
+    val initialBspOptions = {
+      val sharedOptions = getSharedOptions()
+      BspReloadableOptions(
+        buildOptions = buildOptions(sharedOptions) orElse finalBuildOptions,
+        bloopRifleConfig = sharedOptions.bloopRifleConfig(Some(finalBuildOptions))
+          .orExit(sharedOptions.logger),
+        logger = sharedOptions.logging.logger,
+        verbosity = sharedOptions.logging.verbosity
+      )
+    }
 
     val bspReloadableOptionsReference = BspReloadableOptions.Reference { () =>
       val sharedOptions = getSharedOptions()
@@ -77,14 +105,13 @@ object Bsp extends ScalaCommand[BspOptions] {
       )
     }
 
-    val inputs = argsToInputs(args.all).orExit(logger)
     CurrentParams.workspaceOpt = Some(inputs.workspace)
     val actionableDiagnostics =
       options.shared.logging.verbosityOptions.actions
 
     BspThreads.withThreads { threads =>
       val bsp = scala.build.bsp.Bsp.create(
-        argsToInputs,
+        preprocessInputs.andThen(_.map(_._1)),
         bspReloadableOptionsReference,
         threads,
         System.in,
@@ -93,7 +120,7 @@ object Bsp extends ScalaCommand[BspOptions] {
       )
 
       try {
-        val doneFuture = bsp.run(inputs)
+        val doneFuture = bsp.run(inputs, initialBspOptions)
         Await.result(doneFuture, Duration.Inf)
       }
       finally bsp.shutdown()

--- a/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
@@ -97,6 +97,9 @@ object Bsp extends ScalaCommand[BspOptions] {
 
     val bspReloadableOptionsReference = BspReloadableOptions.Reference { () =>
       val sharedOptions = getSharedOptions()
+      val bloopRifleConfig = sharedOptions.bloopRifleConfig(Some(finalBuildOptions))
+        .orExit(sharedOptions.logger)
+
       BspReloadableOptions(
         buildOptions = buildOptions(sharedOptions),
         bloopRifleConfig = sharedOptions.bloopRifleConfig().orExit(sharedOptions.logger),

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalCommand.scala
@@ -138,7 +138,7 @@ object PgpExternalCommand {
         scalaCliSigningJvmVersion,
         jvmOptions,
         coursierOptions
-      ).orThrow
+      ).orThrow.javaCommand
 
     launcher(
       cache,
@@ -159,7 +159,7 @@ object PgpExternalCommand {
       JvmUtils.getJavaCmdVersionOrHigher(
         scalaCliSigningJvmVersion,
         buildOptions
-      ).orThrow
+      ).orThrow.javaCommand
 
     launcher(
       cache,

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedCompilationServerOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedCompilationServerOptions.scala
@@ -276,7 +276,7 @@ final case class SharedCompilationServerOptions(
       javaOpts =
         (if (bloopDefaultJavaOpts) baseConfig.javaOpts
          else Nil) ++ bloopJavaOpt ++ bloopDefaultJvmOptions(logger).getOrElse(Nil),
-      minimumBloopJvm = javaV.getOrElse(8),
+      minimumBloopJvm = javaV.getOrElse(17),
       retainedBloopVersion = retainedBloopVersion
     )
   }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -513,8 +513,9 @@ final case class SharedOptions(
         .getOrElse(None)
     )
 
-  def bloopRifleConfig(): Either[BuildException, BloopRifleConfig] = either {
-    val options = value(buildOptions(false, None))
+  def bloopRifleConfig(extraBuildOptions: Option[BuildOptions] = None)
+    : Either[BuildException, BloopRifleConfig] = either {
+    val options = extraBuildOptions.foldLeft(value(buildOptions(false, None)))(_ orElse _)
     lazy val defaultJvmHome = value {
       JvmUtils.downloadJvm(OsLibc.defaultJvm(OsLibc.jvmIndexOs), options)
     }

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -26,7 +26,7 @@ import scala.build.internal.util.ConsoleUtils.ScalaCliConsole
 import scala.build.internal.util.WarningMessages
 import scala.build.internal.{Constants, FetchExternalBinary, ObjectCodeWrapper, OsLibc, Util}
 import scala.build.options.ScalaVersionUtil.fileWithTtl0
-import scala.build.options.{ComputeVersion, Platform, ScalacOpt, ShadowingSeq}
+import scala.build.options.{BuildOptions, ComputeVersion, Platform, ScalacOpt, ShadowingSeq}
 import scala.build.preprocessing.directives.ClasspathUtils.*
 import scala.build.preprocessing.directives.Toolkit
 import scala.build.options as bo
@@ -515,27 +515,28 @@ final case class SharedOptions(
 
   def bloopRifleConfig(): Either[BuildException, BloopRifleConfig] = either {
     val options = value(buildOptions(false, None))
-    lazy val defaultJvmCmd = value {
+    lazy val defaultJvmHome = value {
       JvmUtils.downloadJvm(OsLibc.defaultJvm(OsLibc.jvmIndexOs), options)
     }
 
-    val javaCmd = compilationServer.bloopJvm
+    val javaHomeInfo = compilationServer.bloopJvm
       .map(jvmId => value(JvmUtils.downloadJvm(jvmId, options)))
       .orElse {
         for (javaHome <- options.javaHomeLocationOpt()) yield {
           val (javaHomeVersion, javaHomeCmd) = OsLibc.javaHomeVersion(javaHome.value)
-          if (javaHomeVersion >= 17) javaHomeCmd
-          else defaultJvmCmd
+          if (javaHomeVersion >= 17)
+            BuildOptions.JavaHomeInfo(javaHome.value, javaHomeCmd, javaHomeVersion)
+          else defaultJvmHome
         }
-      }.getOrElse(defaultJvmCmd)
+      }.getOrElse(defaultJvmHome)
 
     compilationServer.bloopRifleConfig(
       logging.logger,
       coursierCache,
       logging.verbosity,
-      javaCmd,
+      javaHomeInfo.javaCommand,
       Directories.directories,
-      Some(17)
+      Some(javaHomeInfo.version)
     )
   }
 

--- a/modules/core/src/main/scala/scala/build/errors/Diagnostic.scala
+++ b/modules/core/src/main/scala/scala/build/errors/Diagnostic.scala
@@ -14,7 +14,9 @@ object Diagnostic {
   case class TextEdit(title: String, newText: String)
   object Messages {
     val bloopTooOld =
-      "JVM that is hosting bloop is older than the requested runtime. Please run command `bloop exit`, and then use `--jvm` flag to restart Bloop"
+      """JVM that is hosting bloop is older than the requested runtime. Please restart the Build Server from your IDE.
+        |Or run the command `bloop exit`, and then use `--jvm` flag to request a sufficient JVM version.
+        |""".stripMargin
   }
 
   private case class ADiagnostic(

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -1160,6 +1160,57 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
 
+  test("bsp should start bloop with correct JVM version from directives") {
+    val sourceFilePath = os.rel / "ReloadTest.java"
+    val inputs = TestInputs(
+      sourceFilePath ->
+        s"""//> using jvm 19
+           |//> using javacOpt --enable-preview
+           |
+           |public class ReloadTest {
+           |  public static void main(String[] args) {
+           |    String a = "Hello World";
+           |
+           |    switch (a) {
+           |      case String s when s.length() > 6 -> System.out.println(s.toUpperCase());
+           |      case String s -> System.out.println(s.toLowerCase());
+           |    }
+           |  }
+           |}
+           |""".stripMargin
+    )
+    inputs.fromRoot { root =>
+      os.proc(TestUtil.cli, "--power", "bloop", "exit")
+        .call(
+          cwd = root,
+          stdout = os.Inherit
+        )
+      os.proc(TestUtil.cli, "--power", "bloop", "start", "--jvm", "17")
+        .call(
+          cwd = root,
+          stdout = os.Inherit
+        )
+      os.proc(TestUtil.cli, "setup-ide", ".", extraOptions)
+        .call(
+          cwd = root,
+          stdout = os.Inherit
+        )
+      val ideOptionsPath = root / Constants.workspaceDirName / "ide-options-v2.json"
+      val jsonOptions    = List("--json-options", ideOptionsPath.toString)
+      withBsp(inputs, Seq("."), bspOptions = jsonOptions, reuseRoot = Some(root)) {
+        (_, _, remoteServer) =>
+          async {
+            val buildTargetsResp = await(remoteServer.workspaceBuildTargets().asScala)
+            val targets          = buildTargetsResp.getTargets.asScala.map(_.getId).toSeq
+
+            val resp =
+              await(remoteServer.buildTargetCompile(new b.CompileParams(targets.asJava)).asScala)
+            expect(resp.getStatusCode == b.StatusCode.OK)
+          }
+      }
+    }
+  }
+
   test("bloop projects are initialised properly for an invalid directive value") {
     val inputs = TestInputs(
       os.rel / "InvalidUsingDirective.scala" ->

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -1160,6 +1160,145 @@ abstract class BspTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
 
+  test("workspace/reload should restart bloop with correct JVM version from options") {
+    val sourceFilePath = os.rel / "ReloadTest.java"
+    val inputs = TestInputs(
+      sourceFilePath ->
+        s"""public class ReloadTest {
+           |  public static void main(String[] args) {
+           |    String a = "Hello World";
+           |
+           |    switch (a) {
+           |      case String s when s.length() > 6 -> System.out.println(s.toUpperCase());
+           |      case String s -> System.out.println(s.toLowerCase());
+           |    }
+           |  }
+           |}""".stripMargin
+    )
+    inputs.fromRoot { root =>
+      os.proc(TestUtil.cli, "--power", "bloop", "exit")
+        .call(
+          cwd = root,
+          stdout = os.Inherit
+        )
+      os.proc(TestUtil.cli, "setup-ide", ".", "--jvm", "11", extraOptions)
+        .call(
+          cwd = root,
+          stdout = os.Inherit
+        )
+      val ideOptionsPath = root / Constants.workspaceDirName / "ide-options-v2.json"
+      val jsonOptions    = List("--json-options", ideOptionsPath.toString)
+      withBsp(inputs, Seq("."), bspOptions = jsonOptions, reuseRoot = Some(root)) {
+        (_, _, remoteServer) =>
+          async {
+            val buildTargetsResp = await(remoteServer.workspaceBuildTargets().asScala)
+            val targets          = buildTargetsResp.getTargets.asScala.map(_.getId).toSeq
+
+            val errorResponse =
+              await(remoteServer.buildTargetCompile(new b.CompileParams(targets.asJava)).asScala)
+            expect(errorResponse.getStatusCode == b.StatusCode.ERROR)
+
+            val javacOptions = Seq("--javac-opt", "--enable-preview")
+
+            os.proc(TestUtil.cli, "setup-ide", ".", "--jvm", "19", javacOptions, extraOptions)
+              .call(
+                cwd = root,
+                stdout = os.Inherit
+              )
+
+            val reloadResponse =
+              extractWorkspaceReloadResponse(await(remoteServer.workspaceReload().asScala))
+            expect(reloadResponse.isEmpty)
+
+            val buildTargetsResp0 = await(remoteServer.workspaceBuildTargets().asScala)
+            val reloadedTargets   = buildTargetsResp0.getTargets.asScala.map(_.getId).toSeq
+
+            val okResponse =
+              await(
+                remoteServer.buildTargetCompile(new b.CompileParams(reloadedTargets.asJava)).asScala
+              )
+            expect(okResponse.getStatusCode == b.StatusCode.OK)
+          }
+      }
+
+    }
+  }
+
+  test("workspace/reload should restart bloop with correct JVM version from directives") {
+    val sourceFilePath = os.rel / "ReloadTest.java"
+    val inputs = TestInputs(
+      sourceFilePath ->
+        s"""//> using jvm 11
+           |
+           |public class ReloadTest {
+           |  public static void main(String[] args) {
+           |    System.out.println("Hello World");
+           |  }
+           |}
+           |""".stripMargin
+    )
+    inputs.fromRoot { root =>
+      os.proc(TestUtil.cli, "--power", "bloop", "exit")
+        .call(
+          cwd = root,
+          stdout = os.Inherit
+        )
+      os.proc(TestUtil.cli, "setup-ide", ".", extraOptions)
+        .call(
+          cwd = root,
+          stdout = os.Inherit
+        )
+      val ideOptionsPath = root / Constants.workspaceDirName / "ide-options-v2.json"
+      val jsonOptions    = List("--json-options", ideOptionsPath.toString)
+      withBsp(inputs, Seq("."), bspOptions = jsonOptions, reuseRoot = Some(root)) {
+        (_, _, remoteServer) =>
+          async {
+            val buildTargetsResp = await(remoteServer.workspaceBuildTargets().asScala)
+            val targets          = buildTargetsResp.getTargets.asScala.map(_.getId).toSeq
+
+            val resp =
+              await(remoteServer.buildTargetCompile(new b.CompileParams(targets.asJava)).asScala)
+            expect(resp.getStatusCode == b.StatusCode.OK)
+
+            val updatedSourceFile =
+              s"""//> using jvm 19
+                 |//> using javacOpt --enable-preview
+                 |
+                 |public class ReloadTest {
+                 |  public static void main(String[] args) {
+                 |    String a = "Hello World";
+                 |
+                 |    switch (a) {
+                 |      case String s when s.length() > 6 -> System.out.println(s.toUpperCase());
+                 |      case String s -> System.out.println(s.toLowerCase());
+                 |    }
+                 |  }
+                 |}
+                 |""".stripMargin
+            os.write.over(root / sourceFilePath, updatedSourceFile)
+
+            val errorResponse =
+              await(remoteServer.buildTargetCompile(new b.CompileParams(targets.asJava)).asScala)
+            expect(errorResponse.getStatusCode == b.StatusCode.ERROR)
+
+            val reloadResponse =
+              extractWorkspaceReloadResponse(await(remoteServer.workspaceReload().asScala))
+            expect(reloadResponse.isEmpty)
+
+            val buildTargetsResp0 = await(remoteServer.workspaceBuildTargets().asScala)
+            val reloadedTargets   = buildTargetsResp0.getTargets.asScala.map(_.getId).toSeq
+
+            val okResponse =
+              await(
+                remoteServer.buildTargetCompile(new b.CompileParams(reloadedTargets.asJava)).asScala
+              )
+            expect(okResponse.getStatusCode == b.StatusCode.OK)
+          }
+      }
+
+    }
+  }
+
   test("bsp should start bloop with correct JVM version from directives") {
     val sourceFilePath = os.rel / "ReloadTest.java"
     val inputs = TestInputs(

--- a/scala-cli-src
+++ b/scala-cli-src
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
-LAUNCHER="$(cd "$SCRIPT_DIR" && ./mill show cli.launcher </dev/null | jq -r . | sed 's/ref:[a-z0-9]*://')"
+LAUNCHER="$(cd "$SCRIPT_DIR" && ./mill show cli.launcher </dev/null | jq -r . | sed 's/ref:[a-z0-9]*:[a-z0-9]*://')"
 exec "$LAUNCHER" "$@"


### PR DESCRIPTION
Fixes #2412

Root cause:
- our Bsp command didn't take into consideration the options set with `using directives`, so the `using jvm 19` could never be taken into consideration when downloading jvm for bloop
- adding a different version of the jvm to the build made [Scala CLI add a different `--release` flag to the project](https://github.com/VirtusLab/scala-cli/blob/d8a4d59308b4f65368fac36d68b720e425170469/modules/build/src/main/scala/scala/build/Build.scala#L1028), the build client gets notified about this fact with [OnBuildTargetDidChange: notification](https://build-server-protocol.github.io/docs/specification/#onbuildtargetdidchange-notification), in case of metals the response for it is to restart the build server thus the constant recompilation. 

EDIT: The `-release` flag should not be set if the jvm of bloop is too low, thus it should not result in the buildTargetChange notification. However one of our functions (here )did not get passed a compiler argument thus it didn't check if the '-release' flag should be set. This resulted in the flag being set and reset which resulted in the buildTargetChange notification.

Since we already preprocess sources with `CrossSources.forInputs` there's no significant additional time complexity of the solution proposed.