### PR TITLE
Fix instant-startup-scala-scripts.md overeager `docs-tests`

### DIFF
--- a/website/docs/cookbooks/introduction/instant-startup-scala-scripts.md
+++ b/website/docs/cookbooks/introduction/instant-startup-scala-scripts.md
@@ -55,7 +55,6 @@ We can fix that by either running with a `—-native` option, or,
 in this case, by including an additional using directive:
 
 ```scala compile title=size-higher-than.scala
-//> using scala 3
 //> using dep com.lihaoyi::os-lib::0.10.0
 //> using platform scala-native
  
@@ -81,7 +80,6 @@ We can make the runtime itself even faster, using various Scala Native optimizat
 We pass these using a `-–native-mode` scala-cli option or, like previously, by adding a using directive:
 
 ```scala compile title=size-higher-than.scala
-//> using scala 3
 //> using dep com.lihaoyi::os-lib::0.10.0
 //> using platform scala-native
 //> using nativeMode release-full


### PR DESCRIPTION
This is just a cherry pick of https://github.com/VirtusLab/scala-cli/pull/2905/commits/cac52771b71c87c35c84427cba8c5531fa17f855 to the `stable` branch, so that the CI stops acting up.