### PR TITLE
Recover from invalid paths returned from Bloop diagnostics

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalacCompatTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalacCompatTestDefinitions.scala
@@ -606,4 +606,40 @@ trait RunScalacCompatTestDefinitions {
         expect(r.out.trim() == macroSettings.mkString(", "))
       }
     }
+
+  if (actualScalaVersion.startsWith("3"))
+    test("-Ysafe-init-global doesnt crash the CLI when a dependency produces a warning") {
+      val (org, name, version) = ("hello-world", "test-safe-init-global-works", "0.0.1-SNAPSHOT")
+      val (depDir, mainDir)    = ("dep", "main")
+      val (depPackage, depClass, depMethod) = ("hello", "DepMain", "x")
+      val expectedMessage                   = "Hello, world!"
+      TestInputs(
+        os.rel / depDir / "Main.scala" ->
+          s"""//> using publish.organization $org
+             |//> using publish.name $name
+             |//> using publish.version $version
+             |package $depPackage
+             |
+             |object $depClass {
+             |  val $depMethod: Int = y
+             |  val y: Int = $depMethod
+             |}
+             |""".stripMargin,
+        os.rel / mainDir / "Main.scala" ->
+          s"""//> using option -Ysafe-init-global
+             |//> using dep $org::$name:$version
+             |
+             |import $depPackage.$depClass
+             |
+             |object Main extends App {
+             |  val a = $depClass.$depMethod
+             |  println("$expectedMessage")
+             |}
+             |""".stripMargin
+      ).fromRoot { root =>
+        os.proc(TestUtil.cli, "--power", "publish", "local", depDir, extraOptions).call(cwd = root)
+        val res = os.proc(TestUtil.cli, "run", mainDir, extraOptions).call(cwd = root)
+        expect(res.out.trim() == expectedMessage)
+      }
+    }
 }


### PR DESCRIPTION
Fixes #3370 

This is sort of a band-aid, as we still might require a fix upstream in Bloop. (cc @tgodzik)
It seems we're getting an invalid path in a diagnostic coming from Bloop.
Refer to https://github.com/VirtusLab/scala-cli/blob/60f73228e31c26861bc375d4f69befb4be780795/modules/build/src/main/scala/scala/build/ConsoleBloopBuildClient.scala#L81

I just make sure we recover from it in the CLI.