### PR TITLE
Ensure test source directives with test scope equivalents are migrated by `fix` to `project.scala`

### DIFF
--- a/website/docs/commands/fix.md
+++ b/website/docs/commands/fix.md
@@ -30,7 +30,9 @@ Files containing (experimental) `using target` directives, e.g. `//> using targe
 The original scope (`main` or `test`) of each extracted directive is respected. `main` scope directives are transformed 
 them into their `test.*` equivalent when needed.
 
-Note: directives won't be extracted for single-file projects.
+Exceptions:
+- directives won't be extracted for single-file projects;
+- directives in test inputs with no test scope equivalents won't be extracted to preserve their initial scope.
 
 ## `scalafix` integration
 


### PR DESCRIPTION
Fixes #3410 
Fixes #3409 (actually already works as expected, with the line length limit equal to 100 characters atm; a test is added in this PR)
Requires:
- #3422 

So the tricky part is that, when migrating directives from test sources to the `project.scala` configuration file, we can only migrate the ones which have test scope equivalents.
`//> using dep` has an equivalent in `//> using test.dep`, but `//> using scala` has none.
So the directives with no equivalents have to stay where they are, otherwise behaviour will change.