### PR TITLE
Switch `lightweight-spark-distrib` to the VL fork & bump to `0.0.5`

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -163,7 +163,7 @@ Here's some of the more important external projects used by Scala CLI:
   stripped up of its benchmark infrastructure and build integrations.
 - [no-crc32-zip-input-stream](https://github.com/scala-cli/no-crc32-zip-input-stream): A copy of `ZipInputStream` 
   from OpenJDK, with CRC32 calculations disabled.
-- [lightweight-spark-distrib](https://github.com/scala-cli/lightweight-spark-distrib): a small application allowing
+- [lightweight-spark-distrib](https://github.com/VirtusLab/lightweight-spark-distrib): a small application allowing
   to make Spark distributions more lightweight.
 - [java-class-name](https://github.com/scala-cli/java-class-name): a small library to extract class names
   from Java sources.

--- a/modules/integration/src/test/scala/scala/cli/integration/SparkTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SparkTestDefinitions.scala
@@ -9,7 +9,7 @@ import scala.util.Properties
 
 object SparkTestDefinitions {
 
-  def lightweightSparkDistribVersionOpt = Option("0.0.4")
+  def lightweightSparkDistribVersionOpt: Option[String] = Option("0.0.5")
 
   final class Spark(val sparkVersion: String, val scalaVersion: String) {
     private def sbv         = scalaVersion.split('.').take(2).mkString(".")
@@ -17,7 +17,7 @@ object SparkTestDefinitions {
     lazy val sparkHome: os.Path = {
       val url = lightweightSparkDistribVersionOpt match {
         case Some(lightweightSparkDistribVersion) =>
-          s"https://github.com/scala-cli/lightweight-spark-distrib/releases/download/v$lightweightSparkDistribVersion/spark-$sparkVersion-bin-hadoop2.7-scala$sbv.tgz"
+          s"https://github.com/VirtusLab/lightweight-spark-distrib/releases/download/v$lightweightSparkDistribVersion/spark-$sparkVersion-bin-hadoop2.7-scala$sbv.tgz"
         case None =>
           // original URL (too heavyweight, often fails / times out…)
           s"https://archive.apache.org/dist/spark/spark-$sparkVersion/spark-$sparkVersion-bin-hadoop2.7.tgz"


### PR DESCRIPTION
https://github.com/VirtusLab/lightweight-spark-distrib/releases/tag/v0.0.5