### PR TITLE
Bump `scala-js-cli` to 1.17.0.1

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -28,7 +28,7 @@ object Scala {
   val testRunnerScalaVersions = runnerScalaVersions ++ allScala3
 
   def scalaJs    = "1.17.0"
-  def scalaJsCli = scalaJs // this must be compatible with the Scala.js version
+  def scalaJsCli = "1.17.0.1" // this must be compatible with the Scala.js version
 
   def listAll: Seq[String] = {
     def patchVer(sv: String): Int =

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1358,7 +1358,7 @@ Path to the Scala.js linker
 ### `--js-cli-version`
 
 [Internal]
-Scala.js CLI version to use for linking (1.17.0 by default).
+Scala.js CLI version to use for linking (1.17.0.1 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -814,7 +814,7 @@ Path to the Scala.js linker
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Scala.js CLI version to use for linking (1.17.0 by default).
+Scala.js CLI version to use for linking (1.17.0.1 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -418,7 +418,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.17.0 by default).
+Scala.js CLI version to use for linking (1.17.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -1181,7 +1181,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.17.0 by default).
+Scala.js CLI version to use for linking (1.17.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -1776,7 +1776,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.17.0 by default).
+Scala.js CLI version to use for linking (1.17.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -2395,7 +2395,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.17.0 by default).
+Scala.js CLI version to use for linking (1.17.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -3023,7 +3023,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.17.0 by default).
+Scala.js CLI version to use for linking (1.17.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -3609,7 +3609,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.17.0 by default).
+Scala.js CLI version to use for linking (1.17.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -4270,7 +4270,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.17.0 by default).
+Scala.js CLI version to use for linking (1.17.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -4938,7 +4938,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.17.0 by default).
+Scala.js CLI version to use for linking (1.17.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -5871,7 +5871,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.17.0 by default).
+Scala.js CLI version to use for linking (1.17.0.1 by default).
 
 **--js-cli-java-arg**
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-js-cli/releases/tag/v1.17.0.1
https://github.com/VirtusLab/scala-cli/issues/3213#issuecomment-2441891787
cc @Quafadas 