### PR TITLE
Fix error output since --version has been replaced with --project-version

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -381,7 +381,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
     if (mayDefaultToGitTag) Some(ComputeVersion.GitTag(os.rel, dynVer = false, positions = Nil))
     else None
   def defaultVersionError =
-    new MissingPublishOptionError("version", "--version", "publish.version")
+    new MissingPublishOptionError("version", "--project-version", "publish.version")
   def defaultVersion: Either[BuildException, String] =
     Left(defaultVersionError)
 


### PR DESCRIPTION
Fixes #2485
Bug introduced in #2310 [[more precisely, here]](https://github.com/VirtusLab/scala-cli/pull/2310/commits/eafd736d04b4ded5dafabefeeb957610d1d496ee)