### PR TITLE
Adjust test report generation to mill 0.11.6 bump changes

### DIFF
--- a/.github/scripts/generate-junit-reports.sc
+++ b/.github/scripts/generate-junit-reports.sc
@@ -27,7 +27,7 @@ def findFiles(paths: Seq[os.Path], result: Seq[os.Path] = Nil): Seq[os.Path] =
     case Nil => result
     case head :: tail =>
       val newFiles =
-        if head.last == "test.dest" && os.isDir(head) then
+        if head.segments.contains("test") && head.last.endsWith(".dest") && os.isDir(head) then
           os.list(head).filter(f => f.last == "out.json").toList
         else Seq.empty
       val newDirs = os.list(head).filter(p => os.isDir(p)).toList

--- a/.github/scripts/generate-junit-reports.sc
+++ b/.github/scripts/generate-junit-reports.sc
@@ -62,6 +62,10 @@ if !os.isDir(rootPath) then {
 val reports: Seq[os.Path] = findFiles(Seq(rootPath))
 println(s"Found ${reports.length} mill json reports:")
 println(reports.mkString("\n"))
+if reports.isEmpty then {
+  println("Error: no reports found!")
+  System.exit(1)
+}
 println("Reading reports...")
 val tests: Seq[Test] = reports.map(x => ujson.read(x.toNIO)).flatMap { json =>
   json(1).value.asInstanceOf[ArrayBuffer[ujson.Obj]].map { test =>
@@ -87,6 +91,10 @@ val tests: Seq[Test] = reports.map(x => ujson.read(x.toNIO)).flatMap { json =>
   }
 }
 println(s"Found ${tests.length} tests.")
+if tests.isEmpty then {
+  println("Error: no tests found!")
+  System.exit(1)
+}
 println("Generating JUnit XML report...")
 val suites = tests.groupBy(_.fullyQualifiedName).map { case (suit, tests) =>
   val testcases = tests.map { test =>

--- a/DEV.md
+++ b/DEV.md
@@ -74,6 +74,18 @@ The debug option uses 5005 port by default. It is possible to change it as follo
 ./mill integration.test.native 'scala.cli.integration.RunTestsDefault.*'
 ```
 
+#### Generate JUnit test reports
+
+As running tests with mill generates output in a non-standard JSON format, we have a script for converting it to the 
+more well known JUnit XML test report format which we can then process and view on the CI.
+In case you want to generate a test report locally, you can run the following command:
+
+```bash
+.github/scripts/generate-junit-reports.sc <test suite title> <test report title> <output-path out/
+```
+
+The test should fail when no test reports were found or if no tests were actually run.
+
 #### Generate native packages
 
 Build native packagers:


### PR DESCRIPTION
Due to either our build script adjustments or the changes from mill itself, the directories structure in `out` is slightly different, which caused some of our test reports to get borked.
I changed our test report generation script to adjust for it and to fail fast if no tests are found in the script (the script should fail if the output wasn't found and no valid report was actually generated)