### PR TITLE
Set Scala 3.6.3-RC2 as the latest announced RC version

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -10,9 +10,9 @@ object Scala {
   def scala3Lts        = s"$scala3LtsPrefix.4"  // the LTS version currently used in the build
   def scala3NextPrefix = "3.6"
   def scala3Next       = s"$scala3NextPrefix.2" // the newest/next version of Scala
-  def scala3NextAnnounced   = scala3Next  // the newest/next version of Scala that's been announced
-  def scala3NextRc          = "3.6.3-RC2" // the latest RC version of Scala Next
-  def scala3NextRcAnnounced = "3.6.3-RC1" // the latest RC version of Scala Next
+  def scala3NextAnnounced   = scala3Next   // the newest/next version of Scala that's been announced
+  def scala3NextRc          = "3.6.3-RC2"  // the latest RC version of Scala Next
+  def scala3NextRcAnnounced = scala3NextRc // the latest announced RC version of Scala Next
 
   // The Scala version used to build the CLI itself.
   def defaultInternal = sys.props.get("scala.version.internal").getOrElse(scala3Lts)


### PR DESCRIPTION
https://github.com/scala/scala3/releases/tag/3.6.3-RC2