### PR TITLE
Incremental Scala.js Linking

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/Runner.scala
+++ b/modules/build/src/main/scala/scala/build/internal/Runner.scala
@@ -30,14 +30,16 @@ object Runner {
       logger,
       allowExecve = true,
       cwd,
-      extraEnv
+      extraEnv,
+      inheritStreams = true
     )
 
   def run(
     command: Seq[String],
     logger: Logger,
     cwd: Option[os.Path] = None,
-    extraEnv: Map[String, String] = Map.empty
+    extraEnv: Map[String, String] = Map.empty,
+    inheritStreams: Boolean = true
   ): Process =
     run0(
       "unused",
@@ -45,7 +47,8 @@ object Runner {
       logger,
       allowExecve = false,
       cwd,
-      extraEnv
+      extraEnv,
+      inheritStreams
     )
 
   def run0(
@@ -54,7 +57,8 @@ object Runner {
     logger: Logger,
     allowExecve: Boolean,
     cwd: Option[os.Path],
-    extraEnv: Map[String, String]
+    extraEnv: Map[String, String],
+    inheritStreams: Boolean
   ): Process = {
 
     import logger.{log, debug}
@@ -81,6 +85,12 @@ object Runner {
     else {
       val b = new ProcessBuilder(command: _*)
         .inheritIO()
+
+      if (!inheritStreams) {
+        b.redirectInput(ProcessBuilder.Redirect.PIPE)
+        b.redirectOutput(ProcessBuilder.Redirect.PIPE)
+      }
+
       if (extraEnv.nonEmpty) {
         val env = b.environment()
         for ((k, v) <- extraEnv)

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalCommand.scala
@@ -62,7 +62,8 @@ abstract class PgpExternalCommand extends ExternalCommand {
       logger,
       allowExecve = allowExecve,
       cwd = None,
-      extraEnv = extraEnv
+      extraEnv = extraEnv,
+      inheritStreams = true
     ).waitFor()
   }
 

--- a/modules/cli/src/main/scala/scala/cli/internal/ScalaJsLinker.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/ScalaJsLinker.scala
@@ -171,7 +171,7 @@ object ScalaJsLinker {
     val useLongRunning = !input.fullOpt
 
     if (useLongRunning)
-      longRunningProcess.runOrGet(input, linkingDir, logger, cache, archiveCache)
+      longRunningProcess.startOrReuse(input, linkingDir, logger, cache, archiveCache)
     else {
       val cmd =
         value(getCommand(input, linkingDir, logger, cache, archiveCache, useLongRunning = false))
@@ -193,7 +193,7 @@ object ScalaJsLinker {
     var currentInput: Option[Input] = None
     var currentProc: Option[Proc]   = None
 
-    def runOrGet(
+    def startOrReuse(
       linkJsInput: LinkJSInput,
       linkingDir: os.Path,
       logger: Logger,

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -25,7 +25,8 @@ object Scala {
   val testRunnerScalaVersions = runnerScalaVersions ++ allScala3
 
   def scalaJs    = "1.16.0"
-  def scalaJsCli = scalaJs // this must be compatible with the Scala.js version
+  // TODO: Use released version
+  def scalaJsCli = "1.16.1-SNAPSHOT" // this must be compatible with the Scala.js version
 
   def listAll: Seq[String] = {
     def patchVer(sv: String): Int =

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -25,8 +25,7 @@ object Scala {
   val testRunnerScalaVersions = runnerScalaVersions ++ allScala3
 
   def scalaJs    = "1.16.0"
-  // TODO: Use released version
-  def scalaJsCli = "1.16.1-SNAPSHOT" // this must be compatible with the Scala.js version
+  def scalaJsCli = "1.16.0.1" // this must be compatible with the Scala.js version
 
   def listAll: Seq[String] = {
     def patchVer(sv: String): Int =


### PR DESCRIPTION
# Motivation

Scala.js has a powerful incremental linker which makes linking very fast for multiple links in a row.
The current way to linking, which spawns a new process every time scala-cli links, doesn't use its capability.

# Changes

This changes scala-cli to launch a `scala-js-cli` process with the newly added `--longRunning` mode.
Then it tries to reuse it, if input did not change, otherwise it kills the process and starts a new one.
`fullOpt` doesn't use the `--longRunning` mode since it doesn't need to be done incrementally and so we can maintain the incremental compilation cache.

# Dependencies

- [x] scala-js-cli release with https://github.com/VirtusLab/scala-js-cli/pull/64

# Comparison

## Before

https://github.com/VirtusLab/scala-cli/assets/5793054/39029bd7-4eac-4d2d-a721-8a1b20a57e04

## After

https://github.com/VirtusLab/scala-cli/assets/5793054/8de8746f-9b56-4848-9c85-157da7aff52c
