### PR TITLE
Bump `scala-packager` to 0.1.32 & linux CI runners to `ubuntu-24.04`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   unit-tests:
     timeout-minutes: 120
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -53,7 +53,7 @@ jobs:
 
   jvm-tests-1:
     timeout-minutes: 120
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -81,7 +81,7 @@ jobs:
 
   jvm-tests-2:
     timeout-minutes: 120
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -106,7 +106,7 @@ jobs:
 
   jvm-tests-3:
     timeout-minutes: 120
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -131,7 +131,7 @@ jobs:
 
   jvm-tests-4:
     timeout-minutes: 120
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -156,7 +156,7 @@ jobs:
 
   jvm-tests-5:
     timeout-minutes: 120
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -181,7 +181,7 @@ jobs:
 
   generate-linux-launcher:
     timeout-minutes: 120
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -208,7 +208,7 @@ jobs:
   native-linux-tests-1:
     needs: generate-linux-launcher
     timeout-minutes: 120
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -241,7 +241,7 @@ jobs:
   native-linux-tests-2:
     needs: generate-linux-launcher
     timeout-minutes: 120
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -274,7 +274,7 @@ jobs:
   native-linux-tests-3:
     needs: generate-linux-launcher
     timeout-minutes: 120
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -307,7 +307,7 @@ jobs:
   native-linux-tests-4:
     needs: generate-linux-launcher
     timeout-minutes: 120
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -340,7 +340,7 @@ jobs:
   native-linux-tests-5:
     needs: generate-linux-launcher
     timeout-minutes: 120
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1037,7 +1037,7 @@ jobs:
 
   generate-mostly-static-launcher:
     timeout-minutes: 120
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1061,7 +1061,7 @@ jobs:
   native-mostly-static-tests-1:
     needs: generate-mostly-static-launcher
     timeout-minutes: 120
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1108,7 +1108,7 @@ jobs:
   native-mostly-static-tests-2:
     needs: generate-mostly-static-launcher
     timeout-minutes: 120
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1141,7 +1141,7 @@ jobs:
   native-mostly-static-tests-3:
     needs: generate-mostly-static-launcher
     timeout-minutes: 120
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1174,7 +1174,7 @@ jobs:
   native-mostly-static-tests-4:
     needs: generate-mostly-static-launcher
     timeout-minutes: 120
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1207,7 +1207,7 @@ jobs:
   native-mostly-static-tests-5:
     needs: generate-mostly-static-launcher
     timeout-minutes: 120
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1240,7 +1240,7 @@ jobs:
 
   generate-static-launcher:
     timeout-minutes: 120
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1264,7 +1264,7 @@ jobs:
   native-static-tests-1:
     needs: generate-static-launcher
     timeout-minutes: 120
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1311,7 +1311,7 @@ jobs:
   native-static-tests-2:
     needs: generate-static-launcher
     timeout-minutes: 120
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1346,7 +1346,7 @@ jobs:
   native-static-tests-3:
     needs: generate-static-launcher
     timeout-minutes: 120
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1381,7 +1381,7 @@ jobs:
   native-static-tests-4:
     needs: generate-static-launcher
     timeout-minutes: 120
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1416,7 +1416,7 @@ jobs:
   native-static-tests-5:
     needs: generate-static-launcher
     timeout-minutes: 120
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -1450,7 +1450,7 @@ jobs:
 
   docs-tests:
     # for now, let's run those tests only on ubuntu
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1478,7 +1478,7 @@ jobs:
 
   checks:
     timeout-minutes: 30
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1505,7 +1505,7 @@ jobs:
 
   format:
     timeout-minutes: 15
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1519,7 +1519,7 @@ jobs:
 
   reference-doc:
     timeout-minutes: 15
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1539,7 +1539,7 @@ jobs:
 
   bloop-memory-footprint:
     timeout-minutes: 120
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1561,7 +1561,7 @@ jobs:
 
   test-hypothetical-sbt-export:
     timeout-minutes: 120
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1637,7 +1637,7 @@ jobs:
       - reference-doc
       - docs-tests
     if: github.event_name == 'push' && github.repository == 'VirtusLab/scala-cli'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1717,7 +1717,7 @@ jobs:
       - generate-linux-arm64-native-launcher
       - publish
     if: github.event_name == 'push'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -1782,7 +1782,7 @@ jobs:
     needs:
       - launchers
       - publish
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'VirtusLab/scala-cli'
     steps:
       - uses: actions/checkout@v4

--- a/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
@@ -196,7 +196,7 @@ class NativePackagerTests extends ScalaCliSuite {
             "/workdir",
             "-v",
             s"${root / destDir}:/workdir",
-            "openjdk:17-slim",
+            "eclipse-temurin:17-jdk",
             "./run.sh"
           ).call(
             cwd = root,

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -125,7 +125,7 @@ object Deps {
     def maxScalaNativeForTypelevelToolkit = scalaNative04
     def maxScalaNativeForScalaPy          = scalaNative04
     def maxScalaNativeForMillExport       = scalaNative04
-    def scalaPackager                     = "0.1.31"
+    def scalaPackager                     = "0.1.32"
     def signingCli                        = "0.2.4"
     def signingCliJvmVersion              = Java.defaultJava
     def javaSemanticdb                    = "0.10.0"


### PR DESCRIPTION
The `ubuntu-24.04` bump is necessary for `scala-packager`, which since 0.1.32 is also built on `ubuntu-24.04`.
This is in preparation to the `scalafmt` 3.9.1 bump:
- https://github.com/VirtusLab/scala-cli/pull/3521