### PR TITLE
`fix` built-in rules: don't wrap directive values in double quotes if not necessary

### DIFF
--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/StrictDirective.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/StrictDirective.scala
@@ -46,7 +46,10 @@ case class StrictDirective(
       Seq(usingKeyString)
     else {
       val distinctValuesStrings = validValues
-        .map(v => s"\"${v.toString}\"")
+        .map {
+          case s if s.toString.exists(_.isWhitespace) => s"\"$s\""
+          case s                                      => s.toString
+        }
         .distinct
         .sorted
 

--- a/modules/integration/src/test/scala/scala/cli/integration/FixScalafixRulesTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixScalafixRulesTestDefinitions.scala
@@ -90,7 +90,7 @@ trait FixScalafixRulesTestDefinitions {
     }
     val expectedProjectContent: String = noCrLf {
       s"""// Main
-         |//> using options "$scalafixUnusedRuleOption"
+         |//> using options $scalafixUnusedRuleOption
          |
          |""".stripMargin
     }
@@ -150,7 +150,7 @@ trait FixScalafixRulesTestDefinitions {
       }
       val expectedProjectContent: String = noCrLf {
         s"""// Main
-           |//> using options "$scalafixUnusedRuleOption"
+           |//> using options $scalafixUnusedRuleOption
            |
            |""".stripMargin
       }
@@ -242,7 +242,7 @@ trait FixScalafixRulesTestDefinitions {
   }
 
   test("external rule") {
-    val directive = s"//> using scalafixDependency \"com.github.xuwei-k::scalafix-rules:0.5.1\""
+    val directive = s"//> using scalafixDependency com.github.xuwei-k::scalafix-rules:0.5.1"
     val original: String =
       s"""|$directive
           |

--- a/modules/integration/src/test/scala/scala/cli/integration/FixTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixTestDefinitions.scala
@@ -22,13 +22,13 @@ abstract class FixTestDefinitions
   test("built-in + scalafix rules") {
     val mainFileName  = "Main.scala"
     val unusedValName = "unused"
-    val directive1    = "//> using dep \"com.lihaoyi::os-lib:0.11.3\""
-    val directive2    = "//> using dep \"com.lihaoyi::pprint:0.9.0\""
+    val directive1    = "//> using dep com.lihaoyi::os-lib:0.11.3"
+    val directive2    = "//> using dep com.lihaoyi::pprint:0.9.0"
     val mergedDirective1And2 =
-      "using dependency \"com.lihaoyi::os-lib:0.11.3\" \"com.lihaoyi::pprint:0.9.0\""
+      "using dependency com.lihaoyi::os-lib:0.11.3 com.lihaoyi::pprint:0.9.0"
     val directive3 =
-      if (actualScalaVersion.startsWith("2")) "//> using options \"-Xlint:unused\""
-      else "//> using options \"-Wunused:all\""
+      if (actualScalaVersion.startsWith("2")) "//> using options -Xlint:unused"
+      else "//> using options -Wunused:all"
     TestInputs(
       os.rel / "Foo.scala" ->
         s"""$directive1


### PR DESCRIPTION
Fixes #3052 