### PR TITLE
improvement: Use distinct on ScalacOpt

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -862,10 +862,10 @@ object Build {
           )
         }
 
-        val pluginScalacOptions = scalaArtifacts.compilerPlugins.distinct.map {
+        val pluginScalacOptions = scalaArtifacts.compilerPlugins.map {
           case (_, _, path) =>
             ScalacOpt(s"-Xplugin:$path")
-        }
+        }.distinct
 
         val semanticDbTargetRootOptions: Seq[ScalacOpt] =
           (semanticDbTargetRoot match


### PR DESCRIPTION
I am still getting an issue with multiple same plugin options and my guess is that the distinct doesn't work, especially that it is hard to figure out what can actually be contained there. Moving distinct to the end should be a much safer option.

Related to https://github.com/VirtusLab/scala-cli/issues/2708