### PR TITLE
bugfix: Don't try to always get system jvm first

### DIFF
--- a/modules/core/src/main/scala/scala/build/internals/OsLibc.scala
+++ b/modules/core/src/main/scala/scala/build/internals/OsLibc.scala
@@ -74,14 +74,7 @@ object OsLibc {
   }
 
   def defaultJvm(os: String): String = {
-    val hasEmptyJavaHome = Option(System.getenv("JAVA_HOME")).exists(_.trim.isEmpty)
-    val defaultJvm0      = baseDefaultJvm(os, defaultJvmVersion)
-    if (hasEmptyJavaHome)
-      // Not using the system JVM if JAVA_HOME is set to an empty string
-      // (workaround for https://github.com/coursier/coursier/issues/2292)
-      defaultJvm0
-    else
-      s"${JavaHome.systemId}|$defaultJvm0"
+    baseDefaultJvm(os, defaultJvmVersion)
   }
 
   def javaVersion(javaCmd: String): Int = {

--- a/modules/integration/src/test/scala/scala/cli/integration/StandaloneLauncherTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/StandaloneLauncherTests.scala
@@ -6,26 +6,28 @@ import java.io.File
 
 class StandaloneLauncherTests extends ScalaCliSuite {
 
-  if (TestUtil.isJvmCli)
-    test(s"Standalone launcher should run with java 8") {
-      // It should download Java 17 and use it to run itself
-      val message = "Hello World"
-      val inputs = TestInputs(
-        os.rel / "hello.sc" -> s"""println("$message")"""
+  test(s"Standalone launcher should run with java 8") {
+    // It should download Java 17 and use it to run itself
+    val message = "Hello World"
+    val inputs = TestInputs(
+      os.rel / "hello.sc" -> s"""println("$message")"""
+    )
+    inputs.fromRoot { root =>
+      val java8Home =
+        os.Path(os.proc(TestUtil.cs, "java-home", "--jvm", "zulu:8").call().out.trim(), os.pwd)
+
+      val extraEnv = Map(
+        "JAVA_HOME" -> java8Home.toString,
+        "PATH"      -> ((java8Home / "bin").toString + File.pathSeparator + System.getenv("PATH"))
       )
-      inputs.fromRoot { root =>
-        val java8Home =
-          os.Path(os.proc(TestUtil.cs, "java-home", "--jvm", "zulu:8").call().out.trim(), os.pwd)
 
-        val extraEnv = Map(
-          "JAVA_HOME" -> java8Home.toString,
-          "PATH"      -> ((java8Home / "bin").toString + File.pathSeparator + System.getenv("PATH"))
-        )
+      // we need to exit to check if the launcher is actually starting the right version of java
+      os.proc(TestUtil.cli, "--power", "bloop", "exit").call(cwd = root, env = extraEnv).out.trim()
 
-        val output =
-          os.proc(TestUtil.cli, ".").call(cwd = root, env = extraEnv).out.trim()
+      val output =
+        os.proc(TestUtil.cli, ".").call(cwd = root, env = extraEnv).out.trim()
 
-        expect(output == message)
-      }
+      expect(output == message)
     }
+  }
 }

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -557,7 +557,7 @@ object BuildOptions {
     def envUpdates(currentEnv: Map[String, String]): Map[String, String] = {
       // On Windows, AFAIK, env vars are "case-insensitive but case-preserving".
       // If PATH was defined as "Path", we need to update "Path", not "PATH".
-      // Same for JAVA_HOME.
+      // Same for JAVA_HOME
       def keyFor(name: String) =
         if (Properties.isWin)
           currentEnv.keys.find(_.equalsIgnoreCase(name)).getOrElse(name)

--- a/modules/options/src/main/scala/scala/build/options/JavaOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/JavaOptions.scala
@@ -149,7 +149,7 @@ final case class JavaOptions(
     }
 
   private def findLocalDefaultJava(): Option[Positioned[os.Path]] =
-    Option(System.getenv("JAVA_HOME")).map(p =>
+    Option(System.getenv("JAVA_HOME")).filter(_.nonEmpty).map(p =>
       Positioned(Position.Custom("JAVA_HOME env"), os.Path(p, os.pwd))
     ).orElse(
       sys.props.get("java.home").map(p =>


### PR DESCRIPTION
Previously, we would always first specify `system|` when downloading default JVM, which would coursier just return java from JAVA_HOME without any checks even if we needed to download never Java. Now, we only use specific versions, since java home is handled before.

Trying to figure out the tests in https://github.com/VirtusLab/scala-cli/pull/2507