### PR TITLE
Separate Scala REPL classpath from user dependencies

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
@@ -7,6 +7,7 @@ import coursier.cache.FileCache
 import coursier.error.{FetchError, ResolutionError}
 import dependency.*
 
+import java.io.File
 import java.util.zip.ZipFile
 
 import scala.build.EitherCps.{either, value}
@@ -29,7 +30,7 @@ import scala.cli.config.{ConfigDb, Keys}
 import scala.cli.packaging.Library
 import scala.cli.util.ArgHelpers.*
 import scala.cli.util.ConfigDbUtils
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Properties
 
 object Repl extends ScalaCommand[ReplOptions] {
@@ -380,16 +381,23 @@ object Repl extends ScalaCommand[ReplOptions] {
       if (dryRun)
         logger.message("Dry run, not running REPL.")
       else {
+        val depClassPathArgs: Seq[String] =
+          if replArtifacts.depsClassPath.nonEmpty && !replArtifacts.replMainClass.startsWith("ammonite") then
+            Seq(
+              "-classpath",
+              replArtifacts.depsClassPath.map(_.toString).mkString(File.pathSeparator)
+            )
+          else Nil
         val retCode = Runner.runJvm(
-          options.javaHome().value.javaCommand,
-          scalapyJavaOpts ++
+          javaCommand = options.javaHome().value.javaCommand,
+          javaArgs = scalapyJavaOpts ++
             replArtifacts.replJavaOpts ++
             options.javaOptions.javaOpts.toSeq.map(_.value.value) ++
             extraProps.toVector.sorted.map { case (k, v) => s"-D$k=$v" },
-          mainJarOrClassDir.toSeq ++ replArtifacts.replClassPath,
-          replArtifacts.replMainClass,
-          maybeAdaptForWindows(replArgs),
-          logger,
+          classPath = mainJarOrClassDir.toSeq ++ replArtifacts.replClassPath,
+          mainClass = replArtifacts.replMainClass,
+          args = maybeAdaptForWindows(depClassPathArgs ++ replArgs),
+          logger = logger,
           allowExecve = allowExit,
           extraEnv = scalapyExtraEnv ++ extraEnv
         ).waitFor()


### PR DESCRIPTION
Fixes #2582 

This separates the Scala REPL classpath from user dependencies classpath, preventing clashes and unintended bumps of compiler dependencies.

This also allows to use the recent `jna` version on the Scala REPL with `aarch64` Java releases, for more details read https://github.com/VirtusLab/scala-cli/issues/2582#issuecomment-1833825084

NOTE: this only separates the Scala REPL, and not the Ammonite REPL.
Ammonite REPL does not support a `--classpath` argument.
It would likely be possible to either exclude transitive compiler dependencies in the user dependencies when launching the Ammonite REPL, or preload deps with a script to prevent clashes there, too.
However, as the Ammonite REPL does not have much in terms of dependencies in the first place, this is perhaps not much of an issue, really. 
Isolating the Ammonite REPL classpath is out of the scope of this PR, either way.