### PR TITLE
Prevent consecutive `-language:*` options from being ignored

### DIFF
--- a/modules/options/src/main/scala/scala/build/options/ScalacOpt.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalacOpt.scala
@@ -15,7 +15,8 @@ final case class ScalacOpt(value: String) {
 object ScalacOpt {
   private val repeatingKeys = Set(
     "-Xplugin:",
-    "-P" // plugin options
+    "-P", // plugin options
+    "-language:"
   )
 
   implicit val hashedType: HashedType[ScalacOpt] = {


### PR DESCRIPTION
~Depends on #2666~
~Depends on #2668~ 
Fixes #2549 

`-language:*` options can be passed multiple times to the compiler and thus aren't shadowable, so they shouldn't be treated as such.