### PR TITLE
Explicitly set sonatype publishing to use the default cross Scala version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1056,7 +1056,7 @@ jobs:
       env:
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
     - run: ./mill -i ci.setShouldPublish
-    - run: ./mill -i publishSonatype __.publishArtifacts
+    - run: ./mill -i publishSonatype '__[].publishArtifacts'
       if: env.SHOULD_PUBLISH == 'true'
       env:
         PGP_PASSWORD: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
Fixes errors like https://github.com/VirtusLab/scala-cli/actions/runs/8045250685/job/21972628662#step:6:12
Since everything is cross-compiled now, it seems that the `[]` characters to use the default cross Scala version (LTS) need to be passed explicitly.