### PR TITLE
docs: remove `.` from command snippet

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
+++ b/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
@@ -71,7 +71,7 @@ object WarningMessages {
       if specificationLevel == SpecificationLevel.EXPERIMENTAL then "experimental" else "restricted"
     s"""The `$featureName` $featureType is $powerType.
        |You can run it with the `--power` flag or turn power mode on globally by running:
-       |  ${Console.BOLD}${invokeData.progName} config power true${Console.RESET}.""".stripMargin
+       |  ${Console.BOLD}${invokeData.progName} config power true${Console.RESET}""".stripMargin
   }
 
   def powerCommandUsedInSip(commandName: String, specificationLevel: SpecificationLevel)(using

--- a/website/docs/release_notes.md
+++ b/website/docs/release_notes.md
@@ -1782,7 +1782,7 @@ only be available in `--power` mode.
 scala-cli config httpProxy.address
 # The 'httpProxy.address' configuration key is restricted.
 # You can run it with the '--power' flag or turn power mode on globally by running:
-#   scala-cli config power true.
+#   scala-cli config power true
 ```
 
 Added by  [@Gedochao](https://github.com/Gedochao) in [#1953](https://github.com/VirtusLab/scala-cli/pull/1953)


### PR DESCRIPTION
`scala-cli` contains in an error message:
```
You can run it with the `--power` flag or turn power mode on globally by running:
  scala-cli config power true.
```

The period `.` at the end makes the snippet no longer a valid terminal command, so copy pasting it will result in an error contrary to what most users will expect.
```
$ scala-cli config power true.
[error]  Config DB error: Malformed value 'true.' for the 'power' entry, expected a single boolean value ('true' or 'false').
```