### PR TITLE
Fix Windows secrets path in the documentation

### DIFF
--- a/website/docs/commands/config.md
+++ b/website/docs/commands/config.md
@@ -114,5 +114,5 @@ Configuration values are stored in a directory under your home directory, with r
 
 - on macOS: `~/Library/Application Support/ScalaCli/secrets/config.json`
 - on Linux: `~/.config/scala-cli/secrets/config.json`
-- on Windows: `%LOCALAPPDATA%\ScalaCli\secrets\config.json` (
-  typically `C:\Users\username\AppData\Local\ScalaCli\secrets\config.json`)
+- on Windows: `%LOCALAPPDATA%\ScalaCli\data\secrets\config.json` (
+  typically `C:\Users\username\AppData\Local\ScalaCli\data\secrets\config.json`)


### PR DESCRIPTION
The secrets dir uses Coursier's `dataLocalDir` (https://github.com/VirtusLab/scala-cli/blob/main/modules/build/src/main/scala/scala/build/Directories.scala#L57), which has a `data` directory in Windows (https://github.com/coursier/directories-jvm/blob/7acadf2ab9a4ce306d840d652cdb77fade11b94b/src/main/java/dev/dirs/ProjectDirectories.java#L126)