### PR TITLE
Pass java opts to scalac

### DIFF
--- a/modules/build/src/main/scala/scala/build/compiler/SimpleScalaCompiler.scala
+++ b/modules/build/src/main/scala/scala/build/compiler/SimpleScalaCompiler.scala
@@ -98,6 +98,9 @@ final case class SimpleScalaCompiler(
       javaHomeOpt.map(SimpleJavaCompiler.javaCommand(_)).getOrElse(defaultJavaCommand)
 
     val javaOptions = defaultJavaOptions ++
+      scalacOptions
+        .filter(_.startsWith("-J"))
+        .map(_.stripPrefix("-J")) ++
       javacOptions
         .filter(_.startsWith("-J"))
         .map(_.stripPrefix("-J"))


### PR DESCRIPTION
Fixes #2477

Should we leave passing options from `--javac-opts` flag to scalac? I can't really backtrace why it is like that now.