### PR TITLE
Fix logging malformed JVM id when compiling

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -2021,4 +2021,17 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
       expect(withDependencyCacheWalkSize == os.walk(cachePath).size)
     }
   }
+
+  test("JVM id is printed with compilation info correctly") {
+    val msg   = "Hello"
+    val input = "jvm.sc"
+    TestInputs(os.rel / input ->
+      s"""//> using jvm 11
+         |println("$msg")
+         |""".stripMargin).fromRoot { root =>
+      val res = os.proc(TestUtil.cli, "run", extraOptions, input).call(cwd = root, stderr = os.Pipe)
+      expect(res.out.trim() == msg)
+      expect(res.err.trim().contains("JVM (11)"))
+    }
+  }
 }

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -58,7 +58,7 @@ final case class BuildOptions(
         val platform0 = platform.value match {
           case Platform.JVM =>
             val jvmIdSuffix =
-              javaOptions.jvmIdOpt
+              javaOptions.jvmIdOpt.map(_.value)
                 .orElse(Some(javaHome().value.version.toString))
                 .map(" (" + _ + ")").getOrElse("")
             s"JVM$jvmIdSuffix"


### PR DESCRIPTION
when customising the JVM, like
```scala
//> using jvm 11
```
we shouldn't be getting malformed logs like
```
Compiling project (Scala 3.3.1, JVM (Positioned(List(File(Right(/Users/pchabelski/IdeaProjects/scala-cli-tests/watch-test/simple.sc),(0,14),(0,16),0)),11)))
```
this should fix it to
```
Compiling project (Scala 3.3.1, JVM (11))
```