### PR TITLE
Tag `GitHubTests.create secret` as flaky on all Mac tests (including M1)

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/GitHubTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/GitHubTests.scala
@@ -52,8 +52,7 @@ class GitHubTests extends ScalaCliSuite {
     }
   }
 
-  override def munitFlakyOK =
-    TestUtil.isCI && TestUtil.isNativeCli && Properties.isMac && !TestUtil.isM1
+  override def munitFlakyOK: Boolean = TestUtil.isCI && Properties.isMac
 
   // currently having issues loading libsodium from the static launcher
   // that launcher is mainly meant to be used on CIs or from docker, missing


### PR DESCRIPTION
`GitHubTests.create secret` used to be flaky only on specific images of non-M1 Mac GitHub action runners, but it seems to be happening on our M1 runner now, as well. 
To be investigated under #2676 