### PR TITLE
fix: start bloop with jvm version from using directives for JVMs > 17

### DIFF
--- a/modules/build/src/main/scala/scala/build/compiler/BloopCompilerMaker.scala
+++ b/modules/build/src/main/scala/scala/build/compiler/BloopCompilerMaker.scala
@@ -4,14 +4,15 @@ import bloop.rifle.{BloopRifleConfig, BloopServer, BloopThreads}
 import ch.epfl.scala.bsp4j.BuildClient
 
 import scala.build.Logger
-import scala.build.errors.{FetchingDependenciesError, Severity}
+import scala.build.errors.{BuildException, FetchingDependenciesError, Severity}
 import scala.build.internal.Constants
 import scala.build.internal.util.WarningMessages
+import scala.build.options.BuildOptions
 import scala.concurrent.duration.DurationInt
 import scala.util.Try
 
 final class BloopCompilerMaker(
-  config: BloopRifleConfig,
+  getConfig: BuildOptions => Either[BuildException, BloopRifleConfig],
   threads: BloopThreads,
   strictBloopJsonCheck: Boolean,
   offline: Boolean
@@ -20,37 +21,48 @@ final class BloopCompilerMaker(
     workspace: os.Path,
     classesDir: os.Path,
     buildClient: BuildClient,
-    logger: Logger
-  ): ScalaCompiler = {
-    val createBuildServer =
-      () =>
-        BloopServer.buildServer(
-          config,
-          "scala-cli",
-          Constants.version,
-          workspace.toNIO,
-          classesDir.toNIO,
+    logger: Logger,
+    buildOptions: BuildOptions
+  ): Either[BuildException, ScalaCompiler] =
+    getConfig(buildOptions) match
+      case Left(ex) if offline =>
+        logger.diagnostic(WarningMessages.offlineModeBloopJvmNotFound, Severity.Warning)
+        SimpleScalaCompilerMaker("java", Nil).create(
+          workspace,
+          classesDir,
           buildClient,
-          threads,
-          logger.bloopRifleLogger
+          logger,
+          buildOptions
         )
+      case Right(config) =>
+        val createBuildServer =
+          () =>
+            BloopServer.buildServer(
+              config,
+              "scala-cli",
+              Constants.version,
+              workspace.toNIO,
+              classesDir.toNIO,
+              buildClient,
+              threads,
+              logger.bloopRifleLogger
+            )
 
-    Try(new BloopCompiler(createBuildServer, 20.seconds, strictBloopJsonCheck))
-      .toEither
-      .left.flatMap {
-        case e if offline =>
-          e.getCause match
-            case _: FetchingDependenciesError =>
-              logger.diagnostic(
-                WarningMessages.offlineModeBloopNotFound,
-                Severity.Warning
-              )
-              Right(
-                SimpleScalaCompilerMaker("java", Nil)
-                  .create(workspace, classesDir, buildClient, logger)
-              )
-            case _ => Left(e)
-        case e => Left(e)
-      }.fold(t => throw t, identity)
-  }
+        val res = Try(new BloopCompiler(createBuildServer, 20.seconds, strictBloopJsonCheck))
+          .toEither
+          .left.flatMap {
+            case e if offline =>
+              e.getCause match
+                case _: FetchingDependenciesError =>
+                  logger.diagnostic(
+                    WarningMessages.offlineModeBloopNotFound,
+                    Severity.Warning
+                  )
+                  SimpleScalaCompilerMaker("java", Nil)
+                    .create(workspace, classesDir, buildClient, logger, buildOptions)
+                case _ => Left(e)
+            case e => Left(e)
+          }.fold(t => throw t, identity)
+        Right(res)
+      case Left(ex) => Left(ex)
 }

--- a/modules/build/src/main/scala/scala/build/compiler/SimpleScalaCompilerMaker.scala
+++ b/modules/build/src/main/scala/scala/build/compiler/SimpleScalaCompilerMaker.scala
@@ -3,6 +3,8 @@ package scala.build.compiler
 import ch.epfl.scala.bsp4j.BuildClient
 
 import scala.build.Logger
+import scala.build.errors.BuildException
+import scala.build.options.BuildOptions
 
 final case class SimpleScalaCompilerMaker(
   defaultJavaCommand: String,
@@ -13,7 +15,8 @@ final case class SimpleScalaCompilerMaker(
     workspace: os.Path,
     classesDir: os.Path,
     buildClient: BuildClient,
-    logger: Logger
-  ): SimpleScalaCompiler =
-    SimpleScalaCompiler(defaultJavaCommand, defaultJavaOptions, scaladoc)
+    logger: Logger,
+    buildOptions: BuildOptions
+  ): Either[BuildException, ScalaCompiler] =
+    Right(SimpleScalaCompiler(defaultJavaCommand, defaultJavaOptions, scaladoc))
 }

--- a/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestInputs.scala
@@ -87,7 +87,7 @@ final case class TestInputs(
       val compilerMaker = bloopConfigOpt match {
         case Some(bloopConfig) =>
           new BloopCompilerMaker(
-            bloopConfig,
+            _ => Right(bloopConfig),
             buildThreads.bloop,
             strictBloopJsonCheck = true,
             offline = false

--- a/modules/cli/src/main/scala/scala/cli/commands/compile/Compile.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/compile/Compile.scala
@@ -94,7 +94,7 @@ object Compile extends ScalaCommand[CompileOptions] with BuildCommandHelpers {
 
     val threads = BuildThreads.create()
 
-    val compilerMaker = options.shared.compilerMaker(threads).orExit(logger)
+    val compilerMaker = options.shared.compilerMaker(threads)
     val configDb      = ConfigDbUtils.configDb.orExit(logger)
     val actionableDiagnostics =
       options.shared.logging.verbosityOptions.actions.orElse(

--- a/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
@@ -38,7 +38,7 @@ object Doc extends ScalaCommand[DocOptions] {
     CurrentParams.workspaceOpt = Some(inputs.workspace)
     val threads = BuildThreads.create()
 
-    val maker               = options.shared.compilerMaker(threads).orExit(logger)
+    val maker               = options.shared.compilerMaker(threads)
     val compilerMaker       = ScalaCompilerMaker.IgnoreScala2(maker)
     val docCompilerMakerOpt = Some(SimpleScalaCompilerMaker("java", Nil, scaladoc = true))
 

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
@@ -250,7 +250,7 @@ final case class PackageOptions(
   }
 
   def compilerMaker(threads: BuildThreads): Either[BuildException, ScalaCompilerMaker] = either {
-    val maker = value(shared.compilerMaker(threads))
+    val maker = shared.compilerMaker(threads)
     if (forcedPackageTypeOpt.contains(PackageType.DocJar))
       ScalaCompilerMaker.IgnoreScala2(maker)
     else

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -230,8 +230,8 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
     ).orExit(logger)
     val threads = BuildThreads.create()
 
-    val compilerMaker    = options.shared.compilerMaker(threads).orExit(logger)
-    val docCompilerMaker = options.shared.compilerMaker(threads, scaladoc = true).orExit(logger)
+    val compilerMaker    = options.shared.compilerMaker(threads)
+    val docCompilerMaker = options.shared.compilerMaker(threads, scaladoc = true)
 
     val cross = options.compileCross.cross.getOrElse(false)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
@@ -51,8 +51,8 @@ object PublishLocal extends ScalaCommand[PublishLocalOptions] {
     ).orExit(logger)
     val threads = BuildThreads.create()
 
-    val compilerMaker    = options.shared.compilerMaker(threads).orExit(logger)
-    val docCompilerMaker = options.shared.compilerMaker(threads, scaladoc = true).orExit(logger)
+    val compilerMaker    = options.shared.compilerMaker(threads)
+    val docCompilerMaker = options.shared.compilerMaker(threads, scaladoc = true)
 
     val cross = options.compileCross.cross.getOrElse(false)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
@@ -113,7 +113,7 @@ object Repl extends ScalaCommand[ReplOptions] {
 
     val threads = BuildThreads.create()
     // compilerMaker should be a lazy val to prevent download a JAVA 17 for bloop when users run the repl without sources
-    lazy val compilerMaker = options.shared.compilerMaker(threads).orExit(logger)
+    lazy val compilerMaker = options.shared.compilerMaker(threads)
 
     val directories = Directories.directories
 

--- a/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
@@ -142,7 +142,7 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
     CurrentParams.workspaceOpt = Some(inputs.workspace)
     val threads = BuildThreads.create()
 
-    val compilerMaker = options.shared.compilerMaker(threads).orExit(logger)
+    val compilerMaker = options.shared.compilerMaker(threads)
 
     def maybeRun(
       build: Build.Successful,

--- a/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
@@ -72,7 +72,7 @@ object Test extends ScalaCommand[TestOptions] {
 
     val threads = BuildThreads.create()
 
-    val compilerMaker = options.shared.compilerMaker(threads).orExit(logger)
+    val compilerMaker = options.shared.compilerMaker(threads)
 
     val cross    = options.compileCross.cross.getOrElse(false)
     val configDb = ConfigDbUtils.configDb.orExit(logger)

--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -185,6 +185,8 @@ class BloopTests extends ScalaCliSuite {
     inputs.fromRoot { root =>
       val res = runScalaCli("Simple.java").call(cwd = root)
       res.out.text().contains(hello)
+      // shut down bloop so other tests are run on JDK 17
+      runScalaCli("bloop", "exit", "--power").call(cwd = root)
     }
   }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -183,6 +183,8 @@ class BloopTests extends ScalaCliSuite {
             |}""".stripMargin
     )
     inputs.fromRoot { root =>
+      // start bloop with jvm 17
+      runScalaCli("--power", "bloop", "start", "--jvm", "17").call(cwd = root)
       val res = runScalaCli("Simple.java").call(cwd = root)
       res.out.text().contains(hello)
       // shut down bloop so other tests are run on JDK 17

--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -168,4 +168,23 @@ class BloopTests extends ScalaCliSuite {
         }
       }
     }
+
+  test("run bloop with jvm version if > 17") {
+    val hello = "Hello from Java 21"
+    val inputs = TestInputs(
+      os.rel / "Simple.java" ->
+        s"""|//> using jvm 21
+            |//> using javacOpt --enable-preview -Xlint:preview
+            |//> using javaOpt --enable-preview
+            |//> using mainClass Simple
+            |
+            |void main() {
+            |    System.out.println("$hello");
+            |}""".stripMargin
+    )
+    inputs.fromRoot { root =>
+      val res = runScalaCli("Simple.java").call(cwd = root)
+      res.out.text().contains(hello)
+    }
+  }
 }


### PR DESCRIPTION
resolves: https://github.com/VirtusLab/scala-cli/issues/2969