### PR TITLE
fix for #3510

### DIFF
--- a/.github/scripts/generate-native-image.sh
+++ b/.github/scripts/generate-native-image.sh
@@ -8,8 +8,7 @@ COMMAND="cli[].base-image.writeNativeImageScript"
 export USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM=false
 
 # Using 'mill -i' so that the Mill process doesn't outlive this invocation
-
-if [[ "$OSTYPE" == "msys" ]]; then
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
   ./mill.bat -i ci.copyJvm --dest jvm
   export JAVA_HOME="$(pwd -W | sed 's,/,\\,g')\\jvm"
   export GRAALVM_HOME="$JAVA_HOME"

--- a/.github/scripts/generate-os-packages.sh
+++ b/.github/scripts/generate-os-packages.sh
@@ -127,7 +127,7 @@ generate_sdk() {
       sdkDirectory="scala-cli-x86_64-apple-darwin-sdk"
     fi
     binName="scala-cli"
-  elif [[ "$OSTYPE" == "msys" ]]; then
+  elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
     sdkDirectory="scala-cli-x86_64-pc-win32-sdk"
     binName="scala-cli.exe"
   else
@@ -138,7 +138,7 @@ generate_sdk() {
   mkdir -p "$sdkDirectory"/bin
   cp "$(launcher)" "$sdkDirectory"/bin/"$binName"
 
-  if [[ "$OSTYPE" == "msys" ]]; then
+  if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
     7z a "$sdkDirectory".zip "$sdkDirectory"
   else
     zip -r "$sdkDirectory".zip "$sdkDirectory"
@@ -160,7 +160,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     generate_pkg "x86_64"
   fi
   generate_sdk
-elif [[ "$OSTYPE" == "msys" ]]; then
+elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
   generate_msi
   generate_sdk
 else


### PR DESCRIPTION
Fix for #3510.
The problem occurs because the default value of `OSTYPE` in bash sessions changed from  `msys` to `cygwin`.
This permits msys2 development environments to continue to be supported.

