### PR TITLE
corrected instructions for downloading the launcher in Windows (fixes #2921)

### DIFF
--- a/website/docs/_advanced_install.mdx
+++ b/website/docs/_advanced_install.mdx
@@ -181,7 +181,7 @@ to be installed. See below for how to install it.
 Download the launcher from GitHub release assets with
 ```bash
 curl -fLo scala-cli.zip https://github.com/Virtuslab/scala-cli/releases/latest/download/scala-cli-x86_64-pc-win32.zip
-tar -xf scala-cli.zip
+jar -xf scala-cli.zip
 ```
 
 Check that it runs fine by running its `version` command:


### PR DESCRIPTION
Corrected website instructions for manually downloading Windows version of the launcher.

See #2921