### PR TITLE
chore: Bump outdated `javac-semanticdb` plugin to 0.10.0

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -995,6 +995,7 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
            |  def scalaNativeVersion         = "${Deps.Versions.scalaNative}"
            |  def scalaNativeVersion04       = "${Deps.Versions.scalaNative04}"
            |  def scalaNativeVersion05       = "${Deps.Versions.scalaNative05}"
+           |  def semanticDbJavacPluginVersion = "${Deps.semanticDbJavac.dep.version}"
            |  def ammoniteVersion            = "${Deps.ammonite.dep.version}"
            |  def defaultGraalVMJavaVersion  = "${deps.graalVmJavaVersion}"
            |  def defaultGraalVMVersion      = "${deps.graalVmVersion}"

--- a/modules/integration/src/test/scala/scala/cli/integration/SemanticDbTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SemanticDbTestDefinitions.scala
@@ -44,7 +44,7 @@ trait SemanticDbTestDefinitions { _: CompileTestDefinitions =>
           .flatMap(opt => List("--javac-opt", opt))
         val javaSemDbOptions = Seq(
           "--javac-plugin",
-          "com.sourcegraph:semanticdb-javac:0.7.4",
+          s"com.sourcegraph:semanticdb-javac:${Constants.semanticDbJavacPluginVersion}",
           "--javac-opt",
           s"-Xplugin:semanticdb -sourceroot:$root -targetroot:javac-classes-directory"
         ) ++ exports

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -108,6 +108,7 @@ object Deps {
     def scalaPackager                     = "0.1.29"
     def signingCli                        = "0.2.3"
     def signingCliJvmVersion              = 17
+    def javaSemanticdb                    = "0.10.0"
     def javaClassName                     = "0.1.3"
     def bloop                             = "1.5.17-sc-2"
   }
@@ -187,7 +188,7 @@ object Deps {
   def scalaPackagerCli = ivy"org.virtuslab:scala-packager-cli_2.13:${Versions.scalaPackager}"
   def scalaPy          = ivy"dev.scalapy::scalapy-core::0.5.3"
   def scalaReflect(sv: String) = ivy"org.scala-lang:scala-reflect:$sv"
-  def semanticDbJavac          = ivy"com.sourcegraph:semanticdb-javac:0.7.4"
+  def semanticDbJavac          = ivy"com.sourcegraph:semanticdb-javac:${Versions.javaSemanticdb}"
   def semanticDbScalac         = ivy"org.scalameta:::semanticdb-scalac:${Versions.scalaMeta}"
   def signingCliShared =
     ivy"org.virtuslab.scala-cli-signing::shared:${Versions.signingCli}"


### PR DESCRIPTION
This causes some issues when running Java via metals if there is no package defined (java semanticdb has some wierd stuff)

Not sure why this isn't being bumped.