### PR TITLE
updated method for choosing a free drive letter (fixes #2743)

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/packaging/NativeImage.scala
+++ b/modules/cli/src/main/scala/scala/cli/packaging/NativeImage.scala
@@ -93,14 +93,24 @@ object NativeImage {
     res.exitCode
   }
 
+  private lazy val mountedDrives: String = {
+    val str = "HKEY_LOCAL_MACHINE/SYSTEM/MountedDevices".replace('/', '\\')
+    val queryDrives = s"reg query $str"
+    val lines = os.proc("cmd", "/c", queryDrives).call().out.lines()
+    val dosDevices = lines.filter { s =>
+      s.contains("DosDevices")
+    }.map { s =>
+      s.replaceAll(".DosDevices.", "").replaceAll(":.*", "")
+    }
+    dosDevices.mkString
+  }
   private def availableDriveLetter(): Char = {
-
+    
     @tailrec
     def helper(from: Char): Char =
       if (from > 'Z') sys.error("Cannot find free drive letter")
       else {
-        val p = os.Path(s"$from:" + "\\")
-        if (os.exists(p)) helper((from + 1).toChar)
+        if (mountedDrives.contains(from)) helper((from + 1).toChar)
         else from
       }
 


### PR DESCRIPTION
In order to shorten the `native-image` command line in `Windows`, it is necessary to find a free drive letter to be used as an alias for `graalvm` home.

The original approach can sometimes choose a drive letter that is not actually free (details below).

The new method queries the Windows registry to identify mounted Devices.

Command line to get a list of unavailable drive letters from the registry:
```
$ reg query 'HKEY_LOCAL_MACHINE\SYSTEM\MountedDevices' | grep 'DosDevices' | sed -E -e 's#REG_BINARY.*##'
    \DosDevices\C:
    \DosDevices\D:
    \DosDevices\E:
    \DosDevices\F:
    \DosDevices\H:
```
See #2743 for more details.

Because the failure is a function of the Windows hardware configuration, an automated regression test might be difficult.

The fix was verified manually.  Here are the before-and-after manual sessions.

The original problem session, caused by choosing `E:` as a free drive letter:
```sh
# scala-cli --power package versionSort.sc --graal
Invalid parameter - E:
Error: os.SubprocessException: Result of cmdà: 1

For more details, please see 'C:\opt\ue\clisrc\.scala-build\stacktraces\1708383535-2865679820207472018.log'`
```
Here's the result with the changes (`I:` is now the chosen free drive letter` rather than `E:`):
```sh
# ./mill -i scala --power package versionSort.sc --graal
[587/863] runner[3.0.2].publishLocalNoFluff
Publishing Artifact(org.virtuslab.scala-cli,runner_3,0.0.1-SNAPSHOT) to ivy repo C:\Users\philwalk\workspace\scala-cli-2743\out\repo\0.0.1-SNAPSHOT
[643/863] test-runner[3.0.2].publishLocalNoFluff
Publishing Artifact(org.virtuslab.scala-cli,test-runner_3,0.0.1-SNAPSHOT) to ivy repo C:\Users\philwalk\workspace\scala-cli-2743\out\repo\0.0.1-SNAPSHOT
[705/863] runner[2.13.12].publishLocalNoFluff
Publishing Artifact(org.virtuslab.scala-cli,runner_2.13,0.0.1-SNAPSHOT) to ivy repo C:\Users\philwalk\workspace\scala-cli-2743\out\repo\0.0.1-SNAPSHOT
[728/863] test-runner[2.13.12].publishLocalNoFluff
Publishing Artifact(org.virtuslab.scala-cli,test-runner_2.13,0.0.1-SNAPSHOT) to ivy repo C:\Users\philwalk\workspace\scala-cli-2743\out\repo\0.0.1-SNAPSHOT
[790/863] runner[2.12.18].publishLocalNoFluff
Publishing Artifact(org.virtuslab.scala-cli,runner_2.12,0.0.1-SNAPSHOT) to ivy repo C:\Users\philwalk\workspace\scala-cli-2743\out\repo\0.0.1-SNAPSHOT
[852/863] test-runner[2.12.18].publishLocalNoFluff
Publishing Artifact(org.virtuslab.scala-cli,test-runner_2.12,0.0.1-SNAPSHOT) to ivy repo C:\Users\philwalk\workspace\scala-cli-2743\out\repo\0.0.1-SNAPSHOT
[862/863] cli.run
Starting compilation server
Compiling project (Scala 3.3.1, JVM (17))
Compiled project (Scala 3.3.1, JVM (17))

C:\Users\philwalk\workspace\scala-cli-2743>chcp 437
Active code page: 437
**********************************************************************
** Visual Studio 2022 Developer Command Prompt v17.9.0
** Copyright (c) 2022 Microsoft Corporation
**********************************************************************
[vcvarsall.bat] Environment initialized for: 'x64'
========================================================================================================================
GraalVM Native Image: Generating 'versionSort' (executable)...
========================================================================================================================
[1/7] Initializing...                                                                                    (6.4s @ 0.23GB)
 Version info: 'GraalVM 22.3.1 Java 17 CE'
 Java version info: '17.0.6+10-jvmci-22.3-b13'
 C compiler: cl.exe (microsoft, x64, 19.39.33519)
 Garbage collector: Serial GC
 1 user-specific feature(s)
 - com.oracle.svm.polyglot.scala.ScalaFeature
[2/7] Performing analysis...  [******]                                                                   (9.5s @ 1.03GB)
   3,061 (73.87%) of  4,144 classes reachable
   3,559 (51.90%) of  6,858 fields reachable
  13,352 (38.50%) of 34,685 methods reachable
      29 classes,    42 fields, and   418 methods registered for reflection
      62 classes,    53 fields, and    52 methods registered for JNI access
       1 native library: version
[3/7] Building universe...                                                                               (1.2s @ 1.56GB)
[4/7] Parsing methods...      [*]                                                                        (0.9s @ 0.73GB)
[5/7] Inlining methods...     [***]                                                                      (0.6s @ 1.13GB)
[6/7] Compiling methods...    [***]                                                                      (6.4s @ 2.20GB)
[7/7] Creating image...                                                                                  (1.3s @ 2.59GB)
   4.28MB (37.50%) for code area:     7,608 compilation units
   6.95MB (60.88%) for image heap:   94,903 objects and 5 resources
 189.36KB ( 1.62%) for other data
  11.41MB in total
------------------------------------------------------------------------------------------------------------------------
Top 10 packages in code area:                               Top 10 object types in image heap:
 667.18KB java.util                                          922.63KB byte[] for code metadata
 336.15KB java.lang                                          906.34KB java.lang.String
 266.91KB java.text                                          854.46KB byte[] for general heap data
 218.85KB java.util.regex                                    736.92KB byte[] for java.lang.String
 196.46KB java.util.concurrent                               672.07KB java.lang.Class
 149.11KB java.math                                          387.80KB java.util.HashMap$Node
 128.83KB com.oracle.svm.core.code                           239.14KB com.oracle.svm.core.hub.DynamicHubCompanion
 120.51KB com.oracle.svm.core.genscavenge                    167.58KB java.util.HashMap$Node[]
 116.84KB java.lang.invoke                                   164.54KB java.lang.String[]
 104.38KB java.util.logging                                  154.92KB java.util.concurrent.ConcurrentHashMap$Node
   1.97MB for 122 more packages                                1.45MB for 800 more object types
------------------------------------------------------------------------------------------------------------------------
                        0.7s (2.4% of total time) in 17 GCs | Peak RSS: 3.18GB | CPU load: 6.33
------------------------------------------------------------------------------------------------------------------------
Produced artifacts:
 C:\Users\philwalk\workspace\scala-cli-2743\versionSort.build_artifacts.txt (txt)
 C:\Users\philwalk\workspace\scala-cli-2743\versionSort.exe (executable)
========================================================================================================================
Finished generating 'versionSort' in 27.6s.
Wrote C:\Users\philwalk\workspace\scala-cli-2743\versionSort.exe, run it with
  .\versionSort.exe
[863/863] scala
```


