### PR TITLE
Change how help is referenced to avoid initialization oddness & update `case-app` to 2.1.0-M29

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
@@ -50,7 +50,6 @@ final case class PackageOptions(
   @HelpMessage("Generate a source JAR rather than an executable JAR")
   @Name("sources")
   @Name("src")
-  @Name("sourceJar")
   @Tag(tags.restricted)
   @Tag(tags.inShortHelp)
     source: Boolean = false,

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPushOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpPushOptions.scala
@@ -24,10 +24,6 @@ final case class PgpPushOptions(
   @Group(HelpGroup.PGP.toString)
   @HelpMessage("Whether to exit with code 0 if no key is passed")
     allowEmpty: Boolean = false,
-  @Group(HelpGroup.PGP.toString)
-  @HelpMessage("When running Scala CLI on the JVM, force running scala-cli-singing using a native launcher or a JVM launcher")
-  @Hidden
-    forceSigningExternally: Boolean = false
 ) extends HasGlobalOptions
 // format: on
 

--- a/modules/integration/src/test/scala/scala/cli/integration/InstallAndUninstallCompletionsTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/InstallAndUninstallCompletionsTests.scala
@@ -69,9 +69,7 @@ class InstallAndUninstallCompletionsTests extends ScalaCliSuite {
   lazy val fishRcScript: String = {
     val progName = "scala-cli"
     val script =
-      s"""
-    complete $progName -a '($progName complete fish-v1 (math 1 + (count (__fish_print_cmd_args))) (__fish_print_cmd_args))'
-         |""".stripMargin
+      s"""complete $progName -a '($progName complete fish-v1 (math 1 + (count (__fish_print_cmd_args))) (__fish_print_cmd_args))'"""
     addTags(script)
   }
 

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -142,7 +142,7 @@ object Deps {
     .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-core_2.13"))
   def bloopRifle       = ivy"ch.epfl.scala:bloop-rifle_2.13:${Versions.bloop}"
   def bsp4j            = ivy"ch.epfl.scala:bsp4j:2.1.1"
-  def caseApp          = ivy"com.github.alexarchambault::case-app:2.1.0-M28"
+  def caseApp          = ivy"com.github.alexarchambault::case-app:2.1.0-M29"
   def collectionCompat = ivy"org.scala-lang.modules::scala-collection-compat:2.12.0"
   // Force using of 2.13 - is there a better way?
   def coursier    = ivy"io.get-coursier:coursier_2.13:${Versions.coursier}"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -2122,11 +2122,6 @@ Try to push the key even if Scala CLI thinks it's not a public key
 [Internal]
 Whether to exit with code 0 if no key is passed
 
-### `--force-signing-externally`
-
-[Internal]
-When running Scala CLI on the JVM, force running scala-cli-singing using a native launcher or a JVM launcher
-
 ### Pgp scala signing options
 
 Available in commands:

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -751,7 +751,7 @@ Generate a library JAR rather than an executable JAR
 
 ### `--source`
 
-Aliases: `--source-jar`, `--sources`, `--src`
+Aliases: `--sources`, `--src`
 
 Generate a source JAR rather than an executable JAR
 


### PR DESCRIPTION
This includes the update for `case-app`.

This supersedes pull #2964

Draft because I don't really understand why this only effected some options and not others and why only with this version of case app. That said...

`scala-cli` overrides `val messages`. This override references `name` which is a `def` in `CaseApp` equal to `help.progName`. Which is equal to `messages.progName`. Which is the `val messages` being defined. I'm not entirely sure on that last bit but I suspect Scala is not entirely sure as well. :)

Breaking these recursive dependencies appears to work. That's what this patch tries to do.
 
I suspect there is an issue in how `CaseApp` is constructed. Or perhaps `def help` should be overriden instead of `val messages`.