### PR TITLE
Remove superfluous traits

### DIFF
--- a/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
@@ -20,7 +20,7 @@ class BspServer(
   compile: (() => CompletableFuture[b.CompileResult]) => CompletableFuture[b.CompileResult],
   logger: Logger,
   presetIntelliJ: Boolean = false
-) extends b.BuildServer with b.ScalaBuildServer with b.JavaBuildServer with BuildServerForwardStubs
+) extends BuildServerForwardStubs
     with ScalaScriptBuildServer
     with ScalaBuildServerForwardStubs
     with JavaBuildServerForwardStubs


### PR DESCRIPTION
Those traits are passed under the `__ForwardStubs` traits