### PR TITLE
Add CLI flag & directive for clang/LLVM target triples when using Scala Native

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaNativeOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaNativeOptions.scala
@@ -32,6 +32,11 @@ final case class ScalaNativeOptions(
     nativeGc: Option[String] = None,
 
   @Group(HelpGroup.ScalaNative.toString)
+  @HelpMessage("Set a target triple to which Scala Native can cross-compile")
+  @Tag(tags.should)
+    nativeTargetTriple: Option[String] = None,
+
+  @Group(HelpGroup.ScalaNative.toString)
   @HelpMessage("Path to the Clang command")
   @Tag(tags.implementation)
     nativeClang: Option[String] = None,

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaNativeOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaNativeOptions.scala
@@ -33,7 +33,7 @@ final case class ScalaNativeOptions(
 
   @Group(HelpGroup.ScalaNative.toString)
   @HelpMessage("Set a target triple to which Scala Native can cross-compile")
-  @Tag(tags.should)
+  @Tag(tags.experimental)
     nativeTargetTriple: Option[String] = None,
 
   @Group(HelpGroup.ScalaNative.toString)

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -282,6 +282,7 @@ final case class SharedOptions(
       modeStr = nativeMode,
       ltoStr = nativeLto,
       gcStr = nativeGc,
+      targetTripleStr = nativeTargetTriple,
       clang = nativeClang,
       clangpp = nativeClangpp,
       linkingOptions = nativeLinking,

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaNative.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaNative.scala
@@ -16,6 +16,8 @@ import scala.cli.commands.SpecificationLevel
     |
     |`//> using nativeLto` _value_
     |
+    |`//> using nativeTargetTriple` _value_
+    |
     |`//> using nativeVersion` _value_
     |
     |`//> using nativeCompile` _value1_ _value2_ …
@@ -38,6 +40,7 @@ final case class ScalaNative(
   nativeGc: Option[String] = None,
   nativeMode: Option[String] = None,
   nativeLto: Option[String] = None,
+  nativeTargetTriple: Option[String] = None,
   nativeVersion: Option[String] = None,
   nativeCompile: List[String] = Nil,
   nativeLinking: List[String] = Nil,
@@ -54,6 +57,7 @@ final case class ScalaNative(
       gcStr = nativeGc,
       modeStr = nativeMode,
       ltoStr = nativeLto,
+      targetTripleStr = nativeTargetTriple,
       version = nativeVersion,
       compileOptions = nativeCompile,
       linkingOptions = nativeLinking,

--- a/modules/options/src/main/scala/scala/build/options/ScalaNativeOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaNativeOptions.scala
@@ -80,11 +80,10 @@ final case class ScalaNativeOptions(
     List("--gc", gc().name)
 
   private def targetTripleCliOption(): List[String] =
-    if (!targetTripleStr.isEmpty) {
+    if (!targetTripleStr.isEmpty)
       return List("--target-triple", targetTripleStr.get)
-    } else {
+    else
       return Nil
-    }
 
   private def mode(): sn.Mode =
     modeStr.map(_.trim).filter(_.nonEmpty) match {

--- a/modules/options/src/main/scala/scala/build/options/ScalaNativeOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaNativeOptions.scala
@@ -32,6 +32,7 @@ final case class ScalaNativeOptions(
   modeStr: Option[String] = None,
   ltoStr: Option[String] = None,
   gcStr: Option[String] = None,
+  targetTripleStr: Option[String] = None,
   clang: Option[String] = None,
   clangpp: Option[String] = None,
   linkingOptions: List[String] = Nil,
@@ -77,6 +78,13 @@ final case class ScalaNativeOptions(
     }
   private def gcCliOption(): List[String] =
     List("--gc", gc().name)
+
+  private def targetTripleCliOption(): List[String] =
+    if (!targetTripleStr.isEmpty) {
+      return List("--target-triple", targetTripleStr.get)
+    } else {
+      return Nil
+    }
 
   private def mode(): sn.Mode =
     modeStr.map(_.trim).filter(_.nonEmpty) match {
@@ -155,7 +163,7 @@ final case class ScalaNativeOptions(
           BloopConfig.LinkerMode.Release
         else BloopConfig.LinkerMode.Debug,
       gc = gc().name,
-      targetTriple = None,
+      targetTriple = targetTripleStr,
       clang = clangPath(),
       clangpp = clangppPath(),
       toolchain = Nil,
@@ -173,6 +181,7 @@ final case class ScalaNativeOptions(
     gcCliOption() ++
       modeCliOption() ++
       ltoOptions() ++
+      targetTripleCliOption() ++
       clangCliOption() ++
       clangppCliOption() ++
       linkingCliOptions() ++

--- a/modules/options/src/main/scala/scala/build/options/ScalaNativeOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaNativeOptions.scala
@@ -108,9 +108,9 @@ final case class ScalaNativeOptions(
     List("--clang-pp", clangppPath().toString())
 
   private def finalLinkingOptions(): List[String] =
-    linkingOptions ++ (if (linkingDefaults.getOrElse(true)) sn.Discover.linkingOptions() else Nil)
+    linkingOptions ++ (if (linkingDefaults.getOrElse(true) && targetTripleStr.isEmpty) sn.Discover.linkingOptions() else Nil)
   private def finalCompileOptions(): List[String] =
-    compileOptions ++ (if (compileDefaults.getOrElse(true)) sn.Discover.compileOptions() else Nil)
+    compileOptions ++ (if (compileDefaults.getOrElse(true) && targetTripleStr.isEmpty) sn.Discover.compileOptions() else Nil)
 
   private def linkingCliOptions(): List[String] =
     finalLinkingOptions().flatMap(option => List("--linking-option", option))

--- a/modules/options/src/main/scala/scala/build/options/ScalaNativeOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaNativeOptions.scala
@@ -81,9 +81,9 @@ final case class ScalaNativeOptions(
 
   private def targetTripleCliOption(): List[String] =
     if (!targetTripleStr.isEmpty)
-      return List("--target-triple", targetTripleStr.get)
+      List("--target-triple", targetTripleStr.get)
     else
-      return Nil
+      Nil
 
   private def mode(): sn.Mode =
     modeStr.map(_.trim).filter(_.nonEmpty) match {

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1434,6 +1434,10 @@ Link-time optimisation mode (none by default): none, full, thin
 
 Set the Scala Native garbage collector (immix by default): immix, commix, boehm, none
 
+### `--native-target-triple`
+
+Set a target triple to which Scala Native can cross-compile
+
 ### `--native-clang`
 
 Path to the Clang command

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -349,6 +349,8 @@ Add Scala Native options
 
 `//> using nativeLinking` _value1_ _value2_ …
 
+`//> using nativeTargetTriple` _value_
+
 `//> using nativeClang` _value_
 
 `//> using nativeClangPP` _value_

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -343,13 +343,13 @@ Add Scala Native options
 
 `//> using nativeLto` _value_
 
+`//> using nativeTargetTriple` _value_
+
 `//> using nativeVersion` _value_
 
 `//> using nativeCompile` _value1_ _value2_ …
 
 `//> using nativeLinking` _value1_ _value2_ …
-
-`//> using nativeTargetTriple` _value_
 
 `//> using nativeClang` _value_
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -874,6 +874,12 @@ Link-time optimisation mode (none by default): none, full, thin
 
 Set the Scala Native garbage collector (immix by default): immix, commix, boehm, none
 
+### `--native-target-triple`
+
+`SHOULD have` per Scala Runner specification
+
+Set a target triple to which Scala Native can cross-compile
+
 ### `--native-clang`
 
 `IMPLEMENTATION specific` per Scala Runner specification

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -233,6 +233,8 @@ Add Scala Native options
 
 `//> using nativeLto` _value_
 
+`//> using nativeTargetTriple` _value_
+
 `//> using nativeVersion` _value_
 
 `//> using nativeCompile` _value1_ _value2_ …


### PR DESCRIPTION
This commit is meant to resolve issue #2766 by adding both a directive:
```scala
//> using nativeTargetTriple arch-mnfctr-opsys
```
and a command line option (`--native-target-triple`) that can successfully pass the target triple to Scala Native for cross-compiling projects.

As previously mentioned, this is a *very* experimental option with limited reach. Use with caution, and don't hesitate to provide suggestions for a better approach :)