### PR TITLE
Use the new, shorter link for downloading the install script

### DIFF
--- a/gifs/scenarios/complete-install.sh
+++ b/gifs/scenarios/complete-install.sh
@@ -25,7 +25,7 @@ else
 
   doSleep 2
   
-  pe "curl -sSLf https://virtuslab.github.io/scala-cli-packages/scala-setup.sh | sh"
+  pe "curl -sSLf https://scala-cli.virtuslab.org/get | sh"
   pe 'source ~/.profile'
   pe "echo 'println(\"Hello from scala-cli\")' | scala-cli -"
 

--- a/modules/cli/src/main/scala/scala/cli/commands/update/Update.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/update/Update.scala
@@ -79,7 +79,7 @@ object Update extends ScalaCommand[UpdateOptions] {
     }
 
     val installationScript =
-      ProcUtil.downloadFile("https://virtuslab.github.io/scala-cli-packages/scala-setup.sh")
+      ProcUtil.downloadFile("https://scala-cli.virtuslab.org/get")
 
     // format: off
     val res = os.proc(
@@ -128,7 +128,7 @@ object Update extends ScalaCommand[UpdateOptions] {
     else if (isOutdated)
       println(
         s"""Your $fullRunnerName $currentVersion is outdated, please update $fullRunnerName to $newestScalaCliVersion0
-           |Run 'curl -sSLf https://virtuslab.github.io/scala-cli-packages/scala-setup.sh | sh' to update $fullRunnerName.""".stripMargin
+           |Run 'curl -sSLf https://scala-cli.virtuslab.org/get | sh' to update $fullRunnerName.""".stripMargin
       )
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
@@ -522,26 +522,30 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
   test("script wrappers satisfy strict compiler flags") {
     val inputs = TestInputs(
       os.rel / "strictClassWrapper.sc" ->
-      """//> using scala 3.3.1
-        |//> using options -Werror -Wnonunit-statement -Wunused:all -Wvalue-discard
-        |//> using options -Yno-experimental -Ysafe-init -deprecation -feature -language:strictEquality
-        |//> using options -new-syntax -old-syntax -unchecked -no-indent
-        |
-        |println(strictObjectWrapper.Foo(42).x)
-        |""".stripMargin,
-
+        """//> using scala 3.3.1
+          |//> using options -Werror -Wnonunit-statement -Wunused:all -Wvalue-discard
+          |//> using options -Yno-experimental -Ysafe-init -deprecation -feature -language:strictEquality
+          |//> using options -new-syntax -old-syntax -unchecked -no-indent
+          |
+          |println(strictObjectWrapper.Foo(42).x)
+          |""".stripMargin,
       os.rel / "strictObjectWrapper.sc" ->
-      """//> using objectWrapper
-        |//> using scala 3.3.1
-        |//> using options -Werror -Wnonunit-statement -Wunused:all -Wvalue-discard
-        |//> using options -Yno-experimental -Ysafe-init -deprecation -feature -language:strictEquality
-        |//> using options -new-syntax -old-syntax -unchecked -no-indent
-        |
-        |case class Foo(x: Int)
-        |""".stripMargin
+        """//> using objectWrapper
+          |//> using scala 3.3.1
+          |//> using options -Werror -Wnonunit-statement -Wunused:all -Wvalue-discard
+          |//> using options -Yno-experimental -Ysafe-init -deprecation -feature -language:strictEquality
+          |//> using options -new-syntax -old-syntax -unchecked -no-indent
+          |
+          |case class Foo(x: Int)
+          |""".stripMargin
     )
     inputs.fromRoot { root =>
-      val p = os.proc(TestUtil.cli, "--power", "strictClassWrapper.sc", "strictObjectWrapper.sc").call(cwd = root)
+      val p = os.proc(
+        TestUtil.cli,
+        "--power",
+        "strictClassWrapper.sc",
+        "strictObjectWrapper.sc"
+      ).call(cwd = root)
       expect(p.out.trim() == "42")
     }
   }

--- a/website/src/components/BasicInstall.js
+++ b/website/src/components/BasicInstall.js
@@ -26,7 +26,7 @@ export default function BasicInstall(props){
           <TabItem value="linux" >
             <p>Run the following one-line command in your terminal:</p>
             <code>
-              curl -sSLf https://virtuslab.github.io/scala-cli-packages/scala-setup.sh | sh
+              curl -sSLf https://scala-cli.virtuslab.org/get | sh
             </code>
           </TabItem>
 


### PR DESCRIPTION
Fixes #2427 

We can now use the shorter link to get the install script: https://scala-cli.virtuslab.org/get