### PR TITLE
Increase `--watch` integration test timeouts

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -136,7 +136,7 @@ class BloopTests extends ScalaCliSuite {
 
   test("Restart Bloop server while watching") {
     TestUtil.withThreadPool("bloop-restart-test", 2) { pool =>
-      val timeout = Duration("20 seconds")
+      val timeout = Duration("90 seconds")
       val ec      = ExecutionContext.fromExecutorService(pool)
 
       def content(message: String) =
@@ -150,7 +150,7 @@ class BloopTests extends ScalaCliSuite {
         sourcePath -> content("Hello")
       )
       inputs.fromRoot { root =>
-        val proc = os.proc(TestUtil.cli, "run", "-w", ".")
+        val proc = os.proc(TestUtil.cli, "run", "--power", "--offline", "-w", ".")
           .spawn(cwd = root)
         val firstLine = TestUtil.readLine(proc.stdout, ec, timeout)
         expect(firstLine == "Hello")

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
@@ -102,12 +102,21 @@ class RunTestsDefault extends RunTestDefinitions(scalaVersionOpt = None) {
 
       publishLib()
 
-      val proc = os.proc(TestUtil.cli, "run", "app", "-w", "-r", testRepo.toNIO.toUri.toASCIIString)
+      val proc = os.proc(
+        TestUtil.cli,
+        "--power",
+        "run",
+        "--offline",
+        "app",
+        "-w",
+        "-r",
+        testRepo.toNIO.toUri.toASCIIString
+      )
         .spawn(cwd = root)
 
       try
         TestUtil.withThreadPool("watch-artifacts-test", 2) { pool =>
-          val timeout = Duration("20 seconds")
+          val timeout = Duration("90 seconds")
           val ec      = ExecutionContext.fromExecutorService(pool)
 
           val output = TestUtil.readLine(proc.stdout, ec, timeout)


### PR DESCRIPTION
Increasing timeouts in an attempt to make tests more stable (they got very wonky, we have plenty intermittent timeouts on these)