### PR TITLE
Pin Fedora docker image at `fedora:40`

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1817,7 +1817,7 @@ object ci extends Module {
       "--env", "GPG_EMAIL",
       "--env", "KEYGRIP",
       "--privileged",
-      "fedora",
+      "fedora:40",
       "sh", "updateCentOsPackages.sh"
     )
     // format: on


### PR DESCRIPTION
Follow-up to https://github.com/VirtusLab/scala-cli/issues/3273#issuecomment-2476641331
Seems that `fedora:latest` lacks the `gpg` command, so we need to pin the image at `fedora:40`.