### PR TITLE
Switch `java-class-name` to the VL fork & bump to `0.1.3`

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -165,7 +165,7 @@ Here's some of the more important external projects used by Scala CLI:
   from OpenJDK, with CRC32 calculations disabled.
 - [lightweight-spark-distrib](https://github.com/VirtusLab/lightweight-spark-distrib): a small application allowing
   to make Spark distributions more lightweight.
-- [java-class-name](https://github.com/scala-cli/java-class-name): a small library to extract class names
+- [java-class-name](https://github.com/VirtusLab/java-class-name): a small library to extract class names
   from Java sources.
 
 The use of external binaries allows to make the Scala CLI binary slimmer and faster

--- a/modules/build/src/main/scala/scala/build/internal/JavaParserProxyBinary.scala
+++ b/modules/build/src/main/scala/scala/build/internal/JavaParserProxyBinary.scala
@@ -46,7 +46,7 @@ class JavaParserProxyBinary(
       else ("v" + version, false)
     val ext = if (Properties.isWin) ".zip" else ".gz"
     val url =
-      s"https://github.com/scala-cli/java-class-name/releases/download/$tag/java-class-name-$platformSuffix$ext"
+      s"https://github.com/VirtusLab/java-class-name/releases/download/$tag/java-class-name-$platformSuffix$ext"
 
     val params = ExternalBinaryParams(
       url,

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -95,6 +95,7 @@ object Deps {
     def scalaPackager        = "0.1.29"
     def signingCli           = "0.2.3"
     def signingCliJvmVersion = 17
+    def javaClassName        = "0.1.3"
   }
   // DO NOT hardcode a Scala version in this dependency string
   // This dependency is used to ensure that Ammonite is available for Scala versions
@@ -116,14 +117,15 @@ object Deps {
   def dependency         = ivy"io.get-coursier::dependency:0.2.3"
   def dockerClient       = ivy"com.spotify:docker-client:8.16.0"
   // TODO bump once 0.15.5 is out
-  def expecty       = ivy"com.eed3si9n.expecty::expecty:0.16.0"
-  def fansi         = ivy"com.lihaoyi::fansi:0.4.0"
-  def giter8        = ivy"org.foundweekends.giter8:giter8:0.16.2"
-  def guava         = ivy"com.google.guava:guava:32.1.3-jre"
-  def javaClassName = ivy"io.github.alexarchambault.scala-cli:java-class-name_3:0.1.0"
-  def jgit          = ivy"org.eclipse.jgit:org.eclipse.jgit:6.7.0.202309050840-r"
-  def jimfs         = ivy"com.google.jimfs:jimfs:1.3.0"
-  def jniUtils      = ivy"io.get-coursier.jniutils:windows-jni-utils:0.3.3"
+  def expecty = ivy"com.eed3si9n.expecty::expecty:0.16.0"
+  def fansi   = ivy"com.lihaoyi::fansi:0.4.0"
+  def giter8  = ivy"org.foundweekends.giter8:giter8:0.16.2"
+  def guava   = ivy"com.google.guava:guava:32.1.3-jre"
+  def javaClassName =
+    ivy"org.virtuslab.scala-cli.java-class-name:java-class-name_3:${Versions.javaClassName}"
+  def jgit     = ivy"org.eclipse.jgit:org.eclipse.jgit:6.7.0.202309050840-r"
+  def jimfs    = ivy"com.google.jimfs:jimfs:1.3.0"
+  def jniUtils = ivy"io.get-coursier.jniutils:windows-jni-utils:0.3.3"
   def jsoniterCore =
     ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:${Versions.jsoniterScalaJava8}"
   def jsoniterCoreJava8 =


### PR DESCRIPTION
https://github.com/VirtusLab/java-class-name/releases/tag/v0.1.3