### PR TITLE
Include `scala3-staging` and `scala3-tasty-inspector` artifacts when the `--with-compiler` option is passed in Scala 3

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -692,6 +692,21 @@ class SipScalaTests extends ScalaCliSuite with SbtTestHelper with MillTestHelper
     }
   }
 
+  test("--with-compiler option includes scala3-staging & scala3-tasty-inspector artifacts") {
+    TestInputs(os.rel / "example.sc" ->
+      """import scala.quoted.staging.Compiler
+        |import scala.tasty.inspector.TastyInspector
+        |""".stripMargin).fromRoot { root =>
+      val res = os.proc(
+        TestUtil.cli,
+        "compile",
+        "example.sc",
+        "--with-compiler"
+      ).call(cwd = root)
+      expect(res.exitCode == 0)
+    }
+  }
+
   test(s"default Scala version override launcher option is respected by the json export") {
     val input = "printVersion.sc"
     val code  = """println(s"Default version: ${scala.util.Properties.versionNumberString}")"""

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -608,7 +608,8 @@ class SipScalaTests extends ScalaCliSuite with SbtTestHelper with MillTestHelper
           val localRepoPath = root / "local-repo"
           val sv            = "3.4.1-RC1"
           val artifactNames =
-            Seq("scala3-compiler_3") ++ (if (withBloop) Seq("scala3-sbt-bridge") else Nil)
+            Seq("scala3-compiler_3", "scala3-staging_3", "scala3-tasty-inspector_3") ++
+              (if (withBloop) Seq("scala3-sbt-bridge") else Nil)
           for { artifactName <- artifactNames } {
             val csRes = os.proc(
               TestUtil.cs,


### PR DESCRIPTION
Fixes #2879 

cc @bishabosha 