### PR TITLE
Fix handling for `-Xlint:help`

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
@@ -58,7 +58,13 @@ object ScalacOptions {
     * message instead.
     */
   val ScalacPrintOptions: Set[String] =
-    scalacOptionsPurePrefixes ++ Set("-help", "-Xshow-phases", "-Xplugin-list", "-Vphases")
+    scalacOptionsPurePrefixes ++ Set(
+      "-help",
+      "-Xshow-phases",
+      "-Xplugin-list",
+      "-Xlint:help",
+      "-Vphases"
+    )
 
   /** This includes all the scalac options which are redirected to native Scala CLI options. */
   val ScalaCliRedirectedOptions = Set(

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalacCompatTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalacCompatTestDefinitions.scala
@@ -146,7 +146,7 @@ trait RunScalacCompatTestDefinitions {
 
   for {
     printOption <- {
-      val printOptionsForAllVersions   = Seq("-X", "-Xshow-phases", "-Y")
+      val printOptionsForAllVersions   = Seq("-X", "-Xshow-phases", "-Xplugin-list", "-Y")
       val printOptionsScala213OrHigher = Seq("-V", "-Vphases", "-W")
       val printOptionsScala2           = Seq("-Xlint:help")
       actualScalaVersion match {


### PR DESCRIPTION
Fixes #2779 
Also, improves the way we test compiler print options.