### PR TITLE
fix: Don't compile docs if there is no need

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -230,8 +230,8 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
     ).orExit(logger)
     val threads = BuildThreads.create()
 
-    val compilerMaker    = options.shared.compilerMaker(threads)
-    val docCompilerMaker = options.shared.compilerMaker(threads, scaladoc = true)
+    val compilerMaker       = options.shared.compilerMaker(threads)
+    val docCompilerMakerOpt = options.sharedPublish.docCompilerMakerOpt
 
     val cross = options.compileCross.cross.getOrElse(false)
 
@@ -256,7 +256,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
       logger,
       initialBuildOptions,
       compilerMaker,
-      docCompilerMaker,
+      docCompilerMakerOpt,
       cross,
       workingDir,
       ivy2HomeOpt,
@@ -278,7 +278,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
     logger: Logger,
     initialBuildOptions: BuildOptions,
     compilerMaker: ScalaCompilerMaker,
-    docCompilerMaker: ScalaCompilerMaker,
+    docCompilerMaker: Option[ScalaCompilerMaker],
     cross: Boolean,
     workingDir: => os.Path,
     ivy2HomeOpt: Option[os.Path],
@@ -299,7 +299,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
         inputs,
         initialBuildOptions,
         compilerMaker,
-        Some(docCompilerMaker),
+        docCompilerMaker,
         logger,
         crossBuilds = cross,
         buildTests = false,
@@ -333,7 +333,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
           inputs,
           initialBuildOptions,
           compilerMaker,
-          Some(docCompilerMaker),
+          docCompilerMaker,
           logger,
           crossBuilds = cross,
           buildTests = false,

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
@@ -51,8 +51,8 @@ object PublishLocal extends ScalaCommand[PublishLocalOptions] {
     ).orExit(logger)
     val threads = BuildThreads.create()
 
-    val compilerMaker    = options.shared.compilerMaker(threads)
-    val docCompilerMaker = options.shared.compilerMaker(threads, scaladoc = true)
+    val compilerMaker       = options.shared.compilerMaker(threads)
+    val docCompilerMakerOpt = options.sharedPublish.docCompilerMakerOpt
 
     val cross = options.compileCross.cross.getOrElse(false)
 
@@ -75,7 +75,7 @@ object PublishLocal extends ScalaCommand[PublishLocalOptions] {
       logger,
       initialBuildOptions,
       compilerMaker,
-      docCompilerMaker,
+      docCompilerMakerOpt,
       cross,
       workingDir,
       ivy2HomeOpt,

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/SharedPublishOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/SharedPublishOptions.scala
@@ -2,6 +2,7 @@ package scala.cli.commands.publish
 
 import caseapp.*
 
+import scala.build.compiler.{ScalaCompilerMaker, SimpleScalaCompilerMaker}
 import scala.cli.commands.shared.HelpGroup
 import scala.cli.commands.tags
 
@@ -85,8 +86,15 @@ final case class SharedPublishOptions(
   @HelpMessage("Proceed as if publishing, but do not upload / write artifacts to the remote repository")
   @Tag(tags.implementation)
     dummy: Boolean = false
-)
-// format: on
+){
+  // format: on
+
+  def docCompilerMakerOpt: Option[ScalaCompilerMaker] =
+    if (doc.contains(false)) // true by default
+      None
+    else
+      Some(SimpleScalaCompilerMaker("java", Nil, scaladoc = true))
+}
 
 object SharedPublishOptions {
   implicit lazy val parser: Parser[SharedPublishOptions] = Parser.derive


### PR DESCRIPTION
This PR adds a little optimization to the publish commands. 

If `doc=false` is passed it doesn't even attempt to compile javadocs which speeds up the whole process. 

This is important in cases where people use bloop for compilation as javadocs compilation does not use bloop which results in effectively compiling everything twice. 