### PR TITLE
Bump MacOS CI to `macOS-13`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,7 @@ jobs:
 
   generate-macos-launcher:
     timeout-minutes: 120
-    runs-on: "macos-12"
+    runs-on: "macOS-13"
     steps:
     - uses: actions/checkout@v4
       with:
@@ -306,7 +306,7 @@ jobs:
   native-macos-tests-1:
     needs: generate-macos-launcher
     timeout-minutes: 120
-    runs-on: "macos-12"
+    runs-on: "macOS-13"
     steps:
     - uses: actions/checkout@v4
       with:
@@ -339,7 +339,7 @@ jobs:
   native-macos-tests-2:
     needs: generate-macos-launcher
     timeout-minutes: 120
-    runs-on: "macos-12"
+    runs-on: "macOS-13"
     steps:
     - uses: actions/checkout@v4
       with:
@@ -372,7 +372,7 @@ jobs:
   native-macos-tests-3:
     needs: generate-macos-launcher
     timeout-minutes: 120
-    runs-on: "macos-12"
+    runs-on: "macOS-13"
     steps:
     - uses: actions/checkout@v4
       with:

--- a/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
@@ -63,11 +63,7 @@ class NativePackagerTests extends ScalaCliSuite {
         }
       }
     }
-
-    // building dmg package sometimes fails with:
-    // 'hdiutil: couldn't eject "disk2" - Resource busy'
-    test("building dmg package".flaky) {
-
+    def testBuildingDmgPackage(): Unit =
       testInputs.fromRoot { root =>
 
         val appName = helloWorldFileName.stripSuffix(".scala").toLowerCase()
@@ -109,6 +105,15 @@ class NativePackagerTests extends ScalaCliSuite {
           )
         }
       }
+
+    // FIXME: building dmg package sometimes fails with:
+    // 'hdiutil: couldn't eject "disk2" - Resource busy'
+    if (TestUtil.isM1 || !TestUtil.isCI)
+      test("building dmg package") {
+        testBuildingDmgPackage()
+      }
+    else test("building dmg package".flaky) {
+      testBuildingDmgPackage()
     }
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
@@ -64,7 +64,9 @@ class NativePackagerTests extends ScalaCliSuite {
       }
     }
 
-    test("building dmg package") {
+    // building dmg package sometimes fails with:
+    // 'hdiutil: couldn't eject "disk2" - Resource busy'
+    test("building dmg package".flaky) {
 
       testInputs.fromRoot { root =>
 

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -18,6 +18,7 @@ object TestUtil {
   val isNativeCli: Boolean         = cliKind.startsWith("native")
   val isJvmCli: Boolean            = cliKind.startsWith("jvm")
   val isCI: Boolean                = System.getenv("CI") != null
+  val isM1: Boolean                = sys.props.get("os.arch").contains("aarch64")
   val cliPath: String              = sys.props("test.scala-cli.path")
   val debugPortOpt: Option[String] = sys.props.get("test.scala-cli.debug.port")
   val detectCliPath                = if (TestUtil.isNativeCli) TestUtil.cliPath else "scala-cli"


### PR DESCRIPTION
Okay, so here's some context.
We've been running our `macOS` tests on `macOS-12` (not to confuse with `macOS-m1` tests, which use a self-hosted runner)
It seems the `macOS-12` has become very flaky between the `15.11.2023` and `29.10.2023` versions.
As GitHub runners only guarantee the major versions of the image running on the runner node, it seems there's 2 kinds of nodes in the flock:
- https://github.com/actions/runner-images/releases/tag/macOS-12%2F20231029.1
`macOS-12/20231029.1` <- this runs our CI fine with MacOS 12.6.9, version from `29.10.2023` (older)
- https://github.com/actions/runner-images/releases/tag/macOS-12%2F20231115.2
`macOS-12/20241115.2` <- this fails a couple of our tests with invalid `libsodiumjni`, macOS 12.7.1, version from `15.11.2023` (seems to be the latest `macOS-12`)

https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
`macOS-13` seems to be tagged as a beta release as of the time of this PR, but I suspect it should get promoted to stable soon.
For the purposes of our CI, it seems to be a lot more stable than `macOS-12`.
The flakiness detected in this PR (https://github.com/electron-userland/electron-builder/issues/7137, as noted by @MaciejG604) actually happens on `macos-12` as well.

TL;DR bumping to `macOS-13` seems to be the way to go, even though it's still considered to be in beta.
