### PR TITLE
Swap `scalameta` `trees` for `semanticdb-shared` & bump `scalameta` to 4.9.8

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -422,9 +422,10 @@ trait Core extends ScalaCliCrossSbtModule
          |  def runnerVersion = "${runner(Scala.runnerScala3).publishVersion()}"
          |  def runnerMainClass = "$runnerMainClass"
          |
-         |  def semanticDbPluginOrganization = "${Deps.scalametaTrees.dep.module.organization.value}"
-         |  def semanticDbPluginModuleName = "semanticdb-scalac"
-         |  def semanticDbPluginVersion = "${Deps.scalametaTrees.dep.version}"
+         |  def semanticDbPluginOrganization = "${Deps.semanticDbScalac.dep.module.organization
+          .value}"
+         |  def semanticDbPluginModuleName = "${Deps.semanticDbScalac.dep.module.name.value}"
+         |  def semanticDbPluginVersion = "${Deps.semanticDbScalac.dep.version}"
          |
          |  def semanticDbJavacPluginOrganization = "${Deps.semanticDbJavac.dep.module.organization
           .value}"
@@ -678,7 +679,6 @@ trait Build extends ScalaCliCrossSbtModule
     Deps.collectionCompat,
     Deps.javaClassName,
     Deps.jsoniterCore,
-    Deps.scalametaTrees,
     Deps.scalametaSemanticDbShared,
     Deps.nativeTestRunner,
     Deps.osLib,

--- a/build.sc
+++ b/build.sc
@@ -679,6 +679,7 @@ trait Build extends ScalaCliCrossSbtModule
     Deps.javaClassName,
     Deps.jsoniterCore,
     Deps.scalametaTrees,
+    Deps.scalametaSemanticDbShared,
     Deps.nativeTestRunner,
     Deps.osLib,
     Deps.pprint,

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -97,7 +97,7 @@ object Deps {
     def coursierM1Cli                     = coursierDefault
     def jsoniterScala                     = "2.23.2"
     def jsoniterScalaJava8                = "2.13.5.2"
-    def scalaMeta                         = "4.9.7"
+    def scalaMeta                         = "4.9.8"
     def scalaNative04                     = "0.4.17"
     def scalaNative05                     = "0.5.4"
     def scalaNative                       = scalaNative05

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -188,6 +188,7 @@ object Deps {
   def semanticDbScalac         = ivy"org.scalameta:::semanticdb-scalac:${Versions.scalaMeta}"
   def scalametaSemanticDbShared =
     ivy"org.scalameta:semanticdb-shared_${Scala.scala213}:${Versions.scalaMeta}"
+      .exclude("org.jline" -> "jline") // to prevent incompatibilities with GraalVM <23
   def signingCliShared =
     ivy"org.virtuslab.scala-cli-signing::shared:${Versions.signingCli}"
       // to prevent collisions with scala-cli's case-app version

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -184,6 +184,8 @@ object Deps {
   def scalametaTrees = ivy"org.scalameta:trees_2.13:${Versions.scalaMeta}"
     .exclude(("com.lihaoyi", "sourcecode_2.13"))
     .exclude(("org.scala-lang.modules", "scala-collection-compat_2.13"))
+  def scalametaSemanticDbShared =
+    ivy"org.scalameta:semanticdb-shared_${Scala.scala213}:${Versions.scalaMeta}"
   def scalaPackager    = ivy"org.virtuslab:scala-packager_2.13:${Versions.scalaPackager}"
   def scalaPackagerCli = ivy"org.virtuslab:scala-packager-cli_2.13:${Versions.scalaPackager}"
   def scalaPy          = ivy"dev.scalapy::scalapy-core::0.5.3"

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -180,18 +180,14 @@ object Deps {
   def scalaJsLogging   = ivy"org.scala-js:scalajs-logging_2.13:1.1.1"
   // Force using of 2.13 - is there a better way?
   def scalaJsTestAdapter = ivy"org.scala-js:scalajs-sbt-test-adapter_2.13:${Scala.scalaJs}"
-  // Force using of 2.13 - is there a better way?
-  def scalametaTrees = ivy"org.scalameta:trees_2.13:${Versions.scalaMeta}"
-    .exclude(("com.lihaoyi", "sourcecode_2.13"))
-    .exclude(("org.scala-lang.modules", "scala-collection-compat_2.13"))
-  def scalametaSemanticDbShared =
-    ivy"org.scalameta:semanticdb-shared_${Scala.scala213}:${Versions.scalaMeta}"
-  def scalaPackager    = ivy"org.virtuslab:scala-packager_2.13:${Versions.scalaPackager}"
-  def scalaPackagerCli = ivy"org.virtuslab:scala-packager-cli_2.13:${Versions.scalaPackager}"
-  def scalaPy          = ivy"dev.scalapy::scalapy-core::0.5.3"
+  def scalaPackager      = ivy"org.virtuslab:scala-packager_2.13:${Versions.scalaPackager}"
+  def scalaPackagerCli   = ivy"org.virtuslab:scala-packager-cli_2.13:${Versions.scalaPackager}"
+  def scalaPy            = ivy"dev.scalapy::scalapy-core::0.5.3"
   def scalaReflect(sv: String) = ivy"org.scala-lang:scala-reflect:$sv"
   def semanticDbJavac          = ivy"com.sourcegraph:semanticdb-javac:${Versions.javaSemanticdb}"
   def semanticDbScalac         = ivy"org.scalameta:::semanticdb-scalac:${Versions.scalaMeta}"
+  def scalametaSemanticDbShared =
+    ivy"org.scalameta:semanticdb-shared_${Scala.scala213}:${Versions.scalaMeta}"
   def signingCliShared =
     ivy"org.virtuslab.scala-cli-signing::shared:${Versions.signingCli}"
       // to prevent collisions with scala-cli's case-app version


### PR DESCRIPTION
Supersedes #3016 