### PR TITLE
Prevent the toolkit `latest` deprecation warning from being logged more than once

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -2212,7 +2212,10 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
         cwd = root,
         mergeErrIntoOut = true
       )
-      expect(resLatest.out.text().contains("Using 'latest' for toolkit is deprecated"))
+      val warningText = "Using 'latest' for toolkit is deprecated"
+      expect(resLatest.out.text().contains(warningText))
+      val warningCount = resLatest.out.text().sliding(warningText.length).count(_ == warningText)
+      expect(warningCount == 1)
     }
   }
 }


### PR DESCRIPTION
Adding the toolkit dependency with the deprecated `latest` version causes the warning to be logged no less than 6 times (sic!)
```bash
scala-cli --toolkit latest -e 'println(os.pwd)'
# Using 'latest' for toolkit is deprecated, use 'default' to get more stable behaviour:
#  --toolkit default
# Using 'latest' for toolkit is deprecated, use 'default' to get more stable behaviour:
#  --toolkit default
# Using 'latest' for toolkit is deprecated, use 'default' to get more stable behaviour:
#  --toolkit default
# Using 'latest' for toolkit is deprecated, use 'default' to get more stable behaviour:
#  --toolkit default
# Using 'latest' for toolkit is deprecated, use 'default' to get more stable behaviour:
#  --toolkit default
# Using 'latest' for toolkit is deprecated, use 'default' to get more stable behaviour:
#  --toolkit default
# Compiling project (Scala 3.3.1, JVM (17))
# Compiled project (Scala 3.3.1, JVM (17))
# ~/IdeaProjects/scala-cli-tests
```

This scales it down to a reasonable and desired once.

```bash
scala-cli --toolkit latest -e 'println(os.pwd)'
# Using 'latest' for toolkit is deprecated, use 'default' to get more stable behaviour:
#  --toolkit default
# Compiling project (Scala 3.3.1, JVM (17))
# Compiled project (Scala 3.3.1, JVM (17))
# ~/IdeaProjects/scala-cli-tests
```
