### PR TITLE
Update Scala 3 Next RC to 3.5.0-RC7

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -7,7 +7,7 @@ object Scala {
   def scala3LtsPrefix = "3.3"   // used for the LTS version tags
   def scala3Lts    = s"$scala3LtsPrefix.3" // the LTS version currently used in the build
   def scala3Next   = "3.4.2"               // the newest/next version of Scala
-  def scala3NextRc = "3.5.1-RC1"           // the latest RC version of Scala Next
+  def scala3NextRc = "3.5.0-RC7"           // the latest RC version of Scala Next
 
   // The Scala version used to build the CLI itself.
   def defaultInternal = sys.props.get("scala.version.internal").getOrElse(scala3Lts)


### PR DESCRIPTION
(was 3.5.1-RC1, but given all of the backports included in 3.5.0-RC7, we might want to change the test suites to that until 3.5.1-RC2 is out)
- https://github.com/scala/scala3/issues/21349