### PR TITLE
Explicitly pass `scala3-sbt-bridge` to Bloop

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -906,7 +906,8 @@ object Build {
           scalaVersion = params.scalaVersion,
           scalaBinaryVersion = params.scalaBinaryVersion,
           scalacOptions = scalacOptions.toSeq.map(_.value),
-          compilerClassPath = scalaArtifacts.compilerClassPath
+          compilerClassPath = scalaArtifacts.compilerClassPath,
+          bridgeJarsOpt = scalaArtifacts.bridgeJarsOpt
         )
         Some(compilerParams)
 

--- a/modules/build/src/main/scala/scala/build/Project.scala
+++ b/modules/build/src/main/scala/scala/build/Project.scala
@@ -48,7 +48,8 @@ final case class Project(
     val scalaConfigOpt = scalaCompiler.map { scalaCompiler0 =>
       bloopScalaConfig("org.scala-lang", "scala-compiler", scalaCompiler0.scalaVersion).copy(
         options = updateScalacOptions(scalaCompiler0.scalacOptions).map(_.value),
-        jars = scalaCompiler0.compilerClassPath.map(_.toNIO).toList
+        jars = scalaCompiler0.compilerClassPath.map(_.toNIO).toList,
+        bridgeJars = scalaCompiler0.bridgeJarsOpt.map(_.map(_.toNIO).toList)
       )
     }
     baseBloopProject(
@@ -229,6 +230,7 @@ object Project {
       options = Nil,
       jars = Nil,
       analysis = None,
-      setup = None
+      setup = None,
+      bridgeJars = None
     )
 }

--- a/modules/build/src/main/scala/scala/build/ScalaCompilerParams.scala
+++ b/modules/build/src/main/scala/scala/build/ScalaCompilerParams.scala
@@ -4,5 +4,6 @@ final case class ScalaCompilerParams(
   scalaVersion: String,
   scalaBinaryVersion: String,
   scalacOptions: Seq[String],
-  compilerClassPath: Seq[os.Path]
+  compilerClassPath: Seq[os.Path],
+  bridgeJarsOpt: Option[Seq[os.Path]]
 )

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -438,7 +438,8 @@ final case class SharedOptions(
         python = sharedPython.python,
         pythonSetup = sharedPython.pythonSetup,
         scalaPyVersion = sharedPython.scalaPyVersion
-      )
+      ),
+      useBuildServer = compilationServer.server
     )
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -608,7 +608,7 @@ class SipScalaTests extends ScalaCliSuite with SbtTestHelper with MillTestHelper
           val localRepoPath = root / "local-repo"
           val sv            = "3.4.1-RC1"
           val artifactNames =
-            Seq("scala3-compiler_3", "scala3-sbt-bridge")
+            Seq("scala3-compiler_3") ++ (if (withBloop) Seq("scala3-sbt-bridge") else Nil)
           for { artifactName <- artifactNames } {
             val csRes = os.proc(
               TestUtil.cs,

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -607,15 +607,19 @@ class SipScalaTests extends ScalaCliSuite with SbtTestHelper with MillTestHelper
         .fromRoot { root =>
           val localRepoPath = root / "local-repo"
           val sv            = "3.4.1-RC1"
-          val csRes = os.proc(
-            TestUtil.cs,
-            "fetch",
-            "--cache",
-            localRepoPath,
-            s"org.scala-lang:scala3-compiler_3:$sv"
-          )
-            .call(cwd = root)
-          expect(csRes.exitCode == 0)
+          val artifactNames =
+            Seq("scala3-compiler_3", "scala3-sbt-bridge")
+          for { artifactName <- artifactNames } {
+            val csRes = os.proc(
+              TestUtil.cs,
+              "fetch",
+              "--cache",
+              localRepoPath,
+              s"org.scala-lang:$artifactName:$sv"
+            )
+              .call(cwd = root)
+            expect(csRes.exitCode == 0)
+          }
           val buildServerOptions =
             if (withBloop) Nil else Seq("--server=false")
           val r = os.proc(

--- a/modules/options/src/main/scala/scala/build/Artifacts.scala
+++ b/modules/options/src/main/scala/scala/build/Artifacts.scala
@@ -104,6 +104,7 @@ object Artifacts {
     addJmhDependencies: Option[String],
     extraRepositories: Seq[Repository],
     keepResolution: Boolean,
+    includeBuildServerDeps: Boolean,
     cache: FileCache[Task],
     logger: Logger,
     maybeRecoverOnError: BuildException => Option[BuildException]
@@ -176,7 +177,9 @@ object Artifacts {
           ).left.flatMap(_.maybeRecoverWithDefault(Seq.empty, maybeRecoverOnError))
         }
 
-        val bridgeJarsOpt = Option.when(scalaArtifactsParams.params.scalaVersion.startsWith("3.")) {
+        val bridgeJarsOpt = Option.when(
+          scalaArtifactsParams.params.scalaVersion.startsWith("3.") && includeBuildServerDeps
+        ) {
           Seq(dep"org.scala-lang:scala3-sbt-bridge:${scalaArtifactsParams.params.scalaVersion}")
         }.map { bridgeDependencies =>
           value {

--- a/modules/options/src/main/scala/scala/build/ScalaArtifacts.scala
+++ b/modules/options/src/main/scala/scala/build/ScalaArtifacts.scala
@@ -10,7 +10,8 @@ final case class ScalaArtifacts(
   scalaNativeCli: Seq[os.Path],
   internalDependencies: Seq[AnyDependency],
   extraDependencies: Seq[AnyDependency],
-  params: ScalaParameters
+  params: ScalaParameters,
+  bridgeJarsOpt: Option[Seq[os.Path]]
 ) {
 
   lazy val compilerClassPath: Seq[os.Path] =

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -44,7 +44,8 @@ final case class BuildOptions(
   mainClass: Option[String] = None,
   testOptions: TestOptions = TestOptions(),
   notForBloopOptions: PostBuildOptions = PostBuildOptions(),
-  sourceGeneratorOptions: SourceGeneratorOptions = SourceGeneratorOptions()
+  sourceGeneratorOptions: SourceGeneratorOptions = SourceGeneratorOptions(),
+  useBuildServer: Option[Boolean] = None
 ) {
 
   import BuildOptions.JavaHomeInfo
@@ -457,6 +458,7 @@ final case class BuildOptions(
       addJmhDependencies = jmhOptions.addJmhDependencies,
       extraRepositories = value(finalRepositories),
       keepResolution = internal.keepResolution,
+      includeBuildServerDeps = useBuildServer.getOrElse(false),
       cache = finalCache,
       logger = logger,
       maybeRecoverOnError = maybeRecoverOnError

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -115,7 +115,7 @@ object Deps {
   def ammonite = ivy"com.lihaoyi:::ammonite:3.0.0-M1-10-105f9e32"
   def asm      = ivy"org.ow2.asm:asm:9.7"
   // Force using of 2.13 - is there a better way?
-  def bloopConfig = ivy"ch.epfl.scala:bloop-config_2.13:1.5.5"
+  def bloopConfig = ivy"ch.epfl.scala:bloop-config_2.13:2.0.0"
     .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-core_2.13"))
   def bloopRifle       = ivy"io.github.alexarchambault.bleep:bloop-rifle_2.13:${Versions.bloop}"
   def bsp4j            = ivy"ch.epfl.scala:bsp4j:2.1.1"

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -107,7 +107,7 @@ object Deps {
     def signingCli                        = "0.2.3"
     def signingCliJvmVersion              = 17
     def javaClassName                     = "0.1.3"
-    def bloop                             = "1.5.16-sc-2"
+    def bloop                             = "1.5.17-sc-1"
   }
   // DO NOT hardcode a Scala version in this dependency string
   // This dependency is used to ensure that Ammonite is available for Scala versions


### PR DESCRIPTION
Fixes #2802

This is a re-implementation of #1889 by @alexarchambault, to give credit where it's due. 
The old PR never got finished.

Dependency bumps done as part of the implementation:
- `bloop-core` 1.5.17-sc-1: https://github.com/scala-cli/bloop-core/releases/tag/v1.5.17-sc-1
- `bloop-config` 2.0.0: https://github.com/scalacenter/bloop-config/releases/tag/v2.0.0