### PR TITLE
Bump `coursier` to `v2.1.8` where it wasn't consistent

### DIFF
--- a/.github/scripts/build-linux-aarch64.sh
+++ b/.github/scripts/build-linux-aarch64.sh
@@ -6,7 +6,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
 mkdir -p artifacts
 mkdir -p utils
-cp "$(cs get https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.4/cs-aarch64-pc-linux.gz --archive)" utils/cs
+cp "$(cs get https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.8/cs-aarch64-pc-linux.gz --archive)" utils/cs
 chmod +x utils/cs
 
 cp "$DIR/build-linux-aarch64-from-docker.sh" utils/

--- a/.github/scripts/get-latest-cs.sh
+++ b/.github/scripts/get-latest-cs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-CS_VERSION="2.1.4"
+CS_VERSION="2.1.8"
 
 DIR="$(cs get --archive "https://github.com/coursier/coursier/releases/download/v$CS_VERSION/cs-x86_64-pc-win32.zip")"
 

--- a/build.sc
+++ b/build.sc
@@ -1,5 +1,5 @@
 import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`
-import $ivy.`io.get-coursier::coursier-launcher:2.1.4`
+import $ivy.`io.get-coursier::coursier-launcher:2.1.8`
 import $ivy.`io.github.alexarchambault.mill::mill-native-image-upload:0.1.25`
 import $file.project.deps, deps.{Deps, Docker, InternalDeps, Scala, TestDeps}
 import $file.project.publish, publish.{ghOrg, ghName, ScalaCliPublishModule, organization}

--- a/mill
+++ b/mill
@@ -2,7 +2,7 @@
 
 # Adapted from
 
-coursier_version="2.1.4"
+coursier_version="2.1.8"
 
 # https://stackoverflow.com/questions/3466166/how-to-check-if-running-in-cygwin-mac-or-linux/17072017#17072017
 if [ "$(expr substr $(uname -s) 1 5 2>/dev/null)" == "Linux" ]; then


### PR DESCRIPTION
Follow-up to https://github.com/VirtusLab/scala-cli/pull/2575
Corresponding `coursier-m1` release: https://github.com/VirtusLab/coursier-m1/releases/tag/v2.1.8