### PR TITLE
Bump `scala-cli-signing` to 0.2.4

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -119,7 +119,7 @@ object Deps {
     def maxScalaNativeForScalaPy          = scalaNative04
     def maxScalaNativeForMillExport       = scalaNative04
     def scalaPackager                     = "0.1.29"
-    def signingCli                        = "0.2.3"
+    def signingCli                        = "0.2.4"
     def signingCliJvmVersion              = Java.defaultJava
     def javaSemanticdb                    = "0.10.0"
     def javaClassName                     = "0.1.3"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -2133,7 +2133,7 @@ Available in commands:
 ### `--signing-cli-version`
 
 [Internal]
-scala-cli-signing version when running externally (0.2.3 by default)
+scala-cli-signing version when running externally (0.2.4 by default)
 
 ### `--signing-cli-java-arg`
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-cli-signing/releases/tag/v0.2.4