### PR TITLE
Fix Scala Steward post-update hook

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -3,6 +3,6 @@ updates.ignore = [
     { groupId = "com.github.plokhotnyuk.jsoniter-scala", artifactId="jsoniter-scala-core", version="2.13.5.2" }
 ]
 postUpdateHooks = [{
-  command = ["./mill", "-i", "'generate-reference-doc[]'.run"],
+  command = ["./mill", "-i", "generate-reference-doc[].run"],
   commitMessage = "Generate the reference doc"
 }]


### PR DESCRIPTION
This hopefully fixes the Scala Steward post-update hook to generate the reference doc. See scala-steward-org/scala-steward#3213 for more details.

Closes: scala-steward-org/scala-steward#3213