### PR TITLE
Add a `--js-emit-wasm` option and a corresponding `using` directive

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaJsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaJsOptions.scala
@@ -61,6 +61,11 @@ final case class ScalaJsOptions(
 
   @Group(HelpGroup.ScalaJs.toString)
   @Tag(tags.should)
+  @HelpMessage("Experimental: emit WASM")
+    jsEmitWasm: Option[Boolean] = None,
+
+  @Group(HelpGroup.ScalaJs.toString)
+  @Tag(tags.should)
   @HelpMessage("A header that will be added at the top of generated .js files")
     jsHeader: Option[String] = None,
 

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaJsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaJsOptions.scala
@@ -60,7 +60,7 @@ final case class ScalaJsOptions(
     jsDom: Option[Boolean] = None,
 
   @Group(HelpGroup.ScalaJs.toString)
-  @Tag(tags.should)
+  @Tag(tags.experimental)
   @HelpMessage("Experimental: emit WASM")
     jsEmitWasm: Option[Boolean] = None,
 

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaJsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaJsOptions.scala
@@ -61,7 +61,7 @@ final case class ScalaJsOptions(
 
   @Group(HelpGroup.ScalaJs.toString)
   @Tag(tags.experimental)
-  @HelpMessage("Experimental: emit WASM")
+  @HelpMessage("Emit WASM")
     jsEmitWasm: Option[Boolean] = None,
 
   @Group(HelpGroup.ScalaJs.toString)

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -251,7 +251,8 @@ final case class SharedOptions(
       smallModuleForPackage = jsSmallModuleForPackage,
       esVersionStr = jsEsVersion,
       noOpt = jsNoOpt,
-      remapEsModuleImportMap = jsEsModuleImportMap.filter(_.trim.nonEmpty).map(os.Path(_, Os.pwd))
+      remapEsModuleImportMap = jsEsModuleImportMap.filter(_.trim.nonEmpty).map(os.Path(_, Os.pwd)),
+      jsEmitWasm = jsEmitWasm
     )
   }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -252,7 +252,7 @@ final case class SharedOptions(
       esVersionStr = jsEsVersion,
       noOpt = jsNoOpt,
       remapEsModuleImportMap = jsEsModuleImportMap.filter(_.trim.nonEmpty).map(os.Path(_, Os.pwd)),
-      jsEmitWasm = jsEmitWasm
+      jsEmitWasm = jsEmitWasm.getOrElse(false)
     )
   }
 

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaJs.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaJs.scala
@@ -43,6 +43,8 @@ import scala.util.Try
     |`//> using jsModuleSplitStyleStr` _value_
     |
     |`//> using jsEsVersionStr` _value_
+    |    
+    |`//> using jsEmitWasm` _true|false_
     |
     |`//> using jsEsModuleImportMap` _value_
     |""".stripMargin
@@ -65,7 +67,8 @@ final case class ScalaJs(
   jsAvoidClasses: Option[Boolean] = None,
   jsAvoidLetsAndConsts: Option[Boolean] = None,
   jsModuleSplitStyleStr: Option[String] = None,
-  jsEsVersionStr: Option[String] = None
+  jsEsVersionStr: Option[String] = None,
+  jsEmitWasm: Option[Boolean] = None
 ) extends HasBuildOptions {
   // format: on
   def buildOptions: Either[BuildException, BuildOptions] =
@@ -83,7 +86,8 @@ final case class ScalaJs(
       avoidLetsAndConsts = jsAvoidLetsAndConsts,
       moduleSplitStyleStr = jsModuleSplitStyleStr,
       esVersionStr = jsEsVersionStr,
-      noOpt = jsNoOpt
+      noOpt = jsNoOpt,
+      jsEmitWasm = jsEmitWasm.getOrElse(false)
     )
 
     def absFilePath(pathStr: String): Either[ImportMapNotFound, Path] =

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
@@ -291,7 +291,7 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
     }
   }
 
-  test("Emit Wasm".only) {
+  test("Emit Wasm") {
     val outDir = "out"
 
     val inputs = TestInputs(

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
@@ -291,6 +291,50 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
     }
   }
 
+  test("Emit Wasm".only) {
+    val outDir = "out"
+
+    val inputs = TestInputs(
+      os.rel / "run.scala" ->
+        s"""//> using jsEmitWasm true
+           |//> using jsModuleKind es
+           |//> using jsModuleSplitStyleStr fewestmodules
+           |
+           |object Foo {
+           |  def main(args: Array[String]): Unit = {
+           |    println("Hello")
+           |  }
+           |}
+           |""".stripMargin
+    )
+    inputs.fromRoot { root =>
+      val absOutDir = root / outDir
+
+      os.proc(
+        TestUtil.cli,
+        "--power",
+        "package",
+        "run.scala",
+        "--js",
+        "-o",
+        absOutDir.toString(),
+        "-f",
+        extraOptions
+      )
+        .call(cwd = root).out.trim()
+      expect(os.exists(absOutDir / "main.wasm"))
+
+      // This would require node 22. As it's tested in the scala-cli-js repo, I'm going to claim that is isn't necessary here.
+      // os.proc("node", "--experimental-wasm-exnref", "main.js").call(
+      //   cwd = root / outDir,
+      //   check = true,
+      //   stdin = os.Inherit,
+      //   stdout = os.Inherit,
+      //   stderr = os.Inherit
+      // )
+    }
+  }
+
   test("remap imports directive") {
     val importmapFile = "importmap.json"
     val outDir        = "out"

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
@@ -324,14 +324,7 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
         .call(cwd = root).out.trim()
       expect(os.exists(absOutDir / "main.wasm"))
 
-      // This would require node 22. As it's tested in the scala-cli-js repo, I'm going to claim that is isn't necessary here.
-      // os.proc("node", "--experimental-wasm-exnref", "main.js").call(
-      //   cwd = root / outDir,
-      //   check = true,
-      //   stdin = os.Inherit,
-      //   stdout = os.Inherit,
-      //   stderr = os.Inherit
-      // )
+      // TODO : Run WASM using node. Requires node 22.
     }
   }
 

--- a/modules/options/src/main/scala/scala/build/internal/ScalaJsLinkerConfig.scala
+++ b/modules/options/src/main/scala/scala/build/internal/ScalaJsLinkerConfig.scala
@@ -11,7 +11,8 @@ final case class ScalaJsLinkerConfig(
   jsHeader: Option[String] = None,
   prettyPrint: Boolean = false,
   relativizeSourceMapBase: Option[String] = None,
-  remapEsModuleImportMap: Option[os.Path] = None
+  remapEsModuleImportMap: Option[os.Path] = None,
+  emitWasm: Boolean = false
 ) {
   def linkerCliArgs: Seq[String] = {
     val moduleKindArgs       = Seq("--moduleKind", moduleKind)
@@ -34,6 +35,7 @@ final case class ScalaJsLinkerConfig(
     val jsEsModuleImportMap = if (remapEsModuleImportMap.nonEmpty)
       Seq("--importmap", remapEsModuleImportMap.getOrElse(os.pwd / "importmap.json").toString)
     else Nil
+    val jsEmitWasm = if (emitWasm) Seq("--emitWasm") else Nil
 
     val configArgs = Seq[os.Shellable](
       moduleKindArgs,
@@ -45,7 +47,8 @@ final case class ScalaJsLinkerConfig(
       relativizeSourceMapBaseArgs,
       jsHeaderArg,
       prettyPrintArgs,
-      jsEsModuleImportMap
+      jsEsModuleImportMap,
+      jsEmitWasm
     )
 
     configArgs.flatMap(_.value)

--- a/modules/options/src/main/scala/scala/build/options/ScalaJsOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaJsOptions.scala
@@ -25,7 +25,8 @@ final case class ScalaJsOptions(
   moduleSplitStyleStr: Option[String] = None,
   smallModuleForPackage: List[String] = Nil,
   esVersionStr: Option[String] = None,
-  noOpt: Option[Boolean] = None
+  noOpt: Option[Boolean] = None,
+  jsEmitWasm: Boolean = false
 ) {
   def fullOpt: Either[UnrecognizedJsOptModeError, Boolean] =
     if (mode.isValid)
@@ -150,7 +151,8 @@ final case class ScalaJsOptions(
       smallModuleForPackage = smallModuleForPackage,
       esFeatures = esFeatures,
       jsHeader = header,
-      remapEsModuleImportMap = remapEsModuleImportMap
+      remapEsModuleImportMap = remapEsModuleImportMap,
+      emitWasm = jsEmitWasm
     )
   }
 }

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1310,10 +1310,6 @@ The Scala.js module kind: commonjs/common, esmodule/es, nomodule/none
 
 Emit source maps
 
-### `--js-emit-wasm`
-
-Experimental (!): Use the webassembly (WASM) backend of the scala JS linker. 
-
 ### `--js-source-maps-path`
 
 Set the destination path of source maps
@@ -1325,6 +1321,10 @@ A file relative to the root directory containing import maps for ES module impor
 ### `--js-dom`
 
 Enable jsdom
+
+### `--js-emit-wasm`
+
+Experimental: emit WASM
 
 ### `--js-header`
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1324,7 +1324,7 @@ Enable jsdom
 
 ### `--js-emit-wasm`
 
-Experimental: emit WASM
+Emit WASM
 
 ### `--js-header`
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1310,6 +1310,10 @@ The Scala.js module kind: commonjs/common, esmodule/es, nomodule/none
 
 Emit source maps
 
+### `--js-emit-wasm`
+
+Experimental (!): Use the webassembly (WASM) backend of the scala JS linker. 
+
 ### `--js-source-maps-path`
 
 Set the destination path of source maps

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -394,8 +394,6 @@ Add Scala.js options
 
 `//> using jsEmitSourceMaps` _true|false_
 
-`//> using jsEmitWasm` _true|false_
-
 `//> using jsDom` _true|false_
 
 `//> using jsHeader` _value_
@@ -409,6 +407,8 @@ Add Scala.js options
 `//> using jsModuleSplitStyleStr` _value_
 
 `//> using jsEsVersionStr` _value_
+    
+`//> using jsEmitWasm` _true|false_
 
 `//> using jsEsModuleImportMap` _value_
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -394,6 +394,8 @@ Add Scala.js options
 
 `//> using jsEmitSourceMaps` _true|false_
 
+`//> using jsEmitWasm` _true|false_
+
 `//> using jsDom` _true|false_
 
 `//> using jsHeader` _value_

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -269,6 +269,8 @@ Add Scala.js options
 
 `//> using jsEmitSourceMaps` _true|false_
 
+`//> using jsEmitWasm` _true|false_
+
 `//> using jsDom` _true|false_
 
 `//> using jsHeader` _value_

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -269,8 +269,6 @@ Add Scala.js options
 
 `//> using jsEmitSourceMaps` _true|false_
 
-`//> using jsEmitWasm` _true|false_
-
 `//> using jsDom` _true|false_
 
 `//> using jsHeader` _value_
@@ -284,6 +282,8 @@ Add Scala.js options
 `//> using jsModuleSplitStyleStr` _value_
 
 `//> using jsEsVersionStr` _value_
+    
+`//> using jsEmitWasm` _true|false_
 
 `//> using jsEsModuleImportMap` _value_
 


### PR DESCRIPTION
- [x] run `./mill -i generate-reference-doc.run` in order to generate doc correctly
- [x] check directive tags (should vs experimental)
- [x]  directive doc
- [x] test
- [x] pass CI