### PR TITLE
bugfix: Fix duplicate options detection

### DIFF
--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -625,10 +625,24 @@ abstract class BuildTests(server: Boolean) extends TestUtil.ScalaCliBuildSuite {
   }
 
   test("cli scalac options shadowing using directives") {
-    val cliScalacOptions            = Seq("-Xmaxwarns", "4", "-g:source")
-    val usingDirectiveScalacOptions = Seq("-nobootcp", "-Xmaxwarns", "5", "-g:none")
+    val cliScalacOptions = Seq("-Xmaxwarns", "4", "-g:source", "-language:no2AutoTupling")
+    val usingDirectiveScalacOptions = Seq(
+      "-nobootcp",
+      "-Xmaxwarns",
+      "5",
+      "-g:none",
+      "-language:no2AutoTupling",
+      "-language:strictEquality"
+    )
 
-    val expectedOptions = Seq("-Xmaxwarns", "4", "-g:source", "-nobootcp")
+    val expectedOptions = Seq(
+      "-Xmaxwarns",
+      "4",
+      "-g:source",
+      "-language:no2AutoTupling",
+      "-nobootcp",
+      "-language:strictEquality"
+    )
 
     val inputs = TestInputs(
       os.rel / "foo.scala" ->
@@ -650,7 +664,7 @@ abstract class BuildTests(server: Boolean) extends TestUtil.ScalaCliBuildSuite {
       assert(maybeBuild.isRight)
       val build         = maybeBuild.toOption.get
       val scalacOptions = build.options.scalaOptions.scalacOptions.toSeq.map(_.value.value)
-      expect(scalacOptions == expectedOptions)
+      assertEquals(scalacOptions, expectedOptions)
     }
   }
 

--- a/modules/options/src/main/scala/scala/build/options/ScalacOpt.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalacOpt.scala
@@ -8,8 +8,9 @@ final case class ScalacOpt(value: String) {
     else Some("@").filter(value.startsWith)
 
   /** @return raw key for the option (only if the key can be shadowed from the CLI) */
-  private[options] def shadowableKey: Option[String] =
-    key.filterNot(key => ScalacOpt.repeatingKeys.exists(_.startsWith(key)))
+  private[options] def shadowableKey: Option[String] = key match
+    case Some(key) if ScalacOpt.repeatingKeys.exists(_.startsWith(key)) => Some(value)
+    case otherwise                                                      => otherwise
 }
 
 object ScalacOpt {


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/2708

Previously, for some of the options we would not deduplicate at all instead of using the full value. Now, for keys that can be added multiple times with different values we deduplicate the full option.