### PR TITLE
Bump `scala-js-cli` to v1.16.0.1

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -25,7 +25,7 @@ object Scala {
   val testRunnerScalaVersions = runnerScalaVersions ++ allScala3
 
   def scalaJs    = "1.16.0"
-  def scalaJsCli = scalaJs // this must be compatible with the Scala.js version
+  def scalaJsCli = "1.16.0.1" // this must be compatible with the Scala.js version
 
   def listAll: Seq[String] = {
     def patchVer(sv: String): Int =

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1326,7 +1326,7 @@ Path to the Scala.js linker
 ### `--js-cli-version`
 
 [Internal]
-Scala.js CLI version to use for linking (1.16.0 by default).
+Scala.js CLI version to use for linking (1.16.0.1 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -806,7 +806,7 @@ Path to the Scala.js linker
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Scala.js CLI version to use for linking (1.16.0 by default).
+Scala.js CLI version to use for linking (1.16.0.1 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -408,7 +408,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.16.0 by default).
+Scala.js CLI version to use for linking (1.16.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -1153,7 +1153,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.16.0 by default).
+Scala.js CLI version to use for linking (1.16.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -1724,7 +1724,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.16.0 by default).
+Scala.js CLI version to use for linking (1.16.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -2325,7 +2325,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.16.0 by default).
+Scala.js CLI version to use for linking (1.16.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -2935,7 +2935,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.16.0 by default).
+Scala.js CLI version to use for linking (1.16.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -3503,7 +3503,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.16.0 by default).
+Scala.js CLI version to use for linking (1.16.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -4146,7 +4146,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.16.0 by default).
+Scala.js CLI version to use for linking (1.16.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -4796,7 +4796,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.16.0 by default).
+Scala.js CLI version to use for linking (1.16.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -5701,7 +5701,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.16.0 by default).
+Scala.js CLI version to use for linking (1.16.0.1 by default).
 
 **--js-cli-java-arg**
 


### PR DESCRIPTION
includes https://github.com/VirtusLab/scala-js-cli/pull/64 & https://github.com/VirtusLab/scala-js-cli/pull/65
cc @keynmol @lolgab 