### PR TITLE
Fix BSP IllegalArgumentException when loading project in Metals

### DIFF
--- a/modules/cli/src/main/resources/META-INF/native-image/org.virtuslab/scala-cli-core/reflect-config.json
+++ b/modules/cli/src/main/resources/META-INF/native-image/org.virtuslab/scala-cli-core/reflect-config.json
@@ -174,6 +174,41 @@
     "allDeclaredFields": true
   },
   {
+    "name": "ch.epfl.scala.bsp4j.DependencyModule",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ch.epfl.scala.bsp4j.DependencyModulesDataKind",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ch.epfl.scala.bsp4j.DependencyModulesItem",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ch.epfl.scala.bsp4j.DependencyModulesParams",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ch.epfl.scala.bsp4j.DependencyModulesResult",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
     "name": "ch.epfl.scala.bsp4j.DependencySourcesItem",
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,


### PR DESCRIPTION
This fixes the following issue:
```
2024.06.02 23:08:36 INFO  BSP server: Jun 02, 2024 11:08:36 PM org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer fireError
2024.06.02 23:08:36 INFO  BSP server: SEVERE: Unable to create instance of class ch.epfl.scala.bsp4j.DependencyModulesParams. Registering an InstanceCreator or a TypeAdapter for this type, or adding a no-args constructor may fix this problem.
2024.06.02 23:08:36 INFO  BSP server: java.lang.RuntimeException: Unable to create instance of class ch.epfl.scala.bsp4j.DependencyModulesParams. Registering an InstanceCreator or a TypeAdapter for this type, or adding a no-args constructor may fix this problem.
2024.06.02 23:08:36 INFO  BSP server: 	at com.google.gson.internal.ConstructorConstructor$19.construct(ConstructorConstructor.java:373)
2024.06.02 23:08:36 INFO  BSP server: 	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$FieldReflectionAdapter.createAccumulator(ReflectiveTypeAdapterFactory.java:427)
2024.06.02 23:08:36 INFO  BSP server: 	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:383)
2024.06.02 23:08:36 INFO  BSP server: 	at com.google.gson.Gson.fromJson(Gson.java:1227)
2024.06.02 23:08:36 INFO  BSP server: 	at com.google.gson.Gson.fromJson(Gson.java:1186)
2024.06.02 23:08:36 INFO  BSP server: 	at org.eclipse.lsp4j.jsonrpc.json.adapters.MessageTypeAdapter.fromJson(MessageTypeAdapter.java:329)
2024.06.02 23:08:36 INFO  BSP server: 	at org.eclipse.lsp4j.jsonrpc.json.adapters.MessageTypeAdapter.parseParams(MessageTypeAdapter.java:249)
2024.06.02 23:08:36 INFO  BSP server: 	at org.eclipse.lsp4j.jsonrpc.json.adapters.MessageTypeAdapter.read(MessageTypeAdapter.java:119)
2024.06.02 23:08:36 INFO  BSP server: 	at org.eclipse.lsp4j.jsonrpc.json.adapters.MessageTypeAdapter.read(MessageTypeAdapter.java:55)
2024.06.02 23:08:36 INFO  BSP server: 	at com.google.gson.Gson.fromJson(Gson.java:1227)
2024.06.02 23:08:36 INFO  BSP server: 	at com.google.gson.Gson.fromJson(Gson.java:1186)
2024.06.02 23:08:36 INFO  BSP server: 	at org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler.parseMessage(MessageJsonHandler.java:119)
2024.06.02 23:08:36 INFO  BSP server: 	at org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler.parseMessage(MessageJsonHandler.java:114)
2024.06.02 23:08:36 INFO  BSP server: 	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:193)
2024.06.02 23:08:36 INFO  BSP server: 	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:94)
2024.06.02 23:08:36 INFO  BSP server: 	at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:113)
2024.06.02 23:08:36 INFO  BSP server: 	at java.base@17.0.6/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
2024.06.02 23:08:36 INFO  BSP server: 	at java.base@17.0.6/java.util.concurrent.FutureTask.run(FutureTask.java:264)
2024.06.02 23:08:36 INFO  BSP server: 	at java.base@17.0.6/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
2024.06.02 23:08:36 INFO  BSP server: 	at java.base@17.0.6/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
2024.06.02 23:08:36 INFO  BSP server: 	at java.base@17.0.6/java.lang.Thread.run(Thread.java:833)
2024.06.02 23:08:36 INFO  BSP server: 	at com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:775)
2024.06.02 23:08:36 INFO  BSP server: 	at com.oracle.svm.core.posix.thread.PosixPlatformThreads.pthreadStartRoutine(PosixPlatformThreads.java:203)
2024.06.02 23:08:36 INFO  BSP server: Caused by: java.lang.reflect.InvocationTargetException
2024.06.02 23:08:36 INFO  BSP server: 	at java.base@17.0.6/java.lang.reflect.Method.invoke(Method.java:568)
2024.06.02 23:08:36 INFO  BSP server: 	at com.google.gson.internal.UnsafeAllocator$1.newInstance(UnsafeAllocator.java:63)
2024.06.02 23:08:36 INFO  BSP server: 	at com.google.gson.internal.ConstructorConstructor$19.construct(ConstructorConstructor.java:370)
2024.06.02 23:08:36 INFO  BSP server: 	... 22 more
2024.06.02 23:08:36 INFO  BSP server: Caused by: java.lang.IllegalArgumentException: Type ch.epfl.scala.bsp4j.DependencyModulesParams is instantiated reflectively but was never registered. Register the type by adding "unsafeAllocated" for the type in reflect-config.json.
2024.06.02 23:08:36 INFO  BSP server: 	at com.oracle.svm.core.graal.snippets.SubstrateAllocationSnippets.instanceHubErrorStub(SubstrateAllocationSnippets.java:309)
2024.06.02 23:08:36 INFO  BSP server: 	at jdk.unsupported@17.0.6/sun.misc.Unsafe.allocateInstance(Unsafe.java:864)
2024.06.02 23:08:36 INFO  BSP server: 	... 25 more
```

Similar change on bleep: https://github.com/oyvindberg/bleep/pull/381/files