### PR TITLE
Fix integration tests when run with a Scala 3 LTS RC version

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalacCompatTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalacCompatTestDefinitions.scala
@@ -598,7 +598,8 @@ trait RunScalacCompatTestDefinitions {
           "run",
           ".",
           if (useDirective) Nil else macroSettingOptions,
-          extraOptions,
+          "-S",
+          Constants.scala3NextRcAnnounced,
           "-experimental"
         )
           .call(cwd = root, stderr = os.Pipe)


### PR DESCRIPTION
- cherry-picked from https://github.com/VirtusLab/scala-cli/pull/3361