### PR TITLE
Lock script wrapper tests on the internally used Scala 2.13 version

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/ScriptWrapperTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ScriptWrapperTests.scala
@@ -166,7 +166,7 @@ class ScriptWrapperTests extends ScalaCliSuite {
   for {
     useDirectives <- Seq(true, false)
     (directive, options) <- Seq(
-      ("//> using scala 2.13", Seq("--scala", "2.13"))
+      (s"//> using scala ${Constants.scala213}", Seq("--scala", Constants.scala213))
     )
   } {
     val inputs = TestInputs(


### PR DESCRIPTION
https://github.com/VirtusLab/scala-cli/actions/runs/8001275750/job/21865919147#step:4:10129
```
integration.test.native 2 tests failed: 
  scala.cli.integration.ScriptWrapperTests.BSP App object wrapper forced with //> using scala 2.13 scala.cli.integration.ScriptWrapperTests.BSP App object wrapper forced with //> using scala 2.13
  scala.cli.integration.ScriptWrapperTests.BSP App object wrapper forced with --scala 2.13 scala.cli.integration.ScriptWrapperTests.BSP App object wrapper forced with --scala 2.13
```
This should fix the failing script wrapper tests on the CI.
The cause seems to be something with `2.13.13`.
Not sure what just yet, but we'll have to figure it out before we bump it.