### PR TITLE
Ensure `--version` passed to the default command works with `--offline`

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/default/Default.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/default/Default.scala
@@ -39,7 +39,15 @@ class Default(actualHelp: => RuntimeCommandsHelp)
 
   override def runCommand(options: DefaultOptions, args: RemainingArgs, logger: Logger): Unit =
     // can't fully re-parse and redirect to Version because of --cli-version and --scala-version clashing
-    if options.version then Version.runCommand(VersionOptions(options.shared.global), args, logger)
+    if options.version then
+      Version.runCommand(
+        options = VersionOptions(
+          global = options.shared.global,
+          offline = options.shared.coursier.getOffline().getOrElse(false)
+        ),
+        args = args,
+        logger = logger
+      )
     else
       {
         val shouldDefaultToRun =

--- a/modules/integration/src/test/scala/scala/cli/integration/VersionTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/VersionTests.scala
@@ -5,17 +5,25 @@ import com.eed3si9n.expecty.Expecty.expect
 import scala.cli.integration.VersionTests.variants
 
 class VersionTests extends ScalaCliSuite {
-  test("version command") {
-    // tests if the format is correct instead of comparing to a version passed via Constants
-    // in order to catch errors in Mill configuration, too
-    val versionRegex = ".*\\d+[.]\\d+[.]\\d+.*".r
-    for (versionOption <- variants) {
-      val version = os.proc(TestUtil.cli, versionOption).call(check = false)
+
+  for (versionOption <- variants) {
+    test(versionOption) {
+      // tests if the format is correct instead of comparing to a version passed via Constants
+      // in order to catch errors in Mill configuration, too
+      val versionRegex = ".*\\d+[.]\\d+[.]\\d+.*".r
+      val version      = os.proc(TestUtil.cli, versionOption).call(check = false)
       assert(
         versionRegex.findFirstMatchIn(version.out.text()).isDefined,
         clues(version.exitCode, version.out.text(), version.err.text())
       )
       expect(version.exitCode == 0)
+    }
+
+    test(s"$versionOption --offline") {
+      TestInputs.empty.fromRoot { root =>
+        // TODO: --power should not be necessary here
+        os.proc(TestUtil.cli, versionOption, "--offline", "--power").call(cwd = root)
+      }
     }
   }
 


### PR DESCRIPTION
https://discord.com/channels/632150470000902164/901153021638082660/1288154845907517480
and also https://github.com/VirtusLab/scala-cli/issues/3123#issuecomment-2371582135
TL;DR `--version` passed together with `--offline` to the default command still checked for the latest version of the CLI, as the `--offline` that was being parsed was tied to coursier, and not `version`.
```bash
scala-cli --version --offline --power
```
What's funny, the 2 different `--offline` options have different spec levels, so this particular usage requires `--power` mode until a proper fix is in place.

It's sort of a quick & dirty fix for now, need to unify `--offline` across the different sub-commands as a follow-up (but that's a larger refactor).
kudos to @kubukoz for spotting the problem.