### PR TITLE
Fix default scaladoc config, so that id doesn't break all scaladoc links

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -116,7 +116,8 @@ object `scala-cli-bsp` extends JavaModule with ScalaCliPublishModule {
 object integration extends CliIntegration {
   object test extends IntegrationScalaTests {
     def ivyDeps = super.ivyDeps() ++ Seq(
-      Deps.jgit
+      Deps.jgit,
+      Deps.jsoup
     )
   }
   object docker extends CliIntegrationDocker {

--- a/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
@@ -125,8 +125,8 @@ object Doc extends ScalaCommand[DocOptions] {
     "-snippet-compiler:compile",
     "-Ygenerate-inkuire",
     "-external-mappings:" +
-      ".*scala.*::scaladoc3::https://scala-lang.org/api/3.x/," +
-      ".*java.*::javadoc::https://docs.oracle.com/javase/8/docs/api/",
+      ".*/scala/.*::scaladoc3::https://scala-lang.org/api/3.x/," +
+      ".*/java/.*::javadoc::https://docs.oracle.com/javase/8/docs/api/",
     "-author",
     "-groups"
   )

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -97,6 +97,7 @@ object Deps {
     def coursierM1Cli                     = coursierDefault
     def jsoniterScala                     = "2.23.2"
     def jsoniterScalaJava8                = "2.13.5.2"
+    def jsoup                             = "1.18.1"
     def scalaMeta                         = "4.9.8"
     def scalaNative04                     = "0.4.17"
     def scalaNative05                     = "0.5.4"
@@ -156,6 +157,7 @@ object Deps {
     ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:${Versions.jsoniterScalaJava8}"
   def jsoniterMacrosJava8 =
     ivy"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:${Versions.jsoniterScalaJava8}"
+  def jsoup         = ivy"org.jsoup:jsoup:${Versions.jsoup}"
   def libsodiumjni  = ivy"org.virtuslab.scala-cli:libsodiumjni:0.0.4"
   def macroParadise = ivy"org.scalamacros:::paradise:2.1.1"
   def metaconfigTypesafe =


### PR DESCRIPTION
Right now running the doc command with default arguments in scala-cli always produced broken scaladoc links, because the default regex for external mappings mapped every tasty file that contained 'scala' to use the `scala-lang.org` mapping. And since scala-cli uses '.scala-build' directory for placing tasty files, almost all links were broken.