### PR TITLE
Fix the REPL crashing when a dependency's classpath is called by a macro

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
@@ -7,7 +7,7 @@ import scala.util.Properties
 
 abstract class ReplTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
   _: TestScalaVersion =>
-  private lazy val extraOptions = scalaVersionArgs ++ TestUtil.extraOptions
+  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
 
   private val retrieveScalaVersionCode = if (actualScalaVersion.startsWith("2."))
     "scala.util.Properties.versionNumberString"

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTests3StableDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTests3StableDefinitions.scala
@@ -1,5 +1,9 @@
 package scala.cli.integration
 
+import com.eed3si9n.expecty.Expecty.expect
+
+import scala.util.Properties
+
 trait ReplTests3StableDefinitions { _: ReplTestDefinitions =>
   if (!actualScalaVersion.equals(actualMaxAmmoniteScalaVersion)) {
     lazy val defaultScalaVersionString =
@@ -14,6 +18,33 @@ trait ReplTests3StableDefinitions { _: ReplTestDefinitions =>
 
     test(s"ammonite with test scope sources$defaultScalaVersionString") {
       ammoniteTestScope(useMaxAmmoniteScalaVersion = false)
+    }
+  }
+
+  test("https://github.com/scala/scala3/issues/21229") {
+    TestInputs(
+      os.rel / "Pprint.scala" ->
+        """//> using dep "com.lihaoyi::pprint::0.9.0"
+          |package stuff
+          |import scala.quoted.*
+          |def foo = pprint(1)
+          |inline def bar = pprint(1)
+          |inline def baz = ${ bazImpl }
+          |def bazImpl(using Quotes) = '{ pprint(1) }
+          |""".stripMargin
+    ).fromRoot { root =>
+      val ammArgs = Seq("-c", "println(stuff.baz)")
+        .map {
+          if (Properties.isWin)
+            a => if (a.contains(" ")) "\"" + a.replace("\"", "\\\"") + "\"" else a
+          else
+            identity
+        }
+        .flatMap(arg => Seq("--ammonite-arg", arg))
+      // FIXME: test this on standard Scala 3 REPL, rather than just Ammonite
+      val res = os.proc(TestUtil.cli, "repl", ".", "--power", "--amm", ammArgs, extraOptions)
+        .call(cwd = root)
+      expect(res.out.trim().nonEmpty)
     }
   }
 }


### PR DESCRIPTION
Scala CLI's side of https://github.com/scala/scala3/issues/21229