### PR TITLE
[OLD PoC] Source generators

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -892,6 +892,10 @@ trait Cli extends CrossSbtModule with ProtoBuildModule with CliLaunchers
 
   def localRepoJar = `local-repo`.localRepoJar()
 
+  def forkArgs = T {
+    super.forkArgs() ++ Seq("-agentlib:jdwp=transport=dt_socket,server=y,address=localhost:5050,suspend=y")
+  }
+
   object test extends ScalaCliTests with ScalaCliScalafixModule {
     def moduleDeps = super.moduleDeps ++ Seq(
       `build-module`(crossScalaVersion).test

--- a/modules/build/src/main/scala/scala/build/Project.scala
+++ b/modules/build/src/main/scala/scala/build/Project.scala
@@ -1,15 +1,16 @@
 package scala.build
 
-import _root_.bloop.config.{Config => BloopConfig, ConfigCodecs => BloopCodecs}
-import _root_.coursier.{Dependency => CsDependency, core => csCore, util => csUtil}
-import com.github.plokhotnyuk.jsoniter_scala.core.{writeToArray => writeAsJsonToArray}
+import _root_.bloop.config.{Config as BloopConfig, ConfigCodecs as BloopCodecs}
+import _root_.coursier.{Dependency as CsDependency, core as csCore, util as csUtil}
+import bloop.config.Config.{SourceGenerator, SourcesGlobs}
+import bloop.config.PlatformFiles
+import com.github.plokhotnyuk.jsoniter_scala.core.writeToArray as writeAsJsonToArray
 import coursier.core.Classifier
 
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 import java.util.Arrays
-
 import scala.build.options.{ScalacOpt, Scope, ShadowingSeq}
 
 final case class Project(
@@ -67,7 +68,12 @@ final case class Project(
         platform = Some(platform),
         `scala` = scalaConfigOpt,
         java = Some(BloopConfig.Java(javacOptions)),
-        resolution = resolution
+        resolution = resolution,
+        sourceGenerators = Some(List(SourceGenerator(
+          List(SourcesGlobs(PlatformFiles.getPath(workspace.toString), None, "glob:*.proto" :: Nil, Nil)),
+          PlatformFiles.getPath(workspace.toString),
+          List("scala-cli", "{some_path}/scala-cli-sandbox/gen.scala", "--server=false", "--")
+        )))
       )
   }
 

--- a/source-generators-example/Foo.scala
+++ b/source-generators-example/Foo.scala
@@ -1,0 +1,1 @@
+object Foo

--- a/source-generators-example/Hello.scala
+++ b/source-generators-example/Hello.scala
@@ -1,0 +1,3 @@
+object Hello {
+  val hello = "Hello"
+}

--- a/source-generators-example/Main.scala
+++ b/source-generators-example/Main.scala
@@ -1,0 +1,12 @@
+////> using plugin "com.thesamet.scalapb::compilerplugin:0.11.3"
+//> using dep "com.thesamet.scalapb::scalapb-runtime:0.11.3"
+
+//> using source.generator scalapbc
+
+import tutorial.addressbook.{AddressBook, Person}
+
+object Main extends App {
+    println("Main")
+    val person = Person(name = "John Doe", id = 123, email = Some("XD"))
+    println(person)
+}

--- a/source-generators-example/addressbook.proto
+++ b/source-generators-example/addressbook.proto
@@ -1,0 +1,26 @@
+syntax = "proto2";
+
+package tutorial;
+
+message Person {
+  required string name = 1;
+  required int32 id = 2;
+  optional string email = 3;
+
+  enum PhoneType {
+    MOBILE = 0;
+    HOME = 1;
+    WORK = 2;
+  }
+
+  message PhoneNumber {
+    required string number = 1;
+    optional PhoneType type = 2 [default = HOME];
+  }
+
+  repeated PhoneNumber phones = 4;
+}
+
+message AddressBook {
+  repeated Person people = 1;
+}

--- a/source-generators-example/generators/gen.scala
+++ b/source-generators-example/generators/gen.scala
@@ -1,0 +1,35 @@
+//> using scala "2.13"
+//> using dep "com.thesamet.scalapb::scalapbc:0.11.13"
+
+import scalapb.ScalaPBC
+
+class ProtobufGenerator {
+  def metadataJson: String =
+    s"""{
+       |  "name" : "Protobuf generator",
+       |  "version" : "1.0.0",
+       |  "supportedExtensions" : ["proto"],
+       |  "isReferentiallyTransparent" : true
+       |}""".stripMargin
+
+  def generate(inputLocation: String, outputLocation: String): Unit = {
+    ScalaPBC.main(Array(
+        s"--scala_out=${outputLocation}",
+        "-I", "/Users/mgajek/Projects/scala-cli-sandbox/source-generators/",
+        inputLocation
+    ))
+  }
+}
+
+object Main {
+    def main(args: Array[String]) = {
+        val outputDir = args.headOption.getOrElse(throw new Exception("Output dir not specified"))
+        val sources = args.tail.toList
+        val generator = new ProtobufGenerator()
+
+        sources.foreach { source =>
+            println(s"Running protobuf generation from [$source] to [$outputDir]")
+            generator.generate(source, outputDir)
+        }
+    }
+}

--- a/source-generators-example/project.scala
+++ b/source-generators-example/project.scala
@@ -1,0 +1,1 @@
+//> using exclude "generators/gen.scala"


### PR DESCRIPTION
This is an old PoC for implementing source generators that was supposed to use Bloops capability to run an arbitrary command that would generate the sources.

Bloop.Project.sourceGenerators accepts a list of objects of this shape:
`SourceGenerator(sourcesGlobs: List[SourcesGlobs], outputDirectory: PlatformFiles.Path, command: List[String])`

By quickly looking [at Bloop's code](https://github.com/scalacenter/bloop/blob/71c5273f561ec6fb2c05e8949526c7b47a4d5c7e/frontend/src/main/scala/bloop/engine/SourceGenerator.scala#L67) the command gets created like this:
`(command :+ outputDirectory.syntax) ++ inputs.keys.map(_.syntax)`, where the inputs are the results of applying sourceGlobs

So trying to work with this, I wanted to run `scala-cli` command on a small app that uses `dep "com.thesamet.scalapb::scalapbc:0.11.13"`, which would generate the sources before Bloop's compilation would run.
Unfortunately this didn't work, I recall that the command never managed to generate sources even though Bloop would run it (I think). Probably there was a problem with the command also calling Bloop.

I thought about a while ago and IMO for it to work we would need to first build the generator app (potentially without Bloop) and pass the run command to Bloop (sth like `java --cp jar1:jar2:scalapbc-jar MainClass outputDir sourceArg1 sourceArg2 ...`
We already do similar stuff in our [Run command](https://github.com/VirtusLab/scala-cli/blob/e1c5c9cbf9fcfdd0badc8eeeb7ffad2244a932ba/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala#L319-L342).

Off the top of my head this generator app could also be released to maven, but I don't see any problems in hardcoding it in our sources.

Additionally I think the easiest way would be to rework the Bloop API to allow more flexibility e.g. for calling ScalaPBC's main without the generator-app from `gen.scala` as it effectively just shuffles arguments around.
