### PR TITLE
Fix using directives crashing on `*/` by removing `/* (..) */` comments support in `using_directives`

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -5,6 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import java.io.File
 
 import scala.cli.integration.util.BloopUtil
+import scala.util.Properties
 
 abstract class CompileTestDefinitions
     extends ScalaCliSuite
@@ -720,4 +721,20 @@ abstract class CompileTestDefinitions
       expect(buildTargetDirs.size == 2)
     }
   }
+
+  if (!Properties.isWin)
+    // TODO: make this work on Windows: https://github.com/VirtusLab/scala-cli/issues/2973
+    test(
+      "nested wildcard path source exclusion with a directive and no special character escaping"
+    ) {
+      val excludedFileName = "Foo.scala"
+      val excludedPath     = os.rel / "dir1" / "dir2" / excludedFileName
+      val inputs = TestInputs(
+        os.rel / "project.scala" -> s"//> using exclude */*/$excludedFileName",
+        excludedPath             -> "val foo // invalid code"
+      )
+      inputs.fromRoot { root =>
+        os.proc(TestUtil.cli, "compile", extraOptions, ".").call(cwd = root)
+      }
+    }
 }

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -254,7 +254,7 @@ object Deps {
   val typelevelToolkitVersion   = "0.1.29"
   def typelevelToolkit          = ivy"org.typelevel:toolkit:$typelevelToolkitVersion"
   def typelevelToolkitTest      = ivy"org.typelevel:toolkit-test:$typelevelToolkitVersion"
-  def usingDirectives           = ivy"org.virtuslab:using_directives:1.1.3"
+  def usingDirectives           = ivy"org.virtuslab:using_directives:1.1.4"
   // Lives at https://github.com/VirtusLab/no-crc32-zip-input-stream, see #865
   // This provides a ZipInputStream that doesn't verify CRC32 checksums, that users
   // can enable by setting SCALA_CLI_VENDORED_ZIS=true in the environment, to workaround


### PR DESCRIPTION
Fixes #3374 

Requires:
- [x] https://github.com/VirtusLab/using_directives/pull/67