### PR TITLE
Retry generating the Windows launcher up to 5 times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -814,8 +814,12 @@ jobs:
       run: .github/scripts/get-latest-cs.sh
       shell: bash
     - name: Generate native launcher
-      run: .github/scripts/generate-native-image.sh
-      shell: bash
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 30
+        max_attempts: 5
+        shell: bash
+        command: .github/scripts/generate-native-image.sh
     - run: ./mill -i ci.setShouldPublish
     - name: Build OS packages
       if: env.SHOULD_PUBLISH == 'true'


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/2930
- relevant to https://github.com/VirtusLab/scala-cli/issues/2937
- uses https://github.com/nick-fields/retry for the retry logic on the CI