### PR TITLE
Fix repeatable compiler options handling from the command line

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/util/ScalacOptionsUtil.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/ScalacOptionsUtil.scala
@@ -1,6 +1,7 @@
 package scala.cli.commands.util
 
 import scala.build.Logger
+import scala.build.options.ScalacOpt.filterScalacOptionKeys
 import scala.build.options.{ScalacOpt, ShadowingSeq}
 import scala.cli.commands.bloop.BloopExit
 import scala.cli.commands.default.LegacyScalaOptions
@@ -31,8 +32,6 @@ object ScalacOptionsUtil {
   }
 
   extension (opts: ShadowingSeq[ScalacOpt]) {
-    def filterScalacOptionKeys(f: String => Boolean): ShadowingSeq[ScalacOpt] =
-      opts.filterKeys(_.key.exists(f))
     def filterNonRedirected: ShadowingSeq[ScalacOpt] =
       opts.filterScalacOptionKeys(!ScalacOptions.ScalaCliRedirectedOptions.contains(_))
     def filterNonDeprecated: ShadowingSeq[ScalacOpt] =

--- a/modules/integration/src/test/scala/scala/cli/integration/CompilerPluginTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompilerPluginTestDefinitions.scala
@@ -10,64 +10,76 @@ trait CompilerPluginTestDefinitions { _: CompileTestDefinitions =>
       CompilerPluginUtil.compilerPluginForScala3(pluginName, pluginErrorMsg)
     else CompilerPluginUtil.compilerPluginForScala2(pluginName, pluginErrorMsg)
 
-  test("build a custom compiler plugin and use it") {
-    val pluginName     = "divbyzero"
-    val usePluginFile  = "Main.scala"
-    val outputJar      = "div-by-zero.jar"
-    val pluginErrorMsg = "definitely division by zero"
-    compilerPluginInputs(pluginName, pluginErrorMsg)
-      .add(os.rel / usePluginFile ->
-        s"""//> using option -Xplugin:$outputJar
-           |
-           |object Test {
-           |  val five = 5
-           |  val amount = five / 0
-           |  def main(args: Array[String]): Unit = {
-           |    println(amount)
-           |  }
-           |}
-           |""".stripMargin)
-      .fromRoot { root =>
-        // build the compiler plugin
-        os.proc(
-          TestUtil.cli,
-          "package",
-          s"$pluginName.scala",
-          "--power",
-          "--with-compiler",
-          "--library",
-          "-o",
-          outputJar,
-          extraOptions
-        ).call(cwd = root)
-        expect(os.isFile(root / outputJar))
-
-        // verify the plugin is loaded
-        val pluginListResult = os.proc(
-          TestUtil.cli,
-          "compile",
-          s"-Xplugin:$outputJar",
-          "-Xplugin-list",
-          extraOptions
-        ).call(cwd = root, mergeErrIntoOut = true)
-        expect(pluginListResult.out.text().contains(pluginName))
-
-        // verify the compiler plugin phase is being added correctly
-        os.proc(
-          TestUtil.cli,
-          "compile",
-          s"-Xplugin:$outputJar",
-          "-Xshow-phases",
-          extraOptions
-        ).call(cwd = root, mergeErrIntoOut = true)
-        expect(pluginListResult.out.text().contains(pluginName))
-
-        // verify the compiler plugin is working
-        // TODO: this shouldn't require running with --server=false
-        val res = os.proc(TestUtil.cli, "compile", usePluginFile, "--server=false", extraOptions)
-          .call(cwd = root, mergeErrIntoOut = true, check = false)
-        expect(res.exitCode == 1)
-        expect(res.out.text().contains(pluginErrorMsg))
-      }
+  for {
+    pluginViaDirective <- Seq(true, false)
+    testLabel = if (pluginViaDirective) "use plugin via directive" else "use plugin via CLI option"
   }
+    test(s"build a custom compiler plugin and use it ($testLabel)") {
+      val pluginName     = "divbyzero"
+      val usePluginFile  = "Main.scala"
+      val outputJar      = "div-by-zero.jar"
+      val pluginErrorMsg = "definitely division by zero"
+      compilerPluginInputs(pluginName, pluginErrorMsg)
+        .add(os.rel / usePluginFile ->
+          s"""${if (pluginViaDirective) s"//> using option -Xplugin:$outputJar" else ""}
+             |
+             |object Test {
+             |  val five = 5
+             |  val amount = five / 0
+             |  def main(args: Array[String]): Unit = {
+             |    println(amount)
+             |  }
+             |}
+             |""".stripMargin)
+        .fromRoot { root =>
+          // build the compiler plugin
+          os.proc(
+            TestUtil.cli,
+            "package",
+            s"$pluginName.scala",
+            "--power",
+            "--with-compiler",
+            "--library",
+            "-o",
+            outputJar,
+            extraOptions
+          ).call(cwd = root)
+          expect(os.isFile(root / outputJar))
+
+          // verify the plugin is loaded
+          val pluginListResult = os.proc(
+            TestUtil.cli,
+            "compile",
+            s"-Xplugin:$outputJar",
+            "-Xplugin-list",
+            extraOptions
+          ).call(cwd = root, mergeErrIntoOut = true)
+          expect(pluginListResult.out.text().contains(pluginName))
+
+          // verify the compiler plugin phase is being added correctly
+          os.proc(
+            TestUtil.cli,
+            "compile",
+            s"-Xplugin:$outputJar",
+            "-Xshow-phases",
+            extraOptions
+          ).call(cwd = root, mergeErrIntoOut = true)
+          expect(pluginListResult.out.text().contains(pluginName))
+
+          val pluginOptions = if (pluginViaDirective) Nil else Seq(s"-Xplugin:$outputJar")
+          // verify the compiler plugin is working
+          // TODO: this shouldn't require running with --server=false
+          val res = os.proc(
+            TestUtil.cli,
+            "compile",
+            pluginOptions,
+            usePluginFile,
+            "--server=false",
+            extraOptions
+          )
+            .call(cwd = root, mergeErrIntoOut = true, check = false)
+          expect(res.exitCode == 1)
+          expect(res.out.text().contains(pluginErrorMsg))
+        }
+    }
 }

--- a/modules/options/src/main/scala/scala/build/options/ScalacOpt.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalacOpt.scala
@@ -1,14 +1,15 @@
 package scala.build.options
 
 final case class ScalacOpt(value: String) {
-  def key: Option[String] =
-    if (value.startsWith("-"))
-      Some(value.takeWhile(_ != ':'))
-        .filterNot(key => ScalacOpt.repeatingKeys.exists(_.startsWith(key)))
-    else if (value.startsWith("@"))
-      Some("@")
-    else
-      None
+
+  /** @return raw key for the option (if valid) */
+  private[options] def key: Option[String] =
+    if value.startsWith("-") then Some(value.takeWhile(_ != ':'))
+    else Some("@").filter(value.startsWith)
+
+  /** @return raw key for the option (only if the key can be shadowed from the CLI) */
+  private[options] def shadowableKey: Option[String] =
+    key.filterNot(key => ScalacOpt.repeatingKeys.exists(_.startsWith(key)))
 }
 
 object ScalacOpt {
@@ -22,7 +23,7 @@ object ScalacOpt {
   }
   implicit val keyOf: ShadowingSeq.KeyOf[ScalacOpt] =
     ShadowingSeq.KeyOf(
-      _.key,
+      _.shadowableKey,
       seq => groupCliOptions(seq.map(_.value))
     )
 
@@ -34,4 +35,9 @@ object ScalacOpt {
         case (opt, idx) if opt.startsWith("-") || opt.startsWith("@") =>
           idx
       }
+
+  extension (opts: ShadowingSeq[ScalacOpt]) {
+    def filterScalacOptionKeys(f: String => Boolean): ShadowingSeq[ScalacOpt] =
+      opts.filterKeys(_.key.exists(f))
+  }
 }


### PR DESCRIPTION
Fixes #2653

Repeatable compiler options (`-P:*:*` and `-Xplugin:*`, specifically) were being filtered out on some code paths. 
This was happening as we do treat them differently, as they can't be shadowed. We have special handling for compiler options with keys which can be passed multiple times, as those cannot be overridden from the CLI when they're also being declared in a `using` directive.

@sequencer This may already be enough to cover your usecase from #2621. It still doesn't seem to work correctly with Bloop, but I can no longer replicate the problem with `--server=false` (although it may be more complicated in your `mill` build, so let's verify it after this gets merged).