### PR TITLE
Ensure docker is logged in on the M1 CI

### DIFF
--- a/.github/scripts/build-linux-aarch64.sh
+++ b/.github/scripts/build-linux-aarch64.sh
@@ -11,6 +11,7 @@ chmod +x utils/cs
 
 cp "$DIR/build-linux-aarch64-from-docker.sh" utils/
 
+docker login --username "$DOCKERHUB_USERNAME" --password "$DOCKERHUB_TOKEN"
 docker run $(if test -t 1; then echo "-it"; fi) --rm \
   --volume "$(pwd):/data" \
   -w /data \


### PR DESCRIPTION
This should fix the `generate-linux-arm64-native-launcher` job on the `main` branch