### PR TITLE
Don't fail the `update-packages` and `windows-packages` jobs on individual distributions' steps

### DIFF
--- a/.github/release/release-procedure.md
+++ b/.github/release/release-procedure.md
@@ -15,6 +15,8 @@
     - [ ] Copy any fixes over to the draft after getting the PR reviewed and merged.
 - [ ] Mark the release draft as `pre-release` and then `Publish Release`
 - [ ] Wait for a green release CI build with all the updated versions.
+  - [ ] Double check if none of the steps failed, including individual distribution channels in 
+    the `update-packages` and `windows-packages` jobs.
 - [ ] ScalaCLI Setup
     - [ ] Merge pull request with updated Scala CLI version
       in [scala-cli-setup](https://github.com/VirtusLab/scala-cli-setup) repository. Pull request should be opened

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1828,31 +1828,38 @@ jobs:
             ${{ secrets.HOMEBREW_SCALA_EXPERIMENTAL_KEY }}
             ${{ secrets.SCALA_CLI_SETUP_KEY }}
       - run: ./mill -i ci.updateInstallationScript
+        continue-on-error: true
       - run: ./mill -i ci.updateScalaCliBrewFormula
+        continue-on-error: true
       - name: GPG setup
         run: .github/scripts/gpg-setup.sh
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
       - run: ./mill -i ci.updateDebianPackages
+        continue-on-error: true
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           GPG_EMAIL: ${{ secrets.GPG_EMAIL }}
       - run: ./mill -i ci.updateCentOsPackages
+        continue-on-error: true
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           KEYGRIP: ${{ secrets.KEYGRIP }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           GPG_EMAIL: ${{ secrets.GPG_EMAIL }}
       - run: ./mill -i ci.updateStandaloneLauncher
+        continue-on-error: true
         env:
           UPLOAD_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to SDKMAN
+        continue-on-error: true
         run: .github/scripts/publish-sdkman.sh
         shell: bash
         env:
           SDKMAN_KEY: ${{ secrets.SDKMAN_KEY }}
           SDKMAN_TOKEN: ${{ secrets.SDKMAN_TOKEN }}
       - run: ./mill -i ci.updateScalaCliSetup
+        continue-on-error: true
       - run: ./mill -i ci.updateScalaExperimentalBrewFormula
 
   update-windows-packages:
@@ -1876,6 +1883,7 @@ jobs:
         path: artifacts/
     - name: Publish to chocolatey
       run: ./mill -i ci.updateChocolateyPackage
+      continue-on-error: true
       env:
         CHOCO_SECRET: ${{ secrets.CHOCO_SECRET_KEY }}
     - uses: vedantmgoyal9/winget-releaser@main


### PR DESCRIPTION
Follow-up to https://github.com/VirtusLab/scala-cli/issues/3273
This wouldn't have prevented the CentOS/Fedora package upload from failing, but it would have allowed the job to still update SDKMAN! (which failed as a ricochet) and execute other following steps.

The downside of this solution is that we'll need to double check the CI if no steps failed.
A potential alternative would be to divide the `update-packages` and `windows-packages` into smaller jobs, but we are already very GitHub-runner-hungry, so perhaps this is good enough...?