### PR TITLE
Bump gifs tests Ubuntu Docker image to `ubuntu:24.04`

### DIFF
--- a/gifs/Dockerfile
+++ b/gifs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 RUN curl -fsSL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update
@@ -6,7 +6,7 @@ RUN apt-get install ca-certificates-java openjdk-17-jdk openjdk-17-jre -y
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y pv curl clang rubygems nodejs python3-pip &&\
     rm -rf /var/lib/apt/lists/* &&\
     gem install rouge &&\
-    pip3 install asciinema==2.1.0
+    pip3 install --break-system-packages asciinema==2.1.0
 
 RUN mkdir /data
 WORKDIR /data


### PR DESCRIPTION
I wonder if this is the trick to fixing the flaky gifs tests.

https://github.com/VirtusLab/scala-cli/actions/runs/13625742426/job/38085162945#step:6:7557

```scala
+ test -f status.txt
rm: can't remove '.' or '..'
rm: can't remove '.' or '..'
sclicheck.GifTests:
  + complete-install 167.323s
==> X sclicheck.GifTests.defaults  12.839s os.SubprocessException: Result of docker…: 1

    at os.SubprocessException$.apply(Model.scala:211)
    at os.proc.call(ProcessOps.scala:230)
    at sclicheck.GifTests.$init$$$anonfun$8$$anonfun$1$$anonfun$1(GifTests.scala:82)
    at sclicheck.TestUtil$.withTmpDir(TestUtil.scala:7)
    at sclicheck.GifTests.$init$$$anonfun$8$$anonfun$1(GifTests.scala:67)
```