### PR TITLE
NIT add brackets when trimming integration test console outputs

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/FixTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixTests.scala
@@ -69,7 +69,7 @@ class FixTests extends ScalaCliSuite {
       val runProc = os.proc(TestUtil.cli, "--power", "compile", ".", extraOptions)
         .call(cwd = root, stderr = os.Pipe)
 
-      expect(!runProc.err.trim.contains("Using directives detected in multiple files"))
+      expect(!runProc.err.trim().contains("Using directives detected in multiple files"))
     }
   }
 
@@ -128,7 +128,7 @@ class FixTests extends ScalaCliSuite {
       val runProc = os.proc(TestUtil.cli, "--power", "compile", ".", extraOptions)
         .call(cwd = root, stderr = os.Pipe)
 
-      expect(!runProc.err.trim.contains("Using directives detected in multiple files"))
+      expect(!runProc.err.trim().contains("Using directives detected in multiple files"))
     }
   }
 
@@ -223,7 +223,7 @@ class FixTests extends ScalaCliSuite {
       val runProc = os.proc(TestUtil.cli, "--power", "compile", ".", extraOptions)
         .call(cwd = root, stderr = os.Pipe)
 
-      expect(!runProc.err.trim.contains("Using directives detected in multiple files"))
+      expect(!runProc.err.trim().contains("Using directives detected in multiple files"))
     }
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -1614,9 +1614,9 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
           env = Map("SCALA_CLI_INTERACTIVE_INPUTS" -> "Run-1") ++ configEnv
         )
 
-      expect(proc.out.trim.contains("[0] Run-1"))
-      expect(proc.out.trim.contains("[1] Run-2"))
-      expect(proc.out.trim.contains("Run-1 launched"))
+      expect(proc.out.trim().contains("[0] Run-1"))
+      expect(proc.out.trim().contains("[1] Run-2"))
+      expect(proc.out.trim().contains("Run-1 launched"))
     }
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -436,7 +436,7 @@ class SipScalaTests extends ScalaCliSuite {
       val res = os.proc(TestUtil.cli, "--power", "export", ".", "--object-wrapper", "--md")
         .call(cwd = root, mergeErrIntoOut = true)
 
-      val output = res.out.trim
+      val output = res.out.trim()
 
       assertNoDiff(
         output,


### PR DESCRIPTION
This gets rid of warnings like:
```
(...)
[warn] Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method trim,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function. [quickfixable]
[warn]       val output = res.out.trim
[warn]                            ^
(...)
```