### PR TITLE
Deprecate the `--source` command line option for the `package` sub-command

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
@@ -49,10 +49,11 @@ final case class PackageOptions(
   @Group(HelpGroup.Package.toString)
   @HelpMessage("Generate a source JAR rather than an executable JAR")
   @Name("sources")
-  @Name("src")
+  @Name("source")
+  @Tag(tags.deprecated("source")) // alias to be removed in 1.6.x
   @Tag(tags.restricted)
   @Tag(tags.inShortHelp)
-    source: Boolean = false,
+    src: Boolean = false,
   @Group(HelpGroup.Package.toString)
   @HelpMessage("Generate a scaladoc JAR rather than an executable JAR")
   @ExtraName("scaladoc")
@@ -144,7 +145,7 @@ final case class PackageOptions(
   def packageTypeOpt: Option[PackageType] =
     forcedPackageTypeOpt.orElse {
       if (library) Some(PackageType.LibraryJar)
-      else if (source) Some(PackageType.SourceJar)
+      else if (src) Some(PackageType.SourceJar)
       else if (assembly) Some(
         PackageType.Assembly(
           addPreamble = preamble,

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
@@ -48,6 +48,8 @@ final case class PackageOptions(
     library: Boolean = false,
   @Group(HelpGroup.Package.toString)
   @HelpMessage("Generate a source JAR rather than an executable JAR")
+  @Name("sourcesJar")
+  @Name("jarSources")
   @Name("sources")
   @Name("source")
   @Tag(tags.deprecated("source")) // alias to be removed in 1.6.x

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
@@ -207,7 +207,11 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
               names
                 .tail
                 .sortBy(_.dropWhile(_ == '-'))
-                .map(n => s"`$n`")
+                .map {
+                  case name if arg.deprecatedOptionAliases.contains(name) =>
+                    s"[deprecated] `$name`"
+                  case name => s"`$name`"
+                }
                 .mkString("Aliases: ", ", ", "\n\n")
             )
 

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -859,11 +859,16 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
   test("source JAR") {
     val dest = os.rel / "sources.jar"
     simpleInputWithScalaAndSc.fromRoot { root =>
-      os.proc(TestUtil.cli, "--power", "package", extraOptions, ".", "-o", dest, "--source").call(
-        cwd = root,
-        stdin = os.Inherit,
-        stdout = os.Inherit
-      )
+      val r =
+        os.proc(TestUtil.cli, "--power", "package", extraOptions, ".", "-o", dest, "--source").call(
+          cwd = root,
+          stdin = os.Inherit,
+          stdout = os.Inherit,
+          stderr = os.Pipe
+        )
+      expect(r.err.trim().contains(
+        "The --source option alias has been deprecated and may be removed in a future version"
+      ))
 
       expect(os.isFile(root / dest))
 

--- a/modules/specification-level/src/main/scala/scala/cli/commands/SpecificationLevel.scala
+++ b/modules/specification-level/src/main/scala/scala/cli/commands/SpecificationLevel.scala
@@ -58,6 +58,8 @@ object SpecificationLevel {
 }
 
 object tags {
+  val valueSeparator: String = ":" // separates values in a tag
+
   // specification level tags
   val experimental: String   = SpecificationLevel.EXPERIMENTAL.toString
   val restricted: String     = SpecificationLevel.RESTRICTED.toString
@@ -68,7 +70,10 @@ object tags {
   // other tags
   // the `inShortHelp` tag whitelists options to be included in --help
   // this is in contrast to blacklisting options in --help with the @Hidden annotation
-  val inShortHelp: String = "inShortHelp" // included in --help by default
+  val inShortHelp: String      = "inShortHelp" // included in --help by default
+  val deprecatedPrefix: String = "deprecated"
+  def deprecated(name: String): String =
+    s"$deprecatedPrefix$valueSeparator$name" // produces a deprecated warning for the given name
 
   def levelFor(name: String): Option[SpecificationLevel] = name match {
     case `experimental`   => Some(SpecificationLevel.EXPERIMENTAL)

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -751,7 +751,7 @@ Generate a library JAR rather than an executable JAR
 
 ### `--src`
 
-Aliases: [deprecated] `--source`, `--sources`
+Aliases: `--jar-sources`, [deprecated] `--source`, `--sources`, `--sources-jar`
 
 Generate a source JAR rather than an executable JAR
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -749,9 +749,9 @@ Overwrite the destination file, if it exists
 
 Generate a library JAR rather than an executable JAR
 
-### `--source`
+### `--src`
 
-Aliases: `--sources`, `--src`
+Aliases: [deprecated] `--source`, `--sources`
 
 Generate a source JAR rather than an executable JAR
 


### PR DESCRIPTION
- the `--source` command line option alias (which makes the `package` sub-command produce source JARs) is getting deprecated in preparation for https://github.com/VirtusLab/scala-cli/pull/3253.
- it will likely be removed in Scala CLI v1.6.0, where `--source` will be treated as a compiler option instead.
- the recommended syntax would now be `--src`.

```bash
scala-cli-jvm --power package --source .                       
# [warn] The --source option alias has been deprecated and may be removed in a future version.
(...)
```