### PR TITLE
Fix publishing of artifacts to include non-cross-compiled modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1056,7 +1056,7 @@ jobs:
       env:
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
     - run: ./mill -i ci.setShouldPublish
-    - run: ./mill -i publishSonatype '__[].publishArtifacts'
+    - run: ./mill -i publishSonatype '{__[],_}.publishArtifacts'
       if: env.SHOULD_PUBLISH == 'true'
       env:
         PGP_PASSWORD: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
Non-cross-compiled modules aren't included in the `__[]` wildcard, which caused `scala-cli-bsp` to be skipped when publishing to sonatype.
That in turn broke our nightlies 
```bash
scala-cli --cli-version nightly -version
# Fetching Scala CLI 1.1.3-38-gac4a7b4a9-SNAPSHOT
# Error downloading org.virtuslab.scala-cli:scala-cli-bsp:1.1.3-38-gac4a7b4a9-SNAPSHOT
#   not found: /Users/pchabelski/.ivy2/local/org.virtuslab.scala-cli/scala-cli-bsp/1.1.3-38-gac4a7b4a9-SNAPSHOT/ivys/ivy.xml
#   not found: https://repo1.maven.org/maven2/org/virtuslab/scala-cli/scala-cli-bsp/1.1.3-38-gac4a7b4a9-SNAPSHOT/scala-cli-bsp-1.1.3-38-gac4a7b4a9-SNAPSHOT.pom
#   not found: https://oss.sonatype.org/content/repositories/snapshots/org/virtuslab/scala-cli/scala-cli-bsp/1.1.3-38-gac4a7b4a9-SNAPSHOT/scala-cli-bsp-1.1.3-38-gac4a7b4a9-SNAPSHOT.pom
#   No fallback URL found
```
(and would have broken the Scala CLI slim jar on a subsequent release, although that'd have been tough to spot)

