### PR TITLE
Enable direct usage of `--repl-init-script` with Scala REPL >= 3.6.4-RC1

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
@@ -48,6 +48,8 @@ object ScalacOptions {
   val YScriptRunnerOption               = "Yscriptrunner"
   private val scalacOptionsPurePrefixes = Set("V", "W", "X", "Y")
   private val scalacOptionsPrefixes     = Set("P") ++ scalacOptionsPurePrefixes
+  val replInitScript                    = "repl-init-script"
+  private val replAliasedOptions        = Set(replInitScript)
   private val scalacAliasedOptions = // these options don't require being passed after -O and accept an arg
     Set(
       "coverage-exclude-classlikes",
@@ -61,7 +63,7 @@ object ScalacOptions {
       "target",
       "source",
       YScriptRunnerOption
-    )
+    ) ++ replAliasedOptions
   private val scalacNoArgAliasedOptions = // these options don't require being passed after -O and don't accept an arg
     Set(
       "experimental",

--- a/modules/cli/src/main/scala/scala/cli/package.scala
+++ b/modules/cli/src/main/scala/scala/cli/package.scala
@@ -1,0 +1,7 @@
+package scala
+
+import coursier.core.Version
+
+package object cli {
+  extension (s: String) def coursierVersion: Version = Version(s)
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
@@ -86,4 +86,26 @@ abstract class ReplTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
       expect(res.exitCode == 0)
     }
   }
+
+  test("--repl-init-script dry run") {
+    TestInputs.empty.fromRoot { root =>
+      val r = os.proc(
+        TestUtil.cli,
+        "repl",
+        extraOptions,
+        "--repl-init-script",
+        "println(\"Hello\")",
+        "--repl-dry-run"
+      )
+        .call(cwd = root, stderr = os.Pipe, check = false)
+      val warningText =
+        "The '--repl-init-script option' is only supported starting with Scala 3.6.4 and onwards."
+      val coursierScalaVersion = actualScalaVersion.coursierVersion
+      val shouldPrintWarning = coursierScalaVersion < "3.6.4".coursierVersion &&
+        coursierScalaVersion < "3.6.4-RC1".coursierVersion &&
+        coursierScalaVersion < "3.6.4-RC1-bin-20250109-a50a1e4-NIGHTLY".coursierVersion
+      if (shouldPrintWarning) expect(r.err.trim().contains(warningText))
+      else expect(!r.err.trim().contains(warningText))
+    }
+  }
 }

--- a/website/docs/commands/repl.md
+++ b/website/docs/commands/repl.md
@@ -80,6 +80,63 @@ scala> :quit
 
 </ChainedSnippets>
 
+## Passing REPL options
+It is also possible to manually pass REPL-specific options.
+It can be done in a couple ways:
+- after the `--` separator, as the REPL itself is the launched app, so its options are app arguments
+
+<ChainedSnippets>
+
+```bash ignore
+scala repl -S 3.6.4-RC1 -- --repl-init-script 'println("Hello")'
+```
+
+```
+Hello
+Welcome to Scala 3.6.4-RC1 (23.0.1, Java OpenJDK 64-Bit Server VM).
+Type in expressions for evaluation. Or try :help.
+                                                                                                                 
+scala> 
+```
+</ChainedSnippets>
+
+
+- with the `-O`, effectively passing them as compiler options:
+
+<ChainedSnippets>
+
+```bash ignore
+scala repl -S 3.6.4-RC1 -O --repl-init-script -O 'println("Hello")'
+```
+
+```
+Hello
+Welcome to Scala 3.6.4-RC1 (23.0.1, Java OpenJDK 64-Bit Server VM).
+Type in expressions for evaluation. Or try :help.
+                                                                                                                 
+scala> 
+```
+
+</ChainedSnippets>
+
+- directly, as a Scala CLI option (do note that newly added options from an RC version or a snapshot may not be supported this way just yet):
+
+<ChainedSnippets>
+
+```bash ignore
+scala repl -S 3.6.4-RC1 --repl-init-script 'println("Hello")'
+```
+
+```
+Hello
+Welcome to Scala 3.6.4-RC1 (23.0.1, Java OpenJDK 64-Bit Server VM).
+Type in expressions for evaluation. Or try :help.
+                                                                                                                 
+scala> 
+```
+
+</ChainedSnippets>
+
 ## Using Toolkit in REPL
 It is also possible to start the scala-cli REPL with [toolkit](https://scala-cli.virtuslab.org/docs/guides/introduction/toolkit/) enabled
 


### PR DESCRIPTION
A follow-up to https://github.com/scala/scala3/issues/21242

Meant to clear-up confusion like in https://contributors.scala-lang.org/t/scala-3-6-4-release-thread/7010/2

This adds some docs and improves the UX of `--repl-init-script`, enabling it to be used directly with the REPL, rather than after `--` or with `-O`.

```bash
scala-cli repl -S 3.6.4-RC1 --repl-init-script 'println("Hello")'
# Hello
# Welcome to Scala 3.6.4-RC1 (23.0.1, Java OpenJDK 64-Bit Server VM).
# Type in expressions for evaluation. Or try :help.
#                                                                                                                  
# scala> 
```

cc @noti0na1 @bjornregnell 