### PR TITLE
Fix ultra-long invalid Scala version errors

### DIFF
--- a/modules/core/src/main/scala/scala/build/errors/InvalidBinaryScalaVersionError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/InvalidBinaryScalaVersionError.scala
@@ -3,4 +3,4 @@ package scala.build.errors
 import scala.build.errors.ScalaVersionError.getTheGeneralErrorInfo
 
 final class InvalidBinaryScalaVersionError(val invalidBinaryVersion: String)
-    extends ScalaVersionError(s"Cannot find matching Scala version for '$invalidBinaryVersion")
+    extends ScalaVersionError(s"Cannot find matching Scala version for '$invalidBinaryVersion'")

--- a/modules/core/src/main/scala/scala/build/errors/NoValidScalaVersionFoundError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/NoValidScalaVersionFoundError.scala
@@ -1,7 +1,7 @@
 package scala.build.errors
 
-import scala.build.errors.ScalaVersionError.getTheGeneralErrorInfo
-
-final class NoValidScalaVersionFoundError(val foundVersions: Seq[String]) extends ScalaVersionError(
-      s"Cannot find a valid matching Scala version among ${foundVersions.mkString(", ")}"
-    )
+final class NoValidScalaVersionFoundError(val versionString: String = "")
+    extends ScalaVersionError({
+      val suffix = if versionString.nonEmpty then s" for $versionString" else ""
+      s"Cannot find a valid matching Scala version$suffix."
+    })

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -337,7 +337,9 @@ final case class BuildOptions(
                 repositories
               )
             case sv if ScalaVersionUtil.scala2Lts.contains(sv) =>
-              Left(new ScalaVersionError(s"Invalid Scala version: ${sv}. There is no official LTS version for Scala 2."))
+              Left(new ScalaVersionError(
+                s"Invalid Scala version: $sv. There is no official LTS version for Scala 2."
+              ))
             case sv if sv == ScalaVersionUtil.scala3Nightly =>
               ScalaVersionUtil.GetNightly.scala3(cache)
             case scala3NightlyNicknameRegex(threeSubBinaryNum) =>

--- a/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
@@ -33,7 +33,7 @@ object ScalaVersionUtil {
   def scala3Nightly         = "3.nightly"
   def scala3Lts             = List("3.lts", "lts")
   // not valid versions, defined only for informative error messages
-  def scala2Lts            = List("2.13.lts", "2.12.lts", "2.lts")
+  def scala2Lts = List("2.13.lts", "2.12.lts", "2.lts")
   extension (cache: FileCache[Task]) {
     def fileWithTtl0(artifact: Artifact): Either[ArtifactError, File] =
       cache.logger.use {
@@ -65,8 +65,7 @@ object ScalaVersionUtil {
   extension (versionsResult: Versions.Result) {
     def verify(versionString: String): Either[BuildException, Unit] =
       if versionsResult.versions.available.contains(versionString) then Right(())
-      else
-        Left(new NoValidScalaVersionFoundError(versionsResult.versions.available))
+      else Left(NoValidScalaVersionFoundError(versionString))
   }
 
   object GetNightly {
@@ -129,8 +128,8 @@ object ScalaVersionUtil {
         .versions.available.filter(_.endsWith("-NIGHTLY"))
 
       val threeXNightlies = res.filter(_.startsWith(s"3.$threeSubBinaryNum.")).map(Version(_))
-      if (threeXNightlies.nonEmpty) Right(threeXNightlies.max.repr)
-      else Left(new NoValidScalaVersionFoundError(res))
+      if threeXNightlies.nonEmpty then Right(threeXNightlies.max.repr)
+      else Left(NoValidScalaVersionFoundError())
     }
 
     /** @return

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -5,7 +5,7 @@ object Scala {
   def scala213     = "2.13.12"
   def runnerScala3 = "3.0.2" // the newest version that is compatible with all Scala 3.x versions
   def scala3       = "3.3.1"
-  def scala3Lts    = "3.3" //the full version should be resolved later
+  def scala3Lts    = "3.3"   // the full version should be resolved later
 
   // The Scala version used to build the CLI itself.
   def defaultInternal = sys.props.get("scala.version.internal").getOrElse(scala3)


### PR DESCRIPTION
Fixes #2722 

The errors should get down to reasonable lengths from now on.

```bash
scala-cli -S 2.13.13-bin-ffc0292
# [error]  Cannot find a valid matching Scala version for 2.13.13-bin-ffc0292.
# You can only choose one of the 3.x, 2.13.x, and 2.12.x. versions.
# The latest supported stable versions are 2.12.18, 2.13.12, 3.3.1.
# In addition, you can request compilation with the last nightly versions of Scala,
# by passing the 2.nightly, 2.12.nightly, 2.13.nightly, or 3.nightly arguments.
# Specific Scala 2 or Scala 3 nightly versions are also accepted.
# You can also request the latest Scala 3 LTS by passing lts or 3.lts.
```