### PR TITLE
Tag native packager tests as flaky

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
@@ -430,7 +430,8 @@ class NativePackagerTests extends ScalaCliSuite {
   }
 
   if (Properties.isLinux)
-    test("building docker image with scala native app") {
+    // FIXME this got flaky on the CI again
+    test("building docker image with scala native app".flaky) {
       TestUtil.retryOnCi() {
         runNativeTest()
       }


### PR DESCRIPTION
It seems this is intermittently failing on `main` again. 
https://github.com/VirtusLab/scala-cli/actions/runs/12138100458/job/33843240683#step:5:11645

I assumed it got fixed in https://github.com/VirtusLab/scala-cli/pull/3311, but it seems there's something else causing it to be flaky.

I reopened the issue:
- https://github.com/VirtusLab/scala-cli/issues/3271