### PR TITLE
Allow shading of single-choice compiler options from the command line regardless of `-`/`--` prefix

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -177,9 +177,7 @@ abstract class ScalaCommand[T <: HasGlobalOptions](implicit myParser: Parser[T],
     sharedOptions(options).foreach { so =>
       val scalacOpts = so.scalacOptions.toScalacOptShadowingSeq
       scalacOpts.keys
-        .find(k =>
-          k == ScalacOpt(s"-$YScriptRunnerOption") || k == ScalacOpt(s"--$YScriptRunnerOption")
-        )
+        .find(_.value.noDashPrefixes == YScriptRunnerOption)
         .map(_.value)
         .foreach(k =>
           logger.message(LegacyScalaOptions.yScriptRunnerWarning(k, scalacOpts.getOption(k)))

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileScalacCompatTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileScalacCompatTestDefinitions.scala
@@ -205,4 +205,36 @@ trait CompileScalacCompatTestDefinitions { _: CompileTestDefinitions =>
         }
       }
   }
+
+  {
+    val prefixes = Seq("-", "--")
+    for {
+      prefix1 <- prefixes
+      prefix2 <- prefixes
+      optionKey = "Werror"
+      option1   = prefix1 + optionKey
+      option2   = prefix2 + optionKey
+      if actualScalaVersion.startsWith("3")
+    } test(
+      s"allow to override $option1 compiler option passed via directive by passing $option2 from the command line"
+    ) {
+      val file = "example.scala"
+      TestInputs(os.rel / file ->
+        s"""//> using options -Wunused:all $option1
+           |@main def main() = {
+           |  val unused = ""
+           |  println("Hello, world!")
+           |}
+           |""".stripMargin).fromRoot { root =>
+        os.proc(
+          TestUtil.cli,
+          "compile",
+          file,
+          s"$option2:false",
+          extraOptions
+        )
+          .call(cwd = root, stderr = os.Pipe)
+      }
+    }
+  }
 }

--- a/modules/options/src/main/scala/scala/build/options/ShadowingSeq.scala
+++ b/modules/options/src/main/scala/scala/build/options/ShadowingSeq.scala
@@ -2,6 +2,7 @@ package scala.build.options
 
 import dependency.AnyDependency
 
+import scala.build.options.ScalacOpt.noDashPrefixes
 import scala.collection.mutable
 
 /** Seq ensuring some of its values are unique according to some key */
@@ -31,10 +32,11 @@ final case class ShadowingSeq[T] private (values: Seq[Seq[T]]) {
       for (group <- values.iterator ++ other.iterator) {
         assert(group.nonEmpty)
         val keyOpt = key.makeKey(group)
-        if (!keyOpt.exists(seen.contains)) {
+        if !keyOpt.exists(k => seen.contains(k.noDashPrefixes))
+        then {
           l += group
           for (key <- keyOpt)
-            seen += key
+            seen += key.noDashPrefixes
         }
       }
 


### PR DESCRIPTION
Scala CLI allows (even before this PR) to override using directive settings from the command line, including single-choice (non-repeatable) compiler options.

Given a source file `unused.scala`:
```scala
//> using options -Wunused:all -Werror
@main def main() = {
  val unusedValue = "something"
  println("Hello, world!")
}
```
The unused warning produced by `-Wunused:all` would get raised to an error due to `-Werror`.
```bash
scala-cli compile unused.scala
# Compiling project (Scala 3.5.1, JVM (17))
# [warn] ./repro.scala:3:7
# [warn] unused local definition
# [warn]   val unusedValue = "something"
# [warn]       ^^^^^^^^^^^
# Error: No warnings can be incurred under -Werror (or -Xfatal-warnings)
# Error compiling project (Scala 3.5.1, JVM (17))
# Compilation failed
```

However, `-Werror` can be overridden from the command line with `-Werror:false`, without editing sources:
```bash
scala-cli compile repro.scala -Werror:false                      
# Compiling project (Scala 3.5.1, JVM (17))
# [warn] ./repro.scala:3:7
# [warn] unused local definition
# [warn]   val unusedValue = "something"
# [warn]       ^^^^^^^^^^^
# Compiled project (Scala 3.5.1, JVM (17))
```

This PR allows to perform overriding like this regardless if the option key is preceded with a single `-` (`-Werror`) or double (`--Werror`). 
So this allows for an override like:
```bash
scala-cli compile repro.scala --Werror:false                    
# Compiling project (Scala 3.5.1, JVM (17))
# [warn] ./repro.scala:3:7
# [warn] unused local definition
# [warn]   val unusedValue = "something"
# [warn]       ^^^^^^^^^^^
# Compiled project (Scala 3.5.1, JVM (17))
```

Dependencies:
- [x] https://github.com/VirtusLab/scala-cli/pull/3253