### PR TITLE
Improve deprecation warnings for commas with whitespace used as using directive value separators

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
@@ -115,14 +115,16 @@ class RunTestsDefault extends RunTestDefinitions
   ) {
     val inputPath = os.rel / "example.sc"
     TestInputs(inputPath ->
-      """//> using options -Werror, -Wconf:cat=deprecation:e
+      """//> using options -Werror, -Wconf:cat=deprecation:e, -Wconf:cat=unused:e
         |println("Deprecation warnings should have been printed")
         |""".stripMargin)
       .fromRoot { root =>
         val res = os.proc(TestUtil.cli, "run", extraOptions, inputPath)
           .call(cwd = root, stderr = os.Pipe)
-        val err = res.err.trim()
-        expect(err.contains("Use of commas as separators is deprecated"))
+        val err             = res.err.trim()
+        val expectedWarning = "Use of commas as separators is deprecated"
+        expect(err.contains(expectedWarning))
+        expect(err.linesIterator.count(_.contains(expectedWarning)) == 2)
       }
   }
 }

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -253,7 +253,7 @@ object Deps {
   val typelevelToolkitVersion   = "0.1.29"
   def typelevelToolkit          = ivy"org.typelevel:toolkit:$typelevelToolkitVersion"
   def typelevelToolkitTest      = ivy"org.typelevel:toolkit-test:$typelevelToolkitVersion"
-  def usingDirectives           = ivy"org.virtuslab:using_directives:1.1.2"
+  def usingDirectives           = ivy"org.virtuslab:using_directives:1.1.3"
   // Lives at https://github.com/VirtusLab/no-crc32-zip-input-stream, see #865
   // This provides a ZipInputStream that doesn't verify CRC32 checksums, that users
   // can enable by setting SCALA_CLI_VENDORED_ZIS=true in the environment, to workaround


### PR DESCRIPTION
Bumps `using_directives` to 1.1.3.
https://github.com/VirtusLab/using_directives/releases/tag/v1.1.3

The main improvement happens in:
- https://github.com/VirtusLab/using_directives/pull/62

Given:
```scala
//> using options -Werror, -Wconf:cat=deprecation:e, -Wconf:cat=unused:e
println("Deprecation warnings should have been printed")
```
Before: 
```text
[warn] ./example.sc:1:19
[warn] Use of commas as separators is deprecated. Only whitespace is neccessary.
[warn] //> using options -Werror, -Wconf:cat=deprecation:e, -Wconf:cat=unused:e
[warn]                   ^
[warn] ./example.sc:1:26
[warn] Use of commas as separators is deprecated. Only whitespace is neccessary.
[warn] //> using options -Werror, -Wconf:cat=deprecation:e, -Wconf:cat=unused:e
[warn]                          ^
[warn] ./example.sc:1:28
[warn] Use of commas as separators is deprecated. Only whitespace is neccessary.
[warn] //> using options -Werror, -Wconf:cat=deprecation:e, -Wconf:cat=unused:e
[warn]                            ^
[warn] ./example.sc:1:52
[warn] Use of commas as separators is deprecated. Only whitespace is neccessary.
[warn] //> using options -Werror, -Wconf:cat=deprecation:e, -Wconf:cat=unused:e
[warn] 
```
After:
```text
[warn] ./example.sc:1:26
[warn] Use of commas as separators is deprecated. Only whitespace is neccessary.
[warn] //> using options -Werror, -Wconf:cat=deprecation:e, -Wconf:cat=unused:e
[warn]                          ^
[warn] ./example.sc:1:52
[warn] Use of commas as separators is deprecated. Only whitespace is neccessary.
[warn] //> using options -Werror, -Wconf:cat=deprecation:e, -Wconf:cat=unused:e
[warn]                                                    ^
```