### PR TITLE
Ensure the `publish` step to be necessary for updating the native packages upon release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1672,6 +1672,7 @@ jobs:
       - checks
       - reference-doc
       - generate-linux-arm64-native-launcher
+      - publish
     if: github.event_name == 'push'
     runs-on: ubuntu-20.04
     steps:
@@ -1730,7 +1731,9 @@ jobs:
 
   update-packages:
     name: Update packages
-    needs: launchers
+    needs:
+      - launchers
+      - publish
     runs-on: ubuntu-20.04
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'VirtusLab/scala-cli'
     steps:
@@ -1813,7 +1816,9 @@ jobs:
 
   update-windows-packages:
     name: Update Windows packages
-    needs: launchers
+    needs:
+      - launchers
+      - publish
     runs-on: "windows-2019"
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'VirtusLab/scala-cli'
     steps:


### PR DESCRIPTION
This is to prevent future cases of https://github.com/VirtusLab/scala-cli/issues/3047#issuecomment-2265359327