### PR TITLE
Allow to use Bloop snapshot versions

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -368,6 +368,7 @@ trait Core extends ScalaCliCrossSbtModule
     with HasTests
     with ScalaCliScalafixModule {
   def crossScalaVersion = crossValue
+
   def moduleDeps = Seq(
     config(crossScalaVersion)
   )
@@ -377,6 +378,9 @@ trait Core extends ScalaCliCrossSbtModule
   def scalacOptions = T {
     super.scalacOptions() ++ asyncScalacOptions(crossScalaVersion)
   }
+
+  def repositoriesTask =
+    T.task(super.repositoriesTask() ++ deps.customRepositories)
 
   def ivyDeps = super.ivyDeps() ++ Agg(
     Deps.bloopRifle.exclude(("org.scala-lang.modules", "scala-collection-compat_2.13")),

--- a/modules/build/src/main/scala/scala/build/Bloop.scala
+++ b/modules/build/src/main/scala/scala/build/Bloop.scala
@@ -73,7 +73,10 @@ object Bloop {
       val res = value {
         Artifacts.artifacts(
           Seq(Positioned.none(dep)),
-          Nil,
+          Seq(
+            coursier.Repositories.sonatype("snapshots"),
+            coursier.Repositories.sonatypeS01("snapshots")
+          ),
           Some(params),
           logger,
           cache.withMessage(s"Downloading compilation server ${dep.version}")

--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -241,4 +241,15 @@ class BloopTests extends ScalaCliSuite {
         assert(compilationError.contains(message))
       }
     }
+
+  {
+    val bloopSnapshotVersion = "2.0.6-51-38c118d4-SNAPSHOT"
+    test(s"compilation works with a Bloop snapshot version: $bloopSnapshotVersion") {
+      val input                = "script.sc"
+      TestInputs(os.rel / input -> """println("Hello")""").fromRoot { root =>
+        os.proc(TestUtil.cli, "compile", input, "--bloop-version", bloopSnapshotVersion)
+          .call(cwd = root)
+      }
+    }
+  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -245,7 +245,7 @@ class BloopTests extends ScalaCliSuite {
   {
     val bloopSnapshotVersion = "2.0.6-51-38c118d4-SNAPSHOT"
     test(s"compilation works with a Bloop snapshot version: $bloopSnapshotVersion") {
-      val input                = "script.sc"
+      val input = "script.sc"
       TestInputs(os.rel / input -> """println("Hello")""").fromRoot { root =>
         os.proc(TestUtil.cli, "compile", input, "--bloop-version", bloopSnapshotVersion)
           .call(cwd = root)


### PR DESCRIPTION
This allows to pass a snapshot version to the `--bloop-version` command line option.

```bash
scala-cli compile . --bloop-version 2.0.6-51-38c118d4-SNAPSHOT
# Starting compilation server
# Compiling project (Scala 3.6.2, JVM (17))
# Compiled project (Scala 3.6.2, JVM (17))
```

It also fixes the `core` module to respect custom repositories (including `sonatype:snapshots`), to enable using Bloop snapshots as a Scala CLI dependency when testing on the CI.

Functionality extracted out of #3404 