### PR TITLE
Fallback to using GitHub releases of `libsodium` if the download site is unavailable

### DIFF
--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -282,7 +282,7 @@ def buildCsM1Version = Deps.Versions.coursierM1Cli
 // Native library used to encrypt GitHub secrets
 def libsodiumVersion = "1.0.20"
 // Using the libsodium static library from this Alpine version (in the static launcher)
-def alpineVersion = "3.16"
+def alpineVersion = "3.21"
 def ubuntuVersion = "24.04"
 
 object Docker {

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -280,7 +280,7 @@ def buildCsVersion   = Deps.Versions.coursierCli
 def buildCsM1Version = Deps.Versions.coursierM1Cli
 
 // Native library used to encrypt GitHub secrets
-def libsodiumVersion = "1.0.18"
+def libsodiumVersion = "1.0.20"
 // Using the libsodium static library from this Alpine version (in the static launcher)
 def alpineVersion = "3.16"
 def ubuntuVersion = "24.04"


### PR DESCRIPTION
Meant to provide a fallback for downloading `libsodium`, which fails our CI consistently.
```scala
download error: Caught java.net.ConnectException (Connection timed out: connect) while downloading https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip
1 targets failed
cli[3.3.5].base-image.staticLibDir os.SubprocessException: Result of C:\Users\runneradmin\AppData\Local\Coursier\cache\arc\https\github.com\coursier\coursier\releases\download\v2.1.24\cs-x86_64-pc-win32.zip\cs-x86_64-pc-win32.exe�: 1

    os.proc.call(ProcessOps.scala:95)
    millbuild.project.settings$CliLaunchers$CliNativeImage.copyLibsodiumStaticTo(settings.sc:239)
    millbuild.project.settings$CliLaunchers$CliNativeImage.$anonfun$staticLibDir$3(settings.sc:[280](https://github.com/VirtusLab/scala-cli/actions/runs/13282281463/job/37086740792#step:5:281))
Error: Process completed with exit code 1.
```

We've been relying on https://download.libsodium.org/libsodium/releases/, but perhaps we can fall back to https://github.com/jedisct1/libsodium/releases if that's unavailable.