### PR TITLE
Don't check for newer CLI versions when the `--cli-version` launcher param is passed (v1.4.0 and onwards, only)

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/version/Version.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/version/Version.scala
@@ -37,7 +37,8 @@ object Version extends ScalaCommand[VersionOptions] {
     else if options.scalaVersion then println(defaultScalaVersion)
     else {
       println(versionInfo)
-      if !options.offline then
+      val skipCliUpdates = ScalaCli.launcherOptions.scalaRunner.skipCliUpdates.getOrElse(false)
+      if !options.offline && !skipCliUpdates then
         maybeNewerScalaCliVersion.foreach { v =>
           logger.message(
             s"""Your $fullRunnerName version is outdated. The newest version is $v

--- a/modules/cli/src/main/scala/scala/cli/launcher/ScalaRunnerLauncherOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/launcher/ScalaRunnerLauncherOptions.scala
@@ -32,7 +32,14 @@ case class ScalaRunnerLauncherOptions(
   )
   @Hidden
   @Tag(tags.implementation)
-  progName: Option[String] = None
+  progName: Option[String] = None,
+  @Group(HelpGroup.Launcher.toString)
+  @HelpMessage(
+    "This allows to skip checking for newest Scala CLI versions. --offline covers this scenario as well."
+  )
+  @Hidden
+  @Tag(tags.implementation)
+  skipCliUpdates: Option[Boolean] = None
 ) {
   def toCliArgs: List[String] =
     cliUserScalaVersion.toList.flatMap(v => List("--cli-default-scala-version", v)) ++


### PR DESCRIPTION
Passing the `--skip-cli-updates` launcher arg will now skip checking if the launcher being run is the newest available.
```bash
scala-cli --skip-cli-updates version                    
# Scala CLI version: 1.3.3-SNAPSHOT
# Scala version (default): 3.4.2
```
The `--skip-cli-updates` launcher arg will also be passed implicitly alongside with the `--cli-version` override, but only for Scala CLI versions v.1.4.0 and onwards (we can't support this retroactively).