### PR TITLE
Add directives for JMH

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1045,6 +1045,11 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
            |
            |  def ghOrg  = "$ghOrg"
            |  def ghName = "$ghName"
+           |
+           |  def jmhVersion = "${Deps.Versions.jmh}"
+           |  def jmhOrg = "${Deps.jmhCore.dep.module.organization.value}"
+           |  def jmhCoreModule = "${Deps.jmhCore.dep.module.name.value}"
+           |  def jmhGeneratorBytecodeModule = "${Deps.jmhGeneratorBytecode.dep.module.name.value}"
            |}
            |""".stripMargin
       if (!os.isFile(dest) || os.read(dest) != code)

--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -459,7 +459,7 @@ object Build {
 
     build0 match {
       case successful: Successful =>
-        if (options.jmhOptions.runJmh.getOrElse(false) && scope == Scope.Main)
+        if (options.jmhOptions.canRunJmh && scope == Scope.Main)
           value {
             val res = jmhBuild(
               inputs,

--- a/modules/build/src/main/scala/scala/build/preprocessing/directives/DirectivesPreprocessingUtils.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/directives/DirectivesPreprocessingUtils.scala
@@ -12,6 +12,7 @@ import scala.build.preprocessing.directives
 object DirectivesPreprocessingUtils {
   val usingDirectiveHandlers: Seq[DirectiveHandler[BuildOptions]] =
     Seq[DirectiveHandler[_ <: HasBuildOptions]](
+      directives.Benchmarking.handler,
       directives.BuildInfo.handler,
       directives.ComputeVersion.handler,
       directives.Exclude.handler,

--- a/modules/cli/src/main/scala/scala/cli/commands/bloop/Bloop.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/bloop/Bloop.scala
@@ -33,7 +33,7 @@ object Bloop extends ScalaCommand[BloopOptions] {
       jvm = opts.jvm,
       coursier = opts.coursier
     )
-    val options = sharedOptions.buildOptions(false, None).orExit(opts.global.logging.logger)
+    val options = sharedOptions.buildOptions().orExit(opts.global.logging.logger)
 
     val javaHomeInfo = opts.compilationServer.bloopJvm
       .map(JvmUtils.downloadJvm(_, options))

--- a/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
@@ -30,12 +30,7 @@ object Doc extends ScalaCommand[DocOptions] {
 
   override def buildOptions(options: DocOptions): Option[BuildOptions] =
     sharedOptions(options)
-      .map(shared =>
-        shared.buildOptions(
-          enableJmh = shared.benchmarking.jmh.getOrElse(false),
-          jmhVersion = shared.benchmarking.jmhVersion
-        ).orExit(shared.logger)
-      )
+      .map(shared => shared.buildOptions().orExit(shared.logger))
 
   override def helpFormat: HelpFormat = super.helpFormat.withPrimaryGroup(HelpGroup.Doc)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
@@ -72,11 +72,8 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
   override def buildOptions(options: RunOptions): Some[BuildOptions] = Some {
     import options.*
     import options.sharedRun.*
-    val logger = options.shared.logger
-    val baseOptions = shared.buildOptions(
-      enableJmh = shared.benchmarking.jmh.contains(true),
-      jmhVersion = shared.benchmarking.jmhVersion
-    ).orExit(logger)
+    val logger      = options.shared.logger
+    val baseOptions = shared.buildOptions().orExit(logger)
     baseOptions.copy(
       mainClass = mainClass.mainClass,
       javaOptions = baseOptions.javaOptions.copy(
@@ -375,7 +372,8 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
 
     val mainClassOpt = build.options.mainClass.filter(_.nonEmpty) // trim it too?
       .orElse {
-        if (build.options.jmhOptions.runJmh.contains(false)) Some("org.openjdk.jmh.Main")
+        if build.options.jmhOptions.enableJmh.contains(true) && !build.options.jmhOptions.canRunJmh
+        then Some("org.openjdk.jmh.Main")
         else None
       }
     val mainClass = mainClassOpt match {

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/BenchmarkingOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/BenchmarkingOptions.scala
@@ -2,6 +2,7 @@ package scala.cli.commands.shared
 
 import caseapp.*
 
+import scala.build.internal.Constants
 import scala.cli.commands.tags
 
 // format: off
@@ -12,7 +13,7 @@ final case class BenchmarkingOptions(
     jmh: Option[Boolean] = None,
   @Group(HelpGroup.Benchmarking.toString)
   @Tag(tags.experimental)
-  @HelpMessage("Set JMH version")
+  @HelpMessage(s"Set JMH version (default: ${Constants.jmhVersion})")
   @ValueDescription("version")
     jmhVersion: Option[String] = None
 )

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Benchmarking.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Benchmarking.scala
@@ -1,0 +1,47 @@
+package scala.build.preprocessing.directives
+
+import dependency.*
+
+import scala.build.directives.*
+import scala.build.errors.BuildException
+import scala.build.internal.Constants
+import scala.build.options.{
+  BuildOptions,
+  ClassPathOptions,
+  JmhOptions,
+  ScalaNativeOptions,
+  ShadowingSeq
+}
+import scala.build.{Positioned, options}
+import scala.cli.commands.SpecificationLevel
+
+@DirectiveGroupName("Benchmarking options")
+@DirectiveExamples(s"//> using jmhVersion ${Constants.jmhVersion}")
+@DirectiveUsage(
+  "//> using jmh _value_ | using jmhVersion _value_",
+  """`//> using jmh` _value_
+    |
+    |`//> using jmhVersion` _value_
+    """.stripMargin.trim
+)
+@DirectiveDescription("Add benchmarking options")
+@DirectiveLevel(SpecificationLevel.EXPERIMENTAL)
+case class Benchmarking(
+  jmh: Option[Boolean] = None,
+  jmhVersion: Option[Positioned[String]] = None
+) extends HasBuildOptions {
+  def buildOptions: Either[BuildException, BuildOptions] =
+    Right(
+      BuildOptions(
+        jmhOptions = JmhOptions(
+          enableJmh = jmh,
+          runJmh = jmh,
+          jmhVersion = jmhVersion.map(_.value)
+        )
+      )
+    )
+}
+
+object Benchmarking {
+  val handler: DirectiveHandler[Benchmarking] = DirectiveHandler.derive
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -263,43 +263,53 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
     }
   }
 
-  test("simple jmh") {
-    val inputs = TestInputs(
-      os.rel / "benchmark.scala" ->
-        s"""package bench
-           |
-           |import java.util.concurrent.TimeUnit
-           |import org.openjdk.jmh.annotations._
-           |
-           |@BenchmarkMode(Array(Mode.AverageTime))
-           |@OutputTimeUnit(TimeUnit.NANOSECONDS)
-           |@Warmup(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)
-           |@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
-           |@Fork(0)
-           |class Benchmarks {
-           |
-           |  @Benchmark
-           |  def foo(): Unit = {
-           |    (1L to 10000000L).sum
-           |  }
-           |
-           |}
-           |""".stripMargin
-    )
-
-    withBsp(inputs, Seq(".", "--power", "--jmh")) { (_, _, remoteServer) =>
-      async {
-        val buildTargetsResp = await(remoteServer.workspaceBuildTargets().asScala)
-        val targets          = buildTargetsResp.getTargets.asScala.map(_.getId).toSeq
-        expect(targets.length == 2)
-
-        val compileResult =
-          await(remoteServer.buildTargetCompile(new b.CompileParams(targets.asJava)).asScala)
-        expect(compileResult.getStatusCode == b.StatusCode.OK)
-
-      }
+  for {
+    useDirective <- Seq(None, Some("//> using jmh"))
+    directiveString = useDirective.getOrElse("")
+    jmhOptions      = if (useDirective.isEmpty) Seq("--jmh") else Nil
+    testMessage = useDirective match {
+      case None            => jmhOptions.mkString(" ")
+      case Some(directive) => directive
     }
   }
+    test(s"simple jmh ($testMessage)") {
+      val inputs = TestInputs(
+        os.rel / "benchmark.scala" ->
+          s"""$directiveString
+             |package bench
+             |
+             |import java.util.concurrent.TimeUnit
+             |import org.openjdk.jmh.annotations._
+             |
+             |@BenchmarkMode(Array(Mode.AverageTime))
+             |@OutputTimeUnit(TimeUnit.NANOSECONDS)
+             |@Warmup(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+             |@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+             |@Fork(0)
+             |class Benchmarks {
+             |
+             |  @Benchmark
+             |  def foo(): Unit = {
+             |    (1L to 10000000L).sum
+             |  }
+             |
+             |}
+             |""".stripMargin
+      )
+
+      withBsp(inputs, Seq(".", "--power") ++ jmhOptions) { (_, _, remoteServer) =>
+        async {
+          val buildTargetsResp = await(remoteServer.workspaceBuildTargets().asScala)
+          val targets          = buildTargetsResp.getTargets.asScala.map(_.getId).toSeq
+          expect(targets.length == 2)
+
+          val compileResult =
+            await(remoteServer.buildTargetCompile(new b.CompileParams(targets.asJava)).asScala)
+          expect(compileResult.getStatusCode == b.StatusCode.OK)
+
+        }
+      }
+    }
 
   test("diagnostics") {
     val inputs = TestInputs(

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -263,54 +263,6 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
     }
   }
 
-  for {
-    useDirective <- Seq(None, Some("//> using jmh"))
-    directiveString = useDirective.getOrElse("")
-    jmhOptions      = if (useDirective.isEmpty) Seq("--jmh") else Nil
-    testMessage = useDirective match {
-      case None            => jmhOptions.mkString(" ")
-      case Some(directive) => directive
-    }
-  }
-    test(s"simple jmh ($testMessage)") {
-      val inputs = TestInputs(
-        os.rel / "benchmark.scala" ->
-          s"""$directiveString
-             |package bench
-             |
-             |import java.util.concurrent.TimeUnit
-             |import org.openjdk.jmh.annotations._
-             |
-             |@BenchmarkMode(Array(Mode.AverageTime))
-             |@OutputTimeUnit(TimeUnit.NANOSECONDS)
-             |@Warmup(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)
-             |@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
-             |@Fork(0)
-             |class Benchmarks {
-             |
-             |  @Benchmark
-             |  def foo(): Unit = {
-             |    (1L to 10000000L).sum
-             |  }
-             |
-             |}
-             |""".stripMargin
-      )
-
-      withBsp(inputs, Seq(".", "--power") ++ jmhOptions) { (_, _, remoteServer) =>
-        async {
-          val buildTargetsResp = await(remoteServer.workspaceBuildTargets().asScala)
-          val targets          = buildTargetsResp.getTargets.asScala.map(_.getId).toSeq
-          expect(targets.length == 2)
-
-          val compileResult =
-            await(remoteServer.buildTargetCompile(new b.CompileParams(targets.asJava)).asScala)
-          expect(compileResult.getStatusCode == b.StatusCode.OK)
-
-        }
-      }
-    }
-
   test("diagnostics") {
     val inputs = TestInputs(
       os.rel / "Test.scala" ->

--- a/modules/integration/src/test/scala/scala/cli/integration/JmhSuite.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/JmhSuite.scala
@@ -1,0 +1,27 @@
+package scala.cli.integration
+
+trait JmhSuite { _: ScalaCliSuite =>
+  protected lazy val simpleInputs: TestInputs = TestInputs(
+    os.rel / "benchmark.scala" ->
+      s"""package bench
+         |
+         |import java.util.concurrent.TimeUnit
+         |import org.openjdk.jmh.annotations._
+         |
+         |@BenchmarkMode(Array(Mode.AverageTime))
+         |@OutputTimeUnit(TimeUnit.NANOSECONDS)
+         |@Warmup(iterations = 1, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+         |@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+         |@Fork(0)
+         |class Benchmarks {
+         |
+         |  @Benchmark
+         |  def foo(): Unit = {
+         |    (1L to 10000000L).sum
+         |  }
+         |
+         |}
+         |""".stripMargin
+  )
+  protected lazy val expectedInOutput = """Result "bench.Benchmarks.foo":"""
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/JmhSuite.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/JmhSuite.scala
@@ -1,9 +1,10 @@
 package scala.cli.integration
 
 trait JmhSuite { _: ScalaCliSuite =>
-  protected lazy val simpleInputs: TestInputs = TestInputs(
+  protected def simpleBenchmarkingInputs(directivesString: String = ""): TestInputs = TestInputs(
     os.rel / "benchmark.scala" ->
-      s"""package bench
+      s"""$directivesString
+         |package bench
          |
          |import java.util.concurrent.TimeUnit
          |import org.openjdk.jmh.annotations._
@@ -23,5 +24,6 @@ trait JmhSuite { _: ScalaCliSuite =>
          |}
          |""".stripMargin
   )
-  protected lazy val expectedInOutput = """Result "bench.Benchmarks.foo":"""
+  protected lazy val expectedInBenchmarkingOutput = """Result "bench.Benchmarks.foo":"""
+  protected lazy val exampleOldJmhVersion         = "1.29"
 }

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -459,7 +459,7 @@ final case class BuildOptions(
       fetchSources = classPathOptions.fetchSources.getOrElse(false),
       addJvmRunner = addRunnerDependency0,
       addJvmTestRunner = isTests && addJvmTestRunner,
-      addJmhDependencies = jmhOptions.addJmhDependencies,
+      addJmhDependencies = jmhOptions.finalJmhVersion,
       extraRepositories = value(finalRepositories),
       keepResolution = internal.keepResolution,
       includeBuildServerDeps = useBuildServer.getOrElse(true),

--- a/modules/options/src/main/scala/scala/build/options/JmhOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/JmhOptions.scala
@@ -1,9 +1,28 @@
 package scala.build.options
 
+import scala.build.internal.Constants
+
+/** @param jmhVersion
+  *   the version of JMH to be used in the build
+  * @param enableJmh
+  *   toggle for enabling JMH dependency handling in the build (overrides [[runJmh]] when disabled)
+  * @param runJmh
+  *   toggle for whether JMH should actually be runnable from this build
+  */
 final case class JmhOptions(
-  addJmhDependencies: Option[String] = None,
+  jmhVersion: Option[String] = None,
+  enableJmh: Option[Boolean] = None,
   runJmh: Option[Boolean] = None
-)
+) {
+  def finalJmhVersion: Option[String] = jmhVersion.orElse(enableJmh match {
+    case Some(true) => Some(Constants.jmhVersion)
+    case _          => None
+  })
+
+  def canRunJmh: Boolean =
+    (for { enabled <- enableJmh; runnable <- runJmh } yield enabled && runnable)
+      .getOrElse(false)
+}
 
 object JmhOptions {
   implicit val hasHashData: HasHashData[JmhOptions] = HasHashData.derive

--- a/modules/options/src/main/scala/scala/build/options/JmhOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/JmhOptions.scala
@@ -7,7 +7,8 @@ import scala.build.internal.Constants
   * @param enableJmh
   *   toggle for enabling JMH dependency handling in the build (overrides [[runJmh]] when disabled)
   * @param runJmh
-  *   toggle for whether JMH should actually be runnable from this build
+  *   toggle for whether JMH should actually be runnable from this build (this value gets changed in
+  *   JMH builds to detect which main class is to be called as benchmarks are being run)
   */
 final case class JmhOptions(
   jmhVersion: Option[String] = None,

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -56,7 +56,7 @@ Run JMH benchmarks
 
 ### `--jmh-version`
 
-Set JMH version
+Set JMH version (default: 1.37)
 
 ## Compilation server options
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -5,6 +5,17 @@ sidebar_position: 2
 
 ## using directives
 
+### Benchmarking options
+
+Add benchmarking options
+
+`//> using jmh` _value_
+
+`//> using jmhVersion` _value_
+
+#### Examples
+`//> using jmhVersion 1.37`
+
 ### BuildInfo
 
 Generate BuildInfo for project


### PR DESCRIPTION
This adds the directive counterparts for the `--jmh` and `--jmh-version` CLI options.
```scala
//> using jmh
//> using jmhVersion
```