### PR TITLE
Fix/changing options from sources should not require reload

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
@@ -130,15 +130,16 @@ object Bsp extends ScalaCommand[BspOptions] {
 
     val (inputs, finalBuildOptions) = preprocessInputs(args.all).orExit(logger)
 
-    /** values used for launching the bsp, especially for launching the bloop server, they do not include
-      * options extracted from sources, except in bloopRifleConfig - it's needed for correctly launching the bloop server
+    /** values used for launching the bsp, especially for launching the bloop server, they do not
+      * include options extracted from sources, except in bloopRifleConfig - it's needed for
+      * correctly launching the bloop server
       */
     val initialBspOptions = {
       val sharedOptions   = getSharedOptions()
       val launcherOptions = getLauncherOptions()
       val envs            = getEnvsFromFile()
       val bspBuildOptions = buildOptions(sharedOptions, launcherOptions, envs)
-      
+
       refreshPowerMode(launcherOptions, sharedOptions, envs)
 
       BspReloadableOptions(
@@ -151,9 +152,9 @@ object Bsp extends ScalaCommand[BspOptions] {
     }
 
     val bspReloadableOptionsReference = BspReloadableOptions.Reference { () =>
-      val sharedOptions   = getSharedOptions()
-      val launcherOptions = getLauncherOptions()
-      val envs            = getEnvsFromFile()
+      val sharedOptions    = getSharedOptions()
+      val launcherOptions  = getLauncherOptions()
+      val envs             = getEnvsFromFile()
       val bloopRifleConfig = sharedOptions.bloopRifleConfig()
 
       refreshPowerMode(launcherOptions, sharedOptions, envs)

--- a/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
@@ -130,19 +130,20 @@ object Bsp extends ScalaCommand[BspOptions] {
 
     val (inputs, finalBuildOptions) = preprocessInputs(args.all).orExit(logger)
 
-    /** values used for lauching the bsp, especially for launching a bloop server, they include
-      * options extracted from sources
+    /** values used for launching the bsp, especially for launching the bloop server, they do not include
+      * options extracted from sources, except in bloopRifleConfig - it's needed for correctly launching the bloop server
       */
     val initialBspOptions = {
       val sharedOptions   = getSharedOptions()
       val launcherOptions = getLauncherOptions()
       val envs            = getEnvsFromFile()
       val bspBuildOptions = buildOptions(sharedOptions, launcherOptions, envs)
-        .orElse(finalBuildOptions)
+      
       refreshPowerMode(launcherOptions, sharedOptions, envs)
+      
       BspReloadableOptions(
         buildOptions = bspBuildOptions,
-        bloopRifleConfig = sharedOptions.bloopRifleConfig(Some(bspBuildOptions))
+        bloopRifleConfig = sharedOptions.bloopRifleConfig(Some(finalBuildOptions))
           .orExit(sharedOptions.logger),
         logger = sharedOptions.logging.logger,
         verbosity = sharedOptions.logging.verbosity

--- a/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
@@ -154,7 +154,7 @@ object Bsp extends ScalaCommand[BspOptions] {
       val sharedOptions   = getSharedOptions()
       val launcherOptions = getLauncherOptions()
       val envs            = getEnvsFromFile()
-      val bloopRifleConfig = sharedOptions.bloopRifleConfig(Some(finalBuildOptions))
+      val bloopRifleConfig = sharedOptions.bloopRifleConfig()
 
       refreshPowerMode(launcherOptions, sharedOptions, envs)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bsp/Bsp.scala
@@ -140,7 +140,7 @@ object Bsp extends ScalaCommand[BspOptions] {
       val bspBuildOptions = buildOptions(sharedOptions, launcherOptions, envs)
       
       refreshPowerMode(launcherOptions, sharedOptions, envs)
-      
+
       BspReloadableOptions(
         buildOptions = bspBuildOptions,
         bloopRifleConfig = sharedOptions.bloopRifleConfig(Some(finalBuildOptions))
@@ -155,7 +155,7 @@ object Bsp extends ScalaCommand[BspOptions] {
       val launcherOptions = getLauncherOptions()
       val envs            = getEnvsFromFile()
       val bloopRifleConfig = sharedOptions.bloopRifleConfig(Some(finalBuildOptions))
-        .orExit(sharedOptions.logger)
+
       refreshPowerMode(launcherOptions, sharedOptions, envs)
 
       BspReloadableOptions(

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -786,6 +786,10 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
           |""".stripMargin
     )
 
+    val actualScalaMajorVersion = actualScalaVersion.split("\\.")
+      .take(if (actualScalaVersion.startsWith("3")) 1 else 2)
+      .mkString(".")
+
     withBsp(inputs, Seq(".")) { (root, localClient, remoteServer) =>
       async {
         val buildTargetsResp = await(remoteServer.workspaceBuildTargets().asScala)
@@ -821,18 +825,8 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
               uri.drop(idx + 1)
             }
 
-          if (actualScalaVersion.startsWith("2.13")) {
-            expect(foundDepSources.exists(_.startsWith("utest_2.13-0.7.10")))
-            expect(foundDepSources.exists(_.startsWith("os-lib_2.13-0.7.8")))
-          }
-          else if (actualScalaVersion.startsWith("2.12")) {
-            expect(foundDepSources.exists(_.startsWith("utest_2.12-0.7.10")))
-            expect(foundDepSources.exists(_.startsWith("os-lib_2.12-0.7.8")))
-          }
-          else {
-            expect(foundDepSources.exists(_.startsWith("utest_3-0.7.10")))
-            expect(foundDepSources.exists(_.startsWith("os-lib_3-0.7.8")))
-          }
+          expect(foundDepSources.exists(_.startsWith(s"utest_$actualScalaMajorVersion-0.7.10")))
+          expect(foundDepSources.exists(_.startsWith(s"os-lib_$actualScalaMajorVersion-0.7.8")))
 
           expect(foundDepSources.exists(_.startsWith("test-interface-1.0")))
           expect(foundDepSources.forall(_.endsWith("-sources.jar")))
@@ -870,18 +864,8 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
               uri.drop(idx + 1)
             }
 
-          if (actualScalaVersion.startsWith("2.13")) {
-            expect(foundDepSources.exists(_.startsWith("utest_2.13-0.7.10")))
-            expect(!foundDepSources.exists(_.startsWith("os-lib_2.13-0.7.8")))
-          }
-          else if (actualScalaVersion.startsWith("2.12")) {
-            expect(foundDepSources.exists(_.startsWith("utest_2.12-0.7.10")))
-            expect(!foundDepSources.exists(_.startsWith("os-lib_2.12-0.7.8")))
-          }
-          else {
-            expect(foundDepSources.exists(_.startsWith("utest_3-0.7.10")))
-            expect(!foundDepSources.exists(_.startsWith("os-lib_3-0.7.8")))
-          }
+          expect(foundDepSources.exists(_.startsWith(s"utest_$actualScalaMajorVersion-0.7.10")))
+          expect(!foundDepSources.exists(_.startsWith(s"os-lib_$actualScalaMajorVersion-0.7.8")))
 
           expect(foundDepSources.exists(_.startsWith("test-interface-1.0")))
           expect(foundDepSources.forall(_.endsWith("-sources.jar")))

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -1282,12 +1282,16 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
                  |""".stripMargin
             os.write.over(root / sourceFilePath, updatedSourceFile)
 
-            expect(!localClient.logMessages().exists(_.getMessage.startsWith("Error reading API from class file: ReloadTest : java.lang.UnsupportedClassVersionError: ReloadTest has been compiled by a more recent version of the Java Runtime")))
+            expect(!localClient.logMessages().exists(_.getMessage.startsWith(
+              "Error reading API from class file: ReloadTest : java.lang.UnsupportedClassVersionError: ReloadTest has been compiled by a more recent version of the Java Runtime"
+            )))
 
             val errorResponse =
               await(remoteServer.buildTargetCompile(new b.CompileParams(targets.asJava)).asScala)
             expect(errorResponse.getStatusCode == b.StatusCode.OK)
-            expect(localClient.logMessages().exists(_.getMessage.startsWith("Error reading API from class file: ReloadTest : java.lang.UnsupportedClassVersionError: ReloadTest has been compiled by a more recent version of the Java Runtime")))
+            expect(localClient.logMessages().exists(_.getMessage.startsWith(
+              "Error reading API from class file: ReloadTest : java.lang.UnsupportedClassVersionError: ReloadTest has been compiled by a more recent version of the Java Runtime"
+            )))
 
             val reloadResponse =
               extractWorkspaceReloadResponse(await(remoteServer.workspaceReload().asScala))

--- a/modules/integration/src/test/scala/scala/cli/integration/TestBspClient.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestBspClient.scala
@@ -28,6 +28,12 @@ class TestBspClient extends b.BuildClient {
     p.future
   }
 
+  def logMessages(): Seq[b.LogMessageParams] =
+    lock.synchronized {
+      messages0.reverseIterator.collect {
+        case p: b.LogMessageParams => p
+      }.toSeq
+    }
   def diagnostics(): Seq[b.PublishDiagnosticsParams] =
     lock.synchronized {
       messages0.reverseIterator.collect {


### PR DESCRIPTION
Right now from Bsp we pass to BspImpl build options that are the options from CLI and sources combined, this behaviour is incorrect since those options get used as options from CLI (so override all else) in `BspImpl.compile()` and `BspImpl.build()`. 

As a result we have incorrect project configuration on every change of options from sources after launching the BSP command! From what I remeber this is covered up by Metals since on every change of project configuration (more specific on a change of bloop config json file) we send `buildTarget/didChange` and receive from Metals a `workspace/reload` request. This allows us to fix everything since the options used in `BspImpl.compile() `and `BspImpl.build()` get reloaded to correct values that represent options passed from CLI. (See `initialBspOptions` and `bspReloadableOptionsReference` in Bsp)

No idea if IntelliJ does the same on our `buildTarget/didChange`, but if not this might be a major problem for IntelliJ users.

Also due to this error our tests needed some fixing. The test with correct bloop JVM version is a weird case since in old behaviour we never send `java-19` path to bloop before the workspace reload. So we were sending `java-11` and the `--release 19` resulted in an error during compilation. New behaviour is we send `java-19` path and the compilation succeeds, but we get some error logs from bloop from whetever it's doing with the compiler jar 🤷. We might need to fix this so that Scala CLI fails the compilation when the log is received from bloop, but I'm not sure if this is doable.