### PR TITLE
Fallback to UTF-8 in setup-ide

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/setupide/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/setupide/SetupIde.scala
@@ -5,7 +5,7 @@ import ch.epfl.scala.bsp4j.BspConnectionDetails
 import com.github.plokhotnyuk.jsoniter_scala.core.*
 import com.google.gson.GsonBuilder
 
-import java.nio.charset.Charset
+import java.nio.charset.{Charset, StandardCharsets}
 
 import scala.build.EitherCps.{either, value}
 import scala.build.*
@@ -160,11 +160,12 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
       List("scala", "java").asJava
     )
 
-    val charset = options.charset
-      .map(_.trim)
-      .filter(_.nonEmpty)
-      .map(Charset.forName)
-      .getOrElse(Charset.defaultCharset()) // Should it be UTF-8?
+    val charset =
+      options.charset
+        .map(_.trim)
+        .filter(_.nonEmpty)
+        .map(Charset.forName)
+        .getOrElse(StandardCharsets.UTF_8)
 
     val gson = new GsonBuilder().setPrettyPrinting().create()
 


### PR DESCRIPTION
Uses UTF-8 as the default charset in `setup-ide` as that seems to be the format expected by the other tools (such as metals).

Closes #2598 