### PR TITLE
Add ways to suppress deprecation warnings

### DIFF
--- a/modules/build/src/main/scala/scala/build/preprocessing/DirectivesPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/DirectivesPreprocessor.scala
@@ -38,8 +38,14 @@ case class DirectivesPreprocessor(
   using ScalaCliInvokeData
 ) {
   def preprocess(content: String): Either[BuildException, PreprocessedDirectives] = for {
-    directives <- ExtractedDirectives.from(content.toCharArray, path, logger, maybeRecoverOnError)
-    res        <- preprocess(directives)
+    directives <- ExtractedDirectives.from(
+      content.toCharArray,
+      path,
+      suppressWarningOptions,
+      logger,
+      maybeRecoverOnError
+    )
+    res <- preprocess(directives)
   } yield res
 
   def preprocess(extractedDirectives: ExtractedDirectives)

--- a/modules/build/src/main/scala/scala/build/preprocessing/MarkdownCodeBlockProcessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/MarkdownCodeBlockProcessor.scala
@@ -4,12 +4,14 @@ import scala.build.EitherCps.{either, value}
 import scala.build.Logger
 import scala.build.errors.BuildException
 import scala.build.internal.markdown.MarkdownCodeBlock
+import scala.build.options.SuppressWarningOptions
 
 object MarkdownCodeBlockProcessor {
   def process(
     codeBlocks: Seq[MarkdownCodeBlock],
     reportingPath: Either[String, os.Path],
     scopePath: ScopePath,
+    suppressWarningOptions: SuppressWarningOptions,
     logger: Logger,
     maybeRecoverOnError: BuildException => Option[BuildException]
   ): Either[BuildException, PreprocessedMarkdown] = either {
@@ -23,6 +25,7 @@ object MarkdownCodeBlockProcessor {
             ExtractedDirectives.from(
               contentChars = cb.body.toCharArray,
               path = reportingPath,
+              suppressWarningOptions = suppressWarningOptions,
               logger = logger,
               maybeRecoverOnError = maybeRecoverOnError
             )

--- a/modules/build/src/main/scala/scala/build/preprocessing/MarkdownPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/MarkdownPreprocessor.scala
@@ -120,6 +120,7 @@ case object MarkdownPreprocessor extends Preprocessor {
         codeBlocks,
         reportingPath,
         scopePath,
+        suppressWarningOptions,
         logger,
         maybeRecoverOnError
       ))

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -190,10 +190,11 @@ case object ScalaPreprocessor extends Preprocessor {
   )(using ScalaCliInvokeData): Either[BuildException, Option[ProcessingOutput]] = either {
     val (contentWithNoShebang, _) = SheBang.ignoreSheBangLines(content)
     val extractedDirectives: ExtractedDirectives = value(ExtractedDirectives.from(
-      contentWithNoShebang.toCharArray,
-      path,
-      logger,
-      maybeRecoverOnError
+      contentChars = contentWithNoShebang.toCharArray,
+      path = path,
+      suppressWarningOptions = suppressWarningOptions,
+      logger = logger,
+      maybeRecoverOnError = maybeRecoverOnError
     ))
     value {
       processSources(
@@ -219,7 +220,12 @@ case object ScalaPreprocessor extends Preprocessor {
     suppressWarningOptions: SuppressWarningOptions,
     maybeRecoverOnError: BuildException => Option[BuildException]
   )(using ScalaCliInvokeData): Either[BuildException, Option[ProcessingOutput]] = either {
-    DeprecatedDirectives.issueWarnings(path, extractedDirectives.directives, logger)
+    DeprecatedDirectives.issueWarnings(
+      path,
+      extractedDirectives.directives,
+      suppressWarningOptions,
+      logger
+    )
 
     val (content0, isSheBang) = SheBang.ignoreSheBangLines(content)
     val preprocessedDirectives: PreprocessedDirectives =

--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictableCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictableCommand.scala
@@ -11,12 +11,16 @@ trait RestrictableCommand[T](implicit myParser: Parser[T]) {
   self: Command[T] =>
 
   def shouldSuppressExperimentalFeatureWarnings: Boolean
+  def shouldSuppressDeprecatedFeatureWarnings: Boolean
   def logger: Logger
   protected def invokeData: ScalaCliInvokeData
   override def parser: Parser[T] =
-    RestrictedCommandsParser(myParser, logger, shouldSuppressExperimentalFeatureWarnings)(using
-      invokeData
-    )
+    RestrictedCommandsParser(
+      parser = myParser,
+      logger = logger,
+      shouldSuppressExperimentalWarnings = shouldSuppressExperimentalFeatureWarnings,
+      shouldSuppressDeprecatedWarnings = shouldSuppressDeprecatedFeatureWarnings
+    )(using invokeData)
 
   final def isRestricted: Boolean = scalaSpecificationLevel == SpecificationLevel.RESTRICTED
 

--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
@@ -17,7 +17,8 @@ object RestrictedCommandsParser {
   def apply[T](
     parser: Parser[T],
     logger: Logger,
-    shouldSuppressExperimentalWarnings: Boolean
+    shouldSuppressExperimentalWarnings: Boolean,
+    shouldSuppressDeprecatedWarnings: Boolean
   )(using ScalaCliInvokeData): Parser[T] =
     new Parser[T] {
 
@@ -37,7 +38,8 @@ object RestrictedCommandsParser {
         RestrictedCommandsParser(
           parser.withDefaultOrigin(origin),
           logger,
-          shouldSuppressExperimentalWarnings
+          shouldSuppressExperimentalWarnings,
+          shouldSuppressDeprecatedWarnings
         )
 
       override def step(
@@ -58,7 +60,7 @@ object RestrictedCommandsParser {
             logger.experimentalWarning(passedOption, FeatureType.Option)
             r
           case (r @ Right(Some(_, arg: Arg, _)), passedOption :: _)
-              if arg.isDeprecated =>
+              if arg.isDeprecated && !shouldSuppressDeprecatedWarnings =>
             // TODO implement proper deprecation logic: https://github.com/VirtusLab/scala-cli/issues/3258
             arg.deprecatedOptionAliases.find(_ == passedOption)
               .foreach { deprecatedAlias =>

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -352,6 +352,14 @@ abstract class ScalaCommand[T <: HasGlobalOptions](implicit myParser: Parser[T],
       }
       .getOrElse(false)
 
+  override def shouldSuppressDeprecatedFeatureWarnings: Boolean =
+    globalOptions.globalSuppress.suppressDeprecatedFeatureWarning
+      .orElse {
+        configDb.toOption
+          .flatMap(_.getOpt(Keys.suppressDeprecatedFeatureWarning))
+      }
+      .getOrElse(false)
+
   override def logger: Logger = globalOptions.logging.logger
 
   final override def main(progName: String, args: Array[String]): Unit = {

--- a/modules/cli/src/main/scala/scala/cli/commands/fix/Fix.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/fix/Fix.scala
@@ -25,12 +25,14 @@ object Fix extends ScalaCommand[FixOptions] {
 
   override def runCommand(options: FixOptions, args: RemainingArgs, logger: Logger): Unit = {
     if options.areAnyRulesEnabled then {
-      val inputs   = options.shared.inputs(args.all).orExit(logger)
-      val configDb = ConfigDbUtils.configDb.orExit(logger)
+      val inputs    = options.shared.inputs(args.all).orExit(logger)
+      val buildOpts = buildOptionsOrExit(options)
+      val configDb  = ConfigDbUtils.configDb.orExit(logger)
       if options.enableBuiltInRules then {
         logger.message("Running built-in rules...")
         BuiltInRules.runRules(
           inputs = inputs,
+          buildOptions = buildOpts,
           logger = logger
         )
         logger.message("Built-in rules completed.")
@@ -45,7 +47,7 @@ object Fix extends ScalaCommand[FixOptions] {
             .orElse(configDb.get(Keys.actions).getOrElse(None))
           val scalafixExitCode: Int = value {
             ScalafixRules.runRules(
-              buildOptions = buildOptionsOrExit(options),
+              buildOptions = buildOpts,
               scalafixOptions = options.scalafix,
               inputs = inputs,
               check = options.check,

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpCommand.scala
@@ -29,6 +29,9 @@ abstract class PgpCommand[T](implicit myParser: Parser[T], help: Help[T])
   override def shouldSuppressExperimentalFeatureWarnings: Boolean =
     false // TODO add handling for scala-cli-signing
 
+  override def shouldSuppressDeprecatedFeatureWarnings: Boolean =
+    false // TODO add handling for scala-cli-signing
+
   override def logger: Logger = CliLogger.default // TODO add handling for scala-cli-signing
 
   override def hidden = true

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/GlobalSuppressWarningOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/GlobalSuppressWarningOptions.scala
@@ -9,7 +9,14 @@ final case class GlobalSuppressWarningOptions(
   @Tag(tags.implementation)
   @HelpMessage("Suppress warnings about using experimental features")
   @Name("suppressExperimentalWarning")
-  suppressExperimentalFeatureWarning: Option[Boolean] = None
+  suppressExperimentalFeatureWarning: Option[Boolean] = None,
+  @Group(HelpGroup.SuppressWarnings.toString)
+  @Tag(tags.implementation)
+  @HelpMessage("Suppress warnings about using deprecated features")
+  @Name("suppressDeprecatedWarning")
+  @Name("suppressDeprecatedWarnings")
+  @Name("suppressDeprecatedFeatureWarnings")
+  suppressDeprecatedFeatureWarning: Option[Boolean] = None
 )
 
 object GlobalSuppressWarningOptions {

--- a/modules/config/src/main/scala/scala/cli/config/Keys.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Keys.scala
@@ -92,6 +92,13 @@ object Keys {
       specificationLevel = SpecificationLevel.IMPLEMENTATION,
       description = "Globally suppresses warnings about experimental features."
     )
+  val suppressDeprecatedFeatureWarning =
+    new Key.BooleanEntry(
+      prefix = Seq("suppress-warning"),
+      name = "deprecated-features",
+      specificationLevel = SpecificationLevel.IMPLEMENTATION,
+      description = "Globally suppresses warnings about deprecated features."
+    )
 
   val proxyAddress = new Key.StringEntry(
     prefix = Seq("httpProxy"),
@@ -172,6 +179,7 @@ object Keys {
     suppressDirectivesInMultipleFilesWarning,
     suppressOutdatedDependenciessWarning,
     suppressExperimentalFeatureWarning,
+    suppressDeprecatedFeatureWarning,
     pgpPublicKey,
     pgpSecretKey,
     pgpSecretKeyPassword,

--- a/modules/options/src/main/scala/scala/build/options/SuppressWarningOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/SuppressWarningOptions.scala
@@ -3,7 +3,8 @@ package scala.build.options
 final case class SuppressWarningOptions(
   suppressDirectivesInMultipleFilesWarning: Option[Boolean] = None,
   suppressOutdatedDependencyWarning: Option[Boolean] = None,
-  suppressExperimentalFeatureWarning: Option[Boolean] = None
+  suppressExperimentalFeatureWarning: Option[Boolean] = None,
+  suppressDeprecatedFeatureWarning: Option[Boolean] = None
 )
 
 object SuppressWarningOptions {

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -517,6 +517,12 @@ Aliases: `--suppress-experimental-warning`
 
 Suppress warnings about using experimental features
 
+### `--suppress-deprecated-feature-warning`
+
+Aliases: `--suppress-deprecated-feature-warnings`, `--suppress-deprecated-warning`, `--suppress-deprecated-warnings`
+
+Suppress warnings about using deprecated features
+
 ## Help options
 
 Available in commands:

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -67,6 +67,7 @@ Available keys:
   - repositories.credentials                       Repository credentials, syntax: repositoryAddress value:user value:password [realm]
   - repositories.default                           Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
   - repositories.mirrors                           Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
+  - suppress-warning.deprecated-features           Globally suppresses warnings about deprecated features.
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
   - suppress-warning.experimental-features         Globally suppresses warnings about experimental features.
   - suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -388,6 +388,14 @@ Aliases: `--suppress-experimental-warning`
 
 Suppress warnings about using experimental features
 
+### `--suppress-deprecated-feature-warning`
+
+Aliases: `--suppress-deprecated-feature-warnings`, `--suppress-deprecated-warning`, `--suppress-deprecated-warnings`
+
+`IMPLEMENTATION specific` per Scala Runner specification
+
+Suppress warnings about using deprecated features
+
 ## Help options
 
 Available in commands:

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -66,6 +66,7 @@ Available keys:
   - repositories.credentials                       Repository credentials, syntax: repositoryAddress value:user value:password [realm]
   - repositories.default                           Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
   - repositories.mirrors                           Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
+  - suppress-warning.deprecated-features           Globally suppresses warnings about deprecated features.
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
   - suppress-warning.experimental-features         Globally suppresses warnings about experimental features.
   - suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -362,6 +362,12 @@ Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
 
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
+
 **--verbose**
 
 Increase verbosity (can be specified multiple times)
@@ -674,6 +680,7 @@ Available keys:
   - repositories.credentials                       Repository credentials, syntax: repositoryAddress value:user value:password [realm]
   - repositories.default                           Default repository, syntax: https://first-repo.company.com https://second-repo.company.com
   - repositories.mirrors                           Repository mirrors, syntax: repositories.mirrors maven:*=https://repository.company.com/maven
+  - suppress-warning.deprecated-features           Globally suppresses warnings about deprecated features.
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
   - suppress-warning.experimental-features         Globally suppresses warnings about experimental features.
   - suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
@@ -785,6 +792,12 @@ Use progress bars
 Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
+
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
 
 **--ttl**
 
@@ -1124,6 +1137,12 @@ Suppress warnings about outdated dependencies in project
 Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
+
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
 
 **--verbose**
 
@@ -1719,6 +1738,12 @@ Suppress warnings about outdated dependencies in project
 Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
+
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
 
 **--verbose**
 
@@ -2338,6 +2363,12 @@ Suppress warnings about outdated dependencies in project
 Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
+
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
 
 **--verbose**
 
@@ -2967,6 +2998,12 @@ Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
 
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
+
 **--verbose**
 
 Increase verbosity (can be specified multiple times)
@@ -3552,6 +3589,12 @@ Suppress warnings about outdated dependencies in project
 Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
+
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
 
 **--verbose**
 
@@ -4214,6 +4257,12 @@ Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
 
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
+
 **--verbose**
 
 Increase verbosity (can be specified multiple times)
@@ -4571,6 +4620,12 @@ Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
 
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
+
 **--cli-version**
 
 Show plain Scala CLI version only
@@ -4881,6 +4936,12 @@ Suppress warnings about outdated dependencies in project
 Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
+
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
 
 **--verbose**
 
@@ -5243,6 +5304,12 @@ Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
 
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
+
 **--bsp-directory**
 
 Custom BSP configuration location
@@ -5328,6 +5395,12 @@ Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
 
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
+
 </details>
 
 ---
@@ -5400,6 +5473,12 @@ Use progress bars
 Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
+
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
 
 **--format**
 
@@ -5497,6 +5576,12 @@ Use progress bars
 Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
+
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
 
 **--scala-cli-binary-path**
 
@@ -5814,6 +5899,12 @@ Suppress warnings about outdated dependencies in project
 Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
+
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
 
 **--verbose**
 
@@ -6176,6 +6267,12 @@ Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
 
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
+
 **--bloop-bsp-protocol**
 
 Protocol to use to open a BSP connection with Bloop
@@ -6363,6 +6460,12 @@ Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
 
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
+
 </details>
 
 ---
@@ -6435,6 +6538,12 @@ Use progress bars
 Suppress warnings about using experimental features
 
 Aliases: `--suppress-experimental-warning`
+
+**--suppress-deprecated-feature-warning**
+
+Suppress warnings about using deprecated features
+
+Aliases: `--suppress-deprecated-warning` ,`--suppress-deprecated-warnings` ,`--suppress-deprecated-feature-warnings`
 
 **--binary-name**
 


### PR DESCRIPTION
- covers a subset of the requirements in #3258 
- adds a new `config` key: `suppress-warning.deprecated-features`, which lets globally suppress deprecated feature warnings
```bash
scala-cli config suppress-warning.deprecated-features true
```
- adds a new command line option: `--suppress-deprecated-warnings`, which does the same
```bash
scala-cli project-with-deprecated-stuff --suppress-deprecated-warnings
```
- covers existing ways of deprecating features, including command line options and aliases, deprecation warnings from the using directive parser and deprecated directives
  - others should be covered alongside progress in #3258