### PR TITLE
Tag failing native packager tests as flaky

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
@@ -430,7 +430,8 @@ class NativePackagerTests extends ScalaCliSuite {
   }
 
   if (Properties.isLinux)
-    test("building docker image with scala native app") {
+    // FIXME make this test pass consistently on the CI again
+    test("building docker image with scala native app".flaky) {
       TestUtil.retryOnCi() {
         runNativeTest()
       }


### PR DESCRIPTION
Tagging a test which started failing as flaky.
Note that it started failing on the exact same commit, so the failure wasn't caused by anything in our code.

last green CI: https://github.com/VirtusLab/scala-cli/actions/runs/11702926908
example failure: https://github.com/VirtusLab/scala-cli/actions/runs/11792000662/job/32852054642#step:5:10373