### PR TITLE
Add more env vars & generate reference docs for them

### DIFF
--- a/modules/core/src/main/scala/scala/build/internals/EnvVar.scala
+++ b/modules/core/src/main/scala/scala/build/internals/EnvVar.scala
@@ -57,7 +57,7 @@ object EnvVar {
         }""".stripMargin
     }
   }
-  def allGroups: Seq[EnvVarGroup] = Seq(ScalaCli, Java, Coursier, Spark, Misc, Internal)
+  def allGroups: Seq[EnvVarGroup] = Seq(ScalaCli, Java, Bloop, Coursier, Spark, Misc, Internal)
   def all: Seq[EnvVar]            = allGroups.flatMap(_.all)
   def allBsp: Seq[EnvVar]         = all.filter(_.passToIde)
   object Java extends EnvVarGroup {
@@ -83,6 +83,7 @@ object EnvVar {
     val dyldLibraryPath = EnvVar("DYLD_LIBRARY_PATH", "Runtime library paths on Mac OS X")
     val ldLibraryPath   = EnvVar("LD_LIBRARY_PATH", "Runtime library paths on Linux")
     val pathExt         = EnvVar("PATHEXT", "Executable file extensions on Windows")
+    val pwd             = EnvVar("PWD", "Current working directory", passToIde = false)
     val shell           = EnvVar("SHELL", "The currently used shell")
     val vcVarsAll       = EnvVar("VCVARSALL", "Visual C++ Redistributable Runtimes")
     val zDotDir         = EnvVar("ZDOTDIR", "Zsh configuration directory")
@@ -108,6 +109,7 @@ object EnvVar {
       vendoredZipInputStream
     )
     val config            = EnvVar("SCALA_CLI_CONFIG", "Scala CLI configuration file path")
+    val extraTimeout      = Bloop.bloopExtraTimeout.copy(requiresPower = false)
     val home              = EnvVar("SCALA_CLI_HOME", "Scala CLI home directory")
     val interactive       = EnvVar("SCALA_CLI_INTERACTIVE", "Interactive mode toggle")
     val interactiveInputs = EnvVar("SCALA_CLI_INTERACTIVE_INPUTS", "Interactive mode inputs")
@@ -122,6 +124,35 @@ object EnvVar {
     override def groupName: String = "Spark"
     override def all               = Seq(sparkHome)
     val sparkHome = EnvVar("SPARK_HOME", "Spark installation directory", requiresPower = true)
+  }
+
+  object Bloop extends EnvVarGroup {
+    override def groupName: String = "Bloop"
+    override def all = Seq(
+      bloopComputationCores,
+      bloopDaemonDir,
+      bloopJavaOpts,
+      bloopModule,
+      bloopPort,
+      bloopScalaVersion,
+      bloopVersion,
+      bloopServer,
+      bloopExtraTimeout
+    )
+    val bloopComputationCores = EnvVar(
+      "BLOOP_COMPUTATION_CORES",
+      "Number of computation cores to be used",
+      requiresPower = true
+    )
+    val bloopDaemonDir = EnvVar("BLOOP_DAEMON_DIR", "Bloop daemon directory", requiresPower = true)
+    val bloopJavaOpts  = EnvVar("BLOOP_JAVA_OPTS", "Bloop Java options", requiresPower = true)
+    val bloopModule    = EnvVar("BLOOP_MODULE", "Bloop default module", requiresPower = true)
+    val bloopPort      = EnvVar("BLOOP_PORT", "Bloop default port", requiresPower = true)
+    val bloopScalaVersion =
+      EnvVar("BLOOP_SCALA_VERSION", "Bloop default Scala version", requiresPower = true)
+    val bloopVersion      = EnvVar("BLOOP_VERSION", "Bloop default version", requiresPower = true)
+    val bloopServer       = EnvVar("BLOOP_SERVER", "Bloop default host", requiresPower = true)
+    val bloopExtraTimeout = EnvVar("SCALA_CLI_EXTRA_TIMEOUT", "Extra timeout", requiresPower = true)
   }
 
   object Internal extends EnvVarGroup {

--- a/modules/core/src/main/scala/scala/build/internals/EnvVar.scala
+++ b/modules/core/src/main/scala/scala/build/internals/EnvVar.scala
@@ -87,13 +87,40 @@ object EnvVar {
     val shell           = EnvVar("SHELL", "The currently used shell")
     val vcVarsAll       = EnvVar("VCVARSALL", "Visual C++ Redistributable Runtimes")
     val zDotDir         = EnvVar("ZDOTDIR", "Zsh configuration directory")
+    val mavenHome       = EnvVar("MAVEN_HOME", "Maven home directory")
   }
 
   object Coursier extends EnvVarGroup {
     override def groupName: String = "Coursier"
-    override def all               = Seq(coursierCache, coursierMode)
-    val coursierCache              = EnvVar("COURSIER_CACHE", "Coursier cache location")
-    val coursierMode = EnvVar("COURSIER_MODE", "Coursier mode (can be set to 'offline')")
+    override def all = Seq(
+      coursierBinDir,
+      coursierCache,
+      coursierConfigDir,
+      coursierCredentials,
+      insideEmacs,
+      coursierExperimental,
+      coursierJni,
+      coursierMode,
+      coursierNoTerm,
+      coursierProgress,
+      coursierRepositories,
+      coursierVendoredZis,
+      csMavenHome
+    )
+    val coursierBinDir       = EnvVar("COURSIER_BIN_DIR", "Coursier app binaries directory")
+    val coursierCache        = EnvVar("COURSIER_CACHE", "Coursier cache location")
+    val coursierConfigDir    = EnvVar("COURSIER_CONFIG_DIR", "Coursier configuration directory")
+    val coursierCredentials  = EnvVar("COURSIER_CREDENTIALS", "Coursier credentials")
+    val coursierExperimental = EnvVar("COURSIER_EXPERIMENTAL", "Experimental mode toggle")
+    val coursierJni          = EnvVar("COURSIER_JNI", "Coursier JNI toggle")
+    val coursierMode         = EnvVar("COURSIER_MODE", "Coursier mode (can be set to 'offline')")
+    val coursierNoTerm       = EnvVar("COURSIER_NO_TERM", "Terminal toggle")
+    val coursierProgress     = EnvVar("COURSIER_PROGRESS", "Progress bar toggle")
+    val coursierRepositories = EnvVar("COURSIER_REPOSITORIES", "Coursier repositories")
+    val coursierVendoredZis =
+      EnvVar("COURSIER_VENDORED_ZIS", "Toggle io.github.scala_cli.zip.ZipInputStream")
+    val csMavenHome = EnvVar("CS_MAVEN_HOME", "Coursier Maven home directory")
+    val insideEmacs = EnvVar("INSIDE_EMACS", "Emacs toggle")
   }
 
   object ScalaCli extends EnvVarGroup {

--- a/website/docs/reference/env-vars.md
+++ b/website/docs/reference/env-vars.md
@@ -1,0 +1,68 @@
+---
+title: Environment variables
+sidebar_position: 7
+---
+
+Scala CLI uses environment variables to configure its behavior.
+Below you can find a list of environment variables used and recognized by Scala CLI.
+
+However, it should by no means be treated as an exhaustive list.
+Some tools and libraries Scala CLI integrates with may have their own, which may or may not be listed here.
+
+
+## Scala CLI
+  - `SCALA_CLI_CONFIG`: Scala CLI configuration file path
+  - `SCALA_CLI_HOME`: Scala CLI home directory
+  - `SCALA_CLI_INTERACTIVE`: Interactive mode toggle
+  - `SCALA_CLI_INTERACTIVE_INPUTS`: Interactive mode inputs
+  - `SCALA_CLI_POWER`: Power mode toggle
+  - `SCALA_CLI_PRINT_STACK_TRACES`: Print stack traces toggle
+  - `SCALA_CLI_SODIUM_JNI_ALLOW`: Allow to load libsodiumjni
+  - `SCALA_CLI_VENDORED_ZIS`: Toggle io.github.scala_cli.zip.ZipInputStream
+
+## Java
+  - `JAVA_HOME`: Java installation directory
+  - `JAVA_OPTS`: Java options
+  - `JDK_JAVA_OPTIONS`: JDK Java options
+
+## Bloop
+  - `BLOOP_COMPUTATION_CORES`: ⚡ Number of computation cores to be used
+  - `BLOOP_DAEMON_DIR`: ⚡ Bloop daemon directory
+  - `BLOOP_JAVA_OPTS`: ⚡ Bloop Java options
+  - `BLOOP_MODULE`: ⚡ Bloop default module
+  - `BLOOP_PORT`: ⚡ Bloop default port
+  - `BLOOP_SCALA_VERSION`: ⚡ Bloop default Scala version
+  - `BLOOP_VERSION`: ⚡ Bloop default version
+  - `BLOOP_SERVER`: ⚡ Bloop default host
+  - `SCALA_CLI_EXTRA_TIMEOUT`: ⚡ Extra timeout
+
+## Coursier
+  - `COURSIER_BIN_DIR`: Coursier app binaries directory
+  - `COURSIER_CACHE`: Coursier cache location
+  - `COURSIER_CONFIG_DIR`: Coursier configuration directory
+  - `COURSIER_CREDENTIALS`: Coursier credentials
+  - `INSIDE_EMACS`: Emacs toggle
+  - `COURSIER_EXPERIMENTAL`: Experimental mode toggle
+  - `COURSIER_JNI`: Coursier JNI toggle
+  - `COURSIER_MODE`: Coursier mode (can be set to 'offline')
+  - `COURSIER_NO_TERM`: Terminal toggle
+  - `COURSIER_PROGRESS`: Progress bar toggle
+  - `COURSIER_REPOSITORIES`: Coursier repositories
+  - `COURSIER_VENDORED_ZIS`: Toggle io.github.scala_cli.zip.ZipInputStream
+  - `CS_MAVEN_HOME`: Coursier Maven home directory
+
+## Spark
+  - `SPARK_HOME`: ⚡ Spark installation directory
+
+## Miscellaneous
+  - `PATH`: The app path variable
+  - `DYLD_LIBRARY_PATH`: Runtime library paths on Mac OS X
+  - `LD_LIBRARY_PATH`: Runtime library paths on Linux
+  - `PATHEXT`: Executable file extensions on Windows
+  - `SHELL`: The currently used shell
+  - `VCVARSALL`: Visual C++ Redistributable Runtimes
+  - `ZDOTDIR`: Zsh configuration directory
+
+## Internal
+  - `CI`: ⚡ Marker for running on the CI
+

--- a/website/docs/reference/scala-command/env-vars.md
+++ b/website/docs/reference/scala-command/env-vars.md
@@ -1,0 +1,22 @@
+---
+title: Environment variables
+sidebar_position: 7
+---
+
+Scala CLI uses environment variables to configure its behavior.
+Below you can find a list of environment variables used and recognized by Scala CLI.
+
+However, it should by no means be treated as an exhaustive list.
+Some tools and libraries Scala CLI integrates with may have their own, which may or may not be listed here.
+
+
+## Scala CLI
+  - `SCALA_CLI_CONFIG`: Scala CLI configuration file path
+  - `SCALA_CLI_HOME`: Scala CLI home directory
+  - `SCALA_CLI_INTERACTIVE`: Interactive mode toggle
+  - `SCALA_CLI_INTERACTIVE_INPUTS`: Interactive mode inputs
+  - `SCALA_CLI_POWER`: Power mode toggle
+  - `SCALA_CLI_PRINT_STACK_TRACES`: Print stack traces toggle
+  - `SCALA_CLI_SODIUM_JNI_ALLOW`: Allow to load libsodiumjni
+  - `SCALA_CLI_VENDORED_ZIS`: Toggle io.github.scala_cli.zip.ZipInputStream
+


### PR DESCRIPTION
A follow-up to https://github.com/VirtusLab/scala-cli/pull/3055

Adds more environment variables constants (tied to Bloop and Coursier implementations, specifically).
Additionally, adds reference docs generation for environment variables defined in the code.

![image](https://github.com/user-attachments/assets/f8e9aca5-6f40-48c2-9807-1413d2aa8326)
