### PR TITLE
Retry generating Windows launchers in the `generate-native-image.sh` script directly, rather than the entire CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -814,12 +814,8 @@ jobs:
       run: .github/scripts/get-latest-cs.sh
       shell: bash
     - name: Generate native launcher
-      uses: nick-fields/retry@v3
-      with:
-        timeout_minutes: 30
-        max_attempts: 5
-        shell: bash
-        command: .github/scripts/generate-native-image.sh
+      run: .github/scripts/generate-native-image.sh
+      shell: bash
     - run: ./mill -i ci.setShouldPublish
     - name: Build OS packages
       if: env.SHOULD_PUBLISH == 'true'


### PR DESCRIPTION
A follow-up to https://github.com/VirtusLab/scala-cli/pull/3349
Although the CI step retry does work, it seems our script assumes a clean workspace, so we need to surgically retry just the part that times out, rather than the whole step, it seems.

Currently, the retries fail with:
```text
(...)
Warning: Attempt 1 failed. Reason: Child_process exited with error code 1
Launching Mill as sub-process ...
Initial Java home C:\Users\runneradmin\AppData\Local\Coursier\cache\arc\https\github.com\graalvm\graalvm-ce-builds\releases\download\vm-22.3.1\graalvm-ce-java17-windows-amd64-22.3.1.zip\graalvm-ce-java17-22.3.1
1 targets failed
ci.copyJvm java.nio.file.FileAlreadyExistsException: D:\a\scala-cli\scala-cli\jvm
    java.base/sun.nio.fs.WindowsFileCopy.copy(WindowsFileCopy.java:124)
    java.base/sun.nio.fs.WindowsFileSystemProvider.copy(WindowsFileSystemProvider.java:284)
    java.base/java.nio.file.Files.copy(Files.java:1305)
    os.copy$.copyOne$1(FileOps.scala:200)
    os.copy$.apply(FileOps.scala:204)
    millbuild.build$ci$.$anonfun$copyJvm$2(build.sc:1948)
Warning: Attempt 2 failed. Reason: Child_process exited with error code 1
(...)
```

Example failure: https://github.com/VirtusLab/scala-cli/actions/runs/12177547205/job/33965654304#step:5:302

@tgodzik was likely right in https://github.com/VirtusLab/scala-cli/pull/3349#discussion_r1869677367 😩 