### PR TITLE
Fix publishing with mill `0.11.5`

### DIFF
--- a/.github/scripts/build-linux-aarch64-from-docker.sh
+++ b/.github/scripts/build-linux-aarch64-from-docker.sh
@@ -13,6 +13,6 @@ git config --global --add safe.directory "$(pwd)"
 
 ./mill -i show cli.nativeImage
 ./mill -i copyDefaultLauncher ./artifacts
-if "true" == $(./mill -i ci.shouldPublish); then
+if "true" == $(./mill -i --disable-callgraph-invalidation ci.shouldPublish); then
   .github/scripts/generate-os-packages.sh
 fi

--- a/.github/scripts/build-linux-aarch64.sh
+++ b/.github/scripts/build-linux-aarch64.sh
@@ -6,7 +6,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
 mkdir -p artifacts
 mkdir -p utils
-cp "$(cs get https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.4/cs-aarch64-pc-linux.gz --archive)" utils/cs
+cp "$(cs get https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.7/cs-aarch64-pc-linux.gz --archive)" utils/cs
 chmod +x utils/cs
 
 cp "$DIR/build-linux-aarch64-from-docker.sh" utils/

--- a/.github/scripts/generate-native-image.sh
+++ b/.github/scripts/generate-native-image.sh
@@ -10,12 +10,12 @@ export USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM=false
 # Using 'mill -i' so that the Mill process doesn't outlive this invocation
 
 if [[ "$OSTYPE" == "msys" ]]; then
-  ./mill.bat -i ci.copyJvm --dest jvm
+  ./mill.bat -i --disable-callgraph-invalidation ci.copyJvm --dest jvm
   export JAVA_HOME="$(pwd -W | sed 's,/,\\,g')\\jvm"
   export GRAALVM_HOME="$JAVA_HOME"
   export PATH="$(pwd)/bin:$PATH"
   echo "PATH=$PATH"
-  ./mill.bat -i "$COMMAND" generate-native-image.bat ""
+  ./mill.bat -i --disable-callgraph-invalidation "$COMMAND" generate-native-image.bat ""
   ./generate-native-image.bat
 else
   if [ $# == "0" ]; then
@@ -42,7 +42,7 @@ else
     esac
   fi
 
-  ./mill -i "$COMMAND" generate-native-image.sh ""
+  ./mill -i --disable-callgraph-invalidation "$COMMAND" generate-native-image.sh ""
   bash ./generate-native-image.sh
   "${CLEANUP[@]}"
 fi

--- a/.github/scripts/generate-os-packages.sh
+++ b/.github/scripts/generate-os-packages.sh
@@ -21,7 +21,7 @@ else
 fi
 
 packager() {
-  "$mill" -i packager.run "$@"
+  "$mill" -i --disable-callgraph-invalidation packager.run "$@"
 }
 
 launcher() {
@@ -34,17 +34,17 @@ launcher() {
     launcherName="scala"
   fi
 
-  "$mill" -i copyTo "$launcherMillCommand" "$launcherName" 1>&2
+  "$mill" -i --disable-callgraph-invalidation copyTo "$launcherMillCommand" "$launcherName" 1>&2
   echo "$launcherName"
 }
 
 version() {
-  "$mill" -i writePackageVersionTo scala-cli-version 1>&2
+  "$mill" -i --disable-callgraph-invalidation writePackageVersionTo scala-cli-version 1>&2
   cat scala-cli-version
 }
 
 shortVersion() {
-  "$mill" -i writeShortPackageVersionTo scala-cli-short-version 1>&2
+  "$mill" -i --disable-callgraph-invalidation writeShortPackageVersionTo scala-cli-short-version 1>&2
   cat scala-cli-short-version
 }
 

--- a/.github/scripts/generate-slim-docker-image.sh
+++ b/.github/scripts/generate-slim-docker-image.sh
@@ -5,7 +5,7 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 WORKDIR="$ROOT/out/docker-slim-workdir"
 
 mkdir -p "$WORKDIR"
-./mill -i copyTo cli.nativeImageMostlyStatic "$WORKDIR/scala-cli" 1>&2
+./mill -i --disable-callgraph-invalidation copyTo cli.nativeImageMostlyStatic "$WORKDIR/scala-cli" 1>&2
 
 cd "$WORKDIR"
 docker build -t scala-cli-slim -f "$ROOT/.github/scripts/docker/ScalaCliSlimDockerFile" .

--- a/.github/scripts/get-latest-cs.sh
+++ b/.github/scripts/get-latest-cs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-CS_VERSION="2.1.4"
+CS_VERSION="2.1.7"
 
 DIR="$(cs get --archive "https://github.com/coursier/coursier/releases/download/v$CS_VERSION/cs-x86_64-pc-win32.zip")"
 

--- a/.github/scripts/publish-docker-images.sh
+++ b/.github/scripts/publish-docker-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-SCALA_CLI_VERSION="$(./mill -i ci.publishVersion)"
+SCALA_CLI_VERSION="$(./mill -i --disable-callgraph-invalidation ci.publishVersion)"
 
 docker tag scala-cli virtuslab/scala-cli:latest
 docker tag scala-cli virtuslab/scala-cli:"$SCALA_CLI_VERSION"

--- a/.github/scripts/publish-slim-docker-images.sh
+++ b/.github/scripts/publish-slim-docker-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-SCALA_CLI_VERSION="$(./mill -i ci.publishVersion)"
+SCALA_CLI_VERSION="$(./mill -i --disable-callgraph-invalidation ci.publishVersion)"
 
 docker tag scala-cli-slim virtuslab/scala-cli-slim:latest
 docker tag scala-cli-slim virtuslab/scala-cli-slim:"$SCALA_CLI_VERSION"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
       with:
         jvm: "temurin:17"
     - name: Copy launcher
-      run: ./mill -i copyJvmLauncher artifacts/
+      run: ./mill -i --disable-callgraph-invalidation copyJvmLauncher artifacts/
       if: runner.os == 'Linux'
     - name: Copy bootstrapped launcher
-      run: ./mill -i copyJvmBootstrappedLauncher artifacts/
+      run: ./mill -i --disable-callgraph-invalidation copyJvmBootstrappedLauncher artifacts/
       if: runner.os == 'Linux'
     - uses: actions/upload-artifact@v3
       if: runner.os == 'Linux'
@@ -38,9 +38,9 @@ jobs:
         if-no-files-found: error
         retention-days: 2
     - name: Compile everything
-      run: ./mill -i __.compile
+      run: ./mill -i --disable-callgraph-invalidation __.compile
     - name: Unit tests
-      run: ./mill -i unitTests
+      run: ./mill -i --disable-callgraph-invalidation unitTests
 
   jvm-tests-1:
     timeout-minutes: 120
@@ -54,11 +54,11 @@ jobs:
       with:
         jvm: "temurin:17"
     - name: JVM integration tests
-      run: ./mill -i integration.test.jvm
+      run: ./mill -i --disable-callgraph-invalidation integration.test.jvm
       env:
         SCALA_CLI_IT_GROUP: 1
     - name: Fat jar integration test
-      run: ./mill integration.test.jvmBootstrapped 'scala.cli.integration.StandaloneLauncherTests.*'
+      run: ./mill --disable-callgraph-invalidation integration.test.jvmBootstrapped 'scala.cli.integration.StandaloneLauncherTests.*'
 
   jvm-tests-2:
     timeout-minutes: 120
@@ -72,7 +72,7 @@ jobs:
       with:
         jvm: "temurin:17"
     - name: JVM integration tests
-      run: ./mill -i integration.test.jvm
+      run: ./mill -i --disable-callgraph-invalidation integration.test.jvm
       env:
         SCALA_CLI_IT_GROUP: 2
 
@@ -88,7 +88,7 @@ jobs:
       with:
         jvm: "temurin:17"
     - name: JVM integration tests
-      run: ./mill -i integration.test.jvm
+      run: ./mill -i --disable-callgraph-invalidation integration.test.jvm
       env:
         SCALA_CLI_IT_GROUP: 3
 
@@ -105,12 +105,12 @@ jobs:
         jvm: "temurin:17"
     - name: Generate native launcher
       run: .github/scripts/generate-native-image.sh
-    - run: ./mill -i ci.setShouldPublish
+    - run: ./mill -i --disable-callgraph-invalidation ci.setShouldPublish
     - name: Build OS packages
       if: env.SHOULD_PUBLISH == 'true'
       run: .github/scripts/generate-os-packages.sh
     - name: Copy artifacts
-      run: ./mill -i copyDefaultLauncher artifacts/
+      run: ./mill -i --disable-callgraph-invalidation copyDefaultLauncher artifacts/
     - uses: actions/upload-artifact@v3
       with:
         name: linux-launchers
@@ -135,7 +135,7 @@ jobs:
         name: linux-launchers
         path: artifacts/
     - name: Native integration tests
-      run: ./mill -i nativeIntegrationTests
+      run: ./mill -i --disable-callgraph-invalidation nativeIntegrationTests
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
@@ -159,7 +159,7 @@ jobs:
         name: linux-launchers
         path: artifacts/
     - name: Native integration tests
-      run: ./mill -i nativeIntegrationTests
+      run: ./mill -i --disable-callgraph-invalidation nativeIntegrationTests
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
@@ -183,7 +183,7 @@ jobs:
         name: linux-launchers
         path: artifacts/
     - name: Native integration tests
-      run: ./mill -i nativeIntegrationTests
+      run: ./mill -i --disable-callgraph-invalidation nativeIntegrationTests
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
@@ -226,12 +226,12 @@ jobs:
         jvm: "temurin:17"
     - name: Generate native launcher
       run: .github/scripts/generate-native-image.sh
-    - run: ./mill -i ci.setShouldPublish
+    - run: ./mill -i --disable-callgraph-invalidation ci.setShouldPublish
     - name: Build OS packages
       if: env.SHOULD_PUBLISH == 'true'
       run: .github/scripts/generate-os-packages.sh
     - name: Copy artifacts
-      run: ./mill -i copyDefaultLauncher artifacts/
+      run: ./mill -i --disable-callgraph-invalidation copyDefaultLauncher artifacts/
     - uses: actions/upload-artifact@v3
       with:
         name: macos-launchers
@@ -256,7 +256,7 @@ jobs:
         name: macos-launchers
         path: artifacts/
     - name: Native integration tests
-      run: ./mill -i nativeIntegrationTests
+      run: ./mill -i --disable-callgraph-invalidation nativeIntegrationTests
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
@@ -280,7 +280,7 @@ jobs:
         name: macos-launchers
         path: artifacts/
     - name: Native integration tests
-      run: ./mill -i nativeIntegrationTests
+      run: ./mill -i --disable-callgraph-invalidation nativeIntegrationTests
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
@@ -304,7 +304,7 @@ jobs:
         name: macos-launchers
         path: artifacts/
     - name: Native integration tests
-      run: ./mill -i nativeIntegrationTests
+      run: ./mill -i --disable-callgraph-invalidation nativeIntegrationTests
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
@@ -326,12 +326,12 @@ jobs:
           jvm: "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.2.0/graalvm-ce-java17-darwin-aarch64-22.2.0.tar.gz"
       - name: Generate native launcher
         run: .github/scripts/generate-native-image.sh
-      - run: ./mill -i ci.setShouldPublish
+      - run: ./mill -i --disable-callgraph-invalidation ci.setShouldPublish
       - name: Build OS packages
         if: env.SHOULD_PUBLISH == 'true'
         run: .github/scripts/generate-os-packages.sh
       - name: Copy artifacts
-        run: ./mill -i copyDefaultLauncher artifacts/
+        run: ./mill -i --disable-callgraph-invalidation copyDefaultLauncher artifacts/
       - uses: actions/upload-artifact@v3
         with:
           name: macos-m1-launchers
@@ -358,7 +358,7 @@ jobs:
           name: macos-m1-launchers
           path: artifacts/
       - name: Native integration tests
-        run: ./mill -i nativeIntegrationTests
+        run: ./mill -i --disable-callgraph-invalidation nativeIntegrationTests
         env:
           UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
@@ -381,13 +381,13 @@ jobs:
     - name: Generate native launcher
       run: .github/scripts/generate-native-image.sh
       shell: bash
-    - run: ./mill -i ci.setShouldPublish
+    - run: ./mill -i --disable-callgraph-invalidation ci.setShouldPublish
     - name: Build OS packages
       if: env.SHOULD_PUBLISH == 'true'
       run: .github/scripts/generate-os-packages.sh
       shell: bash
     - name: Copy artifacts
-      run: ./mill -i copyDefaultLauncher artifacts/
+      run: ./mill -i --disable-callgraph-invalidation copyDefaultLauncher artifacts/
     - uses: actions/upload-artifact@v3
       with:
         name: windows-launchers
@@ -419,7 +419,7 @@ jobs:
         name: windows-launchers
         path: artifacts/
     - name: Native integration tests
-      run: ./mill -i nativeIntegrationTests
+      run: ./mill -i --disable-callgraph-invalidation nativeIntegrationTests
       env:
         COURSIER_JNI: force
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -451,7 +451,7 @@ jobs:
         name: windows-launchers
         path: artifacts/
     - name: Native integration tests
-      run: ./mill -i nativeIntegrationTests
+      run: ./mill -i --disable-callgraph-invalidation nativeIntegrationTests
       env:
         COURSIER_JNI: force
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -483,7 +483,7 @@ jobs:
         name: windows-launchers
         path: artifacts/
     - name: Native integration tests
-      run: ./mill -i nativeIntegrationTests
+      run: ./mill -i --disable-callgraph-invalidation nativeIntegrationTests
       env:
         COURSIER_JNI: force
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -506,7 +506,7 @@ jobs:
       run: .github/scripts/generate-native-image.sh mostly-static
       shell: bash
     - name: Copy artifacts
-      run: ./mill -i copyMostlyStaticLauncher artifacts/
+      run: ./mill -i --disable-callgraph-invalidation copyMostlyStaticLauncher artifacts/
     - uses: actions/upload-artifact@v3
       with:
         name: mostly-static-launchers
@@ -533,7 +533,7 @@ jobs:
     - name: Build slim docker image
       run: .github/scripts/generate-slim-docker-image.sh
     - name: Native integration tests
-      run: ./mill -i integration.test.nativeMostlyStatic
+      run: ./mill -i --disable-callgraph-invalidation integration.test.nativeMostlyStatic
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
@@ -568,7 +568,7 @@ jobs:
         name: mostly-static-launchers
         path: artifacts/
     - name: Native integration tests
-      run: ./mill -i integration.test.nativeMostlyStatic
+      run: ./mill -i --disable-callgraph-invalidation integration.test.nativeMostlyStatic
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
@@ -592,7 +592,7 @@ jobs:
         name: mostly-static-launchers
         path: artifacts/
     - name: Native integration tests
-      run: ./mill -i integration.test.nativeMostlyStatic
+      run: ./mill -i --disable-callgraph-invalidation integration.test.nativeMostlyStatic
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
@@ -614,7 +614,7 @@ jobs:
       run: .github/scripts/generate-native-image.sh static
       shell: bash
     - name: Copy artifacts
-      run: ./mill -i copyStaticLauncher artifacts/
+      run: ./mill -i --disable-callgraph-invalidation copyStaticLauncher artifacts/
     - uses: actions/upload-artifact@v3
       with:
         name: static-launchers
@@ -641,14 +641,14 @@ jobs:
     - name: Build docker image
       run: .github/scripts/generate-docker-image.sh
     - name: Native integration tests
-      run: ./mill -i integration.test.nativeStatic
+      run: ./mill -i --disable-callgraph-invalidation integration.test.nativeStatic
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
         SCALA_CLI_IT_GROUP: 1
         SCALA_CLI_SODIUM_JNI_ALLOW: false
     - name: Docker integration tests
-      run: ./mill integration.docker.test
+      run: ./mill --disable-callgraph-invalidation integration.docker.test
     - name: Login to GitHub Container Registry
       if: startsWith(github.ref, 'refs/tags/v')
       uses: docker/login-action@v3
@@ -678,7 +678,7 @@ jobs:
     - name: Build docker image
       run: .github/scripts/generate-docker-image.sh
     - name: Native integration tests
-      run: ./mill -i integration.test.nativeStatic
+      run: ./mill -i --disable-callgraph-invalidation integration.test.nativeStatic
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
@@ -704,7 +704,7 @@ jobs:
     - name: Build docker image
       run: .github/scripts/generate-docker-image.sh
     - name: Native integration tests
-      run: ./mill -i integration.test.nativeStatic
+      run: ./mill -i --disable-callgraph-invalidation integration.test.nativeStatic
       env:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
@@ -728,7 +728,7 @@ jobs:
     - name: Build documentation
       run: .github/scripts/build-website.sh
     - name: Test documentation
-      run: ./mill -i docs-tests.test
+      run: ./mill -i --disable-callgraph-invalidation docs-tests.test
 
   checks:
     timeout-minutes: 15
@@ -742,16 +742,16 @@ jobs:
       with:
         jvm: "temurin:17"
     - name: Check Scala / Scala.js versions in doc
-      run: ./mill -i ci.checkScalaVersions
+      run: ./mill -i --disable-callgraph-invalidation ci.checkScalaVersions
     - name: Check native-image config format
-      run: ./mill -i __.checkNativeImageConfFormat
+      run: ./mill -i --disable-callgraph-invalidation __.checkNativeImageConfFormat
     - name: Check Ammonite availability
-      run: ./mill -i 'dummy.amm[_].resolvedRunIvyDeps'
+      run: ./mill -i --disable-callgraph-invalidation 'dummy.amm[_].resolvedRunIvyDeps'
     - name: Scalafix check
       run: |
-        ./mill -i __.fix --check || (
+        ./mill -i --disable-callgraph-invalidation __.fix --check || (
           echo "To remove unused import run"
-          echo "  ./mill -i __.fix"
+          echo "  ./mill -i --disable-callgraph-invalidation __.fix"
           exit 1
         )
 
@@ -782,9 +782,9 @@ jobs:
         jvm: "temurin:17"
     - name: Check that reference doc is up-to-date
       run: |
-        ./mill -i generate-reference-doc.run --check || (
+        ./mill -i --disable-callgraph-invalidation generate-reference-doc.run --check || (
           echo "Reference doc is not up-to-date. Run"
-          echo "  ./mill -i generate-reference-doc.run"
+          echo "  ./mill -i --disable-callgraph-invalidation generate-reference-doc.run"
           echo "to update it, then commit the result."
           exit 1
         )
@@ -837,7 +837,7 @@ jobs:
     - uses: VirtusLab/scala-cli-setup@e661495714262ac8cb7968416d35bb19fa863a4a
       with:
         jvm: "temurin:17"
-    - run: ./mill -i ci.copyVcRedist
+    - run: ./mill -i --disable-callgraph-invalidation ci.copyVcRedist
     - uses: actions/upload-artifact@v3
       with:
         name: launchers
@@ -862,8 +862,8 @@ jobs:
       run: .github/scripts/gpg-setup.sh
       env:
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
-    - run: ./mill -i ci.setShouldPublish
-    - run: ./mill -i publishSonatype __.publishArtifacts
+    - run: ./mill -i --disable-callgraph-invalidation ci.setShouldPublish
+    - run: ./mill -i --disable-callgraph-invalidation publishSonatype __.publishArtifacts
       if: env.SHOULD_PUBLISH == 'true'
       env:
         PGP_PASSWORD: ${{ secrets.PGP_PASSPHRASE }}
@@ -920,7 +920,7 @@ jobs:
     - uses: VirtusLab/scala-cli-setup@e661495714262ac8cb7968416d35bb19fa863a4a
       with:
         jvm: "temurin:17"
-    - run: ./mill -i ci.setShouldPublish
+    - run: ./mill -i --disable-callgraph-invalidation ci.setShouldPublish
     - uses: actions/download-artifact@v3
       if: env.SHOULD_PUBLISH == 'true'
       with:
@@ -961,7 +961,7 @@ jobs:
       with:
         name: launchers
         path: artifacts/
-    - run: ./mill -i uploadLaunchers artifacts/
+    - run: ./mill -i --disable-callgraph-invalidation uploadLaunchers artifacts/
       if: env.SHOULD_PUBLISH == 'true'
       env:
         UPLOAD_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1021,23 +1021,23 @@ jobs:
             ${{ secrets.HOMEBREW_SCALA_CLI_KEY }}
             ${{ secrets.HOMEBREW_SCALA_EXPERIMENTAL_KEY }}
             ${{ secrets.SCALA_CLI_SETUP_KEY }}
-      - run: ./mill -i ci.updateInstallationScript
-      - run: ./mill -i ci.updateScalaCliBrewFormula
+      - run: ./mill -i --disable-callgraph-invalidation ci.updateInstallationScript
+      - run: ./mill -i --disable-callgraph-invalidation ci.updateScalaCliBrewFormula
       - name: GPG setup
         run: .github/scripts/gpg-setup.sh
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
-      - run: ./mill -i ci.updateDebianPackages
+      - run: ./mill -i --disable-callgraph-invalidation ci.updateDebianPackages
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           GPG_EMAIL: ${{ secrets.GPG_EMAIL }}
-      - run: ./mill -i ci.updateCentOsPackages
+      - run: ./mill -i --disable-callgraph-invalidation ci.updateCentOsPackages
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           KEYGRIP: ${{ secrets.KEYGRIP }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           GPG_EMAIL: ${{ secrets.GPG_EMAIL }}
-      - run: ./mill -i ci.updateStandaloneLauncher
+      - run: ./mill -i --disable-callgraph-invalidation ci.updateStandaloneLauncher
         env:
           UPLOAD_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to SDKMAN
@@ -1046,8 +1046,8 @@ jobs:
         env:
           SDKMAN_KEY: ${{ secrets.SDKMAN_KEY }}
           SDKMAN_TOKEN: ${{ secrets.SDKMAN_TOKEN }}
-      - run: ./mill -i ci.updateScalaCliSetup
-      - run: ./mill -i ci.updateScalaExperimentalBrewFormula
+      - run: ./mill -i --disable-callgraph-invalidation ci.updateScalaCliSetup
+      - run: ./mill -i --disable-callgraph-invalidation ci.updateScalaExperimentalBrewFormula
 
   update-windows-packages:
     name: Update Windows packages
@@ -1067,7 +1067,7 @@ jobs:
         name: windows-launchers
         path: artifacts/
     - name: Publish to chocolatey
-      run: ./mill -i ci.updateChocolateyPackage
+      run: ./mill -i --disable-callgraph-invalidation ci.updateChocolateyPackage
       env:
         CHOCO_SECRET: ${{ secrets.CHOCO_SECRET_KEY }}
     - uses: vedantmgoyal2009/winget-releaser@v2

--- a/DEV.md
+++ b/DEV.md
@@ -14,8 +14,11 @@ The Scala CLI sources ship with Mill launchers, so that Mill itself doesn't need
 #### Running the CLI from sources
 
 ```bash
-./mill -i scala …arguments…
+./mill -i --disable-callgraph-invalidation scala …arguments…
 ```
+
+Do note that the `--disable-callgraph-invalidation` is temporarily necessary to work around issues with `mill` 0.11.2+
+More details at https://github.com/com-lihaoyi/mill/issues/2844
 
 #### Run unit tests
 

--- a/build.sc
+++ b/build.sc
@@ -1,5 +1,5 @@
 import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`
-import $ivy.`io.get-coursier::coursier-launcher:2.1.4`
+import $ivy.`io.get-coursier::coursier-launcher:2.1.7`
 import $ivy.`io.github.alexarchambault.mill::mill-native-image-upload:0.1.25`
 import $file.project.deps, deps.{Deps, Docker, InternalDeps, Scala, TestDeps}
 import $file.project.publish, publish.{ghOrg, ghName, ScalaCliPublishModule, organization}

--- a/mill
+++ b/mill
@@ -2,7 +2,7 @@
 
 # Adapted from
 
-coursier_version="2.1.4"
+coursier_version="2.1.7"
 
 # https://stackoverflow.com/questions/3466166/how-to-check-if-running-in-cygwin-mac-or-linux/17072017#17072017
 if [ "$(expr substr $(uname -s) 1 5 2>/dev/null)" == "Linux" ]; then

--- a/mill.bat
+++ b/mill.bat
@@ -118,4 +118,4 @@ if defined STRIP_VERSION_PARAMS (
     )
 )
 
-"%MILL%" "--disable-callgraph-invalidation" %MILL_PARAMS%
+"%MILL%" %MILL_PARAMS%

--- a/mill.bat
+++ b/mill.bat
@@ -16,7 +16,7 @@ rem but I don't think we need to support them in 2019
 setlocal enabledelayedexpansion
 
 if [!DEFAULT_MILL_VERSION!]==[] (
-    set "DEFAULT_MILL_VERSION=0.10.12"
+    set "DEFAULT_MILL_VERSION=0.11.5"
 )
 
 set "MILL_REPO_URL=https://github.com/com-lihaoyi/mill"

--- a/millw
+++ b/millw
@@ -172,4 +172,4 @@ unset MILL_VERSION
 unset MILL_VERSION_TAG
 unset MILL_REPO_URL
 
-exec "${MILL}" "--disable-callgraph-invalidation" "$@"
+exec "${MILL}" "$@"

--- a/millw
+++ b/millw
@@ -14,7 +14,7 @@
 set -e
 
 if [ -z "${DEFAULT_MILL_VERSION}" ] ; then
-  DEFAULT_MILL_VERSION=0.10.12
+  DEFAULT_MILL_VERSION=0.11.5
 fi
 
 


### PR DESCRIPTION
This should address the problems with publishing after the `0.11.5` mill bump.
Note that passing `--disable-callgraph-invalidation` explicitly is now necessary until https://github.com/com-lihaoyi/mill/issues/2844 gets resolved.
Another note: `-i` requires to always be the first argument when passed to the `mill` script.
For the initial workaround for the `0.11.5` bump, check the bump PR #2446 