### PR TITLE
Add Scala to pure Java test builds

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -1029,7 +1029,8 @@ object Build {
     either {
 
       val options0 =
-        if (sources.hasJava && !sources.hasScala)
+        // FIXME: don't add Scala to pure Java test builds (need to add pure Java test runner)
+        if (sources.hasJava && !sources.hasScala && scope != Scope.Test)
           options.copy(
             scalaOptions = options.scalaOptions.copy(
               scalaVersion = options.scalaOptions.scalaVersion.orElse {

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -779,4 +779,27 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
       }
     }
   }
+
+  test("successful pure Java test with JUnit") {
+    val expectedMessage = "Hello from JUnit"
+    TestInputs(
+      os.rel / "test" / "MyTests.java" ->
+        s"""//> using test.dependencies junit:junit:4.13.2
+           |//> using test.dependencies com.novocode:junit-interface:0.11
+           |import org.junit.Test;
+           |import static org.junit.Assert.assertEquals;
+           |
+           |public class MyTests {
+           |  @Test
+           |  public void foo() {
+           |    assertEquals(4, 2 + 2);
+           |    System.out.println("$expectedMessage");
+           |  }
+           |}
+           |""".stripMargin
+    ).fromRoot { root =>
+      val res = os.proc(TestUtil.cli, "test", extraOptions, ".").call(cwd = root)
+      expect(res.out.text().contains(expectedMessage))
+    }
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/2940

We generally don't add Scala to pure Java builds to keep them clean. Unfortunately, we do not have a pure Java test runner at the moment, so we still need Scala to run tests properly.