### PR TITLE
Bump `coursier` to 2.1.19

### DIFF
--- a/.github/scripts/build-linux-aarch64.sh
+++ b/.github/scripts/build-linux-aarch64.sh
@@ -6,7 +6,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
 mkdir -p artifacts
 mkdir -p utils
-cp "$(cs get https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.18/cs-aarch64-pc-linux.gz --archive)" utils/cs
+cp "$(cs get https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.19/cs-aarch64-pc-linux.gz --archive)" utils/cs
 chmod +x utils/cs
 
 cp "$DIR/build-linux-aarch64-from-docker.sh" utils/

--- a/.github/scripts/get-latest-cs.sh
+++ b/.github/scripts/get-latest-cs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-CS_VERSION="2.1.18"
+CS_VERSION="2.1.19"
 
 DIR="$(cs get --archive "https://github.com/coursier/coursier/releases/download/v$CS_VERSION/cs-x86_64-pc-win32.zip")"
 

--- a/build.sc
+++ b/build.sc
@@ -1,5 +1,5 @@
 import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`
-import $ivy.`io.get-coursier::coursier-launcher:2.1.18`
+import $ivy.`io.get-coursier::coursier-launcher:2.1.19`
 import $ivy.`io.github.alexarchambault.mill::mill-native-image-upload:0.1.29`
 import $file.project.deps, deps.{Deps, Docker, InternalDeps, Java, Scala, TestDeps}
 import $file.project.publish, publish.{ghOrg, ghName, ScalaCliPublishModule, organization}

--- a/mill
+++ b/mill
@@ -2,7 +2,7 @@
 
 # Adapted from
 
-coursier_version="2.1.18"
+coursier_version="2.1.19"
 
 # https://stackoverflow.com/questions/3466166/how-to-check-if-running-in-cygwin-mac-or-linux/17072017#17072017
 if [ "$(expr substr $(uname -s) 1 5 2>/dev/null)" == "Linux" ]; then

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -2289,7 +2289,7 @@ abstract class RunTestDefinitions
     val input          = "example.scala"
     TestInputs(
       os.rel / input ->
-        s"""//> using dep io.get-coursier:coursier_2.13:2.1.18
+        s"""//> using dep io.get-coursier:coursier_2.13:2.1.19
            |@main def $main1() = println("$main1")
            |@main def $main2() = println("$main2")
            |""".stripMargin

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -104,7 +104,7 @@ object Deps {
     def ammoniteForScala3Lts = ammonite
     def argonautShapeless    = "1.3.1"
     // jni-utils version may need to be sync-ed when bumping the coursier version
-    def coursierDefault                   = "2.1.18"
+    def coursierDefault                   = "2.1.19"
     def coursier                          = coursierDefault
     def coursierCli                       = coursierDefault
     def coursierM1Cli                     = coursierDefault


### PR DESCRIPTION
https://github.com/coursier/coursier/releases/tag/v2.1.19
https://github.com/VirtusLab/coursier-m1/releases/tag/v2.1.19