### PR TITLE
Fix commas being treated as `using` directives value separators & deprecate using them with whitespace

### DIFF
--- a/gcbenchmark/gcbenchmark.scala
+++ b/gcbenchmark/gcbenchmark.scala
@@ -1,6 +1,6 @@
-//> using dep "com.lihaoyi::os-lib:0.9.1"
-//> using dep "com.lihaoyi::pprint:0.8.1"
-//> using scala "2.13"
+//> using dep com.lihaoyi::os-lib:0.9.1
+//> using dep com.lihaoyi::pprint:0.8.1
+//> using scala 2.13
 
 // Usage: scala-cli gcbenchmark.scala -- <path_to_scala_cli_executable>
 

--- a/gifs/create_missing.sc
+++ b/gifs/create_missing.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env scala-cli
 
-//> using lib "com.lihaoyi::os-lib:0.7.8"
+//> using lib com.lihaoyi::os-lib:0.7.8
 
 /** Small and handy script to generate stubs for .svg files with nice TODO
   */

--- a/gifs/scenarios/embeddable_scripts.sh
+++ b/gifs/scenarios/embeddable_scripts.sh
@@ -18,7 +18,7 @@ else
   # Put your stuff here
     cat <<EOF | updateFile count_lines.sc
 #!/usr/bin/env scala-cli
-//> using scala "3.0.2"
+//> using scala 3.0.2
 import scala.io.StdIn.readLine
 import LazyList.continually
 

--- a/gifs/scenarios/projects.sh
+++ b/gifs/scenarios/projects.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 if [[ -z "${ASCIINEMA_REC}" ]]; then
   # Warm up scala-cli
   echo "println(1)" | scala-cli -S 2.13.6 -
-  echo "//> using dep \"com.softwaremill.sttp.client3::core:3.8.13\" " | scala-cli -S 2.13.6  -
+  echo "//> using dep com.softwaremill.sttp.client3::core:3.8.13" | scala-cli -S 2.13.6  -
   scala-cli config suppress-warning.outdated-dependencies-files true
   # or do other preparation (e.g. create code)
 else

--- a/modules/build/src/main/scala/scala/build/preprocessing/CustomDirectivesReporter.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/CustomDirectivesReporter.scala
@@ -8,8 +8,8 @@ import scala.build.errors.{Diagnostic, Severity}
 
 class CustomDirectivesReporter(path: Either[String, os.Path], onDiagnostic: Diagnostic => Unit)
     extends Reporter {
-
-  private var errorCount = 0
+  private var errorCount   = 0
+  private var warningCount = 0
 
   private def toScalaCliPosition(position: DirectivePosition): Position = {
     val coords = (position.getLine, position.getColumn)
@@ -28,15 +28,20 @@ class CustomDirectivesReporter(path: Either[String, os.Path], onDiagnostic: Diag
     }
   override def warning(msg: String): Unit =
     onDiagnostic {
+      warningCount += 1
       Diagnostic(msg, Severity.Warning)
     }
   override def warning(position: DirectivePosition, msg: String): Unit =
     onDiagnostic {
+      warningCount += 1
       Diagnostic(msg, Severity.Warning, Seq(toScalaCliPosition(position)))
     }
 
   override def hasErrors(): Boolean =
     errorCount != 0
+
+  override def hasWarnings(): Boolean =
+    warningCount != 0
 
   override def reset(): Unit = {
     errorCount = 0

--- a/modules/build/src/test/scala/scala/build/tests/ActionableDiagnosticTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ActionableDiagnosticTests.scala
@@ -57,7 +57,7 @@ class ActionableDiagnosticTests extends TestUtil.ScalaCliBuildSuite {
     val testInputs = TestInputs(
       os.rel / "Foo.scala" ->
         s"""//> using dep $dependencyOsLib
-           |//> using dep "$dependencyPprintLib"
+           |//> using dep $dependencyPprintLib
            |
            |object Hello extends App {
            |  println("Hello")
@@ -79,7 +79,7 @@ class ActionableDiagnosticTests extends TestUtil.ScalaCliBuildSuite {
           actionableDiagnostics.find(_.suggestion.startsWith("com.lihaoyi::pprint")).get
 
         expect(osLib.positions == Seq(File(Right(root / "Foo.scala"), (0, 14), (0, 39))))
-        expect(pprintLib.positions == Seq(File(Right(root / "Foo.scala"), (1, 15), (1, 40))))
+        expect(pprintLib.positions == Seq(File(Right(root / "Foo.scala"), (1, 14), (1, 39))))
     }
   }
 

--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -330,7 +330,7 @@ abstract class BuildTests(server: Boolean) extends TestUtil.ScalaCliBuildSuite {
           |pprint.log(g)
           |""".stripMargin,
       os.rel / "simple2.sc" ->
-        """//> using dep com.lihaoyi::geny:0.6.5, "com.lihaoyi::pprint:0.6.6"
+        """//> using dep com.lihaoyi::geny:0.6.5 com.lihaoyi::pprint:0.6.6
           |import geny.Generator
           |val g = Generator("Hel", "lo")
           |pprint.log(g)
@@ -422,7 +422,7 @@ abstract class BuildTests(server: Boolean) extends TestUtil.ScalaCliBuildSuite {
           |}
           |""".stripMargin,
       os.rel / "Ignored.scala" ->
-        """//> using target.scala.== "2.12"
+        """//> using target.scala.== 2.12
           |object Ignored {
           |  def foo = 2
           |}
@@ -702,16 +702,16 @@ abstract class BuildTests(server: Boolean) extends TestUtil.ScalaCliBuildSuite {
   test("repeated Java options") {
     val inputs = TestInputs(
       os.rel / "foo.sc" ->
-        """//> using javaOpt --add-opens, "foo/bar"
-          |//> using javaOpt --add-opens, "other/thing"
-          |//> using javaOpt --add-exports, "foo/bar"
-          |//> using javaOpt --add-exports, "other/thing"
-          |//> using javaOpt --add-modules, "foo/bar"
-          |//> using javaOpt --add-modules, other/thing
-          |//> using javaOpt --add-reads, "foo/bar"
-          |//> using javaOpt --add-reads, "other/thing"
-          |//> using javaOpt "--patch-module", "foo/bar"
-          |//> using javaOpt "--patch-module", "other/thing"
+        """//> using javaOpt --add-opens foo/bar
+          |//> using javaOpt --add-opens other/thing
+          |//> using javaOpt --add-exports foo/bar
+          |//> using javaOpt --add-exports other/thing
+          |//> using javaOpt --add-modules foo/bar
+          |//> using javaOpt --add-modules other/thing
+          |//> using javaOpt --add-reads foo/bar
+          |//> using javaOpt --add-reads other/thing
+          |//> using javaOpt --patch-module foo/bar
+          |//> using javaOpt --patch-module other/thing
           |
           |def foo = "bar"
           |""".stripMargin
@@ -743,7 +743,7 @@ abstract class BuildTests(server: Boolean) extends TestUtil.ScalaCliBuildSuite {
   test("-source:future not internally duplicating") {
     val inputs = TestInputs(
       os.rel / "foo.scala" ->
-        """//> using option "-source:future"
+        """//> using option -source:future
           |def foo = "bar"
           |""".stripMargin
     )
@@ -762,7 +762,7 @@ abstract class BuildTests(server: Boolean) extends TestUtil.ScalaCliBuildSuite {
     val inputs = TestInputs(
       os.rel / "foo.scala" ->
         """//> using scala 2.13
-          |//> using options -deprecation, "-feature", "-Xmaxwarns", "1"
+          |//> using options -deprecation -feature -Xmaxwarns 1
           |//> using option -Xdisable-assertions
           |
           |def foo = "bar"

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
@@ -44,10 +44,10 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
     )
   )
 
-  test("resolving position of lib directive") {
+  test("resolving position of dep directive") {
     val testInputs = TestInputs(
       os.rel / "simple.sc" ->
-        """//> using dep "com.lihaoyi::utest:0.7.10"
+        """//> using dep com.lihaoyi::utest:0.7.10
           |""".stripMargin
     )
     testInputs.withBuild(baseOptions, buildThreads, bloopConfigOpt) {
@@ -64,15 +64,15 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
           case _                                     => sys.error("cannot happen")
         }
 
-        expect(startPos == (0, 15))
-        expect(endPos == (0, 40))
+        expect(startPos == (0, 14))
+        expect(endPos == (0, 39))
     }
   }
 
   test("should parse javac options") {
     val testInputs = TestInputs(
       os.rel / "simple.sc" ->
-        """//> using javacOpt "source", "1.8", "target", "1.8"
+        """//> using javacOpt source 1.8 target 1.8
           |""".stripMargin
     )
     testInputs.withBuild(baseOptions, buildThreads, bloopConfigOpt) {
@@ -90,7 +90,7 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
       Seq("--no-fallback", "--enable-url-protocols=http,https")
     TestInputs(
       os.rel / "simple.sc" ->
-        s"""//> using packaging.graalvmArgs "$noFallback", "$enableUrl"
+        s"""//> using packaging.graalvmArgs $noFallback $enableUrl
            |""".stripMargin
     ).withBuild(baseOptions, buildThreads, bloopConfigOpt) {
       (_, _, maybeBuild) =>
@@ -155,8 +155,8 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
     }
 
     test(s"resolve test scope dependencies correctly when building for ${scope.name} scope") {
-      withProjectFile(projectFileContent = """//> using dep "com.lihaoyi::os-lib:0.9.1"
-                                             |//> using test.dep "org.scalameta::munit::0.7.29"
+      withProjectFile(projectFileContent = """//> using dep com.lihaoyi::os-lib:0.9.1
+                                             |//> using test.dep org.scalameta::munit::0.7.29
                                              |""".stripMargin) { (build, isTestScope) =>
         val deps = build.options.classPathOptions.extraDependencies.toSeq.map(_.value)
         expect(deps.nonEmpty)
@@ -172,9 +172,9 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
     }
     test(s"resolve test scope javacOpts correctly when building for ${scope.name} scope") {
       withProjectFile(projectFileContent =
-        """//> using javacOpt "source", "1.8"
-          |//> using test.javacOpt "target", "1.8"
-          |//> using test.dep "org.scalameta::munit::0.7.29"
+        """//> using javacOpt source 1.8
+          |//> using test.javacOpt target 1.8
+          |//> using test.dep org.scalameta::munit::0.7.29
           |""".stripMargin
       ) { (build, isTestScope) =>
         val javacOpts = build.options.javaOptions.javacOptions.map(_.value)
@@ -185,9 +185,9 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
     }
     test(s"resolve test scope scalac opts correctly when building for ${scope.name} scope") {
       withProjectFile(projectFileContent =
-        """//> using option "--explain"
-          |//> using test.option "-deprecation"
-          |//> using test.dep "org.scalameta::munit::0.7.29"
+        """//> using option --explain
+          |//> using test.option -deprecation
+          |//> using test.dep org.scalameta::munit::0.7.29
           |""".stripMargin
       ) { (build, isTestScope) =>
         val scalacOpts = build.options.scalaOptions.scalacOptions.toSeq.map(_.value.value)
@@ -198,9 +198,9 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
     }
     test(s"resolve test scope javaOpts correctly when building for ${scope.name} scope") {
       withProjectFile(projectFileContent =
-        """//> using javaOpt "-Xmx2g"
-          |//> using test.javaOpt "-Dsomething=a"
-          |//> using test.dep "org.scalameta::munit::0.7.29"
+        """//> using javaOpt -Xmx2g
+          |//> using test.javaOpt -Dsomething=a
+          |//> using test.dep org.scalameta::munit::0.7.29
           |""".stripMargin
       ) { (build, isTestScope) =>
         val javaOpts = build.options.javaOptions.javaOpts.toSeq.map(_.value.value)
@@ -211,9 +211,9 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
     }
     test(s"resolve test scope javaProps correctly when building for ${scope.name} scope") {
       withProjectFile(projectFileContent =
-        """//> using javaProp "foo=1"
-          |//> using test.javaProp "bar=2"
-          |//> using test.dep "org.scalameta::munit::0.7.29"
+        """//> using javaProp foo=1
+          |//> using test.javaProp bar=2
+          |//> using test.dep org.scalameta::munit::0.7.29
           |""".stripMargin
       ) { (build, isTestScope) =>
         val javaProps = build.options.javaOptions.javaOpts.toSeq.map(_.value.value)
@@ -224,9 +224,9 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
     }
     test(s"resolve test scope resourceDir correctly when building for ${scope.name} scope") {
       withProjectFile(projectFileContent =
-        """//> using resourceDir "./mainResources"
-          |//> using test.resourceDir "./testResources"
-          |//> using test.dep "org.scalameta::munit::0.7.29"
+        """//> using resourceDir ./mainResources
+          |//> using test.resourceDir ./testResources
+          |//> using test.dep org.scalameta::munit::0.7.29
           |""".stripMargin
       ) { (build, isTestScope) =>
         val resourcesDirs = build.options.classPathOptions.resourcesDir
@@ -265,7 +265,7 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
     val filePath = os.rel / "src" / "simple.scala"
     val testInputs = TestInputs(
       os.rel / filePath ->
-        """//> using options "-coverage-out:${.}""""
+        """//> using options -coverage-out:${.}"""
     )
     testInputs.withBuild(baseOptions, buildThreads, bloopConfigOpt) {
       (root, _, maybeBuild) =>
@@ -284,7 +284,7 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
     val filePath = os.rel / "src" / "simple.scala"
     val testInputs = TestInputs(
       os.rel / filePath ->
-        """//> using options "-coverage-out:$$${.}""""
+        """//> using options -coverage-out:$$${.}"""
     )
     testInputs.withBuild(baseOptions, buildThreads, bloopConfigOpt) {
       (root, _, maybeBuild) =>
@@ -303,7 +303,7 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
     val filePath = os.rel / "src" / "simple.scala"
     val testInputs = TestInputs(
       os.rel / filePath ->
-        """//> using options "-coverage-out:$${.}""""
+        """//> using options -coverage-out:$${.}"""
     )
     testInputs.withBuild(baseOptions, buildThreads, bloopConfigOpt) {
       (_, _, maybeBuild) =>

--- a/modules/build/src/test/scala/scala/build/tests/ExcludeTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ExcludeTests.scala
@@ -33,10 +33,10 @@ class ExcludeTests extends TestUtil.ScalaCliBuildSuite {
   test("throw error when exclude found in multiple files") {
     val testInputs = TestInputs(
       os.rel / "Hello.scala" ->
-        """//> using exclude "*.sc"
+        """//> using exclude *.sc
           |""".stripMargin,
       os.rel / "Main.scala" ->
-        """//> using exclude "*/test/*"
+        """//> using exclude */test/*
           |""".stripMargin
     )
     testInputs.withInputs { (_, inputs) =>
@@ -57,10 +57,10 @@ class ExcludeTests extends TestUtil.ScalaCliBuildSuite {
   test("throw error when exclude found in non top-level project.scala and file") {
     val testInputs = TestInputs(
       os.rel / "Main.scala" ->
-        """//> using exclude "*/test/*"
+        """//> using exclude */test/*
           |""".stripMargin,
       os.rel / "src" / "project.scala" ->
-        s"""//> using exclude "*.sc" """
+        s"""//> using exclude *.sc"""
     )
     testInputs.withInputs { (_, inputs) =>
       val crossSources =
@@ -84,7 +84,7 @@ class ExcludeTests extends TestUtil.ScalaCliBuildSuite {
         """object Main {
           |}""".stripMargin,
       os.rel / "project.scala" ->
-        s"""//> using exclude "Main.scala" """
+        s"""//> using exclude Main.scala"""
     )
     testInputs.withInputs { (root, inputs) =>
       val (crossSources, _) =
@@ -118,7 +118,7 @@ class ExcludeTests extends TestUtil.ScalaCliBuildSuite {
         """object Main {
           |}""".stripMargin,
       os.rel / "project.scala" ->
-        s"""//> using exclude "$${.}${File.separator}Main.scala" """
+        s"""//> using exclude $${.}${File.separator}Main.scala"""
     )
     testInputs.withInputs { (root, inputs) =>
       val (crossSources, _) =
@@ -152,7 +152,7 @@ class ExcludeTests extends TestUtil.ScalaCliBuildSuite {
         """object Main {
           |}""".stripMargin,
       os.rel / "project.scala" ->
-        """//> using exclude "src/*.scala" """
+        """//> using exclude src/*.scala"""
     )
     testInputs.withInputs { (root, inputs) =>
       val (crossSources, _) =
@@ -186,7 +186,7 @@ class ExcludeTests extends TestUtil.ScalaCliBuildSuite {
         """object Main {
           |}""".stripMargin,
       os.rel / "project.scala" ->
-        """//> using exclude "src/*.scala" """
+        """//> using exclude src/*.scala"""
     )
     testInputs.withInputs { (root, inputs) =>
       val (crossSources, _) =

--- a/modules/build/src/test/scala/scala/build/tests/PackagingUsingDirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/PackagingUsingDirectiveTests.scala
@@ -24,7 +24,7 @@ class PackagingUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
   test("package type") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->
-        """//> using packaging.packageType "graalvm"
+        """//> using packaging.packageType graalvm
           |def foo() = println("hello foo")
           |""".stripMargin
     )
@@ -38,7 +38,7 @@ class PackagingUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
     val output = "foo"
     val inputs = TestInputs(
       os.rel / "Bar.scala" ->
-        s"""//> using packaging.output "$output"
+        s"""//> using packaging.output $output
            |def hello() = println("hello")
            |""".stripMargin
     )
@@ -54,10 +54,10 @@ class PackagingUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
   test("docker options") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->
-        """//> using packaging.dockerFrom "openjdk:11"
-          |//> using packaging.dockerImageTag "1.0.0"
-          |//> using packaging.dockerImageRegistry "virtuslab"
-          |//> using packaging.dockerImageRepository "scala-cli"
+        """//> using packaging.dockerFrom openjdk:11
+          |//> using packaging.dockerImageTag 1.0.0
+          |//> using packaging.dockerImageRegistry virtuslab
+          |//> using packaging.dockerImageRepository scala-cli
           |
           |def foo() = println("hello foo")
           |""".stripMargin

--- a/modules/build/src/test/scala/scala/build/tests/ScalaNativeUsingDirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ScalaNativeUsingDirectiveTests.scala
@@ -39,7 +39,7 @@ class ScalaNativeUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
   test("ScalaNativeOptions for native-gc with multiple values") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->
-        """//> using `native-gc` 78, 12
+        """//> using native-gc 78 12
           |def foo() = println("hello foo")
           |""".stripMargin
     )
@@ -54,7 +54,7 @@ class ScalaNativeUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
   test("ScalaNativeOptions for native-gc") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->
-        """//> using `native-gc` "78"
+        """//> using native-gc 78
           |def foo() = println("hello foo")
           |""".stripMargin
     )
@@ -81,7 +81,7 @@ class ScalaNativeUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
   test("ScalaNativeOptions for native-mode with multiple values") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->
-        """//> using `native-mode` "debug", "release-full"
+        """//> using native-mode debug release-full
           |def foo() = println("hello foo")
           |""".stripMargin
     )
@@ -95,7 +95,7 @@ class ScalaNativeUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
   test("ScalaNativeOptions for native-mode") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->
-        """//> using `native-mode` "release-full"
+        """//> using native-mode release-full
           |def foo() = println("hello foo")
           |""".stripMargin
     )
@@ -107,7 +107,7 @@ class ScalaNativeUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
   test("ScalaNativeOptions for native-version with multiple values") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->
-        """//> using `native-version` "0.4.0", "0.3.3"
+        """//> using native-version 0.4.0 0.3.3
           |def foo() = println("hello foo")
           |""".stripMargin
     )
@@ -122,7 +122,7 @@ class ScalaNativeUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
   test("ScalaNativeOptions for native-version") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->
-        """//> using `native-version` "0.4.0"
+        """//> using native-version 0.4.0
           |def foo() = println("hello foo")
           |""".stripMargin
     )
@@ -135,7 +135,7 @@ class ScalaNativeUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
   test("ScalaNativeOptions for native-compile") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->
-        """//> using `native-compile` "compileOption1", "compileOption2"
+        """//> using native-compile compileOption1 compileOption2
           |def foo() = println("hello foo")
           |""".stripMargin
     )
@@ -167,7 +167,7 @@ class ScalaNativeUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
   test("ScalaNativeOptions for native-linking") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->
-        """//> using `native-linking` "linkingOption1", "linkingOption2"
+        """//> using native-linking linkingOption1 linkingOption2
           |def foo() = println("hello foo")
           |""".stripMargin
     )
@@ -184,7 +184,7 @@ class ScalaNativeUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
   test("ScalaNativeOptions for native-clang") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->
-        """//> using `native-clang` "clang/path"
+        """//> using native-clang clang/path
           |def foo() = println("hello foo")
           |""".stripMargin
     )
@@ -198,7 +198,7 @@ class ScalaNativeUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
   test("ScalaNativeOptions for native-clang and multiple values") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->
-        """//> using `native-clang` "path1", "path2"
+        """//> using native-clang path1 path2
           |def foo() = println("hello foo")
           |""".stripMargin
     )
@@ -212,7 +212,7 @@ class ScalaNativeUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
   test("ScalaNativeOptions for native-clang-pp") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->
-        """//> using `native-clang-pp` "clangpp/path"
+        """//> using native-clang-pp clangpp/path
           |def foo() = println("hello foo")
           |""".stripMargin
     )
@@ -226,7 +226,7 @@ class ScalaNativeUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
   test("ScalaNativeOptions for native-clang-pp and multiple values") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->
-        """//> using `native-clang-pp` "path1", "path2"
+        """//> using native-clang-pp path1 path2
           |def foo() = println("hello foo")
           |""".stripMargin
     )

--- a/modules/build/src/test/scala/scala/build/tests/ScalaPreprocessorTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ScalaPreprocessorTests.scala
@@ -58,10 +58,10 @@ class ScalaPreprocessorTests extends TestUtil.ScalaCliBuildSuite {
   }
 
   val lastUsingLines = Seq(
-    "//> using dep \"com.lihaoyi::os-lib::0.8.1\" \"com.lihaoyi::os-lib::0.8.1\"" -> "string literal",
-    "//> using scala 2.13.7"       -> "numerical string",
-    "//> using objectWrapper true" -> "boolean literal",
-    "//> using objectWrapper"      -> "empty value literal"
+    "//> using dep com.lihaoyi::os-lib::0.8.1 com.lihaoyi::os-lib::0.8.1" -> "string literal",
+    "//> using scala 2.13.7"                                              -> "numerical string",
+    "//> using objectWrapper true"                                        -> "boolean literal",
+    "//> using objectWrapper"                                             -> "empty value literal"
   )
 
   for ((lastUsingLine, typeName) <- lastUsingLines) do

--- a/modules/build/src/test/scala/scala/build/tests/ScriptWrapperTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ScriptWrapperTests.scala
@@ -97,13 +97,13 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
   test(s"class wrapper for scala 3") {
     val inputs = TestInputs(
       os.rel / "script1.sc" ->
-        s"""//> using dep "com.lihaoyi::os-lib:0.9.1"
+        s"""//> using dep com.lihaoyi::os-lib:0.9.1
            |
            |def main(args: String*): Unit = println("Hello")
            |main()
            |""".stripMargin,
       os.rel / "script2.sc" ->
-        """//> using dep "com.lihaoyi::os-lib:0.9.1"
+        """//> using dep com.lihaoyi::os-lib:0.9.1
           |
           |println("Hello")
           |""".stripMargin
@@ -136,14 +136,14 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
   } {
     val inputs = TestInputs(
       os.rel / "script1.sc" ->
-        s"""//> using dep "com.lihaoyi::os-lib:0.9.1"
+        s"""//> using dep com.lihaoyi::os-lib:0.9.1
            |${if (useDirectives) directive else ""}
            |
            |def main(args: String*): Unit = println("Hello")
            |main()
            |""".stripMargin,
       os.rel / "script2.sc" ->
-        """//> using dep "com.lihaoyi::os-lib:0.9.1"
+        """//> using dep com.lihaoyi::os-lib:0.9.1
           |
           |println("Hello")
           |""".stripMargin
@@ -179,14 +179,14 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
   } {
     val inputs = TestInputs(
       os.rel / "script1.sc" ->
-        s"""//> using dep "com.lihaoyi::os-lib:0.9.1"
+        s"""//> using dep com.lihaoyi::os-lib:0.9.1
            |${if (useDirectives) directive else ""}
            |
            |def main(args: String*): Unit = println("Hello")
            |main()
            |""".stripMargin,
       os.rel / "script2.sc" ->
-        """//> using dep "com.lihaoyi::os-lib:0.9.1"
+        """//> using dep com.lihaoyi::os-lib:0.9.1
           |
           |println("Hello")
           |""".stripMargin
@@ -222,7 +222,7 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
   } {
     val inputs = TestInputs(
       os.rel / "script1.sc" ->
-        s"""//> using dep "com.lihaoyi::os-lib:0.9.1"
+        s"""//> using dep com.lihaoyi::os-lib:0.9.1
            |//> using $targetDirective
            |//> using objectWrapper
            |
@@ -230,7 +230,7 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
            |main()
            |""".stripMargin,
       os.rel / "script2.sc" ->
-        s"""//> using dep "com.lihaoyi::os-lib:0.9.1"
+        s"""//> using dep com.lihaoyi::os-lib:0.9.1
            |//> using $enablingDirective
            |
            |println("Hello")

--- a/modules/build/src/test/scala/scala/build/tests/SourceGeneratorTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/SourceGeneratorTests.scala
@@ -157,12 +157,12 @@ class SourceGeneratorTests extends TestUtil.ScalaCliBuildSuite {
   test("BuildInfo for native") {
     val inputs = TestInputs(
       os.rel / "main.scala" ->
-        s"""//> using dep "com.lihaoyi::os-lib:0.9.1"
-           |//> using option "-Xasync"
-           |//> using plugin "org.wartremover:::wartremover:3.0.9"
+        s"""//> using dep com.lihaoyi::os-lib:0.9.1
+           |//> using option -Xasync
+           |//> using plugin org.wartremover:::wartremover:3.0.9
            |//> using scala 3.2.2
            |//> using jvm 11
-           |//> using mainClass "Main"
+           |//> using mainClass Main
            |//> using resourceDir ./resources
            |//> using jar TEST1.jar TEST2.jar
            |//> using platform scala-native
@@ -233,12 +233,12 @@ class SourceGeneratorTests extends TestUtil.ScalaCliBuildSuite {
   test("BuildInfo for js") {
     val inputs = TestInputs(
       os.rel / "main.scala" ->
-        s"""//> using dep "com.lihaoyi::os-lib:0.9.1"
-           |//> using option "-Xasync"
-           |//> using plugin "org.wartremover:::wartremover:3.0.9"
+        s"""//> using dep com.lihaoyi::os-lib:0.9.1
+           |//> using option -Xasync
+           |//> using plugin org.wartremover:::wartremover:3.0.9
            |//> using scala 3.2.2
            |//> using jvm 11
-           |//> using mainClass "Main"
+           |//> using mainClass Main
            |//> using resourceDir ./resources
            |//> using jar TEST1.jar TEST2.jar
            |//> using platform scala-js
@@ -310,12 +310,12 @@ class SourceGeneratorTests extends TestUtil.ScalaCliBuildSuite {
   test("BuildInfo for Scala 2") {
     val inputs = TestInputs(
       os.rel / "main.scala" ->
-        s"""//> using dep "com.lihaoyi::os-lib:0.9.1"
-           |//> using option "-Xasync"
-           |//> using plugin "org.wartremover:::wartremover:3.0.9"
+        s"""//> using dep com.lihaoyi::os-lib:0.9.1
+           |//> using option -Xasync
+           |//> using plugin org.wartremover:::wartremover:3.0.9
            |//> using scala 2.13.6
            |//> using jvm 11
-           |//> using mainClass "Main"
+           |//> using mainClass Main
            |//> using resourceDir ./resources
            |//> using jar TEST1.jar TEST2.jar
            |

--- a/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
@@ -40,8 +40,8 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
     test(s"dependencies in .scala - using aliases: $pluralAlias and $singularAlias") {
       val testInputs = TestInputs(
         os.rel / "something.scala" ->
-          s"""//> using $pluralAlias "org1:name1:1.1", "org2::name2:2.2"
-             |//> using $singularAlias "org3:::name3:3.3"
+          s"""//> using $pluralAlias org1:name1:1.1 org2::name2:2.2
+             |//> using $singularAlias org3:::name3:3.3
              |import scala.collection.mutable
              |
              |object Something {
@@ -87,8 +87,8 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
   test("dependencies in .scala - using witin tests") {
     val testInputs = TestInputs(
       os.rel / "something.test.scala" ->
-        """//> using deps "org1:name1:1.1", "org2::name2:2.2"
-          |//> using dep "org3:::name3:3.3"
+        """//> using deps org1:name1:1.1 org2::name2:2.2
+          |//> using dep org3:::name3:3.3
           |import scala.collection.mutable
           |
           |object Something {
@@ -127,8 +127,8 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
   test("dependencies in .test.scala - using") {
     val testInputs = TestInputs(
       os.rel / "something.test.scala" ->
-        """//> using deps "org1:name1:1.1", "org2::name2:2.2"
-          |//> using dep "org3:::name3:3.3"
+        """//> using deps org1:name1:1.1 org2::name2:2.2
+          |//> using dep org3:::name3:3.3
           |import scala.collection.mutable
           |
           |object Something {
@@ -167,8 +167,8 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
   test("dependencies in test/name.scala") {
     val files = Seq(
       os.rel / "test" / "something.scala" ->
-        """//> using deps "org1:name1:1.1", "org2::name2:2.2"
-          |//> using dep "org3:::name3:3.3"
+        """//> using deps org1:name1:1.1 org2::name2:2.2
+          |//> using dep org3:::name3:3.3
           |import scala.collection.mutable
           |
           |object Something {
@@ -205,9 +205,9 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
   test("dependencies in .scala - //> using") {
     val testInputs = TestInputs(
       os.rel / "something.scala" ->
-        """//> using dep "org1:name1:1.1"
-          |//> using dep "org2::name2:2.2"
-          |//> using dep "org3:::name3:3.3"
+        """//> using dep org1:name1:1.1
+          |//> using dep org2::name2:2.2
+          |//> using dep org3:::name3:3.3
           |import scala.collection.mutable
           |
           |object Something {
@@ -251,9 +251,9 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
   test("dependencies in .java - //> using") {
     val testInputs = TestInputs(
       os.rel / "Something.java" ->
-        """//> using dep "org1:name1:1.1"
-          |//> using dep "org2::name2:2.2"
-          |//> using dep "org3:::name3:3.3"
+        """//> using dep org1:name1:1.1
+          |//> using dep org2::name2:2.2
+          |//> using dep org3:::name3:3.3
           |
           |public class Something {
           |  public Int a = 1;
@@ -383,7 +383,7 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
   test("dependencies in .sc - using") {
     val testInputs = TestInputs(
       os.rel / "something.sc" ->
-        """//> using deps "org1:name1:1.1", "org2::name2:2.2", "org3:::name3:3.3"
+        """//> using deps org1:name1:1.1 org2::name2:2.2 org3:::name3:3.3
           |import scala.collection.mutable
           |
           |def a = 1
@@ -425,9 +425,9 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
   test("dependencies in .sc - //> using") {
     val testInputs = TestInputs(
       os.rel / "something.sc" ->
-        """//> using dep "org1:name1:1.1"
-          |//> using dep "org2::name2:2.2"
-          |//> using dep "org3:::name3:3.3"
+        """//> using dep org1:name1:1.1
+          |//> using dep org2::name2:2.2
+          |//> using dep org3:::name3:3.3
           |import scala.collection.mutable
           |
           |def a = 1
@@ -469,8 +469,8 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
   test("java props in using directives") {
     val testInputs = TestInputs(
       os.rel / "something.sc" ->
-        """//> using javaProp "foo1"
-          |//> using javaProp "foo2=bar2"
+        """//> using javaProp foo1
+          |//> using javaProp foo2=bar2
           |""".stripMargin
     )
     testInputs.withInputs { (root, inputs) =>
@@ -495,9 +495,9 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
 
       expect(
         javaOpts(0).value.value == "-Dfoo1",
-        javaOpts(0).positions == Seq(Position.File(Right(root / "something.sc"), (0, 20), (0, 24))),
+        javaOpts(0).positions == Seq(Position.File(Right(root / "something.sc"), (0, 19), (0, 23))),
         javaOpts(1).value.value == "-Dfoo2=bar2",
-        javaOpts(1).positions == Seq(Position.File(Right(root / "something.sc"), (1, 20), (1, 29)))
+        javaOpts(1).positions == Seq(Position.File(Right(root / "something.sc"), (1, 19), (1, 28)))
       )
     }
   }
@@ -505,10 +505,10 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
   test("js options in using directives") {
     val testInputs = TestInputs(
       os.rel / "something.sc" ->
-        """//> using jsVersion "1.8.0"
-          |//> using jsMode "mode"
+        """//> using jsVersion 1.8.0
+          |//> using jsMode mode
           |//> using jsNoOpt
-          |//> using jsModuleKind "commonjs"
+          |//> using jsModuleKind commonjs
           |//> using jsCheckIr true
           |//> using jsEmitSourceMaps true
           |//> using jsDom true
@@ -516,8 +516,8 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
           |//> using jsAllowBigIntsForLongs true
           |//> using jsAvoidClasses false
           |//> using jsAvoidLetsAndConsts false
-          |//> using jsModuleSplitStyleStr "smallestmodules"
-          |//> using jsEsVersionStr "es2017"
+          |//> using jsModuleSplitStyleStr smallestmodules
+          |//> using jsEsVersionStr es2017
           |""".stripMargin
     )
     testInputs.withInputs { (root, inputs) =>
@@ -567,7 +567,7 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
   test("js options in using directives failure - multiple values") {
     val testInputs = TestInputs(
       os.rel / "something.sc" ->
-        """//> using jsVersion "1.8.0","2.3.4"
+        """//> using jsVersion 1.8.0 2.3.4
           |""".stripMargin
     )
     testInputs.withInputs { (_, inputs) =>
@@ -588,7 +588,7 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
   test("js options in using directives failure - not a boolean") {
     val testInputs = TestInputs(
       os.rel / "something.sc" ->
-        """//> using jsDom "fasle"
+        """//> using jsDom fasle
           |""".stripMargin
     )
     testInputs.withInputs { (_, inputs) =>
@@ -611,8 +611,8 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
       Seq("project.scala", "Main.scala", "Abc.scala", "Message.scala")
     val testInputs = TestInputs(
       os.rel / project ->
-        """//> using dep "com.lihaoyi::os-lib::0.8.1"
-          |//> using file "Message.scala"
+        """//> using dep com.lihaoyi::os-lib::0.8.1
+          |//> using file Message.scala
           |""".stripMargin,
       os.rel / main ->
         """object Main extends App {

--- a/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownCodeBlockTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownCodeBlockTests.scala
@@ -119,7 +119,7 @@ class MarkdownCodeBlockTests extends TestUtil.ScalaCliBuildSuite {
 
   test("a test Scala snippet is extracted correctly from markdown") {
     val code =
-      """//> using dep "org.scalameta::munit:0.7.29"
+      """//> using dep org.scalameta::munit:0.7.29
         |class Test extends munit.FunSuite {
         |  assert(true)
         |}""".stripMargin

--- a/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownCodeWrapperTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownCodeWrapperTests.scala
@@ -143,7 +143,7 @@ class MarkdownCodeWrapperTests extends TestUtil.ScalaCliBuildSuite {
 
   test("a test Scala snippet is wrapped correctly") {
     val snippet =
-      """//> using dep "org.scalameta::munit:0.7.29"
+      """//> using dep org.scalameta::munit:0.7.29
         |class Test extends munit.FunSuite {
         |  assert(true)
         |}""".stripMargin
@@ -163,7 +163,7 @@ class MarkdownCodeWrapperTests extends TestUtil.ScalaCliBuildSuite {
 
   test("multiple test Scala snippets are glued together correctly") {
     val snippet1 =
-      """//> using dep "org.scalameta::munit:0.7.29"
+      """//> using dep org.scalameta::munit:0.7.29
         |class Test1 extends munit.FunSuite {
         |  assert(true)
         |}""".stripMargin

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
@@ -263,13 +263,13 @@ object PublishSetup extends ScalaCommand[PublishSetupOptions] {
         def extraDirectivesLines(extraDirectives: Seq[(String, String)]) =
           extraDirectives.map {
             case (k, v) =>
-              s"""//> using $k "$v"""" + nl
+              s"""//> using $k $v""" + nl
           }.mkString
 
         val extraLines = missingFieldsWithDefaultsAndValues.map {
           case (_, default, None) => extraDirectivesLines(default.extraDirectives)
           case (check, default, Some(value)) =>
-            s"""//> using ${check.directivePath} "$value"""" + nl +
+            s"""//> using ${check.directivePath} $value""" + nl +
               extraDirectivesLines(default.extraDirectives)
         }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishSetup.scala
@@ -262,12 +262,15 @@ object PublishSetup extends ScalaCommand[PublishSetupOptions] {
 
         def extraDirectivesLines(extraDirectives: Seq[(String, String)]) =
           extraDirectives.map {
-            case (k, v) =>
-              s"""//> using $k $v""" + nl
+            case (k, v) if v.exists(_.isWhitespace) => s"""//> using $k "$v"""" + nl
+            case (k, v)                             => s"""//> using $k $v""" + nl
           }.mkString
 
         val extraLines = missingFieldsWithDefaultsAndValues.map {
           case (_, default, None) => extraDirectivesLines(default.extraDirectives)
+          case (check, default, Some(value)) if value.exists(_.isWhitespace) =>
+            s"""//> using ${check.directivePath} "$value"""" + nl +
+              extraDirectivesLines(default.extraDirectives)
           case (check, default, Some(value)) =>
             s"""//> using ${check.directivePath} $value""" + nl +
               extraDirectivesLines(default.extraDirectives)

--- a/modules/cli/src/main/scala/scala/cli/commands/test/TestOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/TestOptions.scala
@@ -53,7 +53,7 @@ object TestOptions {
        |A source file is treated as a test source if:
        |  - the file name ends with `.test.scala`
        |  - the file comes from a directory that is provided as input, and the relative path from that file to its original directory contains a `test` directory
-       |  - it contains the `//> using target.scope "test"` directive (Experimental)
+       |  - it contains the `//> using target.scope test` directive (Experimental)
        |
        |${HelpMessages.commandConfigurations(cmdName)}
        |

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Dependency.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Dependency.scala
@@ -22,7 +22,7 @@ import scala.cli.commands.SpecificationLevel
 @DirectiveExamples("//> using test.dep org.scalatest::scalatest:3.2.10")
 @DirectiveExamples("//> using test.dep org.scalameta::munit:0.7.29")
 @DirectiveExamples(
-  "//> using dep \"tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar\""
+  "//> using dep tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar"
 )
 @DirectiveUsage(
   "//> using dep org:name:ver | //> using deps org:name:ver org2:name2:ver2",

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Exclude.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Exclude.scala
@@ -11,8 +11,8 @@ import scala.util.Try
 
 @DirectiveGroupName("Exclude sources")
 @DirectiveExamples("//> using exclude utils.scala")
-@DirectiveExamples("//> using exclude \"examples/*\" \"*/resources/*\"")
-@DirectiveExamples("//> using exclude \"*.sc\"")
+@DirectiveExamples("//> using exclude examples/* */resources/*")
+@DirectiveExamples("//> using exclude *.sc")
 @DirectiveUsage(
   "`//> using exclude `_pattern_ | `//> using exclude `_pattern_ _pattern_ …",
   """`//> using exclude` _pattern_

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavaOptions.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavaOptions.scala
@@ -8,7 +8,7 @@ import scala.build.{Positioned, options}
 import scala.cli.commands.SpecificationLevel
 
 @DirectiveGroupName("Java options")
-@DirectiveExamples("//> using javaOpt -Xmx2g, -Dsomething=a")
+@DirectiveExamples("//> using javaOpt -Xmx2g -Dsomething=a")
 @DirectiveExamples("//> using test.javaOpt -Dsomething=a")
 @DirectiveUsage(
   "//> using javaOpt _options_",

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavaProps.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavaProps.scala
@@ -9,7 +9,7 @@ import scala.build.{Positioned, options}
 import scala.cli.commands.SpecificationLevel
 
 @DirectiveGroupName("Java properties")
-@DirectiveExamples("//> using javaProp foo1=bar, foo2")
+@DirectiveExamples("//> using javaProp foo1=bar foo2")
 @DirectiveExamples("//> using test.javaProp foo3=bar foo4")
 @DirectiveUsage(
   "//> using javaProp _key=val_",

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/RequirePlatform.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/RequirePlatform.scala
@@ -11,7 +11,7 @@ import scala.cli.commands.SpecificationLevel
 @DirectivePrefix("target.")
 @DirectiveDescription("Require a Scala platform for the current file")
 @DirectiveExamples("//> using target.platform scala-js")
-@DirectiveExamples("//> using target.platform scala-js, scala-native")
+@DirectiveExamples("//> using target.platform scala-js scala-native")
 @DirectiveExamples("//> using target.platform jvm")
 @DirectiveUsage(
   "//> using target.platform _platform_",

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaVersion.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaVersion.scala
@@ -10,7 +10,7 @@ import scala.cli.commands.SpecificationLevel
 @DirectiveExamples("//> using scala 3.0.2")
 @DirectiveExamples("//> using scala 2.13")
 @DirectiveExamples("//> using scala 2")
-@DirectiveExamples("//> using scala 2.13.6, 2.12.16")
+@DirectiveExamples("//> using scala 2.13.6 2.12.16")
 @DirectiveUsage(
   "//> using scala _version_+",
   "`//> using scala` _version_+"

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Sources.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Sources.scala
@@ -12,7 +12,7 @@ import scala.util.Try
 @DirectiveGroupName("Custom sources")
 @DirectiveExamples("//> using file utils.scala")
 @DirectiveUsage(
-  "`//> using file `_path_ | `//> using files `_path1_, _path2_ …",
+  "`//> using file `_path_ | `//> using files `_path1_ _path2_ …",
   """`//> using file` _path_
     |
     |`//> using files` _path1_ _path2_ …

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/StrictDirective.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/StrictDirective.scala
@@ -1,6 +1,6 @@
 package scala.build.preprocessing.directives
 
-import com.virtuslab.using_directives.custom.model.{EmptyValue, StringValue, Value}
+import com.virtuslab.using_directives.custom.model.{EmptyValue, Value}
 
 import scala.build.Position
 
@@ -16,11 +16,11 @@ import scala.build.Position
 
 case class StrictDirective(
   key: String,
-  values: Seq[Value[_]],
+  values: Seq[Value[?]],
   startColumn: Int = 0
 ) {
   override def toString: String = {
-    val suffix = if validValues.isEmpty then "" else s" \"${validValues.mkString("\",  \"")}\""
+    val suffix = if validValues.isEmpty then "" else s" ${validValues.mkString("  ")}"
     s"//> using $key$suffix"
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -15,7 +15,7 @@ class BloopTests extends ScalaCliSuite {
 
   val dummyInputs: TestInputs = TestInputs(
     os.rel / "Test.scala" ->
-      """//> using scala "2.13"
+      """//> using scala 2.13
         |object Test {
         |  def main(args: Array[String]): Unit =
         |    println("Hello " + "from test")

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -383,7 +383,7 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
   test("invalid diagnostics at startup") {
     val inputs = TestInputs(
       os.rel / "A.scala" ->
-        s"""//> using resource "./resources"
+        s"""//> using resource ./resources
            |
            |object A {}
            |""".stripMargin
@@ -402,9 +402,9 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
           expectedMessage = "Unrecognized directive: resource with values: ./resources",
           expectedSeverity = b.DiagnosticSeverity.ERROR,
           expectedStartLine = 0,
-          expectedStartCharacter = 20,
+          expectedStartCharacter = 19,
           expectedEndLine = 0,
-          expectedEndCharacter = 31,
+          expectedEndCharacter = 30,
           strictlyCheckMessage = false
         )
       }
@@ -414,7 +414,7 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
   test("directive diagnostics") {
     val inputs = TestInputs(
       os.rel / "Test.scala" ->
-        s"""//> using dep "com.lihaoyi::pprint:0.0.0.0.0.1"
+        s"""//> using dep com.lihaoyi::pprint:0.0.0.0.0.1
            |
            |object Test {
            |  val msg = "Hello"
@@ -442,9 +442,9 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
           expectedMessage = expectedMessage,
           expectedSeverity = b.DiagnosticSeverity.ERROR,
           expectedStartLine = 0,
-          expectedStartCharacter = 15,
+          expectedStartCharacter = 14,
           expectedEndLine = 0,
-          expectedEndCharacter = 46,
+          expectedEndCharacter = 45,
           strictlyCheckMessage = false
         )
       }
@@ -454,14 +454,14 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
   test("directives in multiple files diagnostics") {
     val inputs = TestInputs(
       os.rel / "Foo.scala" ->
-        s"""//> using scala "3.3.0"
+        s"""//> using scala 3.3.0
            |
            |object Foo extends App {
            |  println("Foo")
            |}
            |""".stripMargin,
       os.rel / "Bar.scala"  -> "",
-      os.rel / "Hello.java" -> "//> using jvm \"11\""
+      os.rel / "Hello.java" -> "//> using jvm 11"
     )
 
     withBsp(inputs, Seq(".")) { (root, localClient, remoteServer) =>
@@ -516,8 +516,8 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
           )
         }
 
-        checkDirectivesInMultipleFilesWarnings("Foo.scala", 0, 0, 0, 23)
-        checkDirectivesInMultipleFilesWarnings("Hello.java", 0, 0, 0, 18)
+        checkDirectivesInMultipleFilesWarnings("Foo.scala", 0, 0, 0, 21)
+        checkDirectivesInMultipleFilesWarnings("Hello.java", 0, 0, 0, 16)
       }
     }
   }
@@ -581,7 +581,7 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
 
         val didChangeParamsFuture = localClient.buildTargetDidChange()
         val updatedContent =
-          """//> using dep "com.lihaoyi::pprint:0.6.6"
+          """//> using dep com.lihaoyi::pprint:0.6.6
             |val msg = "Hello"
             |pprint.log(msg)
             |""".stripMargin
@@ -729,13 +729,13 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
   test("test workspace update after adding file to main scope") {
     val inputs = TestInputs(
       os.rel / "Messages.scala" ->
-        """//> using dep "com.lihaoyi::os-lib:0.7.8"
+        """//> using dep com.lihaoyi::os-lib:0.7.8
           |object Messages {
           |  def msg = "Hello"
           |}
           |""".stripMargin,
       os.rel / "MyTests.test.scala" ->
-        """//> using dep "com.lihaoyi::utest::0.7.10"
+        """//> using dep com.lihaoyi::utest::0.7.10
           |import utest._
           |
           |object MyTests extends TestSuite {
@@ -950,7 +950,7 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
             val depName    = "os-lib"
             val depVersion = "0.8.1"
             val updatedSourceFile =
-              s"""//> using dep "com.lihaoyi::$depName:$depVersion"
+              s"""//> using dep com.lihaoyi::$depName:$depVersion
                  |
                  |object ReloadTest {
                  |  println(os.pwd)
@@ -1058,7 +1058,7 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
     val utilsFileName = "Utils.scala"
     val inputs = TestInputs(
       os.rel / "Hello.scala" ->
-        s"""|//> using file "Utils.scala"
+        s"""|//> using file Utils.scala
             |
             |object Hello extends App {
             |   println("Hello World")
@@ -1350,7 +1350,7 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
     val directiveValue = "value"
     val inputs = TestInputs(
       os.rel / sourceFileName ->
-        s"""//> using $directiveKey "$directiveValue"
+        s"""//> using $directiveKey $directiveValue
            |
            |object UnrecognisedUsingDirective extends App {
            |  println("Hello")
@@ -1374,9 +1374,9 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
               s"Unrecognized directive: $directiveKey with values: $directiveValue",
             expectedSeverity = b.DiagnosticSeverity.ERROR,
             expectedStartLine = 0,
-            expectedStartCharacter = 34,
+            expectedStartCharacter = 33,
             expectedEndLine = 0,
-            expectedEndCharacter = 39
+            expectedEndCharacter = 38
           )
         }
     }
@@ -1385,7 +1385,7 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
   test("bloop projects are initialised properly for a directive for an unfetchable dependency") {
     val inputs = TestInputs(
       os.rel / "InvalidUsingDirective.scala" ->
-        s"""//> using dep "no::lib:123"
+        s"""//> using dep no::lib:123
            |
            |object InvalidUsingDirective extends App {
            |  println("Hello")
@@ -1408,9 +1408,9 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
             expectedMessage = "Error downloading no:lib",
             expectedSeverity = b.DiagnosticSeverity.ERROR,
             expectedStartLine = 0,
-            expectedStartCharacter = 15,
+            expectedStartCharacter = 14,
             expectedEndLine = 0,
-            expectedEndCharacter = 26,
+            expectedEndCharacter = 25,
             strictlyCheckMessage = false
           )
         }
@@ -1458,7 +1458,7 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
     val fileName = "Hello.scala"
     val inputs = TestInputs(
       os.rel / fileName ->
-        s"""//> using dep "com.lihaoyi::os-lib:0.7.8"
+        s"""//> using dep com.lihaoyi::os-lib:0.7.8
            |
            |object Hello extends App {
            |  println("Hello")
@@ -1486,9 +1486,9 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
             expectedMessage = "os-lib is outdated",
             expectedSeverity = b.DiagnosticSeverity.HINT,
             expectedStartLine = 0,
-            expectedStartCharacter = 15,
+            expectedStartCharacter = 14,
             expectedEndLine = 0,
-            expectedEndCharacter = 40,
+            expectedEndCharacter = 39,
             expectedSource = Some("scala-cli"),
             strictlyCheckMessage = false
           )
@@ -1506,9 +1506,9 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
 
           expect(textEdit.getNewText.contains("com.lihaoyi::os-lib:"))
           expect(textEdit.getRange.getStart.getLine == 0)
-          expect(textEdit.getRange.getStart.getCharacter == 15)
+          expect(textEdit.getRange.getStart.getCharacter == 14)
           expect(textEdit.getRange.getEnd.getLine == 0)
-          expect(textEdit.getRange.getEnd.getCharacter == 40)
+          expect(textEdit.getRange.getEnd.getCharacter == 39)
         }
     }
   }
@@ -1586,7 +1586,7 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
   test("bsp should support jvmRunEnvironment request") {
     val inputs = TestInputs(
       os.rel / "Hello.scala" ->
-        s"""//> using dep "com.lihaoyi::os-lib:0.7.8"
+        s"""//> using dep com.lihaoyi::os-lib:0.7.8
            |
            |object Hello extends App {
            |  println("Hello")
@@ -1781,7 +1781,7 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
       val inputs = TestInputs(
         os.rel / "test.sc" ->
           """//> using toolkit latest
-            |//> using test.toolkit "typelevel:latest"
+            |//> using test.toolkit typelevel:latest
             |
             |//> using lib org.typelevel::cats-core:2.6.1
             |
@@ -1862,7 +1862,7 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
               expectedStartLine = 1,
               expectedStartCharacter = 10,
               expectedEndLine = 1,
-              expectedEndCharacter = 41
+              expectedEndCharacter = 39
             )
 
             checkScalaAction(
@@ -1873,7 +1873,7 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
               expectedStartLine = 1,
               expectedStartCharacter = 10,
               expectedEndLine = 1,
-              expectedEndCharacter = 41,
+              expectedEndCharacter = 39,
               expectedNewText = "test.toolkit typelevel:default"
             )
           }

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTests3Definitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTests3Definitions.scala
@@ -11,7 +11,7 @@ trait BspTests3Definitions { _: BspTestDefinitions =>
            |main()
            |""".stripMargin,
       os.rel / script2 ->
-        s"""//> using dep "org.scalatest::scalatest:3.2.15"
+        s"""//> using dep org.scalatest::scalatest:3.2.15
            |
            |import org.scalatest.*, flatspec.*, matchers.*
            |

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileScalacCompatTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileScalacCompatTestDefinitions.scala
@@ -54,11 +54,11 @@ trait CompileScalacCompatTestDefinitions { _: CompileTestDefinitions =>
         ),
         Seq(
           Seq(s"${dashPrefix}color:never"),
-          Seq(s"\"${dashPrefix}language:noAutoTupling,strictEquality\"")
+          Seq(s"${dashPrefix}language:noAutoTupling,strictEquality")
         ),
         Seq(
           Seq(s"${dashPrefix}color", "never"),
-          Seq(s"${dashPrefix}language", "\"noAutoTupling,strictEquality\"")
+          Seq(s"${dashPrefix}language", "noAutoTupling,strictEquality")
         )
       )
       (cliOpts, directiveOpts) = {

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -20,7 +20,7 @@ abstract class CompileTestDefinitions
 
   val simpleInputs: TestInputs = TestInputs(
     os.rel / "MyTests.scala" ->
-      """//> using dep "com.lihaoyi::os-lib::0.8.1"
+      """//> using dep com.lihaoyi::os-lib::0.8.1
         |
         |object MyTests {
         |  def main(args: Array[String]): Unit = {
@@ -33,7 +33,7 @@ abstract class CompileTestDefinitions
 
   val mainAndTestInputs: TestInputs = TestInputs(
     os.rel / "Main.scala" ->
-      """//> using dep "com.lihaoyi::utest:0.7.10"
+      """//> using dep com.lihaoyi::utest:0.7.10
         |
         |object Main {
         |  val err = utest.compileError("pprint.log(2)")
@@ -45,7 +45,7 @@ abstract class CompileTestDefinitions
         |}
         |""".stripMargin,
     os.rel / "Tests.test.scala" ->
-      """//> using dep "com.lihaoyi::pprint:0.6.6"
+      """//> using dep com.lihaoyi::pprint:0.6.6
         |
         |import utest._
         |
@@ -82,14 +82,14 @@ abstract class CompileTestDefinitions
   test("with one file per scope, no warning about spread directives should be printed") {
     TestInputs(
       os.rel / "Bar.scala" ->
-        """//> using dep "com.lihaoyi::os-lib:0.9.1"
+        """//> using dep com.lihaoyi::os-lib:0.9.1
           |
           |object Bar extends App {
           |  println(os.pwd)
           |}
           |""".stripMargin,
       os.rel / "Foo.test.scala" ->
-        """//> using dep "org.scalameta::munit:0.7.29"
+        """//> using dep org.scalameta::munit:0.7.29
           |
           |class Foo extends munit.FunSuite {
           |  test("Hello") {
@@ -108,19 +108,19 @@ abstract class CompileTestDefinitions
   test("with >1 file per scope, the warning about spread directives should be printed") {
     TestInputs(
       os.rel / "Bar.scala" ->
-        """//> using dep "com.lihaoyi::os-lib:0.9.1"
+        """//> using dep com.lihaoyi::os-lib:0.9.1
           |
           |object Bar extends App {
           |  pprint.pprintln(Foo(os.pwd.toString).value)
           |}
           |""".stripMargin,
       os.rel / "Foo.scala" ->
-        """//> using dep "com.lihaoyi::pprint:0.8.1"
+        """//> using dep com.lihaoyi::pprint:0.8.1
           |
           |case class Foo(value: String)
           |""".stripMargin,
       os.rel / "Foo.test.scala" ->
-        """//> using dep "org.scalameta::munit:0.7.29"
+        """//> using dep org.scalameta::munit:0.7.29
           |
           |class FooTest extends munit.FunSuite {
           |  test("Hello") {
@@ -141,13 +141,13 @@ abstract class CompileTestDefinitions
   ) {
     val inputs = TestInputs(
       os.rel / "Bar.java" ->
-        """//> using target.platform "jvm"
-          |//> using jvm "17"
+        """//> using target.platform jvm
+          |//> using jvm 17
           |public class Bar {}
           |""".stripMargin,
       os.rel / "Foo.test.scala" ->
-        """//> using target.scala.>= "2.13"
-          |//> using dep "com.lihaoyi::os-lib::0.8.1"
+        """//> using target.scala.>= 2.13
+          |//> using dep com.lihaoyi::os-lib::0.8.1
           |class Foo {}
           |""".stripMargin
     )
@@ -165,11 +165,11 @@ abstract class CompileTestDefinitions
   ) {
     val inputs = TestInputs(
       os.rel / "Bar.java" ->
-        """//> using jvm "17"
+        """//> using jvm 17
           |public class Bar {}
           |""".stripMargin,
       os.rel / "Foo.scala" ->
-        """//> using dep "com.lihaoyi::os-lib::0.8.1"
+        """//> using dep com.lihaoyi::os-lib::0.8.1
           |class Foo {}
           |""".stripMargin
     )
@@ -259,7 +259,7 @@ abstract class CompileTestDefinitions
           |}
           |""".stripMargin,
       os.rel / "Tests.test.scala" ->
-        """//> using dep "com.lihaoyi::utest:0.7.10"
+        """//> using dep com.lihaoyi::utest:0.7.10
           |
           |import utest._
           |
@@ -452,7 +452,7 @@ abstract class CompileTestDefinitions
       val fileName = "Hello.scala"
       val inputs = TestInputs(
         os.rel / fileName ->
-          s"""//> using options "-coverage-out:."
+          s"""//> using options -coverage-out:.
              |
              |@main def main = ()
              |""".stripMargin
@@ -475,7 +475,7 @@ abstract class CompileTestDefinitions
     val sparkVersion = "3.3.0"
     val inputs = TestInputs(
       os.rel / "Hello.scala" ->
-        s"""//> using dep "org.apache.spark::spark-sql:$sparkVersion"
+        s"""//> using dep org.apache.spark::spark-sql:$sparkVersion
            |object Hello {
            |  def main(args: Array[String]): Unit =
            |    println("Hello")
@@ -505,7 +505,7 @@ abstract class CompileTestDefinitions
   test("override settings from tests") {
     val inputs = TestInputs(
       os.rel / "MainStuff.scala" ->
-        """//> using jvm "8"
+        """//> using jvm 8
           |object MainStuff {
           |  def javaVer = sys.props("java.version")
           |  def main(args: Array[String]): Unit = {
@@ -515,8 +515,8 @@ abstract class CompileTestDefinitions
           |}
           |""".stripMargin,
       os.rel / "TestStuff.test.scala" ->
-        """//> using jvm "17"
-          |//> using dep "org.scalameta::munit:0.7.29"
+        """//> using jvm 17
+          |//> using dep org.scalameta::munit:0.7.29
           |class TestStuff extends munit.FunSuite {
           |  test("the test") {
           |    val javaVer = MainStuff.javaVer

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTests3StableDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTests3StableDefinitions.scala
@@ -20,8 +20,8 @@ trait CompileTests3StableDefinitions { _: CompileTestDefinitions =>
     val fileName = "Hello.scala"
     val inputs = TestInputs(
       os.rel / fileName -> // should be dump to 3.3.1 after release
-        s"""//> using scala "3.3.1-RC1-bin-20230203-3ef1e73-NIGHTLY"
-           |//> using options "--explain"
+        s"""//> using scala 3.3.1-RC1-bin-20230203-3ef1e73-NIGHTLY
+           |//> using options --explain
            |
            |class A
            |val i: Int = A()

--- a/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
@@ -381,7 +381,7 @@ class ConfigTests extends ScalaCliSuite {
           |}
           |""".stripMargin,
       os.rel / "hello" / "Hello.scala" ->
-        s"""//> using dep "$testOrg::$testName:$testVersion"
+        s"""//> using dep $testOrg::$testName:$testVersion
            |import messages.Messages
            |object Hello {
            |  def main(args: Array[String]): Unit =

--- a/modules/integration/src/test/scala/scala/cli/integration/DependencyUpdateTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DependencyUpdateTests.scala
@@ -8,8 +8,8 @@ class DependencyUpdateTests extends ScalaCliSuite {
     val fileName = "Hello.scala"
     val message  = "Hello World"
     val fileContent =
-      s"""|//> using dep "com.lihaoyi::os-lib:0.7.8"
-          |//> using dep "com.lihaoyi::utest:0.7.10"
+      s"""|//> using dep com.lihaoyi::os-lib:0.7.8
+          |//> using dep com.lihaoyi::utest:0.7.10
           |
           |object Hello extends App {
           |  println("$message")
@@ -33,11 +33,11 @@ class DependencyUpdateTests extends ScalaCliSuite {
     }
   }
 
-  test("update toolkit dependence") {
+  test("update toolkit dependency") {
     val toolkitVersion = "0.1.3"
     val testInputs = TestInputs(
       os.rel / "Foo.scala" ->
-        s"""//> using toolkit "$toolkitVersion"
+        s"""//> using toolkit $toolkitVersion
            |
            |object Hello extends App {
            |  println("Hello")
@@ -49,7 +49,7 @@ class DependencyUpdateTests extends ScalaCliSuite {
       os.proc(TestUtil.cli, "--power", "dependency-update", "--all", ".")
         .call(cwd = root)
 
-      val toolkitDirective = "//> using toolkit \"(.*)\"".r
+      val toolkitDirective = "//> using toolkit (.*)".r
       val updatedToolkitVersionOpt = {
         val regexMatch = toolkitDirective.findFirstMatchIn(os.read(root / "Foo.scala"))
         regexMatch.map(_.group(1))
@@ -64,7 +64,7 @@ class DependencyUpdateTests extends ScalaCliSuite {
     val toolkitVersion = "0.0.1"
     val testInputs = TestInputs(
       os.rel / "Foo.scala" ->
-        s"""//> using toolkit "typelevel:$toolkitVersion"
+        s"""//> using toolkit typelevel:$toolkitVersion
            |
            |import cats.effect.*
            |
@@ -78,7 +78,7 @@ class DependencyUpdateTests extends ScalaCliSuite {
       os.proc(TestUtil.cli, "--power", "dependency-update", "--all", ".")
         .call(cwd = root)
 
-      val toolkitDirective = "//> using toolkit \"typelevel:(.*)\"".r
+      val toolkitDirective = "//> using toolkit typelevel:(.*)".r
       val updatedToolkitVersionOpt = {
         val regexMatch = toolkitDirective.findFirstMatchIn(os.read(root / "Foo.scala"))
         regexMatch.map(_.group(1))

--- a/modules/integration/src/test/scala/scala/cli/integration/DocTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DocTestsDefault.scala
@@ -6,7 +6,7 @@ class DocTestsDefault extends DocTestDefinitions with TestDefault {
   test("javadoc") {
     val inputs = TestInputs(
       os.rel / "Foo.java" ->
-        """//> using dep "org.graalvm.nativeimage:svm:22.0.0.2"
+        """//> using dep org.graalvm.nativeimage:svm:22.0.0.2
           |
           |import com.oracle.svm.core.annotate.TargetClass;
           |import org.graalvm.nativeimage.Platform;

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportJsonTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportJsonTestDefinitions.scala
@@ -25,7 +25,7 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
   test("export json") {
     val inputs = TestInputs(
       os.rel / "Main.scala" ->
-        """//> using lib "com.lihaoyi::os-lib:0.7.8"
+        """//> using dep com.lihaoyi::os-lib:0.7.8
           |
           |object Main {
           |  def main(args: Array[String]): Unit =
@@ -79,9 +79,9 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
   test("export json with test scope") {
     val inputs = TestInputs(
       os.rel / "Main.scala" ->
-        """//> using lib "com.lihaoyi::os-lib:0.7.8"
-          |//> using option "-Xasync"
-          |//> using plugin "org.wartremover:::wartremover:3.0.9"
+        """//> using dep com.lihaoyi::os-lib:0.7.8
+          |//> using option -Xasync
+          |//> using plugin org.wartremover:::wartremover:3.0.9
           |//> using scala 3.2.2
           |
           |object Main {
@@ -90,9 +90,9 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
           |}
           |""".stripMargin,
       os.rel / "unit.test.scala" ->
-        """//> using repository "sonatype:snapshots"
-          |//> using resourceDir "./resources"
-          |//> using jar "TEST.jar"
+        """//> using repository sonatype:snapshots
+          |//> using resourceDir ./resources
+          |//> using jar TEST.jar
           |""".stripMargin
     )
 
@@ -180,11 +180,11 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
   test("export json with js") {
     val inputs = TestInputs(
       os.rel / "Main.scala" ->
-        """//> using scala "3.1.3"
-          |//> using platform "scala-js"
-          |//> using lib "com.lihaoyi::os-lib:0.7.8"
-          |//> using option "-Xasync"
-          |//> using plugin "org.wartremover:::wartremover:3.0.9"
+        """//> using scala 3.1.3
+          |//> using platform scala-js
+          |//> using lib com.lihaoyi::os-lib:0.7.8
+          |//> using option -Xasync
+          |//> using plugin org.wartremover:::wartremover:3.0.9
           |
           |object Main {
           |  def main(args: Array[String]): Unit =

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportScalaOrientedBuildToolsTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportScalaOrientedBuildToolsTestDefinitions.scala
@@ -31,8 +31,8 @@ trait ExportScalaOrientedBuildToolsTestDefinitions {
       // todo: remove this hack after the PR https://github.com/VirtusLab/scala-cli/pull/3046 is merged
       os.rel / "Hello.scala" -> """object Hello extends App""",
       os.rel / "Zio.test.scala" ->
-        s"""|//> using dep "dev.zio::zio::1.0.8"
-            |//> using dep "dev.zio::zio-test-sbt::1.0.8"
+        s"""|//> using dep dev.zio::zio::1.0.8
+            |//> using dep dev.zio::zio-test-sbt::1.0.8
             |
             |import zio._
             |import zio.test._

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportTestProjects.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportTestProjects.scala
@@ -9,10 +9,10 @@ object ExportTestProjects {
 
     val mainFile =
       if (scalaVersion.startsWith("3."))
-        s"""//> using scala "$scalaVersion"
-           |//> using resourceDir "./input"
-           |//> using dep "org.scala-lang::scala3-compiler:$scalaVersion"
-           |//> using option "-deprecation"
+        s"""//> using scala $scalaVersion
+           |//> using resourceDir ./input
+           |//> using dep org.scala-lang::scala3-compiler:$scalaVersion
+           |//> using option -deprecation
            |
            |import scala.io.Source
            |
@@ -26,10 +26,10 @@ object ExportTestProjects {
            |}
            |""".stripMargin
       else
-        s"""//> using scala "$scalaVersion"
-           |//> using resourceDir "./input"
-           |//> using option "-deprecation"
-           |//> using plugins "com.olegpy::better-monadic-for:0.3.1"
+        s"""//> using scala $scalaVersion
+           |//> using resourceDir ./input
+           |//> using option -deprecation
+           |//> using plugins com.olegpy::better-monadic-for:0.3.1
            |
            |import scala.io.Source
            |
@@ -46,8 +46,8 @@ object ExportTestProjects {
     TestInputs(
       os.rel / s"$mainClassName.scala" -> mainFile,
       os.rel / "Zio.test.scala" ->
-        """|//> using dep "dev.zio::zio::1.0.8"
-           |//> using dep "dev.zio::zio-test-sbt::1.0.8"
+        """|//> using dep dev.zio::zio::1.0.8
+           |//> using dep dev.zio::zio-test-sbt::1.0.8
            |
            |import zio._
            |import zio.test._
@@ -73,8 +73,8 @@ object ExportTestProjects {
 
     val testFile =
       if (scalaVersion.startsWith("3."))
-        s"""//> using scala "$scalaVersion"
-           |//> using platform "scala-js"
+        s"""//> using scala $scalaVersion
+           |//> using platform scala-js
            |
            |import scala.scalajs.js
            |
@@ -84,8 +84,8 @@ object ExportTestProjects {
            |    console.log("Hello from " + "exported Scala CLI project")
            |""".stripMargin
       else
-        s"""//> using scala "$scalaVersion"
-           |//> using platform "scala-js"
+        s"""//> using scala $scalaVersion
+           |//> using platform scala-js
            |
            |import scala.scalajs.js
            |
@@ -139,9 +139,9 @@ object ExportTestProjects {
 
   def repositoryScala3Test(scalaVersion: String): TestInputs = {
     val testFile =
-      s"""//> using scala "$scalaVersion"
-         |//> using dep "com.github.jupyter:jvm-repr:0.4.0"
-         |//> using repository "jitpack"
+      s"""//> using scala $scalaVersion
+         |//> using dep com.github.jupyter:jvm-repr:0.4.0
+         |//> using repository jitpack
          |import jupyter._
          |object Test:
          |  def main(args: Array[String]): Unit =
@@ -153,7 +153,7 @@ object ExportTestProjects {
 
   def mainClassScala3Test(scalaVersion: String): TestInputs = {
     val testFile =
-      s"""//> using scala "$scalaVersion"
+      s"""//> using scala $scalaVersion
          |
          |object Test:
          |  def main(args: Array[String]): Unit =
@@ -174,9 +174,9 @@ object ExportTestProjects {
 
   def scalacOptionsScala2Test(scalaVersion: String): TestInputs = {
     val testFile =
-      s"""//> using scala "$scalaVersion"
-         |//> using dep "org.scala-lang.modules::scala-async:0.10.0"
-         |//> using dep "org.scala-lang:scala-reflect:$scalaVersion"
+      s"""//> using scala $scalaVersion
+         |//> using dep org.scala-lang.modules::scala-async:0.10.0
+         |//> using dep org.scala-lang:scala-reflect:$scalaVersion
          |import scala.async.Async.{async, await}
          |import scala.concurrent.{Await, Future}
          |import scala.concurrent.duration.Duration
@@ -222,9 +222,9 @@ object ExportTestProjects {
 
   def testFrameworkTest(scalaVersion: String): TestInputs = {
     val testFile =
-      s"""//> using scala "$scalaVersion"
-         |//> using dep "com.lihaoyi::utest:0.7.10"
-         |//> using test-framework "utest.runner.Framework"
+      s"""//> using scala $scalaVersion
+         |//> using dep com.lihaoyi::utest:0.7.10
+         |//> using test-framework utest.runner.Framework
          |
          |import utest._
          |
@@ -259,7 +259,7 @@ object ExportTestProjects {
     val shapelessJarStr =
       "\"" + shapelessJar.toString.replace("\\", "\\\\") + "\""
     val testFile =
-      s"""//> using scala "$scalaVersion"
+      s"""//> using scala $scalaVersion
          |//> using jar $shapelessJarStr
          |
          |import shapeless._
@@ -277,8 +277,8 @@ object ExportTestProjects {
 
   def logbackBugCase(scalaVersion: String): TestInputs =
     TestInputs(os.rel / "script.sc" ->
-      s"""//> using scala "$scalaVersion"
-         |//> using lib "ch.qos.logback:logback-classic:1.4.5"
+      s"""//> using scala $scalaVersion
+         |//> using dep ch.qos.logback:logback-classic:1.4.5
          |println("Hello")
          |""".stripMargin)
 
@@ -288,23 +288,23 @@ object ExportTestProjects {
   ): TestInputs =
     TestInputs(
       os.rel / s"$mainClass.scala" ->
-        s"""//> using scala "$scalaVersion"
-           |//> using file "Message.scala"
+        s"""//> using scala $scalaVersion
+           |//> using file Message.scala
            |object $mainClass extends App {
            |  println(Message(value = os.pwd.toString).value)
            |}
            |""".stripMargin,
       os.rel / "Message.scala" ->
-        s"""//> using dep "com.lihaoyi::os-lib:0.9.1"
+        s"""//> using dep com.lihaoyi::os-lib:0.9.1
            |case class Message(value: String)
            |""".stripMargin
     )
   def compileOnlySource(scalaVersion: String, userName: String): TestInputs =
     TestInputs(
       os.rel / "Hello.scala" ->
-        s"""//> using scala "$scalaVersion"
-           |//> using lib "com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:2.23.2"
-           |//> using compileOnly.lib "com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:2.23.2"
+        s"""//> using scala $scalaVersion
+           |//> using dep com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:2.23.2
+           |//> using compileOnly.dep com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:2.23.2
            |
            |import com.github.plokhotnyuk.jsoniter_scala.core._
            |import com.github.plokhotnyuk.jsoniter_scala.macros._

--- a/modules/integration/src/test/scala/scala/cli/integration/FixTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixTests.scala
@@ -322,7 +322,7 @@ class FixTests extends ScalaCliSuite {
              |Removing directives from src/Main.scala
              |Removing directives from test/MyTests.scala
              |  Keeping:
-             |    //> using scala "3.2.2"""".stripMargin
+             |    //> using scala 3.2.2""".stripMargin
         )
 
         val projectFileContents          = os.read(root / projectFileName)
@@ -367,7 +367,7 @@ class FixTests extends ScalaCliSuite {
         // Directives with no 'test.' equivalent are retained
         assertNoDiff(
           testFileContents,
-          """//> using scala "3.2.2"
+          """//> using scala 3.2.2
             |
             |package com.foo.test.bar
             |

--- a/modules/integration/src/test/scala/scala/cli/integration/FixTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixTests.scala
@@ -137,9 +137,9 @@ class FixTests extends ScalaCliSuite {
     val inputs = TestInputs(
       mainSubPath ->
         s"""//> using objectWrapper
-           |//> using dep "com.lihaoyi::os-lib:0.9.1"
+           |//> using dep com.lihaoyi::os-lib:0.9.1
            |
-           |//> using test.dep "org.typelevel::cats-core:2.9.0"
+           |//> using test.dep org.typelevel::cats-core:2.9.0
            |
            |package com.foo.main
            |
@@ -148,7 +148,7 @@ class FixTests extends ScalaCliSuite {
            |}
            |""".stripMargin,
       testSubPath ->
-        s"""//> using options -Xasync, -Xfatal-warnings
+        s"""//> using options -Xasync -Xfatal-warnings
            |//> using dep org.scalameta::munit::0.7.29
            |
            |package com.foo.test.bar
@@ -256,14 +256,14 @@ class FixTests extends ScalaCliSuite {
 
       val inputs = TestInputs(
         mainSubPath ->
-          s"""//> using platforms "jvm"
-             |//> using scala "3.3.0"
-             |//> using jvm "17"
+          s"""//> using platforms jvm
+             |//> using scala 3.3.0
+             |//> using jvm 17
              |//> using objectWrapper
              |//> using dep com.lihaoyi::os-lib:0.9.1
              |//> using file $includePath
              |
-             |//> using test.dep "org.typelevel::cats-core:2.9.0"
+             |//> using test.dep org.typelevel::cats-core:2.9.0
              |
              |package com.foo.main
              |
@@ -274,8 +274,8 @@ class FixTests extends ScalaCliSuite {
         withUsedTargetSubPath   -> withUsedTargetContents,
         withUnusedTargetSubPath -> withUnusedTargetContents,
         testSubPath ->
-          s"""//> using options -Xasync, -Xfatal-warnings
-             |//> using dep "org.scalameta::munit::0.7.29"
+          s"""//> using options -Xasync -Xfatal-warnings
+             |//> using dep org.scalameta::munit::0.7.29
              |//> using scala 3.2.2
              |
              |package com.foo.test.bar

--- a/modules/integration/src/test/scala/scala/cli/integration/HadoopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/HadoopTests.scala
@@ -9,7 +9,7 @@ class HadoopTests extends munit.FunSuite {
     TestUtil.retryOnCi() {
       val inputs = TestInputs(
         os.rel / "WordCount.java" ->
-          """//> using dep "org.apache.hadoop:hadoop-client-api:3.3.3"
+          """//> using dep org.apache.hadoop:hadoop-client-api:3.3.3
             |
             |// from https://hadoop.apache.org/docs/r3.3.3/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
             |

--- a/modules/integration/src/test/scala/scala/cli/integration/MarkdownTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/MarkdownTests.scala
@@ -154,7 +154,7 @@ class MarkdownTests extends ScalaCliSuite {
         s"""# Sample Markdown file
            |A simple scala script snippet.
            |```scala
-           |//> using dep "com.lihaoyi::os-lib:0.8.1"
+           |//> using dep com.lihaoyi::os-lib:0.8.1
            |println(os.pwd)
            |```
            |""".stripMargin
@@ -170,7 +170,7 @@ class MarkdownTests extends ScalaCliSuite {
         s"""# Sample Markdown file
            |A simple scala raw snippet.
            |```scala raw
-           |//> using dep "com.lihaoyi::os-lib:0.8.1"
+           |//> using dep com.lihaoyi::os-lib:0.8.1
            |object Hello extends App {
            |  println(os.pwd)
            |}
@@ -193,7 +193,7 @@ class MarkdownTests extends ScalaCliSuite {
            |## Circe
            |Let's depend on `circe-parser` in this one.
            |```scala
-           |//> using dep "io.circe::circe-parser:0.14.3"
+           |//> using dep io.circe::circe-parser:0.14.3
            |import io.circe._, io.circe.parser._
            |val json = \"\"\"{ "message": "$msg1"}\"\"\"
            |val parsed = parse(json).getOrElse(Json.Null)
@@ -204,7 +204,7 @@ class MarkdownTests extends ScalaCliSuite {
            |## `pprint`
            |And `pprint`, too.
            |```scala
-           |//> using dep "com.lihaoyi::pprint:0.8.0"
+           |//> using dep com.lihaoyi::pprint:0.8.0
            |pprint.PPrinter.BlackWhite.pprintln("$msg2")
            |```
            |
@@ -212,7 +212,7 @@ class MarkdownTests extends ScalaCliSuite {
            |And then on `os-lib`, just because.
            |And let's reset the scope for good measure, too.
            |```scala reset
-           |//> using dep "com.lihaoyi::os-lib:0.8.1"
+           |//> using dep com.lihaoyi::os-lib:0.8.1
            |val msg = os.pwd.toString
            |println(msg)
            |```
@@ -238,7 +238,7 @@ class MarkdownTests extends ScalaCliSuite {
            |## Circe
            |Let's depend on `circe-parser` in this one.
            |```scala raw
-           |//> using dep "io.circe::circe-parser:0.14.3"
+           |//> using dep io.circe::circe-parser:0.14.3
            |
            |object CirceSnippet {
            |  import io.circe._, io.circe.parser._
@@ -255,7 +255,7 @@ class MarkdownTests extends ScalaCliSuite {
            |## `pprint`
            |And `pprint`, too.
            |```scala raw
-           |//> using dep "com.lihaoyi::pprint:0.8.0"
+           |//> using dep com.lihaoyi::pprint:0.8.0
            |object PprintSnippet {
            |  def printStuff(): Unit =
            |    pprint.PPrinter.BlackWhite.pprintln("$msg2")
@@ -266,7 +266,7 @@ class MarkdownTests extends ScalaCliSuite {
            |And then on `os-lib`, just because.
            |And let's reset the scope for good measure, too.
            |```scala raw
-           |//> using dep "com.lihaoyi::os-lib:0.8.1"
+           |//> using dep com.lihaoyi::os-lib:0.8.1
            |
            |object OsLibSnippet extends App {
            |  CirceSnippet.printStuff()

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -78,7 +78,7 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     val message  = "1,2,3"
     val inputs = TestInputs(
       os.rel / fileName ->
-        s"""|//> using resourceDir "."
+        s"""|//> using resourceDir .
             |import scala.io.Source
             |
             |val inputs = Source.fromResource("input").getLines.toSeq
@@ -107,7 +107,7 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     val resourceFile = "input"
     val inputs = TestInputs(
       os.rel / fileName ->
-        s"""|//> using resourceDir "."
+        s"""|//> using resourceDir .
             |
             |class MyLibrary {
             |  def message = "Hello"
@@ -140,7 +140,7 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
   test("Zip with Scala Script containing resource directive") {
     val inputs = TestInputs(
       os.rel / "hello.sc" ->
-        s"""//> using resourceDir "./"
+        s"""//> using resourceDir ./
            |import scala.io.Source
            |
            |val inputs = Source.fromResource("input").getLines.map(_.toInt).toSeq
@@ -240,8 +240,8 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     val message  = "Hello World from JS"
     val inputs = TestInputs(
       os.rel / fileName ->
-        s"""|//> using jsModuleKind "es"
-            |//> using jsModuleSplitStyleStr "smallestmodules"
+        s"""|//> using jsModuleKind es
+            |//> using jsModuleSplitStyleStr smallestmodules
             |
             |case class Foo(bar: String)
             |
@@ -280,9 +280,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     val message  = "Hello World from JS"
     val inputs = TestInputs(
       os.rel / fileName ->
-        s"""|//> using jsModuleKind "es"
-            |//> using jsModuleSplitStyleStr "smallmodulesfor"
-            |//> using jsSmallModuleForPackage "test"
+        s"""|//> using jsModuleKind es
+            |//> using jsModuleSplitStyleStr smallmodulesfor
+            |//> using jsSmallModuleForPackage test
             |
             |package test
             |
@@ -327,7 +327,7 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     val inputs = TestInputs(
       os.rel / fileName ->
         s"""|//> using jsHeader "$jsHeaderNewLine"
-            |//> using jsMode "release"
+            |//> using jsMode release
             |
             |object Hello extends App {
             |  println("Hello")
@@ -539,7 +539,7 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
       val message  = "Hello"
       val inputs = TestInputs(
         os.rel / fileName ->
-          s"""//> using dep "org.typelevel::cats-kernel:2.6.1"
+          s"""//> using dep org.typelevel::cats-kernel:2.6.1
              |import cats.kernel._
              |val m = Monoid.instance[String]("", (a, b) => a + b)
              |val msgStuff = m.combineAll(List("$message", "", ""))
@@ -1164,7 +1164,7 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
 
   test("fat jar") {
     val inputs = TestInputs(
-      os.rel / "OsLibFatJar.scala" -> s"""//> using dep "com.lihaoyi::os-lib:0.9.0" """,
+      os.rel / "OsLibFatJar.scala" -> s"""//> using dep com.lihaoyi::os-lib:0.9.0""",
       os.rel / "Hello.scala" ->
         s"""object Main extends App {
            |  println(os.pwd)

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishLocalTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishLocalTestDefinitions.scala
@@ -18,8 +18,8 @@ abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaV
     def testOrg: String  = "test-local-org.sth"
     def testName: String = "my-proj"
     def projFile(message: String): String =
-      s"""//> using scala "$testedPublishedScalaVersion"
-         |//> using dep "com.lihaoyi::os-lib:0.9.1"
+      s"""//> using scala $testedPublishedScalaVersion
+         |//> using dep com.lihaoyi::os-lib:0.9.1
          |
          |object Project {
          |  def message = "$message"

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
@@ -16,12 +16,12 @@ abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersio
   private object TestCase {
     val testInputs: TestInputs = TestInputs(
       os.rel / "project" / "foo" / "Hello.scala" ->
-        """//> using publish.organization "org.virtuslab.scalacli.test"
-          |//> using publish.name "simple"
-          |//> using publish.version "0.2.0-SNAPSHOT"
-          |//> using publish.url "https://github.com/VirtusLab/scala-cli"
+        """//> using publish.organization org.virtuslab.scalacli.test
+          |//> using publish.name simple
+          |//> using publish.version 0.2.0-SNAPSHOT
+          |//> using publish.url https://github.com/VirtusLab/scala-cli
           |//> using publish.license "Apache 2.0:http://opensource.org/licenses/Apache-2.0"
-          |//> using publish.developer "someone|Someone||https://github.com/someone"
+          |//> using publish.developer someone|Someone||https://github.com/someone
           |
           |package foo
           |

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestsDefault.scala
@@ -9,9 +9,9 @@ class PublishTestsDefault extends PublishTestDefinitions with TestDefault {
     val testVersion = "0.3.1"
     val inputs = TestInputs(
       os.rel / "Foo.java" ->
-        s"""//> using publish.organization "$testOrg"
-           |//> using publish.name "$testName"
-           |//> using publish.version "$testVersion"
+        s"""//> using publish.organization $testOrg
+           |//> using publish.name $testName
+           |//> using publish.version $testVersion
            |
            |package foo;
            |
@@ -154,20 +154,20 @@ class PublishTestsDefault extends PublishTestDefinitions with TestDefault {
   test("missing sonatype requirements") {
     val inputs = TestInputs(
       os.rel / "messages" / "Messages.scala" ->
-        """//> using publish.repository "central"
-          |//> using publish.organization "test-org"
-          |//> using publish.name "test-name"
-          |//> using publish.version "0.1.0"
+        """//> using publish.repository central
+          |//> using publish.organization test-org
+          |//> using publish.name test-name
+          |//> using publish.version 0.1.0
           |package messages
           |object Messages {
           |  def hello = "Hello"
           |}
           |""".stripMargin,
       os.rel / "publish-conf.scala" ->
-        """//> using publish.url "https://github.com/me/my-project"
-          |//> using publish.license "Apache-2.0"
-          |//> using publish.scm "github:test-org/test-name"
-          |//> using publish.developer "me|Me|https://me.me"
+        """//> using publish.url https://github.com/me/my-project
+          |//> using publish.license Apache-2.0
+          |//> using publish.scm github:test-org/test-name
+          |//> using publish.developer me|Me|https://me.me
           |""".stripMargin
     )
     def checkWarnings(output: String, hasWarnings: Boolean): Unit = {

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplAmmoniteTests3StableDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplAmmoniteTests3StableDefinitions.scala
@@ -25,7 +25,7 @@ trait ReplAmmoniteTests3StableDefinitions {
   test("https://github.com/scala/scala3/issues/21229") {
     TestInputs(
       os.rel / "Pprint.scala" ->
-        """//> using dep "com.lihaoyi::pprint::0.9.0"
+        """//> using dep com.lihaoyi::pprint::0.9.0
           |package stuff
           |import scala.quoted.*
           |def foo = pprint(1)
@@ -52,7 +52,7 @@ trait ReplAmmoniteTests3StableDefinitions {
   test("as jar") {
     val inputs = TestInputs(
       os.rel / "CheckCp.scala" ->
-        """//> using lib "com.lihaoyi::os-lib:0.9.1"
+        """//> using dep com.lihaoyi::os-lib:0.9.1
           |package checkcp
           |object CheckCp {
           |  def hasDir: Boolean =

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
@@ -137,7 +137,7 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
     val message  = "Hello"
     val inputs = TestInputs(
       os.rel / fileName ->
-        s"""//> using jsModuleKind "es"
+        s"""//> using jsModuleKind es
            |import scala.scalajs.js
            |import scala.scalajs.js.annotation._
            |
@@ -162,7 +162,7 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
     val message = "Hello"
     val inputs = TestInputs(
       os.rel / "simple.sc" ->
-        s"""//> using platform "scala-js"
+        s"""//> using platform scala-js
            |import scala.scalajs.js
            |val console = js.Dynamic.global.console
            |val msg = "$message"
@@ -179,7 +179,7 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
     val message = "Hello"
     val inputs = TestInputs(
       os.rel / "simple.sc" ->
-        s"""//> using platform "scala-native"
+        s"""//> using platform scala-native
            |import scala.scalajs.js
            |val console = js.Dynamic.global.console
            |val msg = "$message"
@@ -216,7 +216,7 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
   def jsDomTest(): Unit = {
     val inputs = TestInputs(
       os.rel / "JsDom.scala" ->
-        s"""|//> using dep "org.scala-js::scalajs-dom::2.1.0"
+        s"""|//> using dep org.scala-js::scalajs-dom::2.1.0
             |
             |import org.scalajs.dom.document
             |
@@ -279,7 +279,7 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
   test("set es version to scala-js-cli") {
     val inputs = TestInputs(
       os.rel / "run.sc" ->
-        s"""//> using jsEsVersionStr "es2018"
+        s"""//> using jsEsVersionStr es2018
            |
            |import scala.scalajs.js
            |val console = js.Dynamic.global.console
@@ -487,7 +487,7 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
           s"""//> using toolkit default
              |//> using toolkit typelevel:default
              |
-             |//> using platform "scala-js"
+             |//> using platform scala-js
              |
              |import cats.effect._
              |import scala.scalajs.js

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
@@ -54,7 +54,7 @@ trait RunScalaNativeTestDefinitions { _: RunTestDefinitions =>
     val message  = "Hello"
     val inputs = TestInputs(
       os.rel / fileName ->
-        s"""//> using nativeLto "thin"
+        s"""//> using nativeLto thin
            |println("$message")
            |""".stripMargin
     )
@@ -96,8 +96,8 @@ trait RunScalaNativeTestDefinitions { _: RunTestDefinitions =>
       val resourceFileName = "embeddedfile.txt"
       val inputs = TestInputs(
         os.rel / projectDir / "main.scala" ->
-          s"""|//> using platform "scala-native"
-              |//> using resourceDir "resources"
+          s"""|//> using platform scala-native
+              |//> using resourceDir resources
               |
               |import java.nio.charset.StandardCharsets
               |import java.io.{BufferedReader, InputStreamReader}
@@ -132,7 +132,7 @@ trait RunScalaNativeTestDefinitions { _: RunTestDefinitions =>
       val interopMsg      = "Hello C!"
       val inputs = TestInputs(
         os.rel / projectDir / "main.scala" ->
-          s"""|//> using platform "scala-native"
+          s"""|//> using platform scala-native
               |
               |import scala.scalanative.unsafe._
               |

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
@@ -406,7 +406,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
       val inputs = TestInputs(
         os.rel / "f.sc" ->
           s"""|#!/usr/bin/env -S ${TestUtil.cli.mkString(" ")} shebang -S 2.13
-              |//> using scala "$actualScalaVersion"
+              |//> using scala $actualScalaVersion
               |println(args.toList)""".stripMargin
       )
       inputs.fromRoot { root =>
@@ -420,7 +420,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
     val inputs = TestInputs(
       os.rel / "script-with-shebang" ->
         s"""|#!/usr/bin/env -S ${TestUtil.cli.mkString(" ")} shebang -S 2.13
-            |//> using scala "$actualScalaVersion"
+            |//> using scala $actualScalaVersion
             |println(args.toList)""".stripMargin
     )
     inputs.fromRoot { root =>
@@ -438,7 +438,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
   test("script file with NO shebang header and no extension run with scala-cli shebang") {
     val inputs = TestInputs(
       os.rel / "script-no-shebang" ->
-        s"""//> using scala "$actualScalaVersion"
+        s"""//> using scala $actualScalaVersion
            |println(args.toList)""".stripMargin
     )
     inputs.fromRoot { root =>
@@ -465,8 +465,8 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
 
     val inputs = TestInputs(
       os.rel / "script.sc" ->
-        s"""//> using scala "$actualScalaVersion"
-           |//> using dep "$dependencyOsLib"
+        s"""//> using scala $actualScalaVersion
+           |//> using dep $dependencyOsLib
            |
            |println(args.toList)""".stripMargin
     )
@@ -482,7 +482,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
     test("no deadlock when running background threads") {
       val inputs = TestInputs(
         os.rel / "script.sc" ->
-          s"""//> using scala "$actualScalaVersion"
+          s"""//> using scala $actualScalaVersion
              |
              |import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future}
              |import scala.concurrent.duration._
@@ -507,7 +507,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
     test("user readable error when @main is used") {
       val inputs = TestInputs(
         os.rel / "script.sc" ->
-          """//> using dep "com.lihaoyi::os-lib:0.9.1"
+          """//> using dep com.lihaoyi::os-lib:0.9.1
             |/*ignore this while regexing*/ @main def main(args: Strings*): Unit = println("Hello")
             |""".stripMargin
       )
@@ -687,7 +687,7 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
       val inputs = TestInputs(
         os.rel / "script-with-shebang" ->
           s"""|#!/usr/bin/env -S ${TestUtil.cli.mkString(" ")} shebang -S 2.13
-              |//> using scala "$actualScalaVersion"
+              |//> using scala $actualScalaVersion
               |println(args.toList)""".stripMargin
       )
       inputs.fromRoot { root =>

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -314,8 +314,8 @@ abstract class RunTestDefinitions
   test("compile-time only for jsoniter macros") {
     val inputs = TestInputs(
       os.rel / "hello.sc" ->
-        """|//> using lib "com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:2.23.2"
-           |//> using compileOnly.lib "com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:2.23.2"
+        """|//> using dep com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:2.23.2
+           |//> using compileOnly.dep com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:2.23.2
            |
            |import com.github.plokhotnyuk.jsoniter_scala.core._
            |import com.github.plokhotnyuk.jsoniter_scala.macros._
@@ -344,7 +344,7 @@ abstract class RunTestDefinitions
       val directiveName = if (compileOnly) "compileOnly.dep" else "dep"
       TestInputs(
         os.rel / "test.sc" ->
-          s"""//> using $directiveName "com.chuusai::shapeless:2.3.10"
+          s"""//> using $directiveName com.chuusai::shapeless:2.3.10
              |val shapelessFound =
              |  try Thread.currentThread().getContextClassLoader.loadClass("shapeless.HList") != null
              |  catch { case _: ClassNotFoundException => false }
@@ -427,7 +427,7 @@ abstract class RunTestDefinitions
     val message = "Hello"
     val inputs = TestInputs(
       os.rel / "simple.sc" ->
-        s"""//> using javaOpt "-Dtest.message=$message"
+        s"""//> using javaOpt -Dtest.message=$message
            |val msg = sys.props("test.message")
            |println(msg)
            |""".stripMargin
@@ -441,7 +441,7 @@ abstract class RunTestDefinitions
   test("Main class in config file") {
     val inputs = TestInputs(
       os.rel / "simple.scala" ->
-        s"""//> using `main-class` "hello"
+        s"""//> using main-class hello
            |object hello extends App { println("hello") }
            |object world extends App { println("world") }
            |""".stripMargin
@@ -590,7 +590,7 @@ abstract class RunTestDefinitions
   test("resources via directive") {
     val expectedMessage = "hello"
     resourcesInputs(
-      directive = "//> using resourceDirs \"./resources\"",
+      directive = "//> using resourceDirs ./resources",
       resourceContent = expectedMessage
     )
       .fromRoot { root =>
@@ -634,7 +634,7 @@ abstract class RunTestDefinitions
   test("test scope") {
     val inputs = TestInputs(
       os.rel / "Main.scala" ->
-        """//> using dep "com.lihaoyi::utest:0.7.10"
+        """//> using dep com.lihaoyi::utest:0.7.10
           |
           |object Main {
           |  val err = utest.compileError("pprint.log(2)")
@@ -646,7 +646,7 @@ abstract class RunTestDefinitions
           |}
           |""".stripMargin,
       os.rel / "Tests.test.scala" ->
-        """//> using dep "com.lihaoyi::pprint:0.6.6"
+        """//> using dep com.lihaoyi::pprint:0.6.6
           |
           |import utest._
           |
@@ -699,7 +699,7 @@ abstract class RunTestDefinitions
   test("Runs with JVM 8 with using directive") {
     val inputs =
       TestInputs(os.rel / "run.scala" ->
-        """//> using jvm "8"
+        """//> using jvm 8
           |object Main extends App { println(System.getProperty("java.version"))}""".stripMargin)
     inputs.fromRoot { root =>
       val p = os.proc(TestUtil.cli, "run.scala").call(cwd = root)
@@ -710,7 +710,7 @@ abstract class RunTestDefinitions
   test("workspace dir") {
     val inputs = TestInputs(
       os.rel / "Hello.scala" ->
-        """|//> using dep "com.lihaoyi::os-lib:0.7.8"
+        """|//> using dep com.lihaoyi::os-lib:0.7.8
            |
            |object Hello extends App {
            |  println(os.pwd)
@@ -757,7 +757,7 @@ abstract class RunTestDefinitions
     val (hello, world) = ("Hello", "World")
     val inputs = TestInputs(
       os.rel / fileName ->
-        """|//> using file "Utils.scala", "helper"
+        """|//> using file Utils.scala helper
            |
            |object Hello extends App {
            |   println(s"${Utils.hello}${helper.Helper.world}")
@@ -782,20 +782,20 @@ abstract class RunTestDefinitions
   test("multiple using directives warning message") {
     val inputs = TestInputs(
       os.rel / "Foo.scala" ->
-        s"""//> using scala "3.2.0"
+        s"""//> using scala 3.2.0
            |
            |object Foo extends App {
            |  println("Foo")
            |}
            |""".stripMargin,
       os.rel / "Bar.scala"  -> "",
-      os.rel / "Hello.java" -> "//> using jvm \"11\""
+      os.rel / "Hello.java" -> "//> using jvm 11"
     )
     inputs.fromRoot { root =>
       val warningMessage =
         """Using directives detected in multiple files:
-          |- Foo.scala:1:1-24
-          |- Hello.java:1:1-19""".stripMargin
+          |- Foo.scala:1:1-22
+          |- Hello.java:1:1-17""".stripMargin
       val output1 = os.proc(TestUtil.cli, ".").call(cwd = root, stderr = os.Pipe).err.trim()
       val output2 = os.proc(TestUtil.cli, "Foo.scala", "Bar.scala").call(
         cwd = root,
@@ -809,14 +809,14 @@ abstract class RunTestDefinitions
   test("suppress multiple using directives warning message") {
     val inputs = TestInputs(
       os.rel / "Foo.scala" ->
-        s"""//> using scala "3.2.0"
+        s"""//> using scala 3.2.0
            |
            |object Foo extends App {
            |  println("Foo")
            |}
            |""".stripMargin,
       os.rel / "Bar.scala"  -> "",
-      os.rel / "Hello.java" -> "//> using jvm \"11\""
+      os.rel / "Hello.java" -> "//> using jvm 11"
     )
     inputs.fromRoot { root =>
       val warningMessage = "Using directives detected in"
@@ -832,14 +832,14 @@ abstract class RunTestDefinitions
   test("suppress multiple using directives warning message with global config") {
     val inputs = TestInputs(
       os.rel / "Foo.scala" ->
-        s"""//> using scala "3.2.0"
+        s"""//> using scala 3.2.0
            |
            |object Foo extends App {
            |  println("Foo")
            |}
            |""".stripMargin,
       os.rel / "Bar.scala"  -> "",
-      os.rel / "Hello.java" -> "//> using jvm \"11\""
+      os.rel / "Hello.java" -> "//> using jvm 11"
     )
     inputs.fromRoot { root =>
       val warningMessage = "Using directives detected in"
@@ -1175,7 +1175,7 @@ abstract class RunTestDefinitions
     val inputs = TestInputs(
       os.rel / projectDir / fileName ->
         s"""
-           |//> using resourceDir "resources"
+           |//> using resourceDir resources
            |
            |object Main {
            |  def main(args: Array[String]) = {
@@ -1228,7 +1228,7 @@ abstract class RunTestDefinitions
       val exceptionMsg = "Throw exception in Scala"
       val inputs = TestInputs(
         os.rel / "hello.sc" ->
-          s"""//> using scala "3.1.3"
+          s"""//> using scala 3.1.3
              |throw new Exception("$exceptionMsg")""".stripMargin
       )
 
@@ -1391,9 +1391,9 @@ abstract class RunTestDefinitions
     val testFile        = "Tests.test.scala"
     TestInputs(
       os.rel / projectFile ->
-        """//> using dep "com.lihaoyi::os-lib:0.9.1"
-          |//> using test.dep "org.scalameta::munit::0.7.29"
-          |//> using test.dep "com.lihaoyi::pprint:0.8.1"
+        """//> using dep com.lihaoyi::os-lib:0.9.1
+          |//> using test.dep org.scalameta::munit::0.7.29
+          |//> using test.dep com.lihaoyi::pprint:0.8.1
           |""".stripMargin,
       os.rel / invalidMainFile ->
         """object InvalidMain extends App {
@@ -1442,9 +1442,9 @@ abstract class RunTestDefinitions
       )
     TestInputs(
       os.rel / projectFile ->
-        s"""//> using jar "$mainMessageJar"
-           |//> using test.jar "$testMessageJar"
-           |//> using test.dep "org.scalameta::munit::0.7.29"
+        s"""//> using jar $mainMessageJar
+           |//> using test.jar $testMessageJar
+           |//> using test.dep org.scalameta::munit::0.7.29
            |""".stripMargin,
       os.rel / mainMessageFile ->
         """case class MainMessage(value: String)
@@ -1687,7 +1687,7 @@ abstract class RunTestDefinitions
           |}
           |""".stripMargin,
       os.rel / "hello" / "Hello.scala" ->
-        s"""//> using dep "$testOrg::$testName:$testVersion"
+        s"""//> using dep $testOrg::$testName:$testVersion
            |import messages.Messages
            |object Hello {
            |  def main(args: Array[String]): Unit =
@@ -1829,20 +1829,20 @@ abstract class RunTestDefinitions
   test("warn about transitive `using file` directive") {
     TestInputs(
       os.rel / "Main.scala" ->
-        """//> using file "bar/Bar.scala"
-          |//> using file "abc/Abc.scala"
+        """//> using file bar/Bar.scala
+          |//> using file abc/Abc.scala
           |object Main extends App {
           | println(Bar(42))
           |}
           |""".stripMargin,
       os.rel / "bar" / "Bar.scala" ->
-        """//> using file "xyz/Xyz.scala"
-          |//> using file "xyz/NonExistent.scala"
+        """//> using file xyz/Xyz.scala
+          |//> using file xyz/NonExistent.scala
           |case class Bar(x: Int)
           |""".stripMargin,
       os.rel / "abc" / "Abc.scala" ->
-        """//> using file "xyz/Xyz.scala"
-          |//> using file "xyz/NonExistent.scala"
+        """//> using file xyz/Xyz.scala
+          |//> using file xyz/NonExistent.scala
           |case class Abc(x: Int)
           |""".stripMargin,
       os.rel / "xyz" / "Xyz.scala" ->
@@ -1861,29 +1861,29 @@ abstract class RunTestDefinitions
 
       expect(output.contains(
         """[warn] Chaining the 'using file' directive is not supported, the source won't be included in the build.
-          |[warn] //> using file "xyz/Xyz.scala"
-          |[warn]                 ^^^^^^^^^^^^^
+          |[warn] //> using file xyz/Xyz.scala
+          |[warn]                ^^^^^^^^^^^^^
           |""".stripMargin
       ))
 
       expect(output.contains(
         """[warn] Chaining the 'using file' directive is not supported, the source won't be included in the build.
-          |[warn] //> using file "xyz/NonExistent.scala"
-          |[warn]                 ^^^^^^^^^^^^^^^^^^^^^
+          |[warn] //> using file xyz/NonExistent.scala
+          |[warn]                ^^^^^^^^^^^^^^^^^^^^^
           |""".stripMargin
       ))
 
       expect(output.contains(
         """[warn] Chaining the 'using file' directive is not supported, the source won't be included in the build.
-          |[warn] //> using file "xyz/Xyz.scala"
-          |[warn]                 ^^^^^^^^^^^^^
+          |[warn] //> using file xyz/Xyz.scala
+          |[warn]                ^^^^^^^^^^^^^
           |""".stripMargin
       ))
 
       expect(output.contains(
         """[warn] Chaining the 'using file' directive is not supported, the source won't be included in the build.
-          |[warn] //> using file "xyz/NonExistent.scala"
-          |[warn]                 ^^^^^^^^^^^^^^^^^^^^^
+          |[warn] //> using file xyz/NonExistent.scala
+          |[warn]                ^^^^^^^^^^^^^^^^^^^^^
           |""".stripMargin
       ))
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
@@ -72,7 +72,7 @@ class RunTestsDefault extends RunTestDefinitions
   test("as jar") {
     val inputs = TestInputs(
       os.rel / "CheckCp.scala" ->
-        """//> using lib "com.lihaoyi::os-lib:0.9.1"
+        """//> using dep com.lihaoyi::os-lib:0.9.1
           |object CheckCp {
           |  def main(args: Array[String]): Unit = {
           |    val cp = sys.props("java.class.path")

--- a/modules/integration/src/test/scala/scala/cli/integration/RunWithWatchTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunWithWatchTestDefinitions.scala
@@ -175,9 +175,9 @@ trait RunWithWatchTestDefinitions { _: RunTestDefinitions =>
     test("watch artifacts") {
       val libSourcePath = os.rel / "lib" / "Messages.scala"
       def libSource(hello: String) =
-        s"""//> using publish.organization "test-org"
-           |//> using publish.name "messages"
-           |//> using publish.version "0.1.0"
+        s"""//> using publish.organization test-org
+           |//> using publish.name messages
+           |//> using publish.version 0.1.0
            |
            |package messages
            |
@@ -188,7 +188,7 @@ trait RunWithWatchTestDefinitions { _: RunTestDefinitions =>
       TestInputs(
         libSourcePath -> libSource("Hello"),
         os.rel / "app" / "TestApp.scala" ->
-          """//> using lib "test-org::messages:0.1.0"
+          """//> using lib test-org::messages:0.1.0
             |
             |package testapp
             |
@@ -243,7 +243,7 @@ trait RunWithWatchTestDefinitions { _: RunTestDefinitions =>
     val fileName = "watch.scala"
     TestInputs(
       os.rel / fileName ->
-        """//> using lib "org.scalameta::munit::0.7.29"
+        """//> using dep org.scalameta::munit::0.7.29
           |
           |class MyTests extends munit.FunSuite {
           |    test("is true true") { assert(true) }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunZipTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunZipTestDefinitions.scala
@@ -32,7 +32,7 @@ trait RunZipTestDefinitions { _: RunTestDefinitions =>
     val zipInputs: Seq[(os.RelPath, String, Charset)] = Seq(
       (
         os.rel / "Hello.scala",
-        s"""//> using resourceDir "./"
+        s"""//> using resourceDir ./
            |import scala.io.Source
            |import java.nio.charset.StandardCharsets
            |import java.io.{BufferedReader, InputStreamReader}
@@ -73,7 +73,7 @@ trait RunZipTestDefinitions { _: RunTestDefinitions =>
   test("Zip with Scala containing resource directive") {
     val inputs = TestInputs(
       os.rel / "Hello.scala" ->
-        s"""//> using resourceDir "./"
+        s"""//> using resourceDir ./
            |import scala.io.Source
            |
            |object Hello extends App {
@@ -99,7 +99,7 @@ trait RunZipTestDefinitions { _: RunTestDefinitions =>
   test("Zip with Scala Script containing resource directive") {
     val inputs = TestInputs(
       os.rel / "hello.sc" ->
-        s"""//> using resourceDir "./"
+        s"""//> using resourceDir ./
            |import scala.io.Source
            |
            |val inputs = Source.fromResource("input").getLines.map(_.toInt).toSeq
@@ -128,7 +128,7 @@ trait RunZipTestDefinitions { _: RunTestDefinitions =>
         s"""# Example Markdown file
            |A snippet for printing inputs from resources
            |```scala raw
-           |//> using resourceDir "./"
+           |//> using resourceDir ./
            |import scala.io.Source
            |object Hello extends App {
            |  val inputs = Source.fromResource("input").getLines.map(_.toInt).toSeq

--- a/modules/integration/src/test/scala/scala/cli/integration/ScalafixTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ScalafixTestDefinitions.scala
@@ -233,7 +233,7 @@ abstract class ScalafixTestDefinitions extends ScalaCliSuite with TestScalaVersi
 
   test("external rule") {
     val original: String =
-      """|//> using scalafix.dep "com.github.xuwei-k::scalafix-rules:0.5.1"
+      """|//> using scalafix.dep com.github.xuwei-k::scalafix-rules:0.5.1
          |
          |object CollectHeadOptionTest {
          |  def x1: Option[String] = List(1, 2, 3).collect { case n if n % 2 == 0 => n.toString }.headOption
@@ -248,7 +248,7 @@ abstract class ScalafixTestDefinitions extends ScalaCliSuite with TestScalaVersi
       os.rel / "Hello.scala" -> original
     )
     val expectedContent: String = noCrLf {
-      """|//> using scalafix.dep "com.github.xuwei-k::scalafix-rules:0.5.1"
+      """|//> using scalafix.dep com.github.xuwei-k::scalafix-rules:0.5.1
          |
          |object CollectHeadOptionTest {
          |  def x1: Option[String] = List(1, 2, 3).collectFirst{ case n if n % 2 == 0 => n.toString }

--- a/modules/integration/src/test/scala/scala/cli/integration/SharedRunTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SharedRunTests.scala
@@ -54,7 +54,7 @@ class SharedRunTests extends ScalaCliSuite {
     val confSv = "2.13.13"
     val inputs = TestInputs(
       os.rel / "test.sc" ->
-        s"""//> using scala "$confSv"
+        s"""//> using scala $confSv
            |println(scala.util.Properties.versionNumberString)
            |""".stripMargin
     )

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -180,10 +180,9 @@ class SipScalaTests extends ScalaCliSuite
   def testExperimentalDirectives(isPowerMode: Boolean, areWarningsSuppressed: Boolean): Unit =
     TestInputs.empty.fromRoot { root =>
       val code =
-        """
-          | //> using publish.name "my-library"
-          | //> using python
-          | class A
+        """//> using publish.name my-library
+          |//> using python
+          |class A
           |""".stripMargin
 
       val source = root / "A.scala"
@@ -210,13 +209,13 @@ class SipScalaTests extends ScalaCliSuite
         case (true, false) =>
           expect(res.exitCode == 0)
           expect(errOutput.containsExperimentalWarningOf(
-            "`//> using publish.name \"my-library\"`"
+            "`//> using publish.name my-library`"
           ))
           expect(errOutput.containsExperimentalWarningOf("`//> using python`"))
         case (true, true) =>
           expect(res.exitCode == 0)
           expect(!errOutput.containsExperimentalWarningOf(
-            "`//> using publish.name \"my-library\"`"
+            "`//> using publish.name my-library`"
           ))
           expect(!errOutput.containsExperimentalWarningOf("`//> using python`"))
       }
@@ -384,7 +383,7 @@ class SipScalaTests extends ScalaCliSuite
   }
   test("test global config suppressing warnings for an experimental directive") {
     testConfigSuppressingExperimentalFeatureWarnings(
-      "`//> using publish.name \"my-library\"` directive"
+      "`//> using publish.name my-library` directive"
     ) {
       (root: os.Path, homeEnv: Map[String, String]) =>
         val quote = TestUtil.argQuotationMark
@@ -425,7 +424,7 @@ class SipScalaTests extends ScalaCliSuite
       os.rel / "Main.scala" ->
         """//> using target.scope main
           |//> using target.platform jvm
-          |//> using publish.name "my-library"
+          |//> using publish.name my-library
           |
           |object Main {
           |  def main(args: Array[String]): Unit = {
@@ -451,9 +450,9 @@ class SipScalaTests extends ScalaCliSuite
            |If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
            |Exporting to a sbt project...
            |Some utilized directives are marked as experimental:
-           | - `//> using publish.name "my-library"`
-           | - `//> using target.platform "jvm"`
-           | - `//> using target.scope "main"`
+           | - `//> using publish.name my-library`
+           | - `//> using target.platform jvm`
+           | - `//> using target.scope main`
            |Please bear in mind that non-ideal user experience should be expected.
            |If you encounter any bugs or have feedback to share, make sure to reach out to the maintenance team at https://github.com/VirtusLab/scala-cli
            |Exported to: ${root / "dest"}

--- a/modules/integration/src/test/scala/scala/cli/integration/SparkTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SparkTestDefinitions.scala
@@ -60,9 +60,9 @@ abstract class SparkTestDefinitions extends ScalaCliSuite with TestScalaVersionA
   protected def defaultMaster = "local[4]"
   protected def simpleJobInputs(spark: Spark) = TestInputs(
     os.rel / "SparkJob.scala" ->
-      s"""//> using dep "org.apache.spark::spark-sql:${spark.sparkVersion}"
-         |//> using dep "com.chuusai::shapeless:2.3.10"
-         |//> using dep "com.lihaoyi::pprint:0.7.3"
+      s"""//> using dep org.apache.spark::spark-sql:${spark.sparkVersion}
+         |//> using dep com.chuusai::shapeless:2.3.10
+         |//> using dep com.lihaoyi::pprint:0.7.3
          |
          |import org.apache.spark._
          |import org.apache.spark.sql._
@@ -152,7 +152,7 @@ abstract class SparkTestDefinitions extends ScalaCliSuite with TestScalaVersionA
     val jobName = "the test spark job"
     val inputs = TestInputs(
       os.rel / "SparkJob.scala" ->
-        s"""//> using dep "org.apache.spark::spark-sql:3.3.0"
+        s"""//> using dep org.apache.spark::spark-sql:3.3.0
            |
            |import org.apache.spark._
            |import org.apache.spark.sql._

--- a/modules/integration/src/test/scala/scala/cli/integration/TestNativeImageOnScala3.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestNativeImageOnScala3.scala
@@ -42,7 +42,7 @@ class TestNativeImageOnScala3 extends ScalaCliSuite {
 
   test("lazy vals") {
     runTest("1")("2") {
-      """//> using scala "3.1.1"
+      """//> using scala 3.1.1
         |class A(a: String) { lazy val b = a.toInt + 1 }
         |@main def add1(i: String) = println(A(i).b)
         |""".stripMargin

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -102,7 +102,7 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
       """//> using scala 2.13
         |//> using platform native
         |//> using nativeVersion 0.4.17
-        |//> using dep "org.typelevel::cats-kernel-laws::2.8.0"
+        |//> using dep org.typelevel::cats-kernel-laws::2.8.0
         |
         |import org.scalacheck._
         |import Prop.forAll
@@ -117,7 +117,7 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
 
   val successfulJunitInputs: TestInputs = TestInputs(
     os.rel / "MyTests.test.scala" ->
-      """//> using dep "com.novocode:junit-interface:0.11"
+      """//> using dep com.novocode:junit-interface:0.11
         |import org.junit.Test
         |
         |class MyTests {
@@ -156,7 +156,7 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
 
   val successfulWeaverInputs: TestInputs = TestInputs(
     os.rel / "MyTests.test.scala" ->
-      """//> using deps "com.disneystreaming::weaver-cats:0.8.2"
+      """//> using deps com.disneystreaming::weaver-cats:0.8.2
         |import weaver._
         |import cats.effect.IO
         |
@@ -640,10 +640,10 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
     TestUtil.retryOnCi() {
       val supportsNative = actualScalaVersion.startsWith("2.")
       val platforms = {
-        var pf = Seq("\"jvm\"", "\"js\"")
+        var pf = Seq("jvm", "js")
         if (supportsNative)
-          pf = pf :+ "\"native\""
-        pf.mkString(", ")
+          pf = pf :+ "native"
+        pf.mkString(" ")
       }
       val inputs = {
         var inputs0 = TestInputs(
@@ -658,7 +658,7 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
                |}
                |""".stripMargin,
           os.rel / "MyJvmTests.scala" ->
-            """//> using target.platform "jvm"
+            """//> using target.platform jvm
               |
               |class MyJvmTests extends munit.FunSuite {
               |  test("jvm") {
@@ -667,7 +667,7 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
               |}
               |""".stripMargin,
           os.rel / "MyJsTests.scala" ->
-            """//> using target.platform "js"
+            """//> using target.platform js
               |
               |class MyJsTests extends munit.FunSuite {
               |  test("js") {
@@ -679,7 +679,7 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
         if (supportsNative)
           inputs0 = inputs0.add(
             os.rel / "MyNativeTests.scala" ->
-              """//> using target.platform "native"
+              """//> using target.platform native
                 |
                 |class MyNativeTests extends munit.FunSuite {
                 |  test("native") {
@@ -708,7 +708,7 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
     val inputs = TestInputs(
       os.rel / "JsDom.test.scala" ->
         s"""//> using dep com.lihaoyi::utest::$utestVersion
-           |//> using dep "org.scala-js::scalajs-dom::2.2.0"
+           |//> using dep org.scala-js::scalajs-dom::2.2.0
            |
            |import utest._
            |

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
@@ -15,8 +15,8 @@ class TestTestsDefault extends TestTestDefinitions with TestDefault {
           |}
           |""".stripMargin,
       os.rel / "test" / "MessagesTests.scala" ->
-        """//> using scala "2.13"
-          |//> using dep "com.lihaoyi::utest::0.7.10"
+        """//> using scala 2.13
+          |//> using dep com.lihaoyi::utest::0.7.10
           |package messages
           |package tests
           |import utest._

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -253,7 +253,7 @@ object Deps {
   val typelevelToolkitVersion   = "0.1.29"
   def typelevelToolkit          = ivy"org.typelevel:toolkit:$typelevelToolkitVersion"
   def typelevelToolkitTest      = ivy"org.typelevel:toolkit-test:$typelevelToolkitVersion"
-  def usingDirectives           = ivy"org.virtuslab:using_directives:1.1.1"
+  def usingDirectives           = ivy"org.virtuslab:using_directives:1.1.2"
   // Lives at https://github.com/VirtusLab/no-crc32-zip-input-stream, see #865
   // This provides a ZipInputStream that doesn't verify CRC32 checksums, that users
   // can enable by setting SCALA_CLI_VENDORED_ZIS=true in the environment, to workaround

--- a/website/docs/commands/compile.md
+++ b/website/docs/commands/compile.md
@@ -31,7 +31,7 @@ For a full list of options, run `scala-cli compile --help`, or check the options
 `--test` makes Scala CLI compile main and test scopes:
 
 ```scala title=Sample.test.scala
-//> using dep org.scalameta::munit:0.7.29
+//> using dep org.scalameta::munit:1.0.2
 class Test extends munit.FunSuite {
   test("sample") {
     assert(2 + 2 == 4)
@@ -487,7 +487,7 @@ For example, to exclude all files in the `example/scala` directory, add the foll
  `project.file` file:
 
 ```scala title=project.scala
-//> using exclude "example/scala"
+//> using exclude example/scala
 ```
 
 ## Compile-Only Dependencies
@@ -499,7 +499,7 @@ To declare a compile-only dependency, you should use the `compileOnly.dep` direc
 option. For instance, to include the `jsoniter-scala-macros` library at compile-time, you would use:
 
 ```scala title=CompileOnly.scala
-//> using compileOnly.dep "com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:2.23.2"
+//> using compileOnly.dep com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:2.23.2
 ```
 
 or by using the `--compile-lib` command line option:

--- a/website/docs/commands/export.md
+++ b/website/docs/commands/export.md
@@ -3,7 +3,7 @@ title: Export ⚡️
 sidebar_position: 27
 ---
 
-In case your project outgrows the cabapilities of Scala CLI (e.g support for modules) it may be beneficial
+In case your project outgrows the capabilities of Scala CLI (e.g support for modules) it may be beneficial
 to switch to a build tool such as SBT or Mill.
 The `export` sub-command allows to do that by converting a Scala CLI project into an SBT or Mill configuration.
 Additionally the sub-command supports the JSON format for custom analysis of projects.

--- a/website/docs/commands/scalafix.md
+++ b/website/docs/commands/scalafix.md
@@ -41,5 +41,5 @@ Read more about Scalafix:
 
 Adding an [external scalafix rule](https://scalacenter.github.io/scalafix/docs/rules/external-rules.html) to scala-cli might be done by declaring [`scalafix.dep`](./compile.md#compile-only-dependencies):
 ```scala title=externalRule.scala
-//> using scalafix.dep "com.github.xuwei-k::scalafix-rules:0.5.1"
+//> using scalafix.dep com.github.xuwei-k::scalafix-rules:0.5.1
 ```

--- a/website/docs/commands/test.md
+++ b/website/docs/commands/test.md
@@ -29,7 +29,7 @@ The second rule may sound a bit complicated, so let's explain it using following
 
 <ChainedSnippets>
 
-```bash
+```bash ignore
 tree example
 ```
 
@@ -83,7 +83,7 @@ when running your whole app, you only need it in tests. So rather than declare i
 the `test.dep` directive:
 
 ```scala compile
-//> using test.dep org.scalameta::munit::0.7.29
+//> using test.dep org.scalameta::munit::1.0.2
 ```
 
 For more details on test directives,
@@ -94,19 +94,19 @@ see [the `using` directives guide](../guides/introduction/using-directives.md#di
 In order to run tests with a test framework, add the framework dependency to your application.
 Some of the most popular test frameworks in Scala are:
 
-- [munit](https://scalameta.org/munit): `org.scalameta::munit::0.7.29`
-- [utest](https://github.com/com-lihaoyi/utest): `com.lihaoyi::utest::0.8.2`
-- [ScalaTest](https://www.scalatest.org): `org.scalatest::scalatest::3.2.17`
+- [munit](https://scalameta.org/munit): `org.scalameta::munit::1.0.2`
+- [utest](https://github.com/com-lihaoyi/utest): `com.lihaoyi::utest::0.8.4`
+- [ScalaTest](https://www.scalatest.org): `org.scalatest::scalatest::3.2.19`
 - [JUnit 4](https://junit.org/junit4), which can be used via
   a [dedicated interface](https://github.com/sbt/junit-interface): `com.github.sbt:junit-interface:0.13.3`
 - [Weaver](https://disneystreaming.github.io/weaver-test/): `com.disneystreaming::weaver-cats:0.8.3`. You may need to
-  specify weaver's test framework with `//> using testFramework "weaver.framework.CatsEffect"` if you had other test
+  specify weaver's test framework with `//> using testFramework weaver.framework.CatsEffect` if you had other test
   framework in your dependencies.
 
 The following example shows how to run an munit-based test suite:
 
 ```scala title=MyTests.test.scala
-//> using test.dep org.scalameta::munit::0.7.29
+//> using test.dep org.scalameta::munit::1.0.2
 
 class MyTests extends munit.FunSuite {
   test("foo") {
@@ -140,7 +140,7 @@ foo
 Passing the `--test-only` option to the `test` sub-command filters the test suites to be run:
 
 ```scala title=BarTests.test.scala
-//> using test.dep org.scalameta::munit::0.7.29
+//> using test.dep org.scalameta::munit::1.0.2
 package tests.only
 
 class BarTests extends munit.FunSuite {
@@ -178,7 +178,7 @@ tests.only.BarTests:
 To run a specific test case inside the unit test suite pass `*exact-test-name*` as an argument to scala-cli:
 
 ```scala title=BarTests.test.scala
-//> using test.dep org.scalameta::munit::0.7.29
+//> using test.dep org.scalameta::munit::1.0.2
 package tests.only
 
 class Tests extends munit.FunSuite {
@@ -212,7 +212,7 @@ tests.only.Tests:
 You can pass test arguments to your test framework by passing them after `--`:
 
 ```scala title=MyTests.test.scala
-//> using test.dep org.scalatest::scalatest::3.2.9
+//> using test.dep org.scalatest::scalatest::3.2.19
 
 import org.scalatest._
 import org.scalatest.flatspec._

--- a/website/docs/commands/version.md
+++ b/website/docs/commands/version.md
@@ -14,8 +14,8 @@ scala-cli version
 ```
 
 ```text
-Scala CLI version: 0.1.19
-Scala version (default): 3.2.1
+Scala CLI version: 1.5.4
+Scala version (default): 3.5.2
 ```
 
 </ChainedSnippets>
@@ -30,8 +30,8 @@ scala-cli -version
 ```
 
 ```text
-Scala CLI version: 0.1.19
-Scala version (default): 3.2.1
+Scala CLI version: 1.5.4
+Scala version (default): 3.5.2
 ```
 
 </ChainedSnippets>
@@ -60,7 +60,7 @@ scala-cli version --cli-version
 ```
 
 ```text
-0.1.19
+1.5.4
 ```
 
 </ChainedSnippets>
@@ -95,7 +95,7 @@ scala-cli version --scala-version
 ```
 
 ```text
-3.2.1
+3.5.2
 ```
 
 </ChainedSnippets>

--- a/website/docs/cookbooks/ide/intellij-multi-bsp.md
+++ b/website/docs/cookbooks/ide/intellij-multi-bsp.md
@@ -45,7 +45,7 @@ tree -a
 ```
 
 ```scala title=app1/test/MyTests1.scala
-//> using dep org.scalameta::munit:1.0.0-M7
+//> using dep org.scalameta::munit:1.0.2
 class MyTests1 extends munit.FunSuite {
   test("my test 1") {
     assert(2 + 2 == 4)
@@ -58,7 +58,7 @@ class MyTests1 extends munit.FunSuite {
 ```
 
 ```scala title=app2/test/MyTests2.scala
-//> using dep com.lihaoyi::utest::0.8.1
+//> using dep com.lihaoyi::utest::0.8.4
 
 import utest.*
 

--- a/website/docs/cookbooks/ide/intellij.md
+++ b/website/docs/cookbooks/ide/intellij.md
@@ -17,7 +17,7 @@ def hello() = println("Hello, world")
 ```
 
 ```scala title=test/MyTests.test.scala
-//> using dep org.scalameta::munit::1.0.0-M1
+//> using dep org.scalameta::munit::1.0.2
 
 class MyTests extends munit.FunSuite {
   test("test") {

--- a/website/docs/cookbooks/ide/vscode.md
+++ b/website/docs/cookbooks/ide/vscode.md
@@ -13,7 +13,7 @@ def hello() = println("Hello, world")
 ```
 
 ```scala title=MyTests.test.scala
-//> using dep org.scalameta::munit::1.0.0-M1
+//> using dep org.scalameta::munit::1.0.2
 
 class MyTests extends munit.FunSuite {
   test("test") {

--- a/website/docs/cookbooks/introduction/debugging.md
+++ b/website/docs/cookbooks/introduction/debugging.md
@@ -18,7 +18,7 @@ object MyClass extends App  {
 ```
 
 ```scala title=MyTests.test.scala
-//> using dep org.scalameta::munit::0.7.27
+//> using dep org.scalameta::munit::1.0.2
 
 class MyTests extends munit.FunSuite {
   test("foo") {

--- a/website/docs/cookbooks/introduction/gh-action.md
+++ b/website/docs/cookbooks/introduction/gh-action.md
@@ -9,11 +9,11 @@ Scala CLI lets you run, test, and package Scala code in various environments, in
 To use Scala CLI features in a simple way you can use the GitHub Actions [scala-cli-setup](https://github.com/VirtusLab/scala-cli-setup) that installs everything necessary to run your Scala CLI application and more.
 
 For example, here's a simple `ls` application printing the files in a given directory:
-```scala title=Ls.scala
-//> using scala 2.13
-//> using dep com.lihaoyi::os-lib:0.7.8
+```scala compile title=Ls.scala
+//> using scala 3
+//> using dep com.lihaoyi::os-lib:0.11.3
 
-@main def hello(args: String*) =
+@main def hello(args: String*): Unit =
   val path = args.headOption match
     case Some(p) => os.Path(p, os.pwd)
     case _       => os.pwd
@@ -24,8 +24,8 @@ For example, here's a simple `ls` application printing the files in a given dire
 
 and some tests for `ls` application:
 
-```scala title=TestsLs.test.scala
-//> using dep org.scalameta::munit::0.7.27
+```scala compile title=TestsLs.test.scala
+//> using dep org.scalameta::munit::1.0.2
 import scala.util.Properties
 
 class TestsLs extends munit.FunSuite {
@@ -37,7 +37,7 @@ class TestsLs extends munit.FunSuite {
     expectedFiles.foreach(os.write(_, "Hello"))
 
     // check
-    val scalaCLILauncher = if(Properties.isWin) "scala-cli.bat" else "scala-cli"
+    val scalaCLILauncher = if (Properties.isWin) "scala-cli.bat" else "scala-cli"
     val foundFiles =
       os.proc(scalaCLILauncher, "Ls.scala", "--", tempDir).call().out.trim()
 
@@ -105,9 +105,9 @@ Scala CLI allows to build native executable applications using [GraalVM](https:/
 ```
 
 Given this simple Scala Script `package.sc` to package application to every platform:
-```scala title=package.sc
-//> using scala 3.1.2
-//> using dep com.lihaoyi::os-lib:0.8.0
+```scala compile title=package.sc
+//> using scala 3
+//> using dep com.lihaoyi::os-lib:0.11.3
 import scala.util.Properties
 
 val platformSuffix: String = {

--- a/website/docs/cookbooks/introduction/instant-startup-scala-scripts.md
+++ b/website/docs/cookbooks/introduction/instant-startup-scala-scripts.md
@@ -17,8 +17,8 @@ As an example, let’s build a script printing files from
 a directory with sizes bigger than a passed value.
 
 ```scala title=size-higher-than.scala
-//> using scala 3.1.1
-//> using dep com.lihaoyi::os-lib::0.8.1
+//> using scala 3
+//> using dep com.lihaoyi::os-lib::0.11.3
  
 @main
 def sizeHigherThan(dir: String, minSizeMB: Int) =
@@ -44,8 +44,8 @@ scala-cli size-higher-than.scala -- dir 20
 ```
 
 ```text
-Compiling project (Scala 3.4.1, JVM)
-Compiled project (Scala 3.4.1, JVM)
+Compiling project (Scala 3.5.2, JVM)
+Compiled project (Scala 3.5.2, JVM)
 /Users/user/Documents/workspace/dir/large-file.txt
 ```
 </ChainedSnippets>
@@ -80,7 +80,7 @@ We can make the runtime itself even faster, using various Scala Native optimizat
 We pass these using a `-–native-mode` scala-cli option or, like previously, by adding a using directive:
 
 ```scala compile title=size-higher-than.scala
-//> using dep com.lihaoyi::os-lib::0.10.0
+//> using dep com.lihaoyi::os-lib::0.11.3
 //> using platform scala-native
 //> using nativeMode release-full
  

--- a/website/docs/cookbooks/introduction/test-only.md
+++ b/website/docs/cookbooks/introduction/test-only.md
@@ -26,7 +26,7 @@ The `--test-only` option is supported for every test framework running with Scal
 For example, passing `tests.only*` to the `--test-only` option runs only the test suites which start with `tests.only`:
 
 ```scala title=BarTests.scala
-//> using dep org.scalameta::munit::0.7.29
+//> using dep org.scalameta::munit::1.0.2
 package tests.only
 
 class BarTests extends munit.FunSuite {
@@ -70,7 +70,7 @@ To run a specific test case inside a test suite pass `*test-name*` as an argumen
 <!-- clear -->
 
 ```scala title=MunitTests.scala
-//> using dep org.scalameta::munit::0.7.29
+//> using dep org.scalameta::munit::1.0.2
 package tests.only
 
 class Tests extends munit.FunSuite {
@@ -109,9 +109,9 @@ order to run a specific test case you will need to specify the exact name of the
 <!-- clear -->
 
 ```scala title=MyTests.scala
-//> using dep com.lihaoyi::utest::0.7.10
+//> using dep com.lihaoyi::utest::0.8.4
 
-import utest._
+import utest.*
 
 object MyTests extends TestSuite {
   val tests = Tests {

--- a/website/docs/getting_started.md
+++ b/website/docs/getting_started.md
@@ -91,7 +91,7 @@ To demonstrate this, let's start prototyping with [os-lib](https://github.com/co
 <ChainedSnippets>
 
 ```bash ignore
-scala-cli repl --dep com.lihaoyi::os-lib:0.9.0
+scala-cli repl --dep com.lihaoyi::os-lib:0.11.3
 ```
 
 ```scala ignore
@@ -119,7 +119,7 @@ cd scala-cli-getting-started
 Now we can write our logic in a file named `files.scala`:
 
 ```scala title=files.scala
-//> using dep com.lihaoyi::os-lib:0.9.0
+//> using dep com.lihaoyi::os-lib:0.11.3
 
 def filesByExtension(
   extension: String,
@@ -156,7 +156,7 @@ With our IDE in place, how can we test if our code works correctly? The best way
 We also need to add a test framework. Scala CLI support most popular test frameworks, and for this guide we will stick with [munit](https://scalameta.org/munit/). To add a test framework, we just need an ordinary dependency, and once again we'll add that with the `using` directive:
 
 ```scala title=files.test.scala
-//> using dep org.scalameta::munit:1.0.0-M1
+//> using dep org.scalameta::munit:1.0.2
 
 class TestSuite extends munit.FunSuite {
   test("hello") {
@@ -176,8 +176,8 @@ scala-cli test .
 ```
 
 ```
-Compiling project (test, Scala 3.0.2, JVM)
-Compiled project (test, Scala 3.0.2, JVM)
+Compiling project (test, Scala 3.5.2, JVM)
+Compiled project (test, Scala 3.5.2, JVM)
 TestSuite:
   + hello 0.058s
 ```

--- a/website/docs/guides/advanced/custom-toolkit.md
+++ b/website/docs/guides/advanced/custom-toolkit.md
@@ -9,29 +9,29 @@ Let's look at how we can create a new toolkit.
 
 For example, to create a LiHaoyi ecosystem toolkit, we can name the file as `LiHaoyiToolkit.scala` and add the required libraries as dependency directives:
 
-```scala
-//> using scala 2.13, 3
+```scala title=LiHaoyiToolkit.scala
+//> using scala 2.13 3
 //> using publish.name toolkit
-//> using dep com.lihaoyi::upickle::3.1.3
-//> using dep com.lihaoyi::os-lib::0.9.2
-//> using dep com.lihaoyi::requests::0.8.0
-//> using dep com.lihaoyi::fansi::0.4.0
+//> using dep com.lihaoyi::upickle::4.0.2
+//> using dep com.lihaoyi::os-lib::0.11.3
+//> using dep com.lihaoyi::requests::0.9.0
+//> using dep com.lihaoyi::fansi::0.5.0
 ``` 
 This toolkit is a combination of 4 libraries from `com.lihaoyi` organization as defined before. The key `publish.name` must have the value `toolkit` to be used as a toolkit. 
 
 Similarly, define the scalajs version of toolkit in `LiHaoyiToolkit.js.scala` file. Notice the `js.scala` extension. It should also have `publish.name` as `toolkit`. 
 
 If testkit is supported, it can also be added as another file, `LiHaoyiToolkitTest.scala` with `publish.name` as `toolkit-test`:
-```
-//> using scala 2.13, 3
+```scala title=LiHaoyiToolkitTest.scala
+//> using scala 2.13 3
 //> using publish.name toolkit-test
-//> using dep com.lihaoyi::utest::0.8.2
+//> using dep com.lihaoyi::utest::0.8.4
 ```
 
 Additionally, more configurations needed for publishing the toolkit can be kept in a conf file, for example, `publish-conf.scala`:
-```
+```scala title=publish-conf.scala 
 //> using publish.organization com.yadavan88
-//> using publish.version 0.1.0
+//> using publish.version 0.1.1-SNAPSHOT
 //> using publish.url https://github.com/yadavan88/lihaoyi-toolkit
 //> using publish.license Apache-2.0
 //> using publish.repository central
@@ -40,7 +40,7 @@ Additionally, more configurations needed for publishing the toolkit can be kept 
 ```
 
 The toolkit can be published locally using the command:
-```
+```bash
 scala-cli --power publish local --cross LiHaoyiToolkit.scala publish-conf.scala
 ```
 
@@ -48,13 +48,13 @@ Similarly, it is also possible to publish to a central repository. Refer to the 
 
 Once it is published, it can be accessed using the org-name with which it got published. For example, with the published toolkit under the organization `com.yadavan88`, it can be accessed as:
 
-```
-//> using toolkit com.yadavan88:0.1.0
+```scala compile
+//> using toolkit com.yadavan88:0.1.1-SNAPSHOT
 
 @main
 def main() = {
   println(fansi.Color.Blue("Hello world!"))
-  println("path is : " + os.pwd)
+  println("path is: " + os.pwd)
 }
 
 ```

--- a/website/docs/guides/advanced/verbosity.md
+++ b/website/docs/guides/advanced/verbosity.md
@@ -101,11 +101,11 @@ That can be done by passing an appropriate option or by setting the appropriate 
 ### Warnings about `using` directives spread in multiple files
 
 ```scala title=Deps1.sc
-//> using dep com.lihaoyi::os-lib:0.9.1
+//> using dep com.lihaoyi::os-lib:0.11.3
 ```
 
 ```scala title=Deps2.sc
-//> using dep com.lihaoyi::pprint:0.8.0
+//> using dep com.lihaoyi::pprint:0.9.0
 ```
 
 It is generally advised to not spread the `using` directives in multiple files, and put them in the
@@ -144,7 +144,7 @@ scala-cli config suppress-warning.experimental-features true
 ### Warnings about having outdated dependencies
 
 ```scala title=OldDeps.sc
-//> using dep com.lihaoyi::pprint:0.6.6
+//> using dep com.lihaoyi::pprint:0.9.0
 ```
 
 Depending on outdated libraries produces warnings, which can be suppressed with

--- a/website/docs/guides/introduction/configuration.md
+++ b/website/docs/guides/introduction/configuration.md
@@ -80,8 +80,9 @@ The reference documentation lists [all available using directives](/docs/referen
 
 Also, there are some directives which only target tests, like `using test.dep`. 
 Those can be useful when defining configuration specific to your test runs.
+
 ```scala compile
-//> using test.dep com.lihaoyi::utest::0.8.1
+//> using test.dep com.lihaoyi::utest::0.8.4
 ```
 
 More details can be found in the [`using` directives guide](using-directives.md#directives-with-a-test-scope-equivalent).
@@ -91,9 +92,9 @@ More details can be found in the [`using` directives guide](using-directives.md#
 Dependencies can be added right from `.scala` and `.sc` files with [`using` directives](#using-directives):
 
 ```scala compile
-//> using dep com.lihaoyi::upickle::3.1.2
-//> using dep com.lihaoyi::pprint::0.8.1
-import ujson._
+//> using dep com.lihaoyi::upickle::4.0.2
+//> using dep com.lihaoyi::pprint::0.9.0
+import ujson.*
 ```
 
 Both `import $ivy` and `import $dep` are not supported.

--- a/website/docs/guides/introduction/dependencies.md
+++ b/website/docs/guides/introduction/dependencies.md
@@ -82,8 +82,8 @@ To exclude a transitive dependency from a Scala CLI project use the `exclude` pa
 It requires passing the organization and module name of the dependency to be excluded. For example, let's say you have
 the following Scala code:
 
-```scala title=Main.scala
-//> using dep com.lihaoyi::pprint:0.8.1
+```scala compile
+//> using dep com.lihaoyi::pprint:0.9.0
 object Main extends App {
   println("Hello")
 }
@@ -92,8 +92,8 @@ object Main extends App {
 If you want to compile it with the `pprint` library but exclude its `sourcecode` dependency, you can use
 the `exclude` parameter as follows:
 
-```scala title=Main.scala
-//> using dep "com.lihaoyi::pprint:0.8.1,exclude=com.lihaoyi%%sourcecode"
+```scala compile
+//> using dep com.lihaoyi::pprint:0.9.0,exclude=com.lihaoyi%%sourcecode
 object Main extends App {
   println("Hello")
 }
@@ -101,8 +101,8 @@ object Main extends App {
 
 To exclude Scala modules, you can also use a single `%` but with the full name of the module name, like this:
 
-```scala title=Main.scala
-//> using dep "com.lihaoyi::pprint:0.8.1,exclude=com.lihaoyi%sourcecode_3"
+```scala compile
+//> using dep com.lihaoyi::pprint:0.9.0,exclude=com.lihaoyi%sourcecode_3
 object Main extends App {
   println("Hello")
 }
@@ -117,8 +117,8 @@ To specify a classifier of a dependency in a Scala CLI project, use the `classif
 If you want to use the `pytorch` dependency with the classifier `linux-x86_64`, use the `classifier` parameter as
 follows:
 
-```scala title=Main.scala
-//> using dep "org.bytedeco:pytorch:1.12.1-1.5.8,classifier=linux-x86_64"
+```scala compile
+//> using dep org.bytedeco:pytorch:2.5.1-1.5.11,classifier=linux-x86_64
 object Main extends App {
   println("Hello")
 }
@@ -133,9 +133,9 @@ If this is omitted, Scala CLI treats these parameters as dependencies, resulting
 
 It is possible to declare dependencies limited to the test scope with the `using test.dep` directive.
 
-```scala
-//> using test.dep org.scalameta::munit::0.7.29
-`````
+```scala compile
+//> using test.dep org.scalameta::munit::1.0.2
+```
 
 More details can be found in
 the [`using` directives guide](using-directives.md#directives-with-a-test-scope-equivalent).
@@ -195,8 +195,8 @@ scala-cli compile Sample.sc \
 Both can be handled with the appropriate `using` directives, too:
 
 ```scala
-//> using jar "./path/to/custom.jar"
-//> using sourceJar "./path/to/custom-sources.jar"
+//> using jar ./path/to/custom.jar
+//> using sourceJar ./path/to/custom-sources.jar
 ```
 
 :::caution

--- a/website/docs/guides/introduction/update-dependencies.md
+++ b/website/docs/guides/introduction/update-dependencies.md
@@ -24,8 +24,8 @@ scala-cli --power dependency-update Hello.scala
 
 ```text
 Updates
-   * com.lihaoyi::os-lib:0.7.8 -> 0.8.1
-   * com.lihaoyi::utest:0.7.10 -> 0.8.0
+   * com.lihaoyi::os-lib:0.7.8 -> 0.11.3
+   * com.lihaoyi::utest:0.7.10 -> 0.8.4
 To update all dependencies run: 
     scala-cli dependency-update --all
 ```
@@ -41,8 +41,8 @@ scala-cli --power dependency-update Hello.scala --all
 ```
 
 ```text
-Updated dependency to: com.lihaoyi::os-lib:0.8.1
-Updated dependency to: com.lihaoyi::utest:0.8.0
+Updated dependency to: com.lihaoyi::os-lib:0.11.3
+Updated dependency to: com.lihaoyi::utest:0.8.4
 ```
 
 </ChainedSnippets>

--- a/website/docs/guides/introduction/using-directives.md
+++ b/website/docs/guides/introduction/using-directives.md
@@ -106,11 +106,11 @@ Using directives are part of the code so similarly, developers should be able to
 Commenting out comment-based directives does not cause any problems. Below, some examples how to do it:
 
 ```scala compile
-// //> using dep "no::lib:123"
+// //> using dep no::lib:123
 ```
 
 ```scala compile
-// // using dep "no::lib:123"
+// // using dep no::lib:123
 ```
 
 ## Directives with a test scope equivalent
@@ -121,20 +121,20 @@ dependencies that are only used in tests outside test-specific sources.
 For example, this way you can declare the dependency to `munit` in `project.scala` like this:
 
 ```scala title=project.scala
-//> using test.dep org.scalameta::munit::0.7.29
+//> using test.dep org.scalameta::munit::1.0.2
 ```
 
 The dependency will then only be available in test sources.
 It's effectively an equivalent to just `using dep` inside of a test source (except you can define it anywhere):
 
 ```scala title=src/test/scala/Tests.scala
-//> using dep org.scalameta::munit::0.7.29
+//> using dep org.scalameta::munit::1.0.2
 ```
 
 Directives with a test scope equivalent:
 
 ```scala compile
-//> using test.dep org.scalameta::munit::0.7.29
+//> using test.dep org.scalameta::munit::1.0.2
 //> using test.jar path/to/dep.jar
 //> using test.sourceJar path/to/some-sources.jar
 //> using test.javaOpt -Dfoo=bar

--- a/website/docs/guides/power/markdown.md
+++ b/website/docs/guides/power/markdown.md
@@ -274,7 +274,7 @@ You can run `scala test` code blocks with the `test` sub-command.
 This is a simple example of an `.md` file with a test Scala snippet.
 
 ```scala test
-//> using dep org.scalameta::munit:0.7.29
+//> using dep org.scalameta::munit:1.0.2
 class Test extends munit.FunSuite {
   test("example test") {
     assert(true)
@@ -407,7 +407,7 @@ This is supported for all `scala` code block flavours.
 
 ## `scala raw` example
 ```scala raw
-//> using dep com.lihaoyi::pprint:0.8.0
+//> using dep com.lihaoyi::pprint:0.9.0
 object Printer {
   def printHello(): Unit = pprint.pprintln("Hello")
 }
@@ -415,13 +415,13 @@ object Printer {
 
 ## Plain `scala` example
 ```scala
-//> using dep com.lihaoyi::os-lib:0.8.1
+//> using dep com.lihaoyi::os-lib:0.11.3
 println(os.pwd)
 ```
 
 ## `scala test` example
 ```scala test
-//> using dep org.scalameta::munit:1.0.0-M7
+//> using dep org.scalameta::munit:1.0.2
 
 class Test extends munit.FunSuite {
   test("foo") {

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -405,7 +405,7 @@ Test sources are compiled separately (after the 'main' sources), and may use dif
 A source file is treated as a test source if:
   - the file name ends with `.test.scala`
   - the file comes from a directory that is provided as input, and the relative path from that file to its original directory contains a `test` directory
-  - it contains the `//> using target.scope "test"` directive (Experimental)
+  - it contains the `//> using target.scope test` directive (Experimental)
 
 Specific test configurations can be specified with both command line options and using directives defined in sources.
 Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -107,7 +107,7 @@ Add dependencies
 
 `//> using test.dep org.scalameta::munit:0.7.29`
 
-`//> using dep "tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar"`
+`//> using dep tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar`
 
 ### Exclude sources
 
@@ -121,9 +121,9 @@ Exclude sources from the project
 #### Examples
 `//> using exclude utils.scala`
 
-`//> using exclude "examples/*" "*/resources/*"`
+`//> using exclude examples/* */resources/*`
 
-`//> using exclude "*.sc"`
+`//> using exclude *.sc`
 
 ### JVM version
 
@@ -154,7 +154,7 @@ Add Java options which will be passed when running an application.
 `//> using javaOpt` _options_
 
 #### Examples
-`//> using javaOpt -Xmx2g, -Dsomething=a`
+`//> using javaOpt -Xmx2g -Dsomething=a`
 
 `//> using test.javaOpt -Dsomething=a`
 
@@ -168,7 +168,7 @@ Add Java properties
 
 
 #### Examples
-`//> using javaProp foo1=bar, foo2`
+`//> using javaProp foo1=bar foo2`
 
 `//> using test.javaProp foo3=bar foo4`
 
@@ -373,7 +373,7 @@ Set the default Scala version
 
 `//> using scala 2`
 
-`//> using scala 2.13.6, 2.12.16`
+`//> using scala 2.13.6 2.12.16`
 
 ### Scala.js options
 
@@ -450,7 +450,7 @@ Require a Scala platform for the current file
 #### Examples
 `//> using target.platform scala-js`
 
-`//> using target.platform scala-js, scala-native`
+`//> using target.platform scala-js scala-native`
 
 `//> using target.platform jvm`
 

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -194,7 +194,7 @@ Test sources are compiled separately (after the 'main' sources), and may use dif
 A source file is treated as a test source if:
   - the file name ends with `.test.scala`
   - the file comes from a directory that is provided as input, and the relative path from that file to its original directory contains a `test` directory
-  - it contains the `//> using target.scope "test"` directive (Experimental)
+  - it contains the `//> using target.scope test` directive (Experimental)
 
 Specific test configurations can be specified with both command line options and using directives defined in sources.
 Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -48,7 +48,7 @@ Add dependencies
 
 `//> using test.dep org.scalameta::munit:0.7.29`
 
-`//> using dep "tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar"`
+`//> using dep tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar`
 
 ### Java options
 
@@ -57,7 +57,7 @@ Add Java options which will be passed when running an application.
 `//> using javaOpt` _options_
 
 #### Examples
-`//> using javaOpt -Xmx2g, -Dsomething=a`
+`//> using javaOpt -Xmx2g -Dsomething=a`
 
 `//> using test.javaOpt -Dsomething=a`
 
@@ -71,7 +71,7 @@ Add Java properties
 
 
 #### Examples
-`//> using javaProp foo1=bar, foo2`
+`//> using javaProp foo1=bar foo2`
 
 `//> using test.javaProp foo3=bar foo4`
 
@@ -97,7 +97,7 @@ Set the default Scala version
 
 `//> using scala 2`
 
-`//> using scala 2.13.6, 2.12.16`
+`//> using scala 2.13.6 2.12.16`
 
 ## SHOULD have directives:
 
@@ -145,9 +145,9 @@ Exclude sources from the project
 #### Examples
 `//> using exclude utils.scala`
 
-`//> using exclude "examples/*" "*/resources/*"`
+`//> using exclude examples/* */resources/*`
 
-`//> using exclude "*.sc"`
+`//> using exclude *.sc`
 
 ### JVM version
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -3898,7 +3898,7 @@ Test sources are compiled separately (after the 'main' sources), and may use dif
 A source file is treated as a test source if:
   - the file name ends with `.test.scala`
   - the file comes from a directory that is provided as input, and the relative path from that file to its original directory contains a `test` directory
-  - it contains the `//> using target.scope "test"` directive (Experimental)
+  - it contains the `//> using target.scope test` directive (Experimental)
 
 Specific test configurations can be specified with both command line options and using directives defined in sources.
 Command line options always take priority over using directives when a clash occurs, allowing to override configurations defined in sources.


### PR DESCRIPTION
Fixes #3282 

NOTE: these are breaking changes affecting using directives syntax.
It's technically a fix + deprecation, but it is not impossible for existing builds to break.

For example, where
```scala
//> using scala 2.13,3
```
Used to mean that Scala is set to 2.13 and 3 for cross-builds, it will now mean Scala is set to `2.13,3`, which is not a valid version and will produce an error.
The valid syntax for the same would now be:
```scala
//> using scala 2.13 3
```

The fix itself is contained in the `using_directives` bump to 1.1.2:
- https://github.com/VirtusLab/using_directives/releases/tag/v1.1.2

Specifically, it's this change:
- https://github.com/VirtusLab/using_directives/pull/61

What this PR does:
- bumps `using_directives` to 1.1.2
  - using commas (`,`) as separators without whitespace is no longer supported (the comma will now be treated as part of the value)
  - using commas (`,`) with a following whitespace as separator gets deprecated and will produce a warning
- adds tests ensuring the old syntax is no longer honoured (no longer can use commas on their own as value separators)
- adds tests for the deprecation of using commas with whitespace as value separators
- updates the syntax in docs, old code & tests (which contributes the most to the change line count)
- updates the `publish setup` and `fix` sub-commands to use the latest syntax