### PR TITLE
bugfix: Check if last segment of path exists

### DIFF
--- a/modules/build/src/main/scala/scala/build/input/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/input/Inputs.scala
@@ -476,6 +476,6 @@ object Inputs {
   def empty(projectName: String): Inputs =
     Inputs(Nil, None, os.pwd, projectName, false, None, true, false)
 
-  def baseName(p: os.Path) = if (p == os.root) "" else p.baseName
+  def baseName(p: os.Path) = if (p == os.root || p.lastOpt.isEmpty) "" else p.baseName
 
 }


### PR DESCRIPTION
I am not sure why this wouldn't work with `os.root`, but at least this should not throw.

Should fix https://github.com/VirtusLab/scala-cli/issues/2758