### PR TITLE
Add missing Scala.js mode aliases

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
@@ -30,16 +30,16 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
     simpleJsTestOutput()
   }
 
-  test(s"simple script JS in fullLinkJs mode") {
-    val output = simpleJsTestOutput("--js-mode", "fullLinkJs", "-v", "-v", "-v")
+  test(s"simple script JS in fullLinkJS mode") {
+    val output = simpleJsTestOutput("--js-mode", "fullLinkJS", "-v", "-v", "-v")
     expect(output.contains("--fullOpt"))
 
     expect(!output.contains("--fastOpt"))
     expect(!output.contains("--noOpt"))
   }
 
-  test(s"simple script JS in fastLinkJs mode") {
-    val output = simpleJsTestOutput("--js-mode", "fastLinkJs", "-v", "-v", "-v")
+  test(s"simple script JS in fastLinkJS mode") {
+    val output = simpleJsTestOutput("--js-mode", "fastLinkJS", "-v", "-v", "-v")
     expect(output.contains("--fastOpt"))
 
     expect(!output.contains("--fullOpt"))
@@ -47,7 +47,7 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
   }
 
   test(s"simple script JS with noOpt") {
-    val output = simpleJsTestOutput("--js-mode", "fullLinkJs", "--js-no-opt", "-v", "-v", "-v")
+    val output = simpleJsTestOutput("--js-mode", "fullLinkJS", "--js-no-opt", "-v", "-v", "-v")
     expect(output.contains("--noOpt"))
 
     expect(!output.contains("--fastOpt"))

--- a/modules/options/src/main/scala/scala/build/options/ScalaJsOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaJsOptions.scala
@@ -154,22 +154,23 @@ final case class ScalaJsOptions(
 }
 
 case class ScalaJsMode(nameOpt: Option[String] = None) {
-  lazy val isValid = nameOpt.isEmpty ||
-    nameOpt.exists(
-      ScalaJsMode.validFullLinkAliases.union(ScalaJsMode.validFastLinkAliases).contains
-    )
+  lazy val isValid: Boolean = nameOpt.isEmpty || nameOpt.exists(ScalaJsMode.allAliases.contains)
 }
 object ScalaJsMode {
   val validFullLinkAliases = Set(
     "release",
     "fullLinkJs",
+    "fullLinkJS",
     "full"
   )
   val validFastLinkAliases = Set(
     "dev",
     "fastLinkJs",
+    "fastLinkJS",
     "fast"
   )
+  def allAliases: Set[String] =
+    ScalaJsMode.validFullLinkAliases.union(ScalaJsMode.validFastLinkAliases)
 }
 
 object ScalaJsOptions {


### PR DESCRIPTION
Follow-up to #2630 

Adds missing `fullLinkJS` and `fastLinkJS` Scala.js mode aliases.