### PR TITLE
Bump Scala Native to 0.4.16 & log platform version

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
@@ -265,4 +265,22 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
       expect(output == "H")
     }
   }
+
+  test("js defaults & toolkit latest") {
+    val msg = "Hello"
+    TestInputs(
+      os.rel / "script.sc" ->
+        s"""//> using toolkit latest
+           |//> using platform "scala-js"
+           |import scala.scalajs.js
+           |val console = js.Dynamic.global.console
+           |val jsonString = "{\\"msg\\": \\"$msg\\"}"
+           |val json: ujson.Value  = ujson.read(jsonString)
+           |console.log(json("msg").str)
+           |""".stripMargin
+    ).fromRoot { root =>
+      val result = os.proc(TestUtil.cli, "run", "script.sc").call(cwd = root)
+      expect(result.out.trim() == msg)
+    }
+  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
@@ -300,4 +300,17 @@ trait RunScalaNativeTestDefinitions { _: RunTestDefinitions =>
       expect(output2 == "Hello from Main2")
     }
   }
+
+  test("native defaults & toolkit latest") {
+    TestInputs(
+      os.rel / "script.sc" ->
+        """//> using toolkit latest
+          |//> using platform "scala-native"
+          |println(os.pwd)
+          |""".stripMargin
+    ).fromRoot { root =>
+      val result = os.proc(TestUtil.cli, "run", "script.sc").call(cwd = root)
+      expect(result.out.trim() == root.toString)
+    }
+  }
 }

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -56,9 +56,19 @@ final case class BuildOptions(
     value(scalaParams) match {
       case Some(scalaParams0) =>
         val platform0 = platform.value match {
-          case Platform.JVM    => "JVM"
-          case Platform.JS     => "Scala.js"
-          case Platform.Native => "Scala Native"
+          case Platform.JVM =>
+            val jvmIdSuffix =
+              javaOptions.jvmIdOpt
+                .orElse(Some(javaHome().value.version.toString))
+                .map(" (" + _ + ")").getOrElse("")
+            s"JVM$jvmIdSuffix"
+          case Platform.JS =>
+            val scalaJsVersion = scalaJsOptions.version.getOrElse(Constants.scalaJsVersion)
+            s"Scala.js $scalaJsVersion"
+          case Platform.Native =>
+            val scalaNativeVersion =
+              scalaNativeOptions.version.getOrElse(Constants.scalaNativeVersion)
+            s"Scala Native $scalaNativeVersion"
         }
         Seq(s"Scala ${scalaParams0.scalaVersion}", platform0)
       case None =>

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -91,7 +91,7 @@ object Deps {
     def jsoniterScala        = "2.23.2"
     def jsoniterScalaJava8   = "2.13.5.2"
     def scalaMeta            = "4.8.11"
-    def scalaNative          = "0.4.15"
+    def scalaNative          = "0.4.16"
     def scalaPackager        = "0.1.29"
     def signingCli           = "0.2.2"
     def signingCliJvmVersion = 17

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1337,7 +1337,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 ### `--native-version`
 
-Set the Scala Native version (0.4.15 by default).
+Set the Scala Native version (0.4.16 by default).
 
 ### `--native-mode`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -826,7 +826,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 `SHOULD have` per Scala Runner specification
 
-Set the Scala Native version (0.4.15 by default).
+Set the Scala Native version (0.4.16 by default).
 
 ### `--native-mode`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -168,7 +168,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.15 by default).
+Set the Scala Native version (0.4.16 by default).
 
 **--native-mode**
 
@@ -911,7 +911,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.15 by default).
+Set the Scala Native version (0.4.16 by default).
 
 **--native-mode**
 
@@ -1458,7 +1458,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.15 by default).
+Set the Scala Native version (0.4.16 by default).
 
 **--native-mode**
 
@@ -2031,7 +2031,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.15 by default).
+Set the Scala Native version (0.4.16 by default).
 
 **--native-mode**
 
@@ -2623,7 +2623,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.15 by default).
+Set the Scala Native version (0.4.16 by default).
 
 **--native-mode**
 
@@ -3191,7 +3191,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.15 by default).
+Set the Scala Native version (0.4.16 by default).
 
 **--native-mode**
 
@@ -3796,7 +3796,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.15 by default).
+Set the Scala Native version (0.4.16 by default).
 
 **--native-mode**
 
@@ -4452,7 +4452,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.15 by default).
+Set the Scala Native version (0.4.16 by default).
 
 **--native-mode**
 
@@ -5339,7 +5339,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.4.15 by default).
+Set the Scala Native version (0.4.16 by default).
 
 **--native-mode**
 


### PR DESCRIPTION
- bumped Scala Native to 0.4.16
- Platform version will now always be logged during compilation
```bash
scala-cli hello.sc
# Compiling project (Scala 3.3.1, JVM (17))
# Compiled project (Scala 3.3.1, JVM (17))
# Hello
scala-cli hello.sc --js
# Compiling project (Scala 3.3.1, Scala.js 1.13.2)
# Compiled project (Scala 3.3.1, Scala.js 1.13.2)
# Hello
scala-cli hello.sc --native
# Compiling project (Scala 3.3.1, Scala Native 0.4.16)
# Compiled project (Scala 3.3.1, Scala Native 0.4.16)
# Hello
```
- added tests ensuring the latest toolkit version is compatible with platform defaults