### PR TITLE
Apply increased verbosity when compiling via BSP

### DIFF
--- a/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspServer.scala
@@ -26,7 +26,6 @@ class BspServer(
     with JavaBuildServerForwardStubs
     with JvmBuildServerForwardStubs
     with HasGeneratedSourcesImpl {
-
   private var client: Option[BuildClient] = None
 
   @volatile private var intelliJ: Boolean = presetIntelliJ
@@ -200,7 +199,7 @@ class BspServer(
     super.buildTargetCleanCache(check(params))
 
   override def buildTargetCompile(params: b.CompileParams): CompletableFuture[b.CompileResult] =
-    compile(() => super.buildTargetCompile(check(params)))
+    compile(() => super.buildTargetCompile(check(params.withVerbosity(logger.verbosity > 0))))
 
   override def buildTargetDependencySources(
     params: b.DependencySourcesParams

--- a/modules/build/src/main/scala/scala/build/bsp/package.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/package.scala
@@ -9,6 +9,31 @@ import scala.jdk.CollectionConverters.*
 
 package object bsp {
 
+  extension (compileParams: b.CompileParams) {
+    def duplicate(): b.CompileParams = {
+      val params = new b.CompileParams(compileParams.getTargets)
+      params.setOriginId(compileParams.getOriginId)
+      params.setArguments(compileParams.getArguments)
+      params
+    }
+
+    def withExtraArgs(extraArgs: List[String]): b.CompileParams = {
+      val params            = compileParams.duplicate()
+      val previousArguments = Option(params.getArguments).toList.flatMap(_.asScala)
+      val newArguments      = (previousArguments ++ extraArgs).asJava
+      params.setArguments(newArguments)
+      params
+    }
+
+    def withVerbosity(verbose: Boolean): b.CompileParams = {
+      val verboseArg = "--verbose"
+      val argumentsContainVerboseArg =
+        Option(compileParams.getArguments).exists(_.contains(verboseArg))
+      if verbose && !argumentsContainVerboseArg then compileParams.withExtraArgs(List(verboseArg))
+      else compileParams
+    }
+  }
+
   implicit class Ext[T](private val f: CompletableFuture[T]) extends AnyVal {
     def logF: CompletableFuture[T] =
       f.handle { (res, err) =>

--- a/modules/integration/src/test/scala/scala/cli/integration/BspSuite.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspSuite.scala
@@ -86,7 +86,7 @@ trait BspSuite { _: ScalaCliSuite =>
     def attempt(): Try[T] = Try {
       val inputsRoot                              = inputs.root()
       val root                                    = reuseRoot.getOrElse(inputsRoot)
-      val stdErrPathOpt: Option[os.ProcessOutput] = stdErrOpt.map(path => inputsRoot / path)
+      val stdErrPathOpt: Option[os.ProcessOutput] = stdErrOpt.map(path => root / path)
       val stderr: os.ProcessOutput                = stdErrPathOpt.getOrElse(os.Inherit)
 
       val proc = os.proc(TestUtil.cli, "bsp", bspOptions ++ extraOptionsOverride, args)


### PR DESCRIPTION
This passes the `--verbose` argument to Bloop's BSP when verbosity is > 0.

It applies both for passing `-v` to the raw `bsp` sub-command:
```bash
scala-cli bsp . -v
```
as well as the BSP connection loaded by one's IDE after running `setup-ide`:
```bash
scala-cli setup-ide . -v
```