### PR TITLE
Bump Scala CLI launchers to v1.6.0

### DIFF
--- a/scala-cli.bat
+++ b/scala-cli.bat
@@ -7,7 +7,7 @@ rem Download the latest version of this script at https://github.com/VirtusLab/s
 
 setlocal enabledelayedexpansion
 
-set "SCALA_CLI_VERSION=1.5.4"
+set "SCALA_CLI_VERSION=1.6.0"
 
 set SCALA_CLI_URL=https://github.com/VirtusLab/scala-cli/releases/download/v%SCALA_CLI_VERSION%/scala-cli.bat
 set CACHE_BASE=%localappdata%/Coursier/v1

--- a/scala-cli.sh
+++ b/scala-cli.sh
@@ -7,7 +7,7 @@
 
 set -eu
 
-SCALA_CLI_VERSION="1.5.4"
+SCALA_CLI_VERSION="1.6.0"
 
 GH_ORG="VirtusLab"
 GH_NAME="scala-cli"


### PR DESCRIPTION
- bump `scala-cli.bat` and `scala-cli.sh` to v1.6.0
- run the `setup-ide prepares a valid BSP configuration with --cli-version` test for v1.6.0 & retry it on the CI, to prevent connection failures like https://github.com/VirtusLab/scala-cli/actions/runs/12886220338/job/35926331577#step:4:6261