### PR TITLE
Add launcher options allowing to override the default Scala version

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -53,6 +53,10 @@ object ScalaCli {
   private def isGraalvmNativeImage: Boolean =
     sys.props.contains("org.graalvm.nativeimage.imagecode")
 
+  private var defaultScalaVersion: Option[String] = None
+
+  def getDefaultScalaVersion: String = defaultScalaVersion.getOrElse(Constants.defaultScalaVersion)
+
   private def partitionArgs(args: Array[String]): (Array[String], Array[String]) = {
     val systemProps = args.takeWhile(_.startsWith("-D"))
     (systemProps, args.drop(systemProps.size))
@@ -237,6 +241,8 @@ object ScalaCli {
                 && sys.props.get("scala-cli.kind").exists(_.startsWith("jvm")) =>
             JavaLauncherCli.runAndExit(args)
           case None =>
+            if launcherOpts.cliUserScalaVersion.nonEmpty then
+              defaultScalaVersion = launcherOpts.cliUserScalaVersion
             if launcherOpts.powerOptions.power then
               isSipScala = false
               args0.toArray

--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -16,6 +16,7 @@ import scala.cli.javaLauncher.JavaLauncherCli
 import scala.cli.launcher.{LauncherCli, LauncherOptions, PowerOptions}
 import scala.cli.publish.BouncycastleSignerMaker
 import scala.cli.util.ConfigDbUtils
+import scala.collection.mutable.ListBuffer
 import scala.util.Properties
 
 object ScalaCli {
@@ -53,7 +54,8 @@ object ScalaCli {
   private def isGraalvmNativeImage: Boolean =
     sys.props.contains("org.graalvm.nativeimage.imagecode")
 
-  private var defaultScalaVersion: Option[String] = None
+  private var defaultScalaVersion: Option[String]        = None
+  val launcherPredefinedRepositories: ListBuffer[String] = ListBuffer.empty
 
   def getDefaultScalaVersion: String = defaultScalaVersion.getOrElse(Constants.defaultScalaVersion)
 
@@ -243,6 +245,8 @@ object ScalaCli {
           case None =>
             if launcherOpts.cliUserScalaVersion.nonEmpty then
               defaultScalaVersion = launcherOpts.cliUserScalaVersion
+            if launcherOpts.cliPredefinedRepository.nonEmpty then
+              launcherPredefinedRepositories.addAll(launcherOpts.cliPredefinedRepository)
             if launcherOpts.powerOptions.power then
               isSipScala = false
               args0.toArray

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
@@ -166,7 +166,10 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
   }
 
   def finalBuildOptions(options: PackageOptions): BuildOptions = {
-    val finalBuildOptions = options.finalBuildOptions.orExit(options.shared.logger)
+    val initialOptions = options.finalBuildOptions.orExit(options.shared.logger)
+    val finalBuildOptions = initialOptions.copy(scalaOptions =
+      initialOptions.scalaOptions.copy(defaultScalaVersion = Some(defaultScalaVersion))
+    )
     val buildOptions = finalBuildOptions.copy(
       javaOptions = finalBuildOptions.javaOptions.copy(
         javaOpts =

--- a/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
@@ -16,7 +16,6 @@ import scala.build.errors.{BuildException, CantDownloadAmmoniteError, FetchingDe
 import scala.build.input.Inputs
 import scala.build.internal.{Constants, Runner}
 import scala.build.options.{BuildOptions, JavaOpt, MaybeScalaVersion, Scope}
-import scala.cli.CurrentParams
 import scala.cli.commands.publish.ConfigUtil.*
 import scala.cli.commands.run.Run.{
   maybePrintSimpleScalacOutput,
@@ -30,6 +29,7 @@ import scala.cli.config.{ConfigDb, Keys}
 import scala.cli.packaging.Library
 import scala.cli.util.ArgHelpers.*
 import scala.cli.util.ConfigDbUtils
+import scala.cli.{CurrentParams, ScalaCli}
 import scala.jdk.CollectionConverters.*
 import scala.util.Properties
 
@@ -62,7 +62,7 @@ object Repl extends ScalaCommand[ReplOptions] {
       scalaOptions = baseOptions.scalaOptions.copy(
         scalaVersion = baseOptions.scalaOptions.scalaVersion
           .orElse {
-            val defaultScalaVer = scala.build.internal.Constants.defaultScalaVersion
+            val defaultScalaVer = ScalaCli.getDefaultScalaVersion
             val shouldDowngrade = {
               def needsDowngradeForAmmonite = {
                 import coursier.core.Version

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -394,7 +394,10 @@ final case class SharedOptions(
         extraClassPath = extraRegularJarsAndClasspath,
         extraCompileOnlyJars = extraCompileOnlyClassPath,
         extraSourceJars = extraSourceJars.extractedClassPath ++ assumedSourceJars,
-        extraRepositories = dependencies.repository.map(_.trim).filter(_.nonEmpty),
+        extraRepositories =
+          (dependencies.repository ++ ScalaCli.launcherPredefinedRepositories).map(_.trim).filter(
+            _.nonEmpty
+          ),
         extraDependencies = ShadowingSeq.from(
           SharedOptions.parseDependencies(
             dependencies.dependency.map(Positioned.none),

--- a/modules/cli/src/main/scala/scala/cli/commands/version/Version.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/version/Version.scala
@@ -5,12 +5,12 @@ import caseapp.core.help.HelpFormat
 
 import scala.build.Logger
 import scala.build.internal.Constants
-import scala.cli.CurrentParams
 import scala.cli.commands.shared.{HelpCommandGroup, HelpGroup}
 import scala.cli.commands.update.Update
 import scala.cli.commands.{CommandUtils, ScalaCommand, SpecificationLevel}
 import scala.cli.config.PasswordOption
 import scala.cli.util.ArgHelpers.*
+import scala.cli.{CurrentParams, ScalaCli}
 
 object Version extends ScalaCommand[VersionOptions] {
   override def group: String = HelpCommandGroup.Miscellaneous.toString
@@ -34,7 +34,7 @@ object Version extends ScalaCommand[VersionOptions] {
           else None
       }
     if options.cliVersion then println(Constants.version)
-    else if options.scalaVersion then println(Constants.defaultScalaVersion)
+    else if options.scalaVersion then println(ScalaCli.getDefaultScalaVersion)
     else {
       println(versionInfo)
       if !options.offline then
@@ -51,5 +51,5 @@ object Version extends ScalaCommand[VersionOptions] {
     val version            = Constants.version
     val detailedVersionOpt = Constants.detailedVersion.filter(_ != version).fold("")(" (" + _ + ")")
     s"""$fullRunnerName version: $version$detailedVersionOpt
-       |Scala version (default): ${Constants.defaultScalaVersion}""".stripMargin
+       |Scala version (default): ${ScalaCli.getDefaultScalaVersion}""".stripMargin
 }

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/MillProjectDescriptor.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/MillProjectDescriptor.scala
@@ -13,6 +13,7 @@ import scala.build.internal.Runner.frameworkName
 import scala.build.options.{BuildOptions, Platform, ScalaJsOptions, ScalaNativeOptions, Scope}
 import scala.build.testrunner.AsmTestRunner
 import scala.build.{Logger, Sources}
+import scala.cli.ScalaCli
 import scala.cli.util.SeqHelpers.*
 
 final case class MillProjectDescriptor(
@@ -39,7 +40,7 @@ final case class MillProjectDescriptor(
 
     val sv = options.scalaOptions.scalaVersion
       .flatMap(_.versionOpt) // FIXME If versionOpt is empty, the project is pure Java
-      .getOrElse(Constants.defaultScalaVersion)
+      .getOrElse(ScalaCli.getDefaultScalaVersion)
 
     if (pureJava)
       MillProject()

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/SbtProjectDescriptor.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/SbtProjectDescriptor.scala
@@ -21,6 +21,7 @@ import scala.build.options.{
 }
 import scala.build.testrunner.AsmTestRunner
 import scala.build.{Logger, Positioned, Sources}
+import scala.cli.ScalaCli
 
 final case class SbtProjectDescriptor(
   sbtVersion: String,
@@ -122,7 +123,7 @@ final case class SbtProjectDescriptor(
     val scalaVerSetting = {
       val sv = options.scalaOptions.scalaVersion
         .flatMap(_.versionOpt) // FIXME If versionOpt is empty, the project is pure Java
-        .getOrElse(Constants.defaultScalaVersion)
+        .getOrElse(ScalaCli.getDefaultScalaVersion)
       s"""scalaVersion := "$sv""""
     }
 

--- a/modules/cli/src/main/scala/scala/cli/launcher/LauncherOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/launcher/LauncherOptions.scala
@@ -28,6 +28,15 @@ final case class LauncherOptions(
   @Tag(tags.implementation)
   @Name("cliDefaultScalaVersion")
   cliUserScalaVersion: Option[String] = None,
+  @Group(HelpGroup.Launcher.toString)
+  @HelpMessage("")
+  @Hidden
+  @Tag(tags.implementation)
+  @Name("r")
+  @Name("repo")
+  @Name("repository")
+  @Name("predefinedRepository")
+  cliPredefinedRepository: List[String] = Nil,
   @Recurse
   powerOptions: PowerOptions = PowerOptions()
 )

--- a/modules/cli/src/main/scala/scala/cli/launcher/LauncherOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/launcher/LauncherOptions.scala
@@ -3,7 +3,7 @@ package scala.cli.launcher
 import caseapp.*
 
 import scala.cli.commands.shared.HelpGroup
-import scala.cli.commands.tags
+import scala.cli.commands.{Constants, tags}
 
 @HelpMessage("Run another Scala CLI version")
 final case class LauncherOptions(
@@ -19,6 +19,15 @@ final case class LauncherOptions(
   @Hidden
   @Tag(tags.implementation)
   cliScalaVersion: Option[String] = None,
+  @Group(HelpGroup.Launcher.toString)
+  @HelpMessage(
+    s"The default version of Scala used when processing user inputs (current default: ${Constants.defaultScalaVersion}). Can be overridden with --scala-version. "
+  )
+  @ValueDescription("version")
+  @Hidden
+  @Tag(tags.implementation)
+  @Name("cliDefaultScalaVersion")
+  cliUserScalaVersion: Option[String] = None,
   @Recurse
   powerOptions: PowerOptions = PowerOptions()
 )

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestDefinitions.scala
@@ -1,27 +1,8 @@
 package scala.cli.integration
 
 abstract class ExportSbtTestDefinitions extends ScalaCliSuite
-    with TestScalaVersionArgs with ExportCommonTestDefinitions { _: TestScalaVersion =>
-  private lazy val sbtLaunchJar = {
-    val res =
-      os.proc(TestUtil.cs, "fetch", "--intransitive", "org.scala-sbt:sbt-launch:1.5.5").call()
-    val rawPath = res.out.trim()
-    val path    = os.Path(rawPath, os.pwd)
-    if (os.isFile(path)) path
-    else sys.error(s"Something went wrong (invalid sbt launch JAR path '$rawPath')")
-  }
-
-  protected lazy val sbt: os.Shellable =
-    Seq[os.Shellable](
-      "java",
-      "-Xmx512m",
-      "-Xms128m",
-      "-Djline.terminal=jline.UnsupportedTerminal",
-      "-Dsbt.log.noformat=true",
-      "-jar",
-      sbtLaunchJar
-    )
-
+    with TestScalaVersionArgs with ExportCommonTestDefinitions with SbtTestHelper {
+  _: TestScalaVersion =>
   override def exportCommand(args: String*): os.proc =
     os.proc(
       TestUtil.cli,
@@ -34,7 +15,7 @@ abstract class ExportSbtTestDefinitions extends ScalaCliSuite
       args
     )
 
-  override def buildToolCommand(root: os.Path, args: String*): os.proc = os.proc(sbt, args)
+  override def buildToolCommand(root: os.Path, args: String*): os.proc = sbtCommand(args*)
 
   override val runMainArgs: Seq[String]  = Seq("run")
   override val runTestsArgs: Seq[String] = Seq("test")

--- a/modules/integration/src/test/scala/scala/cli/integration/MillTestHelper.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/MillTestHelper.scala
@@ -1,0 +1,26 @@
+package scala.cli.integration
+
+import scala.util.Properties
+
+trait MillTestHelper {
+
+  protected def millLauncher: os.RelPath =
+    if (Properties.isWin) os.rel / "mill.bat"
+    else os.rel / "mill"
+
+  protected val millJvmOptsFileName: String = ".mill-jvm-opts"
+  protected val millJvmOptsContent: String = """-Xmx512m
+                                               |-Xms128m
+                                               |""".stripMargin
+
+  protected val millDefaultProjectName = "project"
+
+  implicit class MillTestInputs(inputs: TestInputs) {
+    def withMillJvmOpts: TestInputs = inputs.add(os.rel / millJvmOptsFileName -> millJvmOptsContent)
+  }
+
+  protected val millOutputDir: os.RelPath = os.rel / "output-project"
+
+  protected def millCommand(root: os.Path, args: String*): os.proc =
+    os.proc(root / millOutputDir / millLauncher, args)
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -14,7 +14,7 @@ import scala.util.{Properties, Using}
 
 abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
   _: TestScalaVersion =>
-  private lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
+  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
 
   def maybeUseBash(cmd: os.Shellable*)(cwd: os.Path = null): os.CommandResult = {
     val res = os.proc(cmd*).call(cwd = cwd, check = false)

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestsDefault.scala
@@ -13,13 +13,14 @@ class PackageTestsDefault extends PackageTestDefinitions with TestDefault {
           |""".stripMargin
     )
     inputs.fromRoot { root =>
-      val runRes = os.proc(TestUtil.cli, "run", "--native", ".")
+      val runRes = os.proc(TestUtil.cli, "run", "--native", ".", extraOptions)
         .call(cwd = root)
       val runOutput = runRes.out.trim().linesIterator.filter(!_.startsWith("[info] ")).toVector
       expect(runOutput == Seq("Hello"))
 
-      val packageRes = os.proc(TestUtil.cli, "--power", "package", "--native", ".", "-o", "hello")
-        .call(cwd = root, mergeErrIntoOut = true)
+      val packageRes =
+        os.proc(TestUtil.cli, "--power", "package", "--native", ".", "-o", "hello", extraOptions)
+          .call(cwd = root, mergeErrIntoOut = true)
       val packageOutput    = packageRes.out.trim()
       val topPackageOutput = packageOutput.linesIterator.takeWhile(!_.startsWith("Wrote ")).toVector
       // no compilation or Scala Native pipeline output, as this should just re-use what the run command wrote

--- a/modules/integration/src/test/scala/scala/cli/integration/SbtTestHelper.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SbtTestHelper.scala
@@ -1,0 +1,25 @@
+package scala.cli.integration
+
+trait SbtTestHelper {
+  protected lazy val sbtLaunchJar: os.Path = {
+    val res =
+      os.proc(TestUtil.cs, "fetch", "--intransitive", "org.scala-sbt:sbt-launch:1.5.5").call()
+    val rawPath = res.out.trim()
+    val path    = os.Path(rawPath, os.pwd)
+    if (os.isFile(path)) path
+    else sys.error(s"Something went wrong (invalid sbt launch JAR path '$rawPath')")
+  }
+
+  protected lazy val sbt: os.Shellable =
+    Seq[os.Shellable](
+      "java",
+      "-Xmx512m",
+      "-Xms128m",
+      "-Djline.terminal=jline.UnsupportedTerminal",
+      "-Dsbt.log.noformat=true",
+      "-jar",
+      sbtLaunchJar
+    )
+
+  protected def sbtCommand(args: String*): os.proc = os.proc(sbt, args)
+}

--- a/modules/options/src/main/scala/scala/build/info/BuildInfo.scala
+++ b/modules/options/src/main/scala/scala/build/info/BuildInfo.scala
@@ -128,6 +128,7 @@ object BuildInfo {
   private def scalaVersionSettings(options: BuildOptions): BuildInfo = {
     val sv = options.scalaParams.toOption.flatten
       .map(_.scalaVersion)
+      .orElse(options.scalaOptions.defaultScalaVersion)
       .getOrElse(Constants.defaultScalaVersion)
 
     BuildInfo(scalaVersion = Some(sv))

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -245,10 +245,6 @@ final case class BuildOptions(
   def javaHomeLocation(): Positioned[os.Path] =
     javaOptions.javaHomeLocation(archiveCache, finalCache, internal.verbosityOrDefault)
 
-  // used when downloading fails
-  private def defaultStableScalaVersions =
-    Seq(defaultScala212Version, defaultScala213Version, defaultScalaVersion)
-
   def javaHome(): Positioned[JavaHomeInfo] = javaCommand0
 
   lazy val javaHomeManager =
@@ -315,7 +311,8 @@ final case class BuildOptions(
     val defaultVersions = Set(
       Constants.defaultScalaVersion,
       Constants.defaultScala212Version,
-      Constants.defaultScala213Version
+      Constants.defaultScala213Version,
+      scalaOptions.defaultScalaVersion.getOrElse(Constants.defaultScalaVersion)
     )
 
     val svOpt: Option[String] = scalaOptions.scalaVersion match {
@@ -379,7 +376,7 @@ final case class BuildOptions(
         }
         Some(sv)
 
-      case None => Some(Constants.defaultScalaVersion)
+      case None => Some(scalaOptions.defaultScalaVersion.getOrElse(Constants.defaultScalaVersion))
     }
 
     svOpt match {

--- a/modules/options/src/main/scala/scala/build/options/ScalaOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaOptions.scala
@@ -14,7 +14,8 @@ final case class ScalaOptions(
   extraScalaVersions: Set[String] = Set.empty,
   compilerPlugins: Seq[Positioned[AnyDependency]] = Nil,
   platform: Option[Positioned[Platform]] = None,
-  extraPlatforms: Map[Platform, Positioned[Unit]] = Map.empty
+  extraPlatforms: Map[Platform, Positioned[Unit]] = Map.empty,
+  defaultScalaVersion: Option[String] = None
 ) {
   def normalize: ScalaOptions = {
     var opt = this


### PR DESCRIPTION
Relevant to #2838 

This PR adds 2 new launcher options: `--cli-default-scala-version` & `--cli-predefined-repository`

`--cli-default-scala-version` allows to override the default Scala version (which can then be overridden with `-S`):
```bash
scala-cli --cli-default-scala-version 3.4.2-RC1 version --offline
# Scala CLI version: 1.2.3-SNAPSHOT
# Scala version (default): 3.4.2-RC1
scala-cli --cli-default-scala-version 3.4.2-RC1 run -e 'println(dotty.tools.dotc.config.Properties.simpleVersionString)' --with-compiler
# Compiling project (Scala 3.4.2-RC1, JVM (17))
# Compiled project (Scala 3.4.2-RC1, JVM (17))
# 3.4.2-RC1
scala-cli --cli-default-scala-version 3.4.2-RC1 run -e 'println(dotty.tools.dotc.config.Properties.simpleVersionString)' --with-compiler -S lts
# Compiling project (Scala 3.3.3, JVM (17))
# Compiled project (Scala 3.3.3, JVM (17))
# 3.3.3
```

`--cli-predefined-repository` is an equivalent to the existing `--repo` option for building sub-commands, but can be passed as a launcher option. This i.e. allows to pass a local repository containing compiler artifacts.

```bash
cs fetch --cache local-repo org.scala-lang:scala3-compiler_3:3.4.2-RC1
# local-repo/https/repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.4.1-RC1/scala3-compiler_3-3.4.1-RC1.jar
# local-repo/https/repo1.maven.org/maven2/org/scala-lang/scala3-interfaces/3.4.1-RC1/scala3-interfaces-3.4.1-RC1.jar
# local-repo/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.4.1-RC1/scala3-library_3-3.4.1-RC1.jar
# local-repo/https/repo1.maven.org/maven2/org/scala-lang/tasty-core_3/3.4.1-RC1/tasty-core_3-3.4.1-RC1.jar
# local-repo/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-asm/9.6.0-scala-1/scala-asm-9.6.0-scala-1.jar
# local-repo/https/repo1.maven.org/maven2/org/scala-sbt/compiler-interface/1.9.6/compiler-interface-1.9.6.jar
# local-repo/https/repo1.maven.org/maven2/org/jline/jline-reader/3.19.0/jline-reader-3.19.0.jar
# local-repo/https/repo1.maven.org/maven2/org/jline/jline-terminal/3.19.0/jline-terminal-3.19.0.jar
# local-repo/https/repo1.maven.org/maven2/org/jline/jline-terminal-jna/3.19.0/jline-terminal-jna-3.19.0.jar
# local-repo/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.12/scala-library-2.13.12.jar
# local-repo/https/repo1.maven.org/maven2/org/scala-sbt/util-interface/1.9.8/util-interface-1.9.8.jar
# local-repo/https/repo1.maven.org/maven2/net/java/dev/jna/jna/5.3.1/jna-5.3.1.jar
scala-cli --cli-default-scala-version 3.4.2-RC1 --cli-predefined-repository file:///Users/pchabelski/IdeaProjects/scala-cli-tests/demo/local-repo/https/repo1.maven.org/maven2 run simple.sc --with-compiler --offline --power
# 3.4.2-RC1
```