### PR TITLE
Update scala-cli.sh launcher for 1.5.3

### DIFF
--- a/scala-cli.bat
+++ b/scala-cli.bat
@@ -7,7 +7,7 @@ rem Download the latest version of this script at https://github.com/VirtusLab/s
 
 setlocal enabledelayedexpansion
 
-set "SCALA_CLI_VERSION=1.5.1"
+set "SCALA_CLI_VERSION=1.5.3"
 
 set SCALA_CLI_URL=https://github.com/VirtusLab/scala-cli/releases/download/v%SCALA_CLI_VERSION%/scala-cli.bat
 set CACHE_BASE=%localappdata%/Coursier/v1

--- a/scala-cli.sh
+++ b/scala-cli.sh
@@ -7,7 +7,7 @@
 
 set -eu
 
-SCALA_CLI_VERSION="1.5.1"
+SCALA_CLI_VERSION="1.5.3"
 
 GH_ORG="VirtusLab"
 GH_NAME="scala-cli"


### PR DESCRIPTION
https://github.com/VirtusLab/scala-cli/issues/3273#issuecomment-2476641331
This PR is normally created automatically, doing it by hand after the recent CI failure.