### PR TITLE
Bump `scala-cli-signing` to 0.2.6

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -127,7 +127,7 @@ object Deps {
     def maxScalaNativeForScalaPy          = scalaNative04
     def maxScalaNativeForMillExport       = scalaNative04
     def scalaPackager                     = "0.1.32"
-    def signingCli                        = "0.2.4"
+    def signingCli                        = "0.2.6"
     def signingCliJvmVersion              = Java.defaultJava
     def javaSemanticdb                    = "0.10.0"
     def javaClassName                     = "0.1.4"
@@ -238,6 +238,8 @@ object Deps {
       .exclude(("com.github.alexarchambault", "case-app_3"))
       .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-core_3"))
       .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-macros_3"))
+      .exclude(("com.lihaoyi", "os-lib_3"))
+      .exclude(("com.lihaoyi", "os-lib_2.13"))
   def signingCli =
     ivy"org.virtuslab.scala-cli-signing::cli:${Versions.signingCli}"
       // to prevent collisions with scala-cli's case-app version
@@ -247,6 +249,8 @@ object Deps {
       .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-core_2.13"))
       .exclude(("io.get-coursier.publish", "publish_2.13"))
       .exclude(("org.scala-lang.modules", "scala-collection-compat_2.13"))
+      .exclude(("com.lihaoyi", "os-lib_3"))
+      .exclude(("com.lihaoyi", "os-lib_2.13"))
   def slf4jNop                  = ivy"org.slf4j:slf4j-nop:2.0.17"
   def sttp                      = ivy"com.softwaremill.sttp.client3:core_2.13:3.10.3"
   def svm                       = ivy"org.graalvm.nativeimage:svm:$graalVmVersion"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -2189,7 +2189,7 @@ Available in commands:
 ### `--signing-cli-version`
 
 [Internal]
-scala-cli-signing version when running externally (0.2.4 by default)
+scala-cli-signing version when running externally (0.2.6 by default)
 
 ### `--signing-cli-java-arg`
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-cli-signing/releases/tag/v0.2.6