### PR TITLE
Fix list of licenses URL

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/package0/PackagerOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/PackagerOptions.scala
@@ -61,7 +61,7 @@ final case class PackagerOptions(
     identifier: Option[String] = None,
   @Group(HelpGroup.RedHat.toString)
   @HelpMessage(
-    "Licenses that are supported by the repository (list of licenses: https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing)"
+    "Licenses that are supported by the repository (list of licenses: https://spdx.org/licenses/)"
   )
   @Tag(tags.restricted)
     license: Option[String] = None,

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -840,7 +840,7 @@ CF Bundle Identifier
 
 ### `--license`
 
-Licenses that are supported by the repository (list of licenses: https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing)
+Licenses that are supported by the repository (list of licenses: https://spdx.org/licenses/)
 
 ### `--release`
 


### PR DESCRIPTION
The old URL now redirects to https://docs.fedoraproject.org/en-US/legal/license-approval/

I was trying to find a list there and I think this is it? https://spdx.org/licenses/