### PR TITLE
Add missing Scala 2 compiler print options

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
@@ -61,8 +61,11 @@ object ScalacOptions {
   val ScalacPrintOptions: Set[String] =
     scalacOptionsPurePrefixes ++ Set(
       "-help",
+      "-opt:help",
       "-Xshow-phases",
+      "-Xsource:help",
       "-Xplugin-list",
+      "-Xmixin-force-forwarders:help",
       "-Xlint:help",
       "-Vphases"
     )

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalacCompatTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalacCompatTestDefinitions.scala
@@ -147,8 +147,8 @@ trait RunScalacCompatTestDefinitions {
   for {
     printOption <- {
       val printOptionsForAllVersions   = Seq("-X", "-Xshow-phases", "-Xplugin-list", "-Y")
-      val printOptionsScala213OrHigher = Seq("-V", "-Vphases", "-W")
-      val printOptionsScala2           = Seq("-Xlint:help")
+      val printOptionsScala213OrHigher = Seq("-V", "-Vphases", "-W", "-Xsource:help")
+      val printOptionsScala2 = Seq("-Xlint:help", "-opt:help", "-Xmixin-force-forwarders:help")
       actualScalaVersion match {
         case v if v.startsWith("3") => printOptionsForAllVersions ++ printOptionsScala213OrHigher
         case v if v.startsWith("2.13") =>


### PR DESCRIPTION
Follow-up to [#2781 (comment)](https://github.com/VirtusLab/scala-cli/pull/2781/files#r1524599242)