### PR TITLE
Update ScalaCliDockerFile

### DIFF
--- a/.github/scripts/docker/ScalaCliDockerFile
+++ b/.github/scripts/docker/ScalaCliDockerFile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim
+FROM debian:bookworm-slim
 RUN apt update && apt install build-essential libz-dev clang procps -y
 ADD scala-cli /usr/bin/
 RUN \


### PR DESCRIPTION
The `stable` tag is not clear about which debian version it uses.

```sh
docker run --rm -it --entrypoint cat  virtuslab/scala-cli:1.1.2 /etc/os-release
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

```sh
docker run --rm -it --entrypoint cat  virtuslab/scala-cli:1.0.0-RC1 /etc/os-release
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```