### PR TITLE
Switch `nocrc32-zip-input-stream` to the VL fork & bump it to `0.1.2`

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -161,7 +161,7 @@ Here's some of the more important external projects used by Scala CLI:
   for `scalafmt`.
 - [bloop-core](https://github.com/scala-cli/bloop-core): a fork of [bloop](https://github.com/scalacenter/bloop)
   stripped up of its benchmark infrastructure and build integrations.
-- [no-crc32-zip-input-stream](https://github.com/scala-cli/no-crc32-zip-input-stream): A copy of `ZipInputStream` 
+- [no-crc32-zip-input-stream](https://github.com/VirtusLab/no-crc32-zip-input-stream): A copy of `ZipInputStream` 
   from OpenJDK, with CRC32 calculations disabled.
 - [lightweight-spark-distrib](https://github.com/VirtusLab/lightweight-spark-distrib): a small application allowing
   to make Spark distributions more lightweight.

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -190,11 +190,11 @@ object Deps {
   def typelevelToolkit        = ivy"org.typelevel:toolkit:$typelevelToolkitVersion"
   def typelevelToolkitTest    = ivy"org.typelevel:toolkit-test:$typelevelToolkitVersion"
   def usingDirectives         = ivy"org.virtuslab:using_directives:1.1.0"
-  // Lives at https://github.com/scala-cli/no-crc32-zip-input-stream, see #865
+  // Lives at https://github.com/VirtusLab/no-crc32-zip-input-stream, see #865
   // This provides a ZipInputStream that doesn't verify CRC32 checksums, that users
   // can enable by setting SCALA_CLI_VENDORED_ZIS=true in the environment, to workaround
   // some bad GraalVM / zlib issues (see #828 and linked issues for more details).
-  def zipInputStream = ivy"io.github.alexarchambault.scala-cli.tmp:zip-input-stream:0.1.1"
+  def zipInputStream = ivy"org.virtuslab.scala-cli.zip-input-stream:zip-input-stream:0.1.2"
 }
 
 def graalVmVersion     = "22.3.1"


### PR DESCRIPTION
https://github.com/VirtusLab/no-crc32-zip-input-stream/releases/tag/v0.1.2