### PR TITLE
Add warning about test files in publish docs

### DIFF
--- a/website/docs/commands/publishing/publish-local.md
+++ b/website/docs/commands/publishing/publish-local.md
@@ -44,6 +44,13 @@ Publishing io.github.scala-cli:hello-scala-cli_3:0.1.0-SNAPSHOT
   ~/.ivy2/local/io.github.scala-cli/hello-scala-cli_3/0.1.0-SNAPSHOT/
 ```
 
+:::caution
+The `publish local` sub-command does not currently support publishing of the test scope.
+This includes any file that is placed in `test` directory or with the `.test.scala` suffix.
+
+Read more about test sources in [testing documentation](../test.md#test-sources).
+:::
+
 </ChainedSnippets>
 
 ## Required settings

--- a/website/docs/commands/publishing/publish.md
+++ b/website/docs/commands/publishing/publish.md
@@ -322,3 +322,10 @@ Publishing io.github.scala-cli:hello-scala-cli_3:0.1.0-SNAPSHOT
 ```
 
 </ChainedSnippets>
+
+:::caution
+The `publish local` sub-command does not currently support publishing of the test scope.
+This includes any file that is placed in `test` directory or with the `.test.scala` suffix.
+
+Read more about test sources in [testing documentation](../test.md#test-sources).
+:::

--- a/website/docs/commands/test.md
+++ b/website/docs/commands/test.md
@@ -68,7 +68,7 @@ path (`test/scala/b.scala`) contains a directory named `test`.
 Conversely, `scala-cli example/src/test` results in no test sources, since the relative path to `b.scala` does not
 contain `test` (the fact that the directory provided as input is named `test` does not make its content a test source).
 
-Directives take precedence over file or path names, so `using target main` can be used to force `test/a.scala`
+Directives take precedence over file or path names, so `using target.scope main` can be used to force `test/a.scala`
 or `a.test.scala` to not be treated as tests.
 
 As a rule of thumb, we recommend naming all of your test files with the `.test.scala` suffix.


### PR DESCRIPTION
This PR clarifies the publishing docs to avoid misconceptions as raised in https://github.com/VirtusLab/scala-cli/issues/3483