### PR TITLE
Bump `ammonite` to 3.0.1

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -55,9 +55,9 @@ object Scala {
   }
 
   def maxAmmoniteScala212Version  = scala212
-  def maxAmmoniteScala213Version  = "2.13.14"
-  def maxAmmoniteScala3Version    = "3.5.1"
-  def maxAmmoniteScala3LtsVersion = "3.3.4"
+  def maxAmmoniteScala213Version  = scala213
+  def maxAmmoniteScala3Version    = scala3NextAnnounced
+  def maxAmmoniteScala3LtsVersion = scala3Lts
   lazy val listMaxAmmoniteScalaVersion =
     Seq(maxAmmoniteScala212Version, maxAmmoniteScala213Version, maxAmmoniteScala3Version)
   lazy val listAllAmmonite = {
@@ -106,7 +106,7 @@ object InternalDeps {
 
 object Deps {
   object Versions {
-    def ammonite             = "3.0.0-2-6342755f"
+    def ammonite             = "3.0.1"
     def ammoniteForScala3Lts = ammonite
     def argonautShapeless    = "1.3.1"
     // jni-utils version may need to be sync-ed when bumping the coursier version

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1246,7 +1246,7 @@ Use Ammonite (instead of the default Scala REPL)
 
 Aliases: `--ammonite-ver`
 
-Set the Ammonite version (3.0.0-2-6342755f by default)
+Set the Ammonite version (3.0.1 by default)
 
 ### `--ammonite-arg`
 


### PR DESCRIPTION
https://github.com/com-lihaoyi/Ammonite/releases/tag/3.0.1
This adds support up to Scala 2.13.16 / 3.3.5 / 3.6.3