### PR TITLE
bugfix: Exclude sourcecode dependency

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -205,6 +205,7 @@ object Deps {
   def scalametaSemanticDbShared =
     ivy"org.scalameta:semanticdb-shared_${Scala.scala213}:${Versions.scalaMeta}"
       .exclude("org.jline" -> "jline") // to prevent incompatibilities with GraalVM <23
+      .exclude("com.lihaoyi" -> "sourcecode")
   def signingCliShared =
     ivy"org.virtuslab.scala-cli-signing::shared:${Versions.signingCli}"
       // to prevent collisions with scala-cli's case-app version


### PR DESCRIPTION
This dependency is not needed for us and might clash with sourcecode_3 on our classpath

We don't shade sourcecode due to issues in scalafmt https://github.com/scalameta/scalameta/pull/3468

Fixes https://github.com/VirtusLab/scala-cli/issues/3088