### PR TITLE
Remove adding test options to the project/build target name hash

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -200,22 +200,15 @@ object Build {
     */
   def updateInputs(
     inputs: Inputs,
-    options: BuildOptions,
-    testOptions: Option[BuildOptions] = None
+    options: BuildOptions
   ): Inputs = {
 
     // If some options are manually overridden, append a hash of the options to the project name
     // Using options, not options0 - only the command-line options are taken into account. No hash is
     // appended for options from the sources.
     val optionsHash     = options.hash
-    val testOptionsHash = testOptions.flatMap(_.hash)
 
-    inputs.copy(
-      baseProjectName =
-        inputs.baseProjectName
-          + optionsHash.map("_" + _).getOrElse("")
-          + testOptionsHash.map("_" + _).getOrElse("")
-    )
+    inputs.copy(baseProjectName = inputs.baseProjectName + optionsHash.fold("")("_" + _))
   }
 
   private def allInputs(
@@ -278,6 +271,11 @@ object Build {
       overrideOptions: BuildOptions
     ): Either[BuildException, NonCrossBuilds] = either {
 
+      val inputs0 = updateInputs(
+        inputs,
+        overrideOptions.orElse(options) // update hash in inputs with options coming from the CLI or cross-building, not from the sources
+      )
+      
       val baseOptions = overrideOptions.orElse(sharedOptions)
 
       val scopedSources = value(crossSources.scopedSources(baseOptions))
@@ -289,12 +287,6 @@ object Build {
       val testSources =
         value(scopedSources.sources(Scope.Test, baseOptions, inputs.workspace, logger))
       val testOptions = testSources.buildOptions
-
-      val inputs0 = updateInputs(
-        inputs,
-        mainOptions, // update hash in inputs with options coming from the CLI or cross-building, not from the sources
-        Some(testOptions).filter(_ != mainOptions)
-      )
 
       def doBuildScope(
         options: BuildOptions,

--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -206,7 +206,7 @@ object Build {
     // If some options are manually overridden, append a hash of the options to the project name
     // Using options, not options0 - only the command-line options are taken into account. No hash is
     // appended for options from the sources.
-    val optionsHash     = options.hash
+    val optionsHash = options.hash
 
     inputs.copy(baseProjectName = inputs.baseProjectName + optionsHash.fold("")("_" + _))
   }
@@ -275,7 +275,7 @@ object Build {
         inputs,
         overrideOptions.orElse(options) // update hash in inputs with options coming from the CLI or cross-building, not from the sources
       )
-      
+
       val baseOptions = overrideOptions.orElse(sharedOptions)
 
       val scopedSources = value(crossSources.scopedSources(baseOptions))

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -183,16 +183,7 @@ abstract class CompileTestDefinitions
 
   test("no arg") {
     simpleInputs.fromRoot { root =>
-      val projectFilePrefix = root.baseName + "_"
       os.proc(TestUtil.cli, "compile", extraOptions, ".").call(cwd = root)
-      val projDirs = os.list(root / Constants.workspaceDirName)
-        .filter(_.last.startsWith(projectFilePrefix))
-        .filter(os.isDir(_))
-      expect(projDirs.length == 1)
-      val projDir     = projDirs.head
-      val projDirName = projDir.last
-      val elems       = projDirName.stripPrefix(projectFilePrefix).split("[-_]").toSeq
-      expect(elems.length == 1)
     }
   }
 
@@ -254,18 +245,6 @@ abstract class CompileTestDefinitions
         )
       expect(isDefinedTestPathInClassPath)
       checkIfCompileOutputIsCopied("Tests", tempOutput)
-
-      val projectFilePrefix = root.baseName + "_"
-
-      val projDirs = os.list(root / Constants.workspaceDirName)
-        .filter(_.last.startsWith(projectFilePrefix))
-        .filter(os.isDir(_))
-      expect(projDirs.length == 1)
-      val projDir     = projDirs.head
-      val projDirName = projDir.last
-      val elems       = projDirName.stripPrefix(projectFilePrefix).split("[-_]").toSeq
-      expect(elems.length == 2)
-      expect(elems.toSet.size == 2)
     }
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -685,7 +685,6 @@ abstract class CompileTestDefinitions
           |  println("Hello")
           |}
           |""".stripMargin,
-
       os.rel / "Test.test.scala" ->
         """object Test extends App {
           |  println("Hello")
@@ -701,17 +700,22 @@ abstract class CompileTestDefinitions
 
       expect(buildTargetDirs.size == 1)
 
-      os.write.over(root/filename, """//> using dep com.lihaoyi::os-lib:0.9.1
-                                      |
-                                      |object Main extends App {
-                                      |  println("Hello")
-                                      |}
-                                      |""".stripMargin)
+      os.write.over(
+        root / filename,
+        """//> using dep com.lihaoyi::os-lib:0.9.1
+          |
+          |object Main extends App {
+          |  println("Hello")
+          |}
+          |""".stripMargin
+      )
 
       os.proc(TestUtil.cli, "compile", extraOptions :+ "--test", ".").call(cwd = root)
       expect(buildTargetDirs.size == 1)
 
-      os.proc(TestUtil.cli, "compile", extraOptions ++ Seq("--test", "-nowarn"), ".").call(cwd = root)
+      os.proc(TestUtil.cli, "compile", extraOptions ++ Seq("--test", "-nowarn"), ".").call(cwd =
+        root
+      )
       expect(buildTargetDirs.size == 2)
     }
   }


### PR DESCRIPTION
The hash in the build target name is used to introduce caching when buildOptions are changed from the CLI. Otherwise, if options are changed from sources, Bloop recompiles the project anyway because the sources changed. Adding this new hash that comes from sources possibly creates new build targets every time somebody fiddles with some test scope options. It's  just nonsense.

Also look at the comments in the code, we've made a rule and then stopped following it.

I understand those are changes with potentially weird consequences - let's see if CI is green