### PR TITLE
Prevent resource directories from breaking sources hash

### DIFF
--- a/modules/build/src/main/scala/scala/build/input/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/input/Inputs.scala
@@ -102,7 +102,8 @@ final case class Inputs(
           case dirInput: Directory =>
             Seq("dir:") ++ dirInput.singleFilesFromDirectory(enableMarkdown)
               .map(file => s"${file.path}:" + os.read(file.path))
-          case _ => Seq(os.read(elem.path))
+          case _: ResourceDirectory => Nil
+          case _                    => Seq(os.read(elem.path))
         }
         (Iterator(elem.path.toString) ++ content.iterator ++ Iterator("\n")).map(bytes)
       case v: Virtual =>


### PR DESCRIPTION
Indirectly tied to #2621 (a compiler plugin could not be packaged when the resources were passed through a command line option instead of a directive)

This effectively fixes the (previously broken) `--resource-dir` command line option, as passing a resource directory through it forced sources hash to crash on the unhandled resource directory path.
What's interesting, this did not happen when the resource directory was passed via a using directive.

Either way, sources hash should not be affected by the resources directory.