### PR TITLE
[ISSUE-296] Add support for fish autocompletions

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/installcompletions/InstallCompletions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/installcompletions/InstallCompletions.scala
@@ -1,7 +1,7 @@
 package scala.cli.commands.installcompletions
 
 import caseapp.*
-import caseapp.core.complete.{Bash, Zsh}
+import caseapp.core.complete.{Bash, Fish, Zsh}
 import caseapp.core.help.HelpFormat
 
 import java.io.File
@@ -47,6 +47,7 @@ object InstallCompletions extends ScalaCommand[InstallCompletionsOptions] {
         )
         System.err.println(s"$name install completions --shell zsh")
         System.err.println(s"$name install completions --shell bash")
+        System.err.println(s"$name install completions --shell fish")
         sys.exit(1)
       }
     }
@@ -75,6 +76,10 @@ object InstallCompletions extends ScalaCommand[InstallCompletionsOptions] {
           s"""fpath=("$dir" $$fpath)""",
           "compinit"
         ).map(_ + System.lineSeparator()).mkString
+        (script, defaultRcFile)
+      case Fish.id | "fish" =>
+        val script        = Fish.script(name)
+        val defaultRcFile = os.home / ".config" / "fish" / "config.fish"
         (script, defaultRcFile)
       case _ =>
         System.err.println(s"Unrecognized or unsupported shell: $format")
@@ -118,6 +123,7 @@ object InstallCompletions extends ScalaCommand[InstallCompletionsOptions] {
         EnvVar.Misc.shell.valueOpt.map(_.split("[\\/]+").last).map {
           case "bash" => Bash.id
           case "zsh"  => Zsh.id
+          case "fish" => Fish.id
           case other  => other
         }
       }

--- a/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/UninstallCompletions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/uninstallcompletions/UninstallCompletions.scala
@@ -37,7 +37,8 @@ object UninstallCompletions extends ScalaCommand[UninstallCompletionsOptions] {
       .getOrElse(os.home)
     val rcFiles = options.shared.rcFile.map(file => Seq(os.Path(file, os.pwd))).getOrElse(Seq(
       zDotDir / ".zshrc",
-      os.home / ".bashrc"
+      os.home / ".bashrc",
+      os.home / ".config" / "fish" / "config.fish"
     )).filter(os.exists(_))
 
     rcFiles.foreach { rcFile =>

--- a/modules/integration/src/test/scala/scala/cli/integration/InstallAndUninstallCompletionsTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/InstallAndUninstallCompletionsTests.scala
@@ -8,18 +8,21 @@ import scala.util.Properties
 class InstallAndUninstallCompletionsTests extends ScalaCliSuite {
   val zshRcFile: String  = ".zshrc"
   val bashRcFile: String = ".bashrc"
+  val fishRcFile: String = "config.fish"
   val rcContent: String = s"""
                              |dummy line
                              |dummy line""".stripMargin
   val testInputs: TestInputs = TestInputs(
-    os.rel / zshRcFile  -> rcContent,
-    os.rel / bashRcFile -> rcContent
+    os.rel / zshRcFile                       -> rcContent,
+    os.rel / bashRcFile                      -> rcContent,
+    os.rel / ".config" / "fish" / fishRcFile -> rcContent
   )
 
   def runInstallAndUninstallCompletions(): Unit = {
     testInputs.fromRoot { root =>
       val zshRcPath  = root / zshRcFile
       val bashRcPath = root / bashRcFile
+      val fishRcPath = root / ".config" / "fish" / fishRcFile
       // install completions to the dummy rc files
       os.proc(TestUtil.cli, "install-completions", "--rc-file", zshRcPath, "--shell", "zsh").call(
         cwd = root
@@ -27,13 +30,19 @@ class InstallAndUninstallCompletionsTests extends ScalaCliSuite {
       os.proc(TestUtil.cli, "install-completions", "--rc-file", bashRcPath, "--shell", "bash").call(
         cwd = root
       )
+      os.proc(TestUtil.cli, "install-completions", "--rc-file", fishRcPath, "--shell", "fish").call(
+        cwd = root
+      )
       expect(os.read(bashRcPath).contains(bashRcScript))
       expect(os.read(zshRcPath).contains(zshRcScript))
+      expect(os.read(fishRcPath).contains(fishRcScript))
       // uninstall completions from the dummy rc files
       os.proc(TestUtil.cli, "uninstall-completions", "--rc-file", zshRcPath).call(cwd = root)
       os.proc(TestUtil.cli, "uninstall-completions", "--rc-file", bashRcPath).call(cwd = root)
+      os.proc(TestUtil.cli, "uninstall-completions", "--rc-file", fishRcPath).call(cwd = root)
       expect(os.read(zshRcPath) == rcContent)
       expect(os.read(bashRcPath) == rcContent)
+      expect(os.read(fishRcPath) == rcContent)
     }
   }
 
@@ -53,6 +62,15 @@ class InstallAndUninstallCompletionsTests extends ScalaCliSuite {
          |}
          |
          |complete -F _${progName}_completions $progName
+         |""".stripMargin
+    addTags(script)
+  }
+
+  lazy val fishRcScript: String = {
+    val progName = "scala-cli"
+    val script =
+      s"""
+    complete $progName -a '($progName complete fish-v1 (math 1 + (count (__fish_print_cmd_args))) (__fish_print_cmd_args))'
          |""".stripMargin
     addTags(script)
   }

--- a/website/docs/_advanced_install.mdx
+++ b/website/docs/_advanced_install.mdx
@@ -447,9 +447,11 @@ Alternatively, you can directly download it from the Maven repository [here](htt
         values={[
         {label: 'Bash', value: 'bash'},
         {label: 'zsh', value: 'zsh'},
+        {label: 'fish', value: 'fish'},
         ]}>
      <TabItem value="bash"></TabItem>
      <TabItem value="zsh"></TabItem>
+     <TabItem value="fish"></TabItem>
     </Tabs>
 </SectionAbout>
 
@@ -463,6 +465,7 @@ Try the completions with
       values={[
         {label: 'Bash', value: 'bash'},
         {label: 'zsh', value: 'zsh'},
+        {label: 'fish', value: 'fish'},
         ]}>
 <TabItem value="bash">
 
@@ -480,6 +483,15 @@ scala-cli --<TAB>
 ```
 
 </TabItem>
+<TabItem value="fish">
+
+```
+eval "$(scala-cli install completions --env --shell fish)"
+fish
+scala-cli --<TAB>
+```
+
+</TabItem>
 </Tabs>
 
 Install them on your system with
@@ -493,6 +505,7 @@ with `--shell`
       values={[
         {label: 'Bash', value: 'bash'},
         {label: 'zsh', value: 'zsh'},
+        {label: 'fish', value: 'fish'},
         ]}>
 <TabItem value="bash">
 
@@ -505,6 +518,13 @@ scala-cli install completions --shell bash
 
 ```bash
 scala-cli install completions --shell zsh
+```
+
+</TabItem>
+<TabItem value="fish">
+
+```bash
+scala-cli install completions --shell fish
 ```
 
 </TabItem>


### PR DESCRIPTION
Hi all, I wanted to contribute a little bit to this fantastic project so I've taken a look at your "Good first Issues" and I've decided to pick up [this one](https://github.com/VirtusLab/scala-cli/issues/296). 
- I've updated the related test and ran all the steps mentioned in the CONTRIBUTING guidelines. 
- I've also updated the Advanced installation doc adding the tab for the new `fish` CLI. 

I've also ran `scala-cli` with my changes locally and installed it from scratch  to test if it works:
<img width="546" alt="image" src="https://github.com/user-attachments/assets/99673996-2d09-410a-b54d-8c3a0e47b415">
