### PR TITLE
Fix support of multiline shebang

### DIFF
--- a/modules/build/src/main/scala/scala/build/preprocessing/SheBang.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/SheBang.scala
@@ -3,7 +3,7 @@ package scala.build.preprocessing
 import scala.util.matching.Regex
 
 object SheBang {
-  private val sheBangRegex: Regex = s"""(^(#!.*(\\r\\n?|\\n)?)+(\\s*!#.*)?)""".r
+  private val sheBangRegex: Regex = s"""(^(#!.*(\\X)?)+(\\X*!#.*)?)""".r
 
   def isShebangScript(content: String): Boolean = sheBangRegex.unanchored.matches(content)
 

--- a/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
@@ -318,6 +318,13 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
       os.rel / "something5.scala" ->
         """#!/usr/bin/scala-cli
           |
+          |println("Hello World #!")""".stripMargin,
+      os.rel / "multiline.scala" ->
+        """#!/usr/bin/scala-cli
+          |# comment
+          |VAL=1
+          |!#
+          |
           |println("Hello World #!")""".stripMargin
     )
     val expectedParsedCodes = Seq(
@@ -335,6 +342,12 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
         |
         |println("Hello World")""".stripMargin,
       """
+        |
+        |println("Hello World #!")""".stripMargin,
+      """
+        |
+        |
+        |
         |
         |println("Hello World #!")""".stripMargin
     )


### PR DESCRIPTION
I expanded a regular expression to support multiline shebang (#2901) and included the appropriate test case. Please see the short demo:



![anim-opt](https://github.com/VirtusLab/scala-cli/assets/22551739/5693fc47-c16c-4b77-adb1-de7e715d0244)
