### PR TITLE
Allow to override prog name with a launcher arg

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -27,8 +27,9 @@ object ScalaCli {
     // the Scala CLI native image, no need to manually load it.
     coursier.jniutils.LoadWindowsLibrary.assumeInitialized()
 
-  val progName = {
-    val argv0 = (new Argv0).get("scala-cli")
+  private val defaultProgName = "scala-cli"
+  var progName: String = {
+    val argv0 = (new Argv0).get(defaultProgName)
     val last  = Paths.get(argv0).getFileName.toString
     last match {
       case s".${name}.aux" =>
@@ -243,6 +244,9 @@ object ScalaCli {
                 && sys.props.get("scala-cli.kind").exists(_.startsWith("jvm")) =>
             JavaLauncherCli.runAndExit(args)
           case None =>
+            launcherOpts.progName.foreach { pn =>
+              progName = pn
+            }
             if launcherOpts.cliUserScalaVersion.nonEmpty then
               defaultScalaVersion = launcherOpts.cliUserScalaVersion
             if launcherOpts.cliPredefinedRepository.nonEmpty then

--- a/modules/cli/src/main/scala/scala/cli/launcher/LauncherOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/launcher/LauncherOptions.scala
@@ -37,6 +37,11 @@ final case class LauncherOptions(
   @Name("repository")
   @Name("predefinedRepository")
   cliPredefinedRepository: List[String] = Nil,
+  @Group(HelpGroup.Launcher.toString)
+  @HelpMessage("This allows to override the program name identified by Scala CLI as itself (the default is 'scala-cli')")
+  @Hidden
+  @Tag(tags.implementation)
+  progName: Option[String] = None,
   @Recurse
   powerOptions: PowerOptions = PowerOptions()
 )

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -666,6 +666,18 @@ class SipScalaTests extends ScalaCliSuite with SbtTestHelper with MillTestHelper
     }
   }
 
+  test("prog name override launcher arg allows to change the identified launcher name") {
+    TestInputs.empty.fromRoot { root =>
+      val progName              = "some-weird-launcher-name-some-dev-thought-of"
+      val invalidSubCommandName = "foo"
+      val res = os.proc(TestUtil.cli, "--prog-name", progName, invalidSubCommandName)
+        .call(cwd = root, stderr = os.Pipe, check = false)
+      expect(res.exitCode == 1)
+      expect(res.err.trim().contains(progName))
+      expect(res.err.trim().contains(invalidSubCommandName))
+    }
+  }
+
   test(s"default Scala version override launcher option is respected by the Mill export") {
     val input     = "printVersion.sc"
     val code      = """println(s"Default version: ${scala.util.Properties.versionNumberString}")"""


### PR DESCRIPTION
allows to work around the issue described in https://github.com/VirtusLab/scala-cli/issues/2838#issuecomment-2085130815

cc @bishabosha @tgodzik 