### PR TITLE
Fix special handling for the `-Xplugin-list` compiler option

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1813,7 +1813,9 @@ object ci extends Module {
 
   def checkScalaVersions() = T.command {
     website.checkMainScalaVersions(os.pwd / "website" / "docs" / "reference" / "scala-versions.md")
-    website.checkScalaJsVersions(os.pwd / "website" / "docs" / "guides" / "advanced" / "scala-js.md")
+    website.checkScalaJsVersions(
+      os.pwd / "website" / "docs" / "guides" / "advanced" / "scala-js.md"
+    )
   }
 }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
@@ -382,7 +382,10 @@ object Repl extends ScalaCommand[ReplOptions] {
         logger.message("Dry run, not running REPL.")
       else {
         val depClassPathArgs: Seq[String] =
-          if replArtifacts.depsClassPath.nonEmpty && !replArtifacts.replMainClass.startsWith("ammonite") then
+          if replArtifacts.depsClassPath.nonEmpty && !replArtifacts.replMainClass.startsWith(
+              "ammonite"
+            )
+          then
             Seq(
               "-classpath",
               replArtifacts.depsClassPath.map(_.toString).mkString(File.pathSeparator)

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
@@ -58,7 +58,7 @@ object ScalacOptions {
     * message instead.
     */
   val ScalacPrintOptions: Set[String] =
-    scalacOptionsPurePrefixes ++ Set("-help", "-Xshow-phases", "-Vphases")
+    scalacOptionsPurePrefixes ++ Set("-help", "-Xshow-phases", "-Xplugin-list", "-Vphases")
 
   /** This includes all the scalac options which are redirected to native Scala CLI options. */
   val ScalaCliRedirectedOptions = Set(

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -7,7 +7,9 @@ import java.io.File
 import scala.cli.integration.util.BloopUtil
 
 abstract class CompileTestDefinitions(val scalaVersionOpt: Option[String])
-    extends ScalaCliSuite with TestScalaVersionArgs {
+    extends ScalaCliSuite
+    with TestScalaVersionArgs
+    with CompilerPluginTestDefinitions {
 
   protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
 

--- a/modules/integration/src/test/scala/scala/cli/integration/CompilerPluginTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompilerPluginTestDefinitions.scala
@@ -1,0 +1,73 @@
+package scala.cli.integration
+
+import com.eed3si9n.expecty.Expecty.expect
+
+import scala.cli.integration.util.CompilerPluginUtil
+
+trait CompilerPluginTestDefinitions { _: CompileTestDefinitions =>
+  def compilerPluginInputs(pluginName: String, pluginErrorMsg: String): TestInputs =
+    if (actualScalaVersion.startsWith("3"))
+      CompilerPluginUtil.compilerPluginForScala3(pluginName, pluginErrorMsg)
+    else CompilerPluginUtil.compilerPluginForScala2(pluginName, pluginErrorMsg)
+
+  test("build a custom compiler plugin and use it") {
+    val pluginName       = "divbyzero"
+    val usePluginFile    = "Main.scala"
+    val outputJar        = "div-by-zero.jar"
+    val pluginErrorMsg   = "definitely division by zero"
+    compilerPluginInputs(pluginName, pluginErrorMsg)
+      .add(os.rel / usePluginFile ->
+        s"""//> using option -Xplugin:$outputJar
+           |
+           |object Test {
+           |  val five = 5
+           |  val amount = five / 0
+           |  def main(args: Array[String]): Unit = {
+           |    println(amount)
+           |  }
+           |}
+           |""".stripMargin)
+      .fromRoot { root =>
+        // build the compiler plugin
+        os.proc(
+          TestUtil.cli,
+          "package",
+          s"$pluginName.scala",
+          "--power",
+          "--with-compiler",
+          "--library",
+          "-o",
+          outputJar,
+          extraOptions
+        ).call(cwd = root)
+        expect(os.isFile(root / outputJar))
+
+        // verify the plugin is loaded
+        val pluginListResult = os.proc(
+          TestUtil.cli,
+          "compile",
+          s"-Xplugin:$outputJar",
+          "-Xplugin-list",
+          extraOptions
+        ).call(cwd = root, mergeErrIntoOut = true)
+        expect(pluginListResult.out.text().contains(pluginName))
+
+        // verify the compiler plugin phase is being added correctly
+        os.proc(
+          TestUtil.cli,
+          "compile",
+          s"-Xplugin:$outputJar",
+          "-Xshow-phases",
+          extraOptions
+        ).call(cwd = root, mergeErrIntoOut = true)
+        expect(pluginListResult.out.text().contains(pluginName))
+
+        // verify the compiler plugin is working
+        // TODO: this shouldn't require running with --server=false
+        val res = os.proc(TestUtil.cli, "compile", usePluginFile, "--server=false", extraOptions)
+          .call(cwd = root, mergeErrIntoOut = true, check = false)
+        expect(res.exitCode == 1)
+        expect(res.out.text().contains(pluginErrorMsg))
+      }
+  }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/util/CompilerPluginUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/util/CompilerPluginUtil.scala
@@ -1,0 +1,97 @@
+package scala.cli.integration.util
+
+import scala.cli.integration.TestInputs
+
+object CompilerPluginUtil {
+  def compilerPluginForScala2(pluginName: String, pluginErrorMsg: String): TestInputs = TestInputs(
+    os.rel / "resources" / "scalac-plugin.xml" ->
+      s"""<plugin>
+         |    <name>$pluginName</name>
+         |    <classname>localhost.DivByZero</classname>
+         |</plugin>
+         |""".stripMargin,
+    os.rel / s"$pluginName.scala" ->
+      s"""//> using resourceDir ./resources/
+         |
+         |package localhost
+         |
+         |import scala.tools.nsc
+         |import nsc.Global
+         |import nsc.Phase
+         |import nsc.plugins.Plugin
+         |import nsc.plugins.PluginComponent
+         |
+         |class DivByZero(val global: Global) extends Plugin {
+         |  import global._
+         |
+         |  val name = "$pluginName"
+         |  val description = "checks for division by zero"
+         |  val components = List[PluginComponent](Component)
+         |
+         |  private object Component extends PluginComponent {
+         |    val global: DivByZero.this.global.type = DivByZero.this.global
+         |    val runsAfter = List[String]("refchecks")
+         |    val phaseName = DivByZero.this.name
+         |    def newPhase(_prev: Phase) = new DivByZeroPhase(_prev)
+         |    class DivByZeroPhase(prev: Phase) extends StdPhase(prev) {
+         |      override def name = DivByZero.this.name
+         |      def apply(unit: CompilationUnit): Unit = {
+         |        for ( tree @ Apply(Select(rcvr, nme.DIV), List(Literal(Constant(0)))) <- unit.body
+         |              if rcvr.tpe <:< definitions.IntClass.tpe)
+         |        {
+         |          global.reporter.error(tree.pos, "$pluginErrorMsg")
+         |        }
+         |      }
+         |    }
+         |  }
+         |}
+         |""".stripMargin
+  )
+
+  def compilerPluginForScala3(pluginName: String, pluginErrorMsg: String): TestInputs = TestInputs(
+    os.rel / "resources" / "plugin.properties" ->
+      s"""pluginClass=localhost.DivideZero
+         |""".stripMargin,
+    os.rel / s"$pluginName.scala" ->
+      s"""//> using resourceDir ./resources/
+         |
+         |package localhost
+         |
+         |import dotty.tools.dotc.ast.Trees.*
+         |import dotty.tools.dotc.ast.tpd
+         |import dotty.tools.dotc.core.Constants.Constant
+         |import dotty.tools.dotc.core.Contexts.Context
+         |import dotty.tools.dotc.core.Decorators.*
+         |import dotty.tools.dotc.core.StdNames.*
+         |import dotty.tools.dotc.core.Symbols.*
+         |import dotty.tools.dotc.plugins.{PluginPhase, StandardPlugin}
+         |import dotty.tools.dotc.transform.{Pickler, Staging}
+         |import dotty.tools.dotc.report
+         |
+         |class DivideZero extends StandardPlugin:
+         |  val name: String = "$pluginName"
+         |  override val description: String = "checks for division by zero"
+         |
+         |  def init(options: List[String]): List[PluginPhase] =
+         |    (new DivideZeroPhase) :: Nil
+         |
+         |class DivideZeroPhase extends PluginPhase:
+         |  import tpd.*
+         |
+         |  val phaseName = "$pluginName"
+         |
+         |  override val runsAfter = Set(Pickler.name)
+         |  override val runsBefore = Set(Staging.name)
+         |
+         |  override def transformApply(tree: Apply)(implicit ctx: Context): Tree =
+         |    tree match
+         |      case Apply(Select(rcvr, nme.DIV), List(Literal(Constant(0))))
+         |      if rcvr.tpe <:< defn.IntType =>
+         |        report.error("$pluginErrorMsg", tree.sourcePos)
+         |      case _ =>
+         |        ()
+         |    tree
+         |end DivideZeroPhase
+         |""".stripMargin
+  )
+}


### PR DESCRIPTION
Relevant ticket: https://github.com/VirtusLab/scala-cli/issues/2621

The `-Xplugin-list` compiler option wasn't being handled correctly and erroneously required an input to be passed at all times.
I also added an integration test for building a custom compiler plugin with Scala CLI & verifying it is applied to the compiler.
This currently requires the `--server=false` flag, as it doesn't work correctly with Bloop 😕 