### PR TITLE
Ensure that passing Java props into Scala CLI as launcher args would also pass it into BSP configuration

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -65,6 +65,10 @@ object ScalaCli {
   def getDefaultScalaVersion: String =
     launcherOptions.scalaRunner.cliUserScalaVersion.getOrElse(Constants.defaultScalaVersion)
 
+  private var launcherJavaPropArgs: List[String] = List.empty
+
+  def getLauncherJavaPropArgs: List[String] = launcherJavaPropArgs
+
   private def partitionArgs(args: Array[String]): (Array[String], Array[String]) = {
     val systemProps = args.takeWhile(_.startsWith("-D"))
     (systemProps, args.drop(systemProps.size))
@@ -294,6 +298,7 @@ object ScalaCli {
         }
     }
     val (systemProps, scalaCliArgs) = partitionArgs(remainingArgs)
+    if systemProps.nonEmpty then launcherJavaPropArgs = systemProps.toList
     setSystemProps(systemProps)
 
     (new BouncycastleSignerMaker).maybeInit()

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -41,9 +41,10 @@ abstract class ScalaCommand[T <: HasGlobalOptions](implicit myParser: Parser[T],
   private val globalOptionsAtomic: AtomicReference[GlobalOptions] =
     new AtomicReference(GlobalOptions.default)
 
-  private def globalOptions: GlobalOptions       = globalOptionsAtomic.get()
-  protected def launcherOptions: LauncherOptions = ScalaCli.launcherOptions
-  protected def defaultScalaVersion: String      = ScalaCli.getDefaultScalaVersion
+  private def globalOptions: GlobalOptions         = globalOptionsAtomic.get()
+  protected def launcherOptions: LauncherOptions   = ScalaCli.launcherOptions
+  protected def defaultScalaVersion: String        = ScalaCli.getDefaultScalaVersion
+  protected def launcherJavaPropArgs: List[String] = ScalaCli.getLauncherJavaPropArgs
 
   def sharedOptions(t: T): Option[SharedOptions] = // hello borked unused warning
     None

--- a/modules/cli/src/main/scala/scala/cli/commands/setupide/SetupIde.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/setupide/SetupIde.scala
@@ -162,6 +162,7 @@ object SetupIde extends ScalaCommand[SetupIdeOptions] {
     val bspArgs =
       List(launcher) ++
         finalLauncherOptions.toCliArgs ++
+        launcherJavaPropArgs ++
         List("bsp") ++
         debugOpt ++
         List("--json-options", scalaCliBspJsonDestination.toString) ++

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -2202,4 +2202,17 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
         expect(bspConfig.argv.indexOfSlice(cliVersionArgs) < bspConfig.argv.indexOf("bsp"))
       }
     }
+
+  test("setup-ide passes Java props to the BSP configuration correctly") {
+    val scriptName = "hello.sc"
+    TestInputs(os.rel / scriptName -> s"""println("Hello")""").fromRoot { root =>
+      val javaProps = List("-Dfoo=bar", "-Dbar=baz")
+      os.proc(TestUtil.cli, javaProps, "setup-ide", scriptName, extraOptions)
+        .call(cwd = root)
+      val bspConfig = readBspConfig(root)
+      expect(bspConfig.argv.head == TestUtil.cliPath)
+      expect(bspConfig.argv.containsSlice(javaProps))
+      expect(bspConfig.argv.indexOfSlice(javaProps) < bspConfig.argv.indexOf("bsp"))
+    }
+  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -2185,7 +2185,7 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
     ) {
       val scriptName = "cli-version.sc"
       val inputs = TestInputs(
-        os.rel / scriptName -> s"""println("Hello from launcher v$cliVersion"""
+        os.rel / scriptName -> s"""println("Hello from launcher v$cliVersion")"""
       )
       inputs.fromRoot { root =>
         val cliVersionArgs = List("--cli-version", cliVersion)


### PR DESCRIPTION
Fixes #2019 
We should also revalidate https://github.com/VirtusLab/scala-cli/issues/2963 after this gets released, as I suspect it would also get fixed by it.