### PR TITLE
fix for 2954 running script in root dir

### DIFF
--- a/modules/build/src/main/scala/scala/build/input/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/input/Inputs.scala
@@ -124,6 +124,7 @@ final case class Inputs(
     workspace / Constants.workspaceDirName / projectName / "jar"
   def docJarWorkDir: os.Path =
     workspace / Constants.workspaceDirName / projectName / "doc"
+
 }
 
 object Inputs {
@@ -152,7 +153,7 @@ object Inputs {
       updatedElems,
       defaultMainClassElemOpt,
       workspace,
-      workspace.baseName,
+      baseName(workspace),
       mayAppendHash = needsHash,
       workspaceOrigin = Some(workspaceOrigin),
       enableMarkdown = enableMarkdown,
@@ -384,7 +385,6 @@ object Inputs {
           }
         }.getOrElse((os.pwd, true, WorkspaceOrigin.Forced))
       }
-
       val (workspace, needsHash, workspaceOrigin0) = forcedWorkspace match {
         case None => (inferredWorkspace, inferredNeedsHash, workspaceOrigin)
         case Some(forcedWorkspace0) =>
@@ -466,7 +466,7 @@ object Inputs {
       elements = Nil,
       defaultMainClassElement = None,
       workspace = workspace,
-      baseProjectName = workspace.baseName,
+      baseProjectName = baseName(workspace),
       mayAppendHash = true,
       workspaceOrigin = None,
       enableMarkdown = enableMarkdown,
@@ -475,4 +475,7 @@ object Inputs {
 
   def empty(projectName: String): Inputs =
     Inputs(Nil, None, os.pwd, projectName, false, None, true, false)
+
+  def baseName(p: os.Path) = if (p == os.root) "" else p.baseName
+
 }

--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -117,7 +117,7 @@ object ScalaCli {
     try main0(args)
     catch {
       case e: Throwable if !isCI && !printStackTraces =>
-        val workspace = CurrentParams.workspaceOpt.getOrElse(os.pwd)
+        val workspace = logDir(CurrentParams.workspaceOpt.getOrElse(os.pwd))
         val dir       = workspace / Constants.workspaceDirName / "stacktraces"
         os.makeDir.all(dir)
         import java.time.Instant
@@ -290,4 +290,6 @@ object ScalaCli {
     new ScalaCliCommands(progName, baseRunnerName, fullRunnerName)
       .main(scalaCliArgs)
   }
+
+  def logDir(p: os.Path) = if (os.isDir(p)) p else os.pwd
 }

--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -117,7 +117,7 @@ object ScalaCli {
     try main0(args)
     catch {
       case e: Throwable if !isCI && !printStackTraces =>
-        val workspace = logDir(CurrentParams.workspaceOpt.getOrElse(os.pwd))
+        val workspace = CurrentParams.workspaceOpt.filter(os.isDir).getOrElse(os.pwd)
         val dir       = workspace / Constants.workspaceDirName / "stacktraces"
         os.makeDir.all(dir)
         import java.time.Instant
@@ -290,6 +290,4 @@ object ScalaCli {
     new ScalaCliCommands(progName, baseRunnerName, fullRunnerName)
       .main(scalaCliArgs)
   }
-
-  def logDir(p: os.Path) = if (os.isDir(p)) p else os.pwd
 }


### PR DESCRIPTION
Adds fix for running script from the root directory.
Fixes #2954.

The problem occurs as a side-effect of calling `workspace.baseName` from within [scala.build.input.Inputs.scala](https://github.com/VirtusLab/scala-cli/blob/main/modules/build/src/main/scala/scala/build/input/Inputs.scala)
which throws an exception if `workspace` equals `os.root`.

See the calls to `.baseName` near lines 155 and 469.

The fix is to set `baseName` to an empty String if `workspace` equals `os.root`.

A change was also made to [scala.cli.ScalaCli.scala](https://github.com/VirtusLab/scala-cli/blob/main/modules/cli/src/main/scala/scala/cli/ScalaCli.scala) to insure that the logfile directory exists.
