### PR TITLE
remove `user.home` hack

### DIFF
--- a/modules/build/src/main/scala/scala/build/input/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/input/Inputs.scala
@@ -16,6 +16,7 @@ import scala.build.preprocessing.ScopePath
 import scala.build.preprocessing.SheBang.isShebangScript
 import scala.util.Properties
 import scala.util.matching.Regex
+import scala.util.Try
 
 final case class Inputs(
   elements: Seq[Element],
@@ -88,9 +89,10 @@ final case class Inputs(
     def reallyOwnedByUser(p: os.Path): Boolean =
       if (Properties.isWin)
         p.toIO.canWrite // Wondering if there's a better way to do that…
-      else
-        os.owner(p) == os.owner(os.home) &&
-        p.toIO.canWrite
+      else {
+        val maybeUserHome = Try(os.owner(os.home)).toOption
+        maybeUserHome.exists(_ == os.owner(p)) && p.toIO.canWrite
+      }
     val canWrite = existingParent(workspace).exists(reallyOwnedByUser)
     if canWrite then this else inHomeDir(directories)
   }

--- a/modules/build/src/main/scala/scala/build/input/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/input/Inputs.scala
@@ -14,9 +14,8 @@ import scala.build.internal.zip.WrappedZipInputStream
 import scala.build.options.Scope
 import scala.build.preprocessing.ScopePath
 import scala.build.preprocessing.SheBang.isShebangScript
-import scala.util.Properties
 import scala.util.matching.Regex
-import scala.util.Try
+import scala.util.{Properties, Try}
 
 final case class Inputs(
   elements: Seq[Element],

--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -19,16 +19,6 @@ import scala.cli.util.ConfigDbUtils
 import scala.util.Properties
 
 object ScalaCli {
-  // TODO: Remove this part once fix is released in os-lib (Issue #2585)
-  sys.env.get("SCALA_CLI_HOME_DIR_OVERRIDE")
-    .filter(_.nonEmpty)
-    .filter(homeDir => scala.util.Try(os.Path(homeDir)).isSuccess)
-    .foreach { homeDirOverride =>
-      System.err.println(
-        s"Warning: user.home property overridden with the SCALA_CLI_HOME_DIR_OVERRIDE env var to: $homeDirOverride"
-      )
-      System.setProperty("user.home", homeDirOverride)
-    }
   private def getInvalidPropMessage(homeDirOpt: Option[String]): String = homeDirOpt match {
     case Some(value) => s"not valid: $value"
     case None        => "not set"

--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -19,29 +19,6 @@ import scala.cli.util.ConfigDbUtils
 import scala.util.Properties
 
 object ScalaCli {
-  private def getInvalidPropMessage(homeDirOpt: Option[String]): String = homeDirOpt match {
-    case Some(value) => s"not valid: $value"
-    case None        => "not set"
-  }
-  sys.props.get("user.home") -> sys.props.get("user.dir") match {
-    case (Some(homeDir), _)
-        if scala.util.Try(os.Path(homeDir)).isSuccess => // all is good, do nothing
-    case (invalidHomeDirOpt, Some(userDir)) if scala.util.Try(os.Path(userDir)).isSuccess =>
-      System.err.println(
-        s"Warning: user.home property is ${getInvalidPropMessage(invalidHomeDirOpt)}, setting it to user.dir value: $userDir"
-      )
-      System.setProperty("user.home", userDir)
-    case (invalidHomeDirOpt, invalidUserDirOpt) =>
-      System.err.println(
-        s"Error: user.home property is ${getInvalidPropMessage(invalidHomeDirOpt)}"
-      )
-      System.err.println(s"Error: user.dir property is ${getInvalidPropMessage(invalidUserDirOpt)}")
-      System.err.println("Scala CLI cannot work correctly without a valid home or user directory.")
-      System.err.println(
-        "Consider overriding it to a valid directory path with the SCALA_CLI_HOME_DIR_OVERRIDE environment variable."
-      )
-      sys.exit(1)
-  }
 
   if (Properties.isWin && isGraalvmNativeImage)
     // have to be initialized before running (new Argv0).get because Argv0SubstWindows uses csjniutils library

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -2107,64 +2107,27 @@ abstract class RunTestDefinitions(val scalaVersionOpt: Option[String])
     }
   }
 
-  // TODO: Remove this part once fix is released in os-lib (Issue #2585)
   def getCoursierCacheRelPath: os.RelPath =
     if (Properties.isWin) os.rel / "Coursier" / "Cache"
     else if (Properties.isMac) os.rel / "Library" / "Caches" / "Coursier"
     else os.rel / ".cache" / "coursier"
 
   if (TestUtil.isJvmCli) // can't reproduce on native image launchers
-    test("user.home is overridden with user.dir") {
+    test("doesn't fail on invalid user.home") {
       val customCall =
         Seq("java", "-Xmx512m", "-Xms128m", "-Duser.home=?", "-jar", TestUtil.cliPath)
       val msg   = "Hello"
       val input = "script.sc"
       TestInputs(os.rel / input -> s"println(\"$msg\")")
         .fromRoot { root =>
-          expect(!os.isDir(root / getCoursierCacheRelPath))
           val res = os.proc(customCall, "run", extraOptions, "--server=false", input)
             .call(
               cwd = root,
               stderr = os.Pipe
             )
           expect(res.out.trim() == msg)
-          expect(
-            res.err.trim().contains(
-              "user.home property is not valid: ?, setting it to user.dir value"
-            )
-          )
-          if (!Properties.isWin) // coursier cache location on Windows does not depend on home dir
-            expect(os.isDir(root / getCoursierCacheRelPath))
         }
     }
-
-  // TODO: Remove this part once fix is released in os-lib (Issue #2585)
-  test("user.home is overridden by SCALA_CLI_HOME_DIR_OVERRIDE") {
-    val msg   = "Hello"
-    val input = "script.sc"
-    TestInputs(os.rel / input -> s"println(\"$msg\")")
-      .fromRoot { root =>
-        val newHomePath = root / "home"
-        os.makeDir(newHomePath)
-        expect(!os.isDir(newHomePath / getCoursierCacheRelPath))
-        val extraEnv = Map("SCALA_CLI_HOME_DIR_OVERRIDE" -> newHomePath.toString())
-
-        val res = os.proc(TestUtil.cli, "run", extraOptions, "--server=false", input)
-          .call(
-            cwd = root,
-            stderr = os.Pipe,
-            env = extraEnv
-          )
-        expect(res.out.trim() == msg)
-        expect(
-          res.err.trim().contains(
-            "user.home property overridden with the SCALA_CLI_HOME_DIR_OVERRIDE"
-          )
-        )
-        if (!Properties.isWin) // coursier cache location on Windows does not depend on home dir
-          expect(os.isDir(newHomePath / getCoursierCacheRelPath))
-      }
-  }
 
   test("toolkit default") {
     val inputs = TestInputs(


### PR DESCRIPTION
resolves: https://github.com/VirtusLab/scala-cli/issues/2585

Upstream fix made `os.pwd` not fail when `os.home` is invalid. But I wonder if `os.home` shouldn't always be wrapped in a try clause, if it can be invalid.