### PR TITLE
Support Scala Native 0.5.x changes in publishing artifacts

### DIFF
--- a/modules/options/src/main/scala/scala/build/options/ScalaNativeOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaNativeOptions.scala
@@ -115,11 +115,19 @@ final case class ScalaNativeOptions(
   def platformSuffix: String =
     "native" + ScalaVersion.nativeBinary(finalVersion).getOrElse(finalVersion)
 
-  def nativeDependencies(scalaVersion: String): Seq[AnyDependency] =
+  def nativeDependencies(scalaVersion: String): Seq[AnyDependency] = {
+    // https://github.com/scala-native/scala-native/pull/3326
+    val scalalibVersion =
+      if (finalVersion.startsWith("0.4.")) finalVersion
+      else s"$scalaVersion+$finalVersion"
+    // Since 0.5.x Scala Native requires explicit dependency on javalib
+    // See https://github.com/scala-native/scala-native/pull/3566
+    val javalib = dep"org.scala-native::javalib::$finalVersion"
     if (scalaVersion.startsWith("2."))
-      Seq(dep"org.scala-native::scalalib::$finalVersion")
+      Seq(dep"org.scala-native::scalalib::$scalalibVersion", javalib)
     else
-      Seq(dep"org.scala-native::scala3lib::$finalVersion")
+      Seq(dep"org.scala-native::scala3lib::$scalalibVersion", javalib)
+  }
 
   def compilerPlugins: Seq[AnyDependency] =
     Seq(dep"org.scala-native:::nscplugin:$finalVersion")


### PR DESCRIPTION
Upcoming Scala Native 0.5.x changes how some artifacts are published: 
1. Scala Standard Library (scalalib) is now published for each Scala version, instead of being published once for Scala binary version. It is required to properly handle possible changes in sources between versions (mostly in Scala3) and to prepare for [SIP-51](https://github.com/scala/improvement-proposals/pull/54/) and potential unfreezing of Scala 2.13 stdlib. 
2. `scalalib` does no longer contain transitive dependency on Java Standard Library (javalib) re-implementation. This dependency is now handled explicitly. 