### PR TITLE
Pin `scala-cli-setup` version to be M1-compatible & use it in `native-macos-m1-tests`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: Copy launcher
@@ -59,7 +59,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: JVM integration tests
@@ -87,7 +87,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: JVM integration tests
@@ -112,7 +112,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: JVM integration tests
@@ -137,7 +137,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: Generate native launcher
@@ -164,7 +164,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - uses: actions/download-artifact@v3
@@ -197,7 +197,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - uses: actions/download-artifact@v3
@@ -230,7 +230,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - uses: actions/download-artifact@v3
@@ -262,7 +262,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+      - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
         with:
           apps: ""
       - name: Generate native launcher and generate os packages
@@ -285,7 +285,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: Generate native launcher
@@ -312,7 +312,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - uses: actions/download-artifact@v3
@@ -345,7 +345,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - uses: actions/download-artifact@v3
@@ -378,7 +378,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - uses: actions/download-artifact@v3
@@ -440,9 +440,10 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - uses: coursier/setup-action@48280172a2c999022e42527711d6b28e4945e6f0
+      - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
+        env:
+          COURSIER_BIN_DIR: ${{ github.workspace }}/cs/bin # necessary for our M1 runner setup
         with:
-          apps: "scala-cli"
           jvm: "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.2.0/graalvm-ce-java17-darwin-aarch64-22.2.0.tar.gz"
       - uses: actions/download-artifact@v3
         with:
@@ -472,7 +473,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: Get latest coursier launcher
@@ -508,7 +509,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: Get latest coursier launcher
@@ -549,7 +550,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: Get latest coursier launcher
@@ -590,7 +591,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: Get latest coursier launcher
@@ -626,7 +627,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: Generate native launcher
@@ -650,7 +651,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - uses: actions/download-artifact@v3
@@ -697,7 +698,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - uses: actions/download-artifact@v3
@@ -730,7 +731,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - uses: actions/download-artifact@v3
@@ -762,7 +763,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: Generate native launcher
@@ -786,7 +787,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - uses: actions/download-artifact@v3
@@ -833,7 +834,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - uses: actions/download-artifact@v3
@@ -868,7 +869,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - uses: actions/download-artifact@v3
@@ -902,7 +903,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "zulu:17"
     - uses: actions/setup-node@v4
@@ -930,7 +931,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: Check Scala / Scala.js versions in doc
@@ -955,7 +956,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
         apps: scalafmt:3.0.0
@@ -969,7 +970,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: Check that reference doc is up-to-date
@@ -989,7 +990,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: Java Version
@@ -1011,7 +1012,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: Try to export to SBT
@@ -1026,7 +1027,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - run: ./mill -i ci.copyVcRedist
@@ -1047,7 +1048,7 @@ jobs:
         fetch-depth: 0
         submodules: true
         ssh-key: ${{ secrets.SSH_PRIVATE_KEY_SCALA_CLI }}
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - name: GPG setup
@@ -1109,7 +1110,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - run: ./mill -i ci.setShouldPublish
@@ -1168,7 +1169,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+      - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
         with:
           jvm: "temurin:17"
       - uses: actions/download-artifact@v3
@@ -1251,7 +1252,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: VirtusLab/scala-cli-setup@6e130d1f4a0d65d57b354dd58cd3de8a60c264d7
+    - uses: VirtusLab/scala-cli-setup@5b1a6c5ca98b5642996812781f6ad9b2d5935f85
       with:
         jvm: "temurin:17"
     - uses: actions/download-artifact@v3


### PR DESCRIPTION
This is to include the fix from https://github.com/VirtusLab/scala-cli-setup/pull/382
Pinning the action to https://github.com/VirtusLab/scala-cli-setup/commit/5b1a6c5ca98b5642996812781f6ad9b2d5935f85 should fix it for our M1 runs.
I pinned it for all CI jobs to be consistent, we can go back to the stable release after `v1.0.7` is out.