### PR TITLE
Bump `scala-js-cli` to 1.15.0.1

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -407,6 +407,7 @@ trait Core extends ScalaCliSbtModule with ScalaCliPublishModule with HasTests
          |  def ghName = "$ghName"
          |
          |  def scalaJsVersion = "${Scala.scalaJs}"
+         |  def scalaJsCliVersion = "${Scala.scalaJsCli}"
          |  def scalajsEnvJsdomNodejsVersion = "${Deps.scalaJsEnvJsdomNodejs.dep.version}"
          |  def scalaNativeVersion = "${Deps.nativeTools.dep.version}"
          |
@@ -768,6 +769,7 @@ trait Cli extends SbtModule with ProtoBuildModule with CliLaunchers
          |object Constants {
          |  def defaultScalaVersion = "${Scala.defaultUser}"
          |  def scalaJsVersion = "${Scala.scalaJs}"
+         |  def scalaJsCliVersion = "${Scala.scalaJsCli}"
          |  def scalaNativeVersion = "${Deps.nativeTools.dep.version}"
          |  def ammoniteVersion = "${Deps.ammonite.dep.version}"
          |  def defaultScalafmtVersion = "${Deps.scalafmtCli.dep.version}"
@@ -954,6 +956,7 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
            |  def defaultScala = "${Scala.defaultUser}"
            |  def defaultScalafmtVersion = "${Deps.scalafmtCli.dep.version}"
            |  def scalaJsVersion = "${Scala.scalaJs}"
+           |  def scalaJsCliVersion = "${Scala.scalaJsCli}"
            |  def scalaNativeVersion = "${Deps.nativeTools.dep.version}"
            |  def ammoniteVersion = "${Deps.ammonite.dep.version}"
            |  def defaultGraalVMJavaVersion = "${deps.graalVmJavaVersion}"

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaJsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaJsOptions.scala
@@ -87,7 +87,7 @@ final case class ScalaJsOptions(
   @Hidden
     jsLinkerPath: Option[String] = None,
   @Group(HelpGroup.ScalaJs.toString)
-  @HelpMessage(s"Scala.js CLI version to use for linking (${Constants.scalaJsVersion} by default).")
+  @HelpMessage(s"Scala.js CLI version to use for linking (${Constants.scalaJsCliVersion} by default).")
   @ValueDescription("version")
   @Tag(tags.implementation)
   @Hidden

--- a/modules/options/src/main/scala/scala/build/options/scalajs/ScalaJsLinkerOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/scalajs/ScalaJsLinkerOptions.scala
@@ -12,7 +12,7 @@ final case class ScalaJsLinkerOptions(
   linkerPath: Option[os.Path] = None
 ) {
   def finalScalaJsCliVersion = scalaJsCliVersion.orElse(scalaJsVersion).getOrElse {
-    Constants.scalaJsVersion
+    Constants.scalaJsCliVersion
   }
 
   /** If right, use JVM, if left, use the value as architecture */

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -19,7 +19,8 @@ object Scala {
   val mainVersions        = (Seq(scala3, scala213) ++ defaults).distinct
   val runnerScalaVersions = runnerScala3 +: allScala2
 
-  def scalaJs = "1.15.0"
+  def scalaJs    = "1.15.0"
+  def scalaJsCli = "1.15.0.1" // this must be compatible with the Scala.js version
 
   def listAll: Seq[String] = {
     def patchVer(sv: String): Int =

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1316,7 +1316,7 @@ Path to the Scala.js linker
 ### `--js-cli-version`
 
 [Internal]
-Scala.js CLI version to use for linking (1.15.0 by default).
+Scala.js CLI version to use for linking (1.15.0.1 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -800,7 +800,7 @@ Path to the Scala.js linker
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Scala.js CLI version to use for linking (1.15.0 by default).
+Scala.js CLI version to use for linking (1.15.0.1 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -402,7 +402,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.15.0 by default).
+Scala.js CLI version to use for linking (1.15.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -1147,7 +1147,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.15.0 by default).
+Scala.js CLI version to use for linking (1.15.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -1718,7 +1718,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.15.0 by default).
+Scala.js CLI version to use for linking (1.15.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -2319,7 +2319,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.15.0 by default).
+Scala.js CLI version to use for linking (1.15.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -2929,7 +2929,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.15.0 by default).
+Scala.js CLI version to use for linking (1.15.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -3497,7 +3497,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.15.0 by default).
+Scala.js CLI version to use for linking (1.15.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -4140,7 +4140,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.15.0 by default).
+Scala.js CLI version to use for linking (1.15.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -4790,7 +4790,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.15.0 by default).
+Scala.js CLI version to use for linking (1.15.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -5695,7 +5695,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.15.0 by default).
+Scala.js CLI version to use for linking (1.15.0.1 by default).
 
 **--js-cli-java-arg**
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-js-cli/releases/tag/v1.15.0.1