### PR TITLE
Ensure external help options are mentioned in short help where available

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommandWithCustomHelp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommandWithCustomHelp.scala
@@ -5,7 +5,12 @@ import caseapp.core.help.{Help, HelpCompanion, RuntimeCommandsHelp}
 import caseapp.core.parser.Parser
 
 import scala.cli.commands.default.{DefaultOptions, LegacyScalaOptions}
-import scala.cli.commands.shared.{HasGlobalOptions, ScalaCliHelp}
+import scala.cli.commands.shared.{
+  AllExternalHelpOptions,
+  HasGlobalOptions,
+  HelpGroupOptions,
+  ScalaCliHelp
+}
 import scala.cli.commands.util.HelpUtils.*
 import scala.cli.launcher.LauncherOptions
 
@@ -25,6 +30,8 @@ abstract class ScalaCommandWithCustomHelp[T <: HasGlobalOptions](
     val helpString            = actualHelp.help(helpFormat, showHidden)
     val launcherHelpString    = launcherHelp.optionsHelp(helpFormat, showHidden)
     val legacyScalaHelpString = legacyScalaHelp.optionsHelp(helpFormat, showHidden)
+    val allExternalHelp       = HelpCompanion.deriveHelp[AllExternalHelpOptions]
+    val allExternalHelpString = allExternalHelp.optionsHelp(helpFormat, showHidden)
     val legacyScalaHelpStringWithPadding =
       if legacyScalaHelpString.nonEmpty then
         s"""
@@ -34,6 +41,8 @@ abstract class ScalaCommandWithCustomHelp[T <: HasGlobalOptions](
     s"""$helpString
        |
        |$launcherHelpString
+       |
+       |$allExternalHelpString
        |$legacyScalaHelpStringWithPadding""".stripMargin
   }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/AllExternalHelpOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/AllExternalHelpOptions.scala
@@ -1,0 +1,22 @@
+package scala.cli.commands.shared
+
+import caseapp.core.Scala3Helpers.*
+import caseapp.core.help.{Help, HelpFormat}
+import caseapp.{Help, *}
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+import com.github.plokhotnyuk.jsoniter_scala.macros.*
+
+@HelpMessage("Print help message")
+// this is an aggregate for all external and internal help options
+case class AllExternalHelpOptions(
+  @Recurse
+  scalacExtra: ScalacExtraOptions = ScalacExtraOptions(),
+  @Recurse
+  helpGroups: HelpGroupOptions = HelpGroupOptions()
+)
+
+object AllExternalHelpOptions {
+  implicit lazy val parser: Parser[AllExternalHelpOptions]            = Parser.derive
+  implicit lazy val help: Help[AllExternalHelpOptions]                = Help.derive
+  implicit lazy val jsonCodec: JsonValueCodec[AllExternalHelpOptions] = JsonCodecMaker.make
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacExtraOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacExtraOptions.scala
@@ -4,6 +4,8 @@ import caseapp.*
 import com.github.plokhotnyuk.jsoniter_scala.core.*
 import com.github.plokhotnyuk.jsoniter_scala.macros.*
 
+import scala.cli.commands.tags
+
 /** Scala CLI options which aren't strictly scalac options, but directly involve the Scala compiler
   * in some way.
   */
@@ -12,11 +14,13 @@ final case class ScalacExtraOptions(
   @Group(HelpGroup.Scala.toString)
   @HelpMessage("Show help for scalac. This is an alias for --scalac-option -help")
   @Name("helpScalac")
+  @Tag(tags.inShortHelp)
     scalacHelp: Boolean = false,
 
   @Group(HelpGroup.Scala.toString)
   @HelpMessage("Turn verbosity on for scalac. This is an alias for --scalac-option -verbose")
   @Name("verboseScalac")
+  @Tag(tags.inShortHelp)
     scalacVerbose: Boolean = false,
 )
 // format: on

--- a/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
@@ -29,6 +29,15 @@ class HelpTests extends ScalaCliSuite {
     test(s"$helpOptionsString output does not include legacy scala runner options") {
       expect(!helpOutput.contains("Legacy Scala runner options"))
     }
+
+    test(s"$helpOptionsString output includes external help options") {
+      expect(helpOutput.contains("--scalac-help"))
+      expect(helpOutput.contains("--help-js"))
+      expect(helpOutput.contains("--help-native"))
+      expect(helpOutput.contains("--help-doc"))
+      expect(helpOutput.contains("--help-repl"))
+      expect(helpOutput.contains("--help-fmt"))
+    }
   }
 
   for (fullHelpOptions <- HelpTests.fullHelpVariants) {


### PR DESCRIPTION
Fixes #2798

```bash
scala-cli -h
Usage: scala-cli <COMMAND>
Scala CLI is a command-line tool to interact with the Scala language. It lets you compile, run and test your Scala code.

Main commands:
  clean                  Clean the workspace.
  compile                Compile Scala code.
  doc                    Generate Scaladoc documentation.
  fmt, format, scalafmt  Formats Scala code.
  repl, console          Fire-up a Scala REPL.
  run                    Compile and run Scala code.
  test                   Compile and test Scala code.

Miscellaneous commands:
  version  Prints the version of the Scala CLI and the default version of Scala.

Other commands:
  config                                        Configure global settings for Scala CLI.
  help                                          Print help message
  install completions, install-completions      Installs Scala CLI completions into your shell
  setup-ide                                     Generates a BSP file that you can import into your IDE.
  shebang                                       Like `run`, but handier for shebang scripts.
  uninstall                                     Uninstalls Scala CLI.
  uninstall completions, uninstall-completions  Uninstalls Scala CLI completions from your shell.
  update                                        Updates Scala CLI.

See 'scala-cli <command> --help' to read about a specific subcommand. To see full help run 'scala-cli <command> --help-full'.

To use launcher options, specify them before any other argument.
For example, to run another Scala CLI version, specify it with the '--cli-version' launcher option:
  scala-cli --cli-version <version> args

Launcher options:
  --cli-version nightly|version  Set the Scala CLI version
  --power                        Allows to use restricted & experimental features

Scala options:
  --scalac-help, --help-scalac        Show help for scalac. This is an alias for --scalac-option -help
  --scalac-verbose, --verbose-scalac  Turn verbosity on for scalac. This is an alias for --scalac-option -verbose

Help options:
  --help-js                    Show options for ScalaJS
  --help-native                Show options for ScalaNative
  --help-doc, --help-scaladoc  Show options for Scaladoc
  --help-repl, --repl-help     Show options for Scala REPL
  --help-fmt, --help-scalafmt  Show options for Scalafmt

When no subcommand is passed explicitly, an implicit subcommand is used based on context:
  - if the '--version' option is passed, it prints the 'version' subcommand output, unmodified by any other options
  - if any inputs were passed, it defaults to the 'run' subcommand
  - additionally, when no inputs were passed, it defaults to the 'run' subcommand in the following scenarios:
    - if a snippet was passed with any of the '--execute*' options
    - if a main class was passed with the '--main-class' option alongside an extra '--classpath'
  - otherwise, if no inputs were passed, it defaults to the 'repl' subcommand
```