### PR TITLE
Update Scala Toolkit to 0.4.0 & dynamically adjust Scala Native defaults

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -406,7 +406,8 @@ trait Core extends ScalaCliCrossSbtModule
          |  def scalaJsVersion = "${Scala.scalaJs}"
          |  def scalaJsCliVersion = "${Scala.scalaJsCli}"
          |  def scalajsEnvJsdomNodejsVersion = "${Deps.scalaJsEnvJsdomNodejs.dep.version}"
-         |  def scalaNativeVersion = "${Deps.nativeTools.dep.version}"
+         |  def scalaNativeVersion04 = "${Deps.Versions.scalaNative04}"
+         |  def scalaNativeVersion = "${Deps.Versions.scalaNative}"
          |
          |  def testRunnerOrganization = "$testRunnerOrganization"
          |  def testRunnerModuleName = "${`test-runner`(Scala.runnerScala3).artifactName()}"
@@ -444,6 +445,8 @@ trait Core extends ScalaCliCrossSbtModule
          |  def toolkitTestName = "${Deps.toolkitTest.dep.module.name.value}"
          |  def toolkitDefaultVersion = "${Deps.toolkitVersion}"
          |  def toolkitMaxScalaNative = "${Deps.Versions.maxScalaNativeForToolkit}"
+         |  def toolkitVersionForNative04 = "${Deps.toolkitVersionForNative04}"
+         |  def toolkitVersionForNative05 = "${Deps.toolkitVersionForNative05}"
          |
          |  def typelevelOrganization = "${Deps.typelevelToolkit.dep.module.organization.value}"
          |  def typelevelToolkitDefaultVersion = "${Deps.typelevelToolkitVersion}"
@@ -982,7 +985,9 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
            |  def maxAmmoniteScala3Version   = "${Scala.maxAmmoniteScala3Version}"
            |  def scalaJsVersion             = "${Scala.scalaJs}"
            |  def scalaJsCliVersion          = "${Scala.scalaJsCli}"
-           |  def scalaNativeVersion         = "${Deps.nativeTools.dep.version}"
+           |  def scalaNativeVersion         = "${Deps.Versions.scalaNative}"
+           |  def scalaNativeVersion04       = "${Deps.Versions.scalaNative04}"
+           |  def scalaNativeVersion05       = "${Deps.Versions.scalaNative05}"
            |  def ammoniteVersion            = "${Deps.ammonite.dep.version}"
            |  def defaultGraalVMJavaVersion  = "${deps.graalVmJavaVersion}"
            |  def defaultGraalVMVersion      = "${deps.graalVmVersion}"
@@ -1004,6 +1009,8 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
            |  def dockerArchLinuxImage       = "${TestDeps.archLinuxImage}"
            |  
            |  def toolkitVersion                 = "${Deps.toolkitVersion}"
+           |  def toolkitVersionForNative04      = "${Deps.toolkitVersionForNative04}"
+           |  def toolkitVersionForNative05      = "${Deps.toolkitVersionForNative05}"
            |  def toolkiMaxScalaNative           = "${Deps.Versions.maxScalaNativeForToolkit}"
            |  def typelevelToolkitVersion        = "${Deps.typelevelToolkitVersion}"
            |  def typelevelToolkitMaxScalaNative = "${Deps.Versions.maxScalaNativeForTypelevelToolkit}"

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -99,7 +99,7 @@ object Deps {
     def scalaNative04                     = "0.4.17"
     def scalaNative05                     = "0.5.3"
     def scalaNative                       = scalaNative05
-    def maxScalaNativeForToolkit          = scalaNative04
+    def maxScalaNativeForToolkit          = scalaNative05
     def maxScalaNativeForTypelevelToolkit = scalaNative04
     def maxScalaNativeForScalaPy          = scalaNative04
     def maxScalaNativeForMillExport       = scalaNative04
@@ -200,18 +200,20 @@ object Deps {
       .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-macros_3"))
       .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-core_2.13"))
       .exclude(("org.scala-lang.modules", "scala-collection-compat_2.13"))
-  def slf4jNop                = ivy"org.slf4j:slf4j-nop:2.0.13"
-  def sttp                    = ivy"com.softwaremill.sttp.client3:core_2.13:3.9.7"
-  def svm                     = ivy"org.graalvm.nativeimage:svm:$graalVmVersion"
-  def swoval                  = ivy"com.swoval:file-tree-views:2.1.12"
-  def testInterface           = ivy"org.scala-sbt:test-interface:1.0"
-  val toolkitVersion          = "0.2.1"
-  def toolkit                 = ivy"org.scala-lang:toolkit:$toolkitVersion"
-  def toolkitTest             = ivy"org.scala-lang:toolkit-test:$toolkitVersion"
-  val typelevelToolkitVersion = "0.1.23"
-  def typelevelToolkit        = ivy"org.typelevel:toolkit:$typelevelToolkitVersion"
-  def typelevelToolkitTest    = ivy"org.typelevel:toolkit-test:$typelevelToolkitVersion"
-  def usingDirectives         = ivy"org.virtuslab:using_directives:1.1.1"
+  def slf4jNop                  = ivy"org.slf4j:slf4j-nop:2.0.13"
+  def sttp                      = ivy"com.softwaremill.sttp.client3:core_2.13:3.9.7"
+  def svm                       = ivy"org.graalvm.nativeimage:svm:$graalVmVersion"
+  def swoval                    = ivy"com.swoval:file-tree-views:2.1.12"
+  def testInterface             = ivy"org.scala-sbt:test-interface:1.0"
+  val toolkitVersion            = "0.4.0"
+  val toolkitVersionForNative04 = "0.3.0"
+  val toolkitVersionForNative05 = toolkitVersion
+  def toolkit                   = ivy"org.scala-lang:toolkit:$toolkitVersion"
+  def toolkitTest               = ivy"org.scala-lang:toolkit-test:$toolkitVersion"
+  val typelevelToolkitVersion   = "0.1.23"
+  def typelevelToolkit          = ivy"org.typelevel:toolkit:$typelevelToolkitVersion"
+  def typelevelToolkitTest      = ivy"org.typelevel:toolkit-test:$typelevelToolkitVersion"
+  def usingDirectives           = ivy"org.virtuslab:using_directives:1.1.1"
   // Lives at https://github.com/VirtusLab/no-crc32-zip-input-stream, see #865
   // This provides a ZipInputStream that doesn't verify CRC32 checksums, that users
   // can enable by setting SCALA_CLI_VENDORED_ZIS=true in the environment, to workaround

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1553,7 +1553,7 @@ Copy compilation results to output directory using either relative or absolute p
 
 Aliases: `--toolkit`
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.2.1, 'default' version for typelevel toolkit: 0.1.23
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.4.0, 'default' version for typelevel toolkit: 0.1.23
 
 ### `--exclude`
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -414,7 +414,7 @@ Set the test framework
 
 ### Toolkit
 
-Use a toolkit as dependency (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.2.1, 'default' version for typelevel toolkit: 0.1.23
+Use a toolkit as dependency (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.4.0, 'default' version for typelevel toolkit: 0.1.23
 
 `//> using toolkit` _version_
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -1050,7 +1050,7 @@ Aliases: `--toolkit`
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.2.1, 'default' version for typelevel toolkit: 0.1.23
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.4.0, 'default' version for typelevel toolkit: 0.1.23
 
 ### `--exclude`
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -300,7 +300,7 @@ Set the test framework
 
 ### Toolkit
 
-Use a toolkit as dependency (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.2.1, 'default' version for typelevel toolkit: 0.1.23
+Use a toolkit as dependency (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.4.0, 'default' version for typelevel toolkit: 0.1.23
 
 `//> using toolkit` _version_
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -608,7 +608,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.2.1, 'default' version for typelevel toolkit: 0.1.23
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.4.0, 'default' version for typelevel toolkit: 0.1.23
 
 Aliases: `--toolkit`
 
@@ -1353,7 +1353,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.2.1, 'default' version for typelevel toolkit: 0.1.23
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.4.0, 'default' version for typelevel toolkit: 0.1.23
 
 Aliases: `--toolkit`
 
@@ -1924,7 +1924,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.2.1, 'default' version for typelevel toolkit: 0.1.23
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.4.0, 'default' version for typelevel toolkit: 0.1.23
 
 Aliases: `--toolkit`
 
@@ -2525,7 +2525,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.2.1, 'default' version for typelevel toolkit: 0.1.23
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.4.0, 'default' version for typelevel toolkit: 0.1.23
 
 Aliases: `--toolkit`
 
@@ -3135,7 +3135,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.2.1, 'default' version for typelevel toolkit: 0.1.23
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.4.0, 'default' version for typelevel toolkit: 0.1.23
 
 Aliases: `--toolkit`
 
@@ -3703,7 +3703,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.2.1, 'default' version for typelevel toolkit: 0.1.23
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.4.0, 'default' version for typelevel toolkit: 0.1.23
 
 Aliases: `--toolkit`
 
@@ -4346,7 +4346,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.2.1, 'default' version for typelevel toolkit: 0.1.23
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.4.0, 'default' version for typelevel toolkit: 0.1.23
 
 Aliases: `--toolkit`
 
@@ -4996,7 +4996,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.2.1, 'default' version for typelevel toolkit: 0.1.23
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.4.0, 'default' version for typelevel toolkit: 0.1.23
 
 Aliases: `--toolkit`
 
@@ -5911,7 +5911,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.2.1, 'default' version for typelevel toolkit: 0.1.23
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.4.0, 'default' version for typelevel toolkit: 0.1.23
 
 Aliases: `--toolkit`
 


### PR DESCRIPTION
This PR does the following:
- bumps the default Scala Toolkit to 0.4.0
- lifts the Scala Native downgrade to 0.4.17 when default Scala toolkit is used (since toolkit 0.4.0 supports Scala Native 0.5.x)
- still downgrades Scla Native to 0.4.17 when default native version is used and the user explicitly uses Toolkit 0.3.0 or older
```bash
scala-cli -e 'println(os.pwd)' --toolkit 0.3.0 --native                          
# [warn] Scala Toolkit Version(0.3.0) does not support Scala Native 0.5.3, 0.4.17 should be used instead.
# [warn] Scala Native default version 0.5.3 is not supported in this build. Using 0.4.17 instead.
# Compiling project (Scala 3.4.2, Scala Native 0.4.17)
# Compiled project (Scala 3.4.2, Scala Native 0.4.17)
# [info] Linking (900 ms)
# [info] Checking intermediate code (quick) (63 ms)
# [info] Discovered 888 classes and 5298 methods
# [info] Optimizing (debug mode) (836 ms)
# [info] Generating intermediate code (620 ms)
# [info] Produced 10 files
# [info] Compiling to native code (1860 ms)
# [info] Linking with [pthread, dl]
# [info] Total (4406 ms)
/~/scala-cli-tests
```

It, however, does not:
- downgrade toolkit to 0.3.0 when built with Scala Native 0.4.x
```bash
scala-cli -e 'println(os.pwd)' --toolkit default --native --native-version 0.4.17
# Downloading 4 dependencies and 2 internal dependencies
# [error]  Error downloading org.scala-lang:toolkit-test_native0.4_3:0.4.0
# [error]   not found: /Users/pchabelski/.ivy2/local/org.scala-lang/toolkit-test_native0.4_3/0.4.0/ivys/ivy.xml
# [error]   not found: https://repo1.maven.org/maven2/org/scala-lang/toolkit-test_native0.4_3/0.4.0/toolkit-test_native0.4_3-0.4.0.pom
# [error]   not found: /Users/pchabelski/Library/Caches/ScalaCli/local-repo/1.3.2-12-70e34f/org.scala-lang/toolkit-test_native0.4_3/0.4.0/ivys/ivy.xml
# [error]   No fallback URL found
# [error] COMMAND_LINE
# [error]  Error downloading org.scala-lang:toolkit_native0.4_3:0.4.0
# [error]   not found: /Users/pchabelski/.ivy2/local/org.scala-lang/toolkit_native0.4_3/0.4.0/ivys/ivy.xml
# [error]   not found: https://repo1.maven.org/maven2/org/scala-lang/toolkit_native0.4_3/0.4.0/toolkit_native0.4_3-0.4.0.pom
# [error]   not found: /Users/pchabelski/Library/Caches/ScalaCli/local-repo/1.3.2-12-70e34f/org.scala-lang/toolkit_native0.4_3/0.4.0/ivys/ivy.xml
# [error]   No fallback URL found
# [error] COMMAND_LINE
```

Downgrading the default toolkit version when Scala Native 0.4.x is explicitly passed should be addressed separately (if we even decide to fix it, as that'd require rewriting a big chunk of the toolkit integration).