### PR TITLE
Make `generate-junit-reports.sc` script recover from test failures containing no trace data

### DIFF
--- a/.github/scripts/generate-junit-reports.sc
+++ b/.github/scripts/generate-junit-reports.sc
@@ -7,6 +7,7 @@ import java.io.File
 import scala.collection.mutable.ArrayBuffer
 import scala.annotation.tailrec
 import java.nio.file.Paths
+import scala.util.Try
 
 case class Trace(declaringClass: String, methodName: String, fileName: String, lineNumber: Int) {
   override def toString: String = s"$declaringClass.$methodName($fileName:$lineNumber)"
@@ -97,11 +98,14 @@ val suites = tests.groupBy(_.fullyQualifiedName).map { case (suit, tests) =>
     } time={test.duration.toString}>
         {
       test.failure.map { failure =>
+        val maybeTrace = Try(failure.trace(1)).toOption
+        val fileName   = maybeTrace.map(_.fileName).getOrElse("unknown")
+        val lineNumber = maybeTrace.map(_.lineNumber).getOrElse(-1)
         <failure message={failure.message} type="ERROR">
             ERROR: {failure.message}
             Category: {failure.name}
-            File: {failure.trace(1).fileName}
-            Line: {failure.trace(1).lineNumber}
+            File: {fileName}
+            Line: {lineNumber}
           </failure>
       }.orNull
     }


### PR DESCRIPTION
Should recover from failures such as:
https://github.com/VirtusLab/scala-cli/actions/runs/12121243198/job/33792136755?pr=3333#step:7:50
```scala
Generating JUnit XML report...
Exception in thread "main" java.lang.IndexOutOfBoundsException: 1
	at scala.collection.LinearSeqOps.apply(LinearSeq.scala:131)
	at scala.collection.LinearSeqOps.apply$(LinearSeq.scala:128)
	at scala.collection.immutable.List.apply(List.scala:79)
	at generate$minusjunit$minusreports$_.$anonfun$1$$anonfun$1(generate-junit-reports.sc:103)
	at scala.Option.map(Option.scala:242)
	at generate$minusjunit$minusreports$_.$anonfun$1(generate-junit-reports.sc:99)
	at scala.collection.immutable.List.map(List.scala:247)
	at scala.collection.immutable.List.map(List.scala:79)
	at generate$minusjunit$minusreports$_.$init$$$anonfun$4(generate-junit-reports.sc:94)
	at scala.collection.StrictOptimizedIterableOps.map(StrictOptimizedIterableOps.scala:100)
	at scala.collection.StrictOptimizedIterableOps.map$(StrictOptimizedIterableOps.scala:87)
	at scala.collection.immutable.HashMap.map(HashMap.scala:39)
	at generate$minusjunit$minusreports$_.<init>(generate-junit-reports.sc:93)
	at generate$minusjunit$minusreports_sc$.script$lzyINIT1(generate-junit-reports.sc:148)
	at generate$minusjunit$minusreports_sc$.script(generate-junit-reports.sc:148)
	at generate$minusjunit$minusreports_sc$.main(generate-junit-reports.sc:1[52](https://github.com/VirtusLab/scala-cli/actions/runs/12121243198/job/33792136755?pr=3333#step:7:53))
	at generate$minusjunit$minusreports_sc.main(generate-junit-reports.sc)
```