### PR TITLE
Fix `update-packages` step of the release job on the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1820,7 +1820,7 @@ jobs:
           path: artifacts/
       - uses: actions/download-artifact@v4
         with:
-          name: launchers
+          name: jvm-launchers
           path: artifacts/
       - name: Display structure of downloaded files
         run: ls -R


### PR DESCRIPTION
This should fix the bug on the CI, which prevented https://github.com/VirtusLab/scala-cli/releases/tag/v1.6.0 from being released to package managers other than Windows ones.