### PR TITLE
Allow to override internal & user default Scala versions for `mill` builds

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -290,3 +290,18 @@ it accordingly before committing:
 For more info about reflection configuration in GraalVM,
 check [the relevant GraalVM Reflection docs](https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/Reflection/).
 
+## Overriding Scala versions in Scala CLI builds
+
+It's possible to override the internal Scala version used to build Scala CLI,
+as well as the default version used by the CLI itself with Java props.
+- `scala.version.internal` - overrides the internal Scala version used to build Scala CLI
+- `scala.version.user` - overrides the default Scala version used by the CLI itself
+
+NOTE: remember to run `./mill clean` to make sure the Scala versions aren't being cached anywhere.
+
+```bash
+./mill -i clean
+./mill -i --define scala.version.internal=3.4.0-RC1-bin-20231012-242ba21-NIGHTLY --define scala.version.user=3.4.0-RC1-bin-20231012-242ba21-NIGHTLY scala version --offline
+# Scala CLI version: 1.x.x-SNAPSHOT
+# Scala version (default): 3.4.0-RC1-bin-20231012-242ba21-NIGHTLY
+```

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -9,9 +9,17 @@ object Scala {
   def scala213     = "2.13.12"
   def runnerScala3 = "3.0.2" // the newest version that is compatible with all Scala 3.x versions
   def scala3       = "3.3.1"
-  val allScala2    = Seq(scala213, scala212)
-  val all          = allScala2 ++ Seq(scala3)
-  val mainVersions = Seq(scala3, scala213)
+
+  // The Scala version used to build the CLI itself.
+  def defaultInternal = sys.props.get("scala.version.internal").getOrElse(scala3)
+
+  // The Scala version used by default to compile user input.
+  def defaultUser = sys.props.get("scala.version.user").getOrElse(scala3)
+
+  val allScala2           = Seq(scala213, scala212)
+  val defaults            = Seq(defaultInternal, defaultUser).distinct
+  val all                 = (allScala2 ++ Seq(scala3) ++ defaults).distinct
+  val mainVersions        = (Seq(scala3, scala213) ++ defaults).distinct
   val runnerScalaVersions = runnerScala3 +: allScala2
 
   def scalaJs = "1.13.2"
@@ -54,12 +62,6 @@ object Scala {
         true
     }
   }
-
-  // The Scala version used to build the CLI itself.
-  def defaultInternal = scala3
-
-  // The Scala version used by default to compile user input.
-  def defaultUser = scala3
 }
 
 // Dependencies used in integration test fixtures

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -23,12 +23,14 @@ object Scala {
     val max213 = patchVer(scala213)
     val max30  = 2
     val max31  = 3
-    val max32  = patchVer(scala3)
+    val max32  = 2
+    val max33  = patchVer(scala3)
     (8 until max212).map(i => s"2.12.$i") ++ Seq(scala212) ++
       (0 until max213).map(i => s"2.13.$i") ++ Seq(scala213) ++
       (0 to max30).map(i => s"3.0.$i") ++
       (0 to max31).map(i => s"3.1.$i") ++
-      (0 until max32).map(i => s"3.2.$i") ++ Seq(scala3)
+      (0 to max32).map(i => s"3.2.$i") ++
+      (0 until max33).map(i => s"3.3.$i") ++ Seq(scala3)
   }
 
   def maxAmmoniteScala212Version = scala212
@@ -54,8 +56,6 @@ object Scala {
   }
 
   // The Scala version used to build the CLI itself.
-  // We should be able to switch to 3.x when it'll have CPS support
-  // (for the either { value(…) } stuff)
   def defaultInternal = scala3
 
   // The Scala version used by default to compile user input.


### PR DESCRIPTION
This makes it possible to override the internal Scala version used to build Scala CLI,
as well as the default version used by the CLI itself with Java props.
- `scala.version.internal` - overrides the internal Scala version used to build Scala CLI
- `scala.version.user` - overrides the default Scala version used by the CLI itself

NOTE: remember to run `./mill clean` to make sure the Scala versions aren't being cached anywhere.

For example:
```bash
./mill -i clean
./mill -i --define scala.version.internal=3.4.0-RC1-bin-20231012-242ba21-NIGHTLY --define scala.version.user=3.4.0-RC1-bin-20231012-242ba21-NIGHTLY scala version --offline
# (...)
# Scala CLI version: 1.0.5-SNAPSHOT
# Scala version (default): 3.4.0-RC1-bin-20231012-242ba21-NIGHTLY
```