### PR TITLE
Update `scala-cli-signing` to 0.2.3

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -93,7 +93,7 @@ object Deps {
     def scalaMeta            = "4.8.12"
     def scalaNative          = "0.4.16"
     def scalaPackager        = "0.1.29"
-    def signingCli           = "0.2.2"
+    def signingCli           = "0.2.3"
     def signingCliJvmVersion = 17
   }
   // DO NOT hardcode a Scala version in this dependency string

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -2062,7 +2062,7 @@ Available in commands:
 ### `--signing-cli-version`
 
 [Internal]
-scala-cli-signing version when running externally (0.2.2 by default)
+scala-cli-signing version when running externally (0.2.3 by default)
 
 ### `--signing-cli-java-arg`
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-cli-signing/releases/tag/v0.2.3