### PR TITLE
cli: report the full Java version

### DIFF
--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -58,11 +58,11 @@ final case class BuildOptions(
       case Some(scalaParams0) =>
         val platform0 = platform.value match {
           case Platform.JVM =>
-            val jvmIdSuffix =
+            val jvmVersion =
               javaOptions.jvmIdOpt.map(_.value)
-                .orElse(Some(javaHome().value.version.toString))
-                .map(" (" + _ + ")").getOrElse("")
-            s"JVM$jvmIdSuffix"
+                .orElse(Some(Properties.javaVersion))
+                .map("(" + _ + ")").getOrElse("")
+            s"JVM $jvmVersion"
           case Platform.JS =>
             val scalaJsVersion = scalaJsOptions.version.getOrElse(Constants.scalaJsVersion)
             s"Scala.js $scalaJsVersion"


### PR DESCRIPTION
Resolves: https://github.com/VirtusLab/scala-cli/issues/2975

When running scala-cli and no JVM options are passed as arguments to the command line, it uses the default configured Java to compile and run the script, and only prints outs the Java major number which is internally extracted by executing `java -version` and manipulating the output that relies on `scala.build.internal.OsLibc#javaVersion()` *

This new proposed approach uses [`scala.util.Properties#javaVersion()`](https://www.scala-lang.org/api/2.13.14/scala/util/Properties$.html#javaVersion:String) to obtain the full version

```scala
def javaVersion = propOrEmpty("java.version")
```

which is a convenient wrapper around [`java.lang.System#getProperty()`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#getProperty(java.lang.String))

```bash
scala> System.getProperty("java.version")
val res0: String = 17.0.11
```

The current set of system properties can be checked here https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#getProperties()





Here's how I tested the change

```bash
1) $ java --version                                                                                                                    naf@lnx
openjdk 17.0.11 2024-04-16
OpenJDK Runtime Environment Temurin-17.0.11+9 (build 17.0.11+9)
OpenJDK 64-Bit Server VM Temurin-17.0.11+9 (build 17.0.11+9, mixed mode, sharing)
 
 
2) $ ./mill -i show 'cli[]'.standaloneLauncher                                                                                         naf@lnx
... 

3) $ /home/naf/oss/scala-cli/out/cli/3.3.3/standaloneLauncher.dest/launcher -e 'println("hello")' 
Compiling project (Scala 3.4.2, JVM (17.0.11))
Compiled project (Scala 3.4.2, JVM (17.0.11))
hello

 
4) $ sdk use java 21.0.2-tem                                                                                                           naf@lnx
Using java version 21.0.2-tem in this shell.


5) $ java --version 
openjdk 21.0.2 2024-01-16 LTS
OpenJDK Runtime Environment Temurin-21.0.2+13 (build 21.0.2+13-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.2+13 (build 21.0.2+13-LTS, mixed mode, sharing)


6) $ /home/naf/oss/scala-cli/out/cli/3.3.3/standaloneLauncher.dest/launcher -e 'println("hello")'                             naf@lnx
Starting compilation server
Compiling project (Scala 3.4.2, JVM (21.0.2))
Compiled project (Scala 3.4.2, JVM (21.0.2))
hello
```

(*): There are plenty of places in the code base that rely on executing the Java binary to extract info, they could be replaced by using systems properties instead which are easier since the output is plain and minimal string manipulation is required. However, that's future work and this is good place to stop.

Note:
I initially didn't modify any tests waiting to the CI build to uncover which specific tests fail because I didn't want to run all the test suite on my machine