### PR TITLE
Skip validation for default Scala versions, add build test

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -678,6 +678,10 @@ trait Build extends ScalaCliSbtModule with ScalaCliPublishModule with HasTests
            |  def toolkitVersion = "${Deps.toolkitTest.dep.version}"
            |  def typelevelToolkitOrganization = "${Deps.typelevelToolkit.dep.module.organization.value}"
            |  def typelevelToolkitVersion = "${Deps.typelevelToolkit.dep.version}"
+           |
+           |  def defaultScalaVersion = "${Scala.defaultUser}"
+           |  def defaultScala212Version = "${Scala.scala212}"
+           |  def defaultScala213Version = "${Scala.scala213}"
            |}
            |""".stripMargin
       if (!os.isFile(dest) || os.read(dest) != code)

--- a/modules/build/src/test/scala/scala/build/tests/BspServerTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BspServerTests.scala
@@ -22,7 +22,7 @@ import scala.build.bsp.{WrappedSourcesItem, WrappedSourcesResult}
 import scala.build.internal.ClassCodeWrapper
 
 class BspServerTests extends TestUtil.ScalaCliBuildSuite {
-  val extraRepoTmpDir = os.temp.dir(prefix = "scala-cli-tests-actionable-diagnostic-")
+  val extraRepoTmpDir = os.temp.dir(prefix = "scala-cli-tests-bsp-server-")
   val directories     = Directories.under(extraRepoTmpDir)
   val baseOptions = BuildOptions(
     internal = InternalOptions(

--- a/modules/build/src/test/scala/scala/build/tests/OfflineTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/OfflineTests.scala
@@ -1,0 +1,71 @@
+package scala.build.tests
+
+import com.eed3si9n.expecty.Expecty.expect
+import coursier.cache.{CacheLogger, FileCache}
+import org.scalajs.logging.{NullLogger, Logger as ScalaJsLogger}
+
+import java.util.concurrent.TimeUnit
+import scala.build.Ops.*
+import scala.build.bsp.{
+  BspServer,
+  ScalaScriptBuildServer,
+  WrappedSourceItem,
+  WrappedSourcesItem,
+  WrappedSourcesParams,
+  WrappedSourcesResult
+}
+import scala.build.errors.{
+  InvalidBinaryScalaVersionError,
+  NoValidScalaVersionFoundError,
+  ScalaVersionError,
+  UnsupportedScalaVersionError
+}
+import scala.build.internal.ClassCodeWrapper
+import scala.build.options.{BuildOptions, InternalOptions, Scope}
+import scala.build.tests.Constants
+import scala.build.{Build, BuildThreads, Directories, GeneratedSource, LocalRepo}
+import scala.collection.mutable.ArrayBuffer
+import scala.jdk.CollectionConverters.*
+
+class OfflineTests extends TestUtil.ScalaCliBuildSuite {
+  val extraRepoTmpDir = os.temp.dir(prefix = "scala-cli-tests-offline-")
+  val directories     = Directories.under(extraRepoTmpDir)
+  val baseOptions = BuildOptions(
+    internal = InternalOptions(
+      cache = Some(FileCache()
+        .withLocation(directories.cacheDir.toString)
+        .withCachePolicies(Seq(coursier.cache.CachePolicy.LocalOnly)))
+    )
+  )
+
+  val buildThreads = BuildThreads.create()
+
+  for (
+    defaultVersion <- Seq(
+      Constants.defaultScalaVersion,
+      Constants.defaultScala212Version,
+      Constants.defaultScala213Version
+    )
+  )
+    test(s"Default versions of Scala should pass without validation for $defaultVersion") {
+      val testInputs = TestInputs(
+        os.rel / "script.sc" ->
+          s"""//> using scala $defaultVersion
+             |def msg: String = "Hello"
+             |
+             |println(msg)
+             |""".stripMargin
+      )
+
+      testInputs.withBuild(baseOptions, buildThreads, None) {
+        (root, _, maybeBuild) =>
+          maybeBuild match {
+            case Left(e: ScalaVersionError) =>
+              munit.Assertions.fail(
+                s"Validation Failed with:${System.lineSeparator()} ${e.getMessage}"
+              )
+            case _ => ()
+          }
+      }
+    }
+}

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -312,10 +312,20 @@ final case class BuildOptions(
     repositories: Seq[Repository] = Nil
   ): Either[BuildException, Option[ScalaParameters]] = either {
 
+    val defaultVersions = Set(
+      Constants.defaultScalaVersion,
+      Constants.defaultScala212Version,
+      Constants.defaultScala213Version
+    )
+
     val svOpt: Option[String] = scalaOptions.scalaVersion match {
       case Some(MaybeScalaVersion(None)) =>
         None
+      // Do not validate Scala version in offline mode
       case Some(MaybeScalaVersion(Some(svInput))) if internal.offline.getOrElse(false) =>
+        Some(svInput)
+      // Do not validate Scala version if it is a default one
+      case Some(MaybeScalaVersion(Some(svInput))) if defaultVersions.contains(svInput) =>
         Some(svInput)
       case Some(MaybeScalaVersion(Some(svInput))) =>
         val sv = value {


### PR DESCRIPTION
Validation requires maven-metadata.xml to be downloaded which can't always be dowloaded even if maven-central itself can be accessed from environment.