### PR TITLE
Remove semantics Compliant for asInstaceOf

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
@@ -690,19 +690,20 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
     destPath: os.Path,
     mainClass: Option[String],
     logger: Logger
-  ): Either[BuildException, os.Path] = {
-    val linkerConfig = build.options.scalaJsOptions.linkerConfig(logger)
-    linkJs(
+  ): Either[BuildException, os.Path] = for {
+    isFullOpt <- build.options.scalaJsOptions.fullOpt
+    linkerConfig = build.options.scalaJsOptions.linkerConfig(logger)
+    linkResult <- linkJs(
       build,
       destPath,
       mainClass,
       addTestInitializer = false,
       linkerConfig,
-      build.options.scalaJsOptions.fullOpt,
+      isFullOpt,
       build.options.scalaJsOptions.noOpt.getOrElse(false),
       logger
     )
-  }
+  } yield linkResult
 
   private def bootstrap(
     build: Build.Successful,

--- a/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
@@ -447,7 +447,7 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
             Some(mainClass),
             addTestInitializer = false,
             linkerConfig,
-            build.options.scalaJsOptions.fullOpt,
+            value(build.options.scalaJsOptions.fullOpt),
             build.options.scalaJsOptions.noOpt.getOrElse(false),
             logger,
             scratchDirOpt

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaJsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaJsOptions.scala
@@ -21,8 +21,9 @@ final case class ScalaJsOptions(
 
   @Group(HelpGroup.ScalaJs.toString)
   @Tag(tags.should)
-  @HelpMessage("The Scala.js mode, either `dev` or `release`")
+  @HelpMessage("The Scala.js mode, for `fastLinkJS` use one of [`dev`, `fastLinkJS` or `fast`], for `fullLinkJS` use one of [`release`, `fullLinkJS`, `full`]")
     jsMode: Option[String] = None,
+
   @HelpMessage("The Scala.js module kind: commonjs/common, esmodule/es, nomodule/none")
   @Group(HelpGroup.ScalaJs.toString)
   @Tag(tags.should)

--- a/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
@@ -205,7 +205,7 @@ object Test extends ScalaCommand[TestOptions] {
             None,
             addTestInitializer = true,
             linkerConfig,
-            build.options.scalaJsOptions.fullOpt,
+            value(build.options.scalaJsOptions.fullOpt),
             build.options.scalaJsOptions.noOpt.getOrElse(false),
             logger,
             esModule

--- a/modules/core/src/main/scala/scala/build/errors/UnrecognizedJsOptModeError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/UnrecognizedJsOptModeError.scala
@@ -1,0 +1,12 @@
+package scala.build.errors
+
+final class UnrecognizedJsOptModeError(
+  mode: String,
+  aliasesForFullLink: Seq[String],
+  aliasesForFastLink: Seq[String]
+) extends BuildException(
+      s"""Unrecognized JS optimization mode: $mode.
+         |Available options:
+         |- for fastLinkJs: ${aliasesForFastLink.mkString(", ")}
+         |- for fullLinkJs: ${aliasesForFullLink.mkString(", ")}""".stripMargin
+    )

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import scala.cli.integration.TestUtil.removeAnsiColors
 
 trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
-  def simpleJsTest(extraArgs: String*): Unit = {
+  def simpleJsTestOutput(extraArgs: String*): String = {
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs = TestInputs(
@@ -17,18 +17,31 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, fileName, "--js", extraArgs).call(cwd =
-        root
+      val output = os.proc(TestUtil.cli, extraOptions, fileName, "--js", extraArgs).call(
+        cwd = root,
+        mergeErrIntoOut = true
       ).out.trim()
       expect(output.linesIterator.toSeq.last == message)
+      output
     }
   }
 
   test("simple script JS") {
-    simpleJsTest()
+    simpleJsTestOutput()
   }
-  test("simple script JS in release mode") {
-    simpleJsTest("--js-mode", "release")
+
+  test(s"simple script JS in fullLinkJs mode") {
+    val output = simpleJsTestOutput("--js-mode", "fullLinkJs", "-v", "-v", "-v")
+    expect(output.contains("--fullOpt"))
+    expect(!output.contains("--fastOpt"))
+    expect(!output.contains("--noOpt"))
+  }
+
+  test(s"simple script JS in fastLinkJs mode") {
+    val output = simpleJsTestOutput("--js-mode", "fastLinkJs", "-v", "-v", "-v")
+    expect(output.contains("--fastOpt"))
+    expect(!output.contains("--fullOpt"))
+    expect(!output.contains("--noOpt"))
   }
 
   test("without node on the PATH") {

--- a/modules/options/src/main/scala/scala/build/internal/ScalaJsLinkerConfig.scala
+++ b/modules/options/src/main/scala/scala/build/internal/ScalaJsLinkerConfig.scala
@@ -10,19 +10,9 @@ final case class ScalaJsLinkerConfig(
   esFeatures: ScalaJsLinkerConfig.ESFeatures = ScalaJsLinkerConfig.ESFeatures(),
   jsHeader: Option[String] = None,
   prettyPrint: Boolean = false,
-  relativizeSourceMapBase: Option[String] = None,
-  semantics: ScalaJsLinkerConfig.Semantics = ScalaJsLinkerConfig.Semantics()
+  relativizeSourceMapBase: Option[String] = None
 ) {
   def linkerCliArgs: Seq[String] = {
-
-    // FIXME Fatal asInstanceOfs should be the default, but it seems we can't
-    // pass Unchecked via the CLI here
-    // It seems we can't pass the other semantics fields either.
-    val semanticsArgs =
-      if (semantics.asInstanceOfs == ScalaJsLinkerConfig.CheckedBehavior.Compliant)
-        Seq("--compliantAsInstanceOfs")
-      else
-        Nil
     val moduleKindArgs       = Seq("--moduleKind", moduleKind)
     val moduleSplitStyleArgs = Seq("--moduleSplitStyle", moduleSplitStyle)
     val smallModuleForPackageArgs =
@@ -41,7 +31,6 @@ final case class ScalaJsLinkerConfig(
       else Nil
     val jsHeaderArg = if (jsHeader.nonEmpty) Seq("--jsHeader", jsHeader.getOrElse("")) else Nil
     val configArgs = Seq[os.Shellable](
-      semanticsArgs,
       moduleKindArgs,
       moduleSplitStyleArgs,
       smallModuleForPackageArgs,
@@ -88,13 +77,5 @@ object ScalaJsLinkerConfig {
     val ES2021 = "ES2021"
 
     def default = ES2015
-  }
-
-  final case class Semantics(
-    asInstanceOfs: String = CheckedBehavior.Compliant
-  )
-
-  object CheckedBehavior {
-    val Compliant = "Compliant"
   }
 }

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1255,7 +1255,7 @@ The Scala.js version (1.14.0 by default).
 
 ### `--js-mode`
 
-The Scala.js mode, either `dev` or `release`
+The Scala.js mode, for `fastLinkJS` use one of [`dev`, `fastLinkJS` or `fast`], for `fullLinkJS` use one of [`release`, `fullLinkJS`, `full`]
 
 ### `--js-module-kind`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -712,7 +712,7 @@ The Scala.js version (1.14.0 by default).
 
 `SHOULD have` per Scala Runner specification
 
-The Scala.js mode, either `dev` or `release`
+The Scala.js mode, for `fastLinkJS` use one of [`dev`, `fastLinkJS` or `fast`], for `fullLinkJS` use one of [`release`, `fullLinkJS`, `full`]
 
 ### `--js-module-kind`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -132,7 +132,7 @@ The Scala.js version (1.14.0 by default).
 
 **--js-mode**
 
-The Scala.js mode, either `dev` or `release`
+The Scala.js mode, for `fastLinkJS` use one of [`dev`, `fastLinkJS` or `fast`], for `fullLinkJS` use one of [`release`, `fullLinkJS`, `full`]
 
 **--js-module-kind**
 
@@ -875,7 +875,7 @@ The Scala.js version (1.14.0 by default).
 
 **--js-mode**
 
-The Scala.js mode, either `dev` or `release`
+The Scala.js mode, for `fastLinkJS` use one of [`dev`, `fastLinkJS` or `fast`], for `fullLinkJS` use one of [`release`, `fullLinkJS`, `full`]
 
 **--js-module-kind**
 
@@ -1422,7 +1422,7 @@ The Scala.js version (1.14.0 by default).
 
 **--js-mode**
 
-The Scala.js mode, either `dev` or `release`
+The Scala.js mode, for `fastLinkJS` use one of [`dev`, `fastLinkJS` or `fast`], for `fullLinkJS` use one of [`release`, `fullLinkJS`, `full`]
 
 **--js-module-kind**
 
@@ -1995,7 +1995,7 @@ The Scala.js version (1.14.0 by default).
 
 **--js-mode**
 
-The Scala.js mode, either `dev` or `release`
+The Scala.js mode, for `fastLinkJS` use one of [`dev`, `fastLinkJS` or `fast`], for `fullLinkJS` use one of [`release`, `fullLinkJS`, `full`]
 
 **--js-module-kind**
 
@@ -2587,7 +2587,7 @@ The Scala.js version (1.14.0 by default).
 
 **--js-mode**
 
-The Scala.js mode, either `dev` or `release`
+The Scala.js mode, for `fastLinkJS` use one of [`dev`, `fastLinkJS` or `fast`], for `fullLinkJS` use one of [`release`, `fullLinkJS`, `full`]
 
 **--js-module-kind**
 
@@ -3155,7 +3155,7 @@ The Scala.js version (1.14.0 by default).
 
 **--js-mode**
 
-The Scala.js mode, either `dev` or `release`
+The Scala.js mode, for `fastLinkJS` use one of [`dev`, `fastLinkJS` or `fast`], for `fullLinkJS` use one of [`release`, `fullLinkJS`, `full`]
 
 **--js-module-kind**
 
@@ -3760,7 +3760,7 @@ The Scala.js version (1.14.0 by default).
 
 **--js-mode**
 
-The Scala.js mode, either `dev` or `release`
+The Scala.js mode, for `fastLinkJS` use one of [`dev`, `fastLinkJS` or `fast`], for `fullLinkJS` use one of [`release`, `fullLinkJS`, `full`]
 
 **--js-module-kind**
 
@@ -4416,7 +4416,7 @@ The Scala.js version (1.14.0 by default).
 
 **--js-mode**
 
-The Scala.js mode, either `dev` or `release`
+The Scala.js mode, for `fastLinkJS` use one of [`dev`, `fastLinkJS` or `fast`], for `fullLinkJS` use one of [`release`, `fullLinkJS`, `full`]
 
 **--js-module-kind**
 
@@ -5303,7 +5303,7 @@ The Scala.js version (1.14.0 by default).
 
 **--js-mode**
 
-The Scala.js mode, either `dev` or `release`
+The Scala.js mode, for `fastLinkJS` use one of [`dev`, `fastLinkJS` or `fast`], for `fullLinkJS` use one of [`release`, `fullLinkJS`, `full`]
 
 **--js-module-kind**
 


### PR DESCRIPTION
Fixes #2602
Connected to https://github.com/VirtusLab/scala-js-cli/pull/40

Also added aliases for optimisation mode for Scala JS, to have the same as in the sbt plugin `fastLinkJs` and `fullLinkJs` to avoid questions such as in #2184 .