### PR TITLE
Update `scalafmt` to 3.9.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.8.6"
+version = "3.9.1"
 
 align.preset = more
 maxColumn = 100

--- a/DEV.md
+++ b/DEV.md
@@ -192,8 +192,6 @@ Here's some of the more important external projects used by Scala CLI:
   [libsodium](https://github.com/jedisct1/libsodium), that is used by Scala CLI to encrypt secrets
   uploaded as GitHub repository secrets in the `publish setup` sub-command
 - [scala-cli-setup](https://github.com/VirtusLab/scala-cli-setup): a GitHub Action to install Scala CLI.
-- [scalafmt-native-image](https://github.com/VirtusLab/scalafmt-native-image): GraalVM native-image launchers
-  for `scalafmt`.
 - [bloop-core](https://github.com/scala-cli/bloop-core): a fork of [bloop](https://github.com/scalacenter/bloop)
   stripped up of its benchmark infrastructure and build integrations.
 - [no-crc32-zip-input-stream](https://github.com/VirtusLab/no-crc32-zip-input-stream): A copy of `ZipInputStream` 
@@ -202,6 +200,10 @@ Here's some of the more important external projects used by Scala CLI:
   to make Spark distributions more lightweight.
 - [java-class-name](https://github.com/VirtusLab/java-class-name): a small library to extract class names
   from Java sources.
+
+Legacy projects:
+- [scalafmt-native-image](https://github.com/VirtusLab/scalafmt-native-image): GraalVM native-image launchers
+  for `scalafmt` (used for `scalafmt` versions < 3.9.1, no longer maintained)
 
 The use of external binaries allows to make the Scala CLI binary slimmer and faster
 to generate, but also allow to lower memory requirements to generate it (allowing to

--- a/modules/cli/src/test/scala/cli/tests/ScalafmtTest.scala
+++ b/modules/cli/src/test/scala/cli/tests/ScalafmtTest.scala
@@ -10,6 +10,7 @@ import scala.cli.commands.fmt.{FmtOptions, FmtUtil}
 import scala.cli.commands.update.Update.Release
 
 class ScalafmtTests extends munit.FunSuite {
+  private lazy val defaultScalafmtVersion = Constants.defaultScalafmtVersion
 
   test("readVersionFromFile with non-default scalafmt version") {
     val confFile = """runner.dialect = scala213
@@ -34,27 +35,25 @@ class ScalafmtTests extends munit.FunSuite {
     }
   }
 
-  test("check native launcher availability for scalafmt") {
+  test(s"check native launcher availability for scalafmt $defaultScalafmtVersion") {
     final case class Asset(name: String)
     final case class Release(tag_name: String, assets: List[Asset])
     lazy val releaseCodec: JsonValueCodec[Release] = JsonCodecMaker.make
-
-    val scalaFmtVersion = Constants.defaultScalafmtVersion
     val url =
-      s"https://api.github.com/repos/virtuslab/scalafmt-native-image/releases/tags/v$scalaFmtVersion"
+      s"https://api.github.com/repos/scalameta/scalafmt/releases/tags/v$defaultScalafmtVersion"
 
     val expectedAssets = Seq(
-      "scalafmt-x86_64-apple-darwin.gz",
-      "scalafmt-x86_64-pc-linux-mostly-static.gz",
-      "scalafmt-x86_64-pc-linux-static.gz",
-      "scalafmt-x86_64-pc-linux.gz",
-      "scalafmt-x86_64-pc-win32.zip"
+      "scalafmt-x86_64-apple-darwin.zip",
+      "scalafmt-x86_64-pc-linux.zip",
+      "scalafmt-x86_64-pc-win32.zip",
+      "scalafmt-aarch64-apple-darwin.zip",
+      "scalafmt-aarch64-pc-linux.zip"
     )
     val errorMsg =
-      s"""scalafmt native images missing for v$scalaFmtVersion, make a release at https://github.com/VirtusLab/scalafmt-native-image
+      s"""scalafmt native images missing for v$defaultScalafmtVersion at https://github.com/scalameta/scalafmt
          |Ensure that all expected assets are available in the release:
          |  ${expectedAssets.mkString(", ")}
-         |for scalafmt-native-image under tag v$scalaFmtVersion.""".stripMargin
+         |under tag v$defaultScalafmtVersion.""".stripMargin
     try {
       val resp    = TestUtil.downloadFile(url).orThrow
       val release = readFromArray(resp)(releaseCodec)
@@ -68,7 +67,7 @@ class ScalafmtTests extends munit.FunSuite {
     catch {
       case e: JsonReaderException => throw new Exception(s"Error reading $url", e)
       case e: Throwable => throw new Exception(
-          s"""Failed to check for the ScalaFmt native launcher assets: ${e.getMessage}
+          s"""Failed to check for the ScalaFmt $defaultScalafmtVersion native launcher assets: ${e.getMessage}
              |
              |$errorMsg
              |""".stripMargin,

--- a/modules/integration/src/test/scala/scala/cli/integration/DependencyUpdateTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DependencyUpdateTests.scala
@@ -25,7 +25,8 @@ class DependencyUpdateTests extends ScalaCliSuite {
         )
       expect(p.out.trim().contains("Updated dependency"))
       expect( // check if dependency update command modify file
-        os.read(root / fileName) != fileContent)
+        os.read(root / fileName) != fileContent
+      )
 
       // after updating dependencies app should run
       val out = os.proc(TestUtil.cli, fileName).call(cwd = root).out.trim()

--- a/modules/integration/src/test/scala/scala/cli/integration/FmtTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FmtTests.scala
@@ -95,11 +95,8 @@ class FmtTests extends ScalaCliSuite {
 
   test("filter correctly with --check") {
     simpleInputsWithFilter.fromRoot { root =>
-      val out      = os.proc(TestUtil.cli, "fmt", ".", "--check").call(cwd = root).out.trim()
-      val outLines = out.linesIterator.toSeq
-      expect(outLines.length == 2)
-      expect(outLines.head == "Looking for unformatted files...")
-      expect(outLines.last == "All files are formatted with scalafmt :)")
+      val out = os.proc(TestUtil.cli, "fmt", ".", "--check").call(cwd = root).out.trim()
+      expect(out == "All files are formatted with scalafmt :)")
     }
   }
 

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -118,6 +118,7 @@ object Deps {
     def jsoniterScalaJava8                = "2.13.5.2"
     def jsoup                             = "1.18.3"
     def scalaMeta                         = "4.13.2"
+    def scalafmt                          = "3.9.1"
     def scalaNative04                     = "0.4.17"
     def scalaNative05                     = "0.5.7"
     def scalaNative                       = scalaNative05
@@ -211,7 +212,7 @@ object Deps {
   def scala3Compiler(sv: String) = ivy"org.scala-lang:scala3-compiler_3:$sv"
   def scalaAsync         = ivy"org.scala-lang.modules::scala-async:1.0.1".exclude("*" -> "*")
   def scalac(sv: String) = ivy"org.scala-lang:scala-compiler:$sv"
-  def scalafmtCli        = ivy"org.scalameta:scalafmt-cli_2.13:3.8.6"
+  def scalafmtCli        = ivy"org.scalameta:scalafmt-cli_2.13:${Versions.scalafmt}"
   // Force using of 2.13 - is there a better way?
   def scalaJsEnvJsdomNodejs =
     ivy"org.scala-js:scalajs-env-jsdom-nodejs_2.13:1.1.0"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -501,7 +501,7 @@ Pass a global dialect for scalafmt. This overrides whatever value is configured 
 
 Aliases: `--fmt-version`
 
-Pass scalafmt version before running it (3.8.6 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
+Pass scalafmt version before running it (3.9.1 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
 
 ## Global suppress warning options
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -370,7 +370,7 @@ Aliases: `--fmt-version`
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Pass scalafmt version before running it (3.8.6 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
+Pass scalafmt version before running it (3.9.1 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
 
 ## Global suppress warning options
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -3936,7 +3936,7 @@ Aliases: `--dialect`
 
 **--scalafmt-version**
 
-Pass scalafmt version before running it (3.8.6 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
+Pass scalafmt version before running it (3.9.1 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
 
 Aliases: `--fmt-version`
 


### PR DESCRIPTION
Supersedes #3516 

- bumps `scalafmt` to 3.9.1
- switches used native images from https://github.com/virtuslab/scalafmt-native-image to https://github.com/scalameta/scalafmt for `scalafmt` versions >= 3.9.1
- tags https://github.com/virtuslab/scalafmt-native-image as a legacy dependency in the docs

Depends on:
- https://github.com/VirtusLab/scala-cli/pull/3528