### PR TITLE
Add information about --preamble in assembly packaging documentation

### DIFF
--- a/website/docs/commands/package.md
+++ b/website/docs/commands/package.md
@@ -127,7 +127,7 @@ Hello
 Hello
 -->
 
-By default assemblies are self-executable, just like the default package format. With the argument ```--preamble=false``` you can build an assembly that just contains the JAR and does not contain any built-in Bash code, and therefore can be launched directly with Java and is more portable:
+By default assemblies are self-executable, just like the default package format. With the `--preamble=false` option, you can build an assembly that just contains the JAR and does not contain any built-in Bash code, and therefore can be launched directly with Java and is more portable:
 
 <ChainedSnippets>
 

--- a/website/docs/commands/package.md
+++ b/website/docs/commands/package.md
@@ -127,6 +127,25 @@ Hello
 Hello
 -->
 
+By default assemblies are self-executable, just like the default package format. With the argument ```--preamble=false``` you can build an assembly that just contains the JAR and does not contain any built-in Bash code, and therefore can be launched directly with Java and is more portable:
+
+<ChainedSnippets>
+
+```bash
+scala-cli --power package Hello.scala -o hello.jar --assembly --preamble=false
+java -jar hello.jar
+```
+
+```text
+Hello
+```
+
+</ChainedSnippets>
+
+<!-- Expected:
+Hello
+-->
+
 ## Docker container
 
 Scala CLI can create an executable application and package it into a docker image.
@@ -506,4 +525,3 @@ The using directive allows you to define the image repository.
 ```scala compile power
 //> using packaging.dockerImageRepository scala-cli
 ```
-


### PR DESCRIPTION
This is a short modification to scala-cli's website documentation. The changed file in question is ```website/docs/commands/package.md```.

The changed area is the part about assembly packaging. I added information on how you can use ```--preamble=false``` to generate an assembly JAR that is not self-executable and therefore can be run with Java directly. This information is followed by a very similar example to the already existing one.