### PR TITLE
Deprecate `--src` and `--sources` to disambiguate with `--source` compiler option

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
@@ -51,9 +51,11 @@ final case class PackageOptions(
   @Name("sourcesJar")
   @Name("jarSources")
   @Name("sources")
+  @Name("src")
+  @Tag(tags.deprecated("src"))
   @Tag(tags.restricted)
   @Tag(tags.inShortHelp)
-    src: Boolean = false,
+    withSources: Boolean = false,
   @Group(HelpGroup.Package.toString)
   @HelpMessage("Generate a scaladoc JAR rather than an executable JAR")
   @ExtraName("scaladoc")
@@ -145,7 +147,7 @@ final case class PackageOptions(
   def packageTypeOpt: Option[PackageType] =
     forcedPackageTypeOpt.orElse {
       if (library) Some(PackageType.LibraryJar)
-      else if (src) Some(PackageType.SourceJar)
+      else if (withSources) Some(PackageType.SourceJar)
       else if (assembly) Some(
         PackageType.Assembly(
           addPreamble = preamble,

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
@@ -51,6 +51,7 @@ final case class PackageOptions(
   @Name("sourcesJar")
   @Name("jarSources")
   @Name("sources")
+  @Tag(tags.deprecated("sources"))
   @Name("src")
   @Tag(tags.deprecated("src"))
   @Tag(tags.restricted)

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -104,7 +104,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
     val contextualOptions = PublishContextualOptions(
       repository = publishRepo.publishRepository.filter(_.trim.nonEmpty),
       repositoryIsIvy2LocalLike = ivy2LocalLike,
-      sourceJar = sharedPublish.sources,
+      sourceJar = sharedPublish.withSources,
       docJar = sharedPublish.doc,
       gpgSignatureId = sharedPublish.gpgKey.map(_.trim).filter(_.nonEmpty),
       gpgOptions = sharedPublish.gpgOption,

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/SharedPublishOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/SharedPublishOptions.scala
@@ -30,9 +30,11 @@ final case class SharedPublishOptions(
 
   @Group(HelpGroup.Publishing.toString)
   @HelpMessage("Whether to build and publish source JARs")
+  @Name("sources")
+  @Tag(tags.deprecated("sources"))
   @Tag(tags.restricted)
   @Tag(tags.inShortHelp)
-    sources: Option[Boolean] = None,
+    withSources: Option[Boolean] = None,
 
   @Group(HelpGroup.Publishing.toString)
   @HelpMessage("Whether to build and publish doc JARs")

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/SharedPublishOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/SharedPublishOptions.scala
@@ -30,6 +30,8 @@ final case class SharedPublishOptions(
 
   @Group(HelpGroup.Publishing.toString)
   @HelpMessage("Whether to build and publish source JARs")
+  @Name("sourcesJar")
+  @Name("jarSources")
   @Name("sources")
   @Tag(tags.deprecated("sources"))
   @Tag(tags.restricted)

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -1712,7 +1712,7 @@ abstract class BspTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
         "--power",
         "package",
         jarSources,
-        "--src",
+        "--with-sources",
         "-o",
         sourceJarPath,
         extraOptions

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -869,7 +869,7 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
   test("source JAR") {
     val dest = os.rel / "sources.jar"
     simpleInputWithScalaAndSc.fromRoot { root =>
-      os.proc(TestUtil.cli, "--power", "package", extraOptions, ".", "-o", dest, "--src").call(
+      os.proc(TestUtil.cli, "--power", "package", extraOptions, ".", "-o", dest, "--with-sources").call(
         cwd = root,
         stdin = os.Inherit,
         stdout = os.Inherit

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
@@ -320,7 +320,7 @@ abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersio
         "--power",
         "publish",
         extraOptions,
-        "--sources=false",
+        "--with-sources=false",
         "--doc=false",
         "--checksum",
         "sha-1",

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -773,9 +773,9 @@ Overwrite the destination file, if it exists
 
 Generate a library JAR rather than an executable JAR
 
-### `--src`
+### `--with-sources`
 
-Aliases: `--jar-sources`, `--sources`, `--sources-jar`
+Aliases: `--jar-sources`, `--sources`, `--sources-jar`, [deprecated] `--src`
 
 Generate a source JAR rather than an executable JAR
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -775,7 +775,7 @@ Generate a library JAR rather than an executable JAR
 
 ### `--with-sources`
 
-Aliases: `--jar-sources`, `--sources`, `--sources-jar`, [deprecated] `--src`
+Aliases: `--jar-sources`, [deprecated] `--sources`, `--sources-jar`, [deprecated] `--src`
 
 Generate a source JAR rather than an executable JAR
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1029,7 +1029,9 @@ Scala version suffix to append to the module name, like "_2.13" or "_3"
 [Internal]
 Scala platform suffix to append to the module name, like "_sjs1" or "_native0.4"
 
-### `--sources`
+### `--with-sources`
+
+Aliases: [deprecated] `--sources`
 
 Whether to build and publish source JARs
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1031,7 +1031,7 @@ Scala platform suffix to append to the module name, like "_sjs1" or "_native0.4"
 
 ### `--with-sources`
 
-Aliases: [deprecated] `--sources`
+Aliases: `--jar-sources`, [deprecated] `--sources`, `--sources-jar`
 
 Whether to build and publish source JARs
 


### PR DESCRIPTION
Follow-up to https://github.com/VirtusLab/scala-cli/pull/3257#issuecomment-2476123941

What it does
- deprecates `--src` and `--sources` aliases for the package sub-command command line option for generating sources jars
- deprecates `--sources` for the publish sub-command line option for including sources jars while publishing
- adds matching aliases for the publish option, to be consistent with package
- adds a new `--with-sources` alias, which now becomes the default and recommended syntax
- `--src` and `--sources` should be removed in 1.7.0 or later
- other aliases (`--sources-jar`, `--jar-sources`) remain unchanged
- this is done to disambiguate with the `--source` compiler option