### PR TITLE
Skip using Scala nightlies in unit tests when they can't be fetched

### DIFF
--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -329,23 +329,23 @@ class BuildOptionsTests extends TestUtil.ScalaCliBuildSuite {
     val allScalaVersions = ScalaVersionUtil.allMatchingVersions(None, cache, repositories)
     for {
       (prefix, defaultMatchingVersion, predefinedDefaultScalaVersion) <- {
-        val scala2Nightlies  = allScalaVersions.filter(ScalaVersionUtil.isScala2Nightly)
-        val latest212Nightly = scala2Nightlies.filter(_.startsWith("2.12")).maxBy(Version(_))
-        val latest213Nightly = scala2Nightlies.filter(_.startsWith("2.13")).maxBy(Version(_))
-        val latestScala3NextNightly =
-          allScalaVersions
-            .filter(ScalaVersionUtil.isScala3Nightly)
-            .filter(_.startsWith(scala3NextPrefix))
-            .maxBy(Version(_))
+        extension (nightlies: Seq[String])
+          private def latestNightly: Option[String] =
+            if nightlies.nonEmpty then Some(nightlies.maxBy(Version(_))) else None
+        val scala2Nightlies     = allScalaVersions.filter(ScalaVersionUtil.isScala2Nightly)
+        val scala212Nightlies   = scala2Nightlies.filter(_.startsWith("2.12"))
+        val scala213Nightlies   = scala2Nightlies.filter(_.startsWith("2.13"))
+        val scala3Nightlies     = allScalaVersions.filter(ScalaVersionUtil.isScala3Nightly)
+        val scala3NextNightlies = scala3Nightlies.filter(_.startsWith(scala3NextPrefix))
         Seq(
           ("2.12", defaultScala212Version, None),
-          ("2.12", defaultScala212Version, Some(latest212Nightly)),
+          ("2.12", defaultScala212Version, scala212Nightlies.latestNightly),
           ("2.13", defaultScala213Version, None),
-          ("2.13", defaultScala213Version, Some(latest213Nightly)),
+          ("2.13", defaultScala213Version, scala213Nightlies.latestNightly),
           ("3", defaultScalaVersion, None),
           (scala3NextPrefix, defaultScalaVersion, None),
-          (scala3NextPrefix, defaultScalaVersion, Some(latestScala3NextNightly))
-        )
+          (scala3NextPrefix, defaultScalaVersion, scala3NextNightlies.latestNightly)
+        ).distinct
       }
       options = BuildOptions(
         scalaOptions = ScalaOptions(


### PR DESCRIPTION
This should fix the CI failing on `main`:
```scala
scala.build.tests.BuildOptionsTests:
==> X scala.build.tests.BuildOptionsTests.initializationError  0.001s java.lang.UnsupportedOperationException: empty.maxBy
    at scala.collection.IterableOnceOps.maxBy(IterableOnce.scala:1160)
    at scala.collection.IterableOnceOps.maxBy$(IterableOnce.scala:1158)
    at scala.collection.AbstractIterable.maxBy(Iterable.scala:935)
    at scala.build.tests.BuildOptionsTests.<init>(BuildOptionsTests.scala:333)
    at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
    at java.lang.reflect.ReflectAccess.newInstance(ReflectAccess.java:128)
    at jdk.internal.reflect.ReflectionFactory.newInstance(ReflectionFactory.java:347)
    at java.lang.Class.newInstance(Class.java:645)
    at munit.MUnitRunner.MUnitRunner$superArg$1$$anonfun$1(MUnitRunner.scala:32)
    at munit.MUnitRunner.<init>(MUnitRunner.scala:34)
    at munit.MUnitRunner.<init>(MUnitRunner.scala:32)
    at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:481)
    at munit.internal.junitinterface.JUnitComputer.getRunner(JUnitComputer.java:75)
    at munit.internal.junitinterface.JUnitComputer$1.runnerForClass(JUnitComputer.java:65)
    ...
```
https://github.com/VirtusLab/scala-cli/actions/runs/13280636786/job/37078168991#step:8:701