### PR TITLE
Pin & update docker images

### DIFF
--- a/.github/scripts/docker/ScalaCliSlimDockerFile
+++ b/.github/scripts/docker/ScalaCliSlimDockerFile
@@ -1,6 +1,6 @@
 FROM debian:stable-slim AS build-env
 
-FROM gcr.io/distroless/base-debian10
+FROM gcr.io/distroless/base-debian12
 ADD scala-cli /usr/local/bin/scala-cli
 COPY --from=build-env /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
 ENTRYPOINT ["/usr/local/bin/scala-cli"]

--- a/build.sc
+++ b/build.sc
@@ -18,7 +18,7 @@ import $file.project.settings, settings.{
   projectFileName,
   jvmPropertiesFileName
 }
-import $file.project.deps, deps.customRepositories
+import $file.project.deps, deps.customRepositories, deps.alpineVersion
 import $file.project.website
 
 import java.io.File
@@ -184,6 +184,7 @@ trait DocsTests extends CrossSbtModule with ScalaCliScalafixModule with HasTests
          |  def coursierCliModule = "${Deps.coursierCli.dep.module.name.value}"
          |  def coursierCliVersion = "${Deps.Versions.coursierCli}"
          |  def defaultScalaVersion = "${Scala.defaultUser}"
+         |  def alpineVersion = "$alpineVersion"
          |}
          |""".stripMargin
     if (!os.isFile(dest) || os.read(dest) != code)
@@ -544,6 +545,8 @@ trait Core extends ScalaCliCrossSbtModule
          |  def mavenAppVersion = "${Deps.Versions.mavenAppVersion}"
          |
          |  def scalafixVersion = "${Deps.Versions.scalafix}"
+         |  
+         |  def alpineVersion = "$alpineVersion"
          |}
          |""".stripMargin
     if (!os.isFile(dest) || os.read(dest) != code)

--- a/modules/cli/src/main/scala/scala/cli/commands/github/LibSodiumJni.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/LibSodiumJni.scala
@@ -40,13 +40,14 @@ object LibSodiumJni {
 
   private def libsodiumVersion    = Constants.libsodiumVersion
   private def libsodiumjniVersion = Constants.libsodiumjniVersion
+  private def alpineVersion       = Constants.alpineVersion
 
   private def archiveUrlAndPath() =
     if (Properties.isLinux && launcherKindOpt.contains("static"))
       // Should actually be unused, as we statically link libsodium from the static launcher
       // Keeping it just-in-case. This could be useful from a musl-based JVM.
       (
-        s"https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/libsodium-$libsodiumVersion-r0.apk",
+        s"https://dl-cdn.alpinelinux.org/alpine/v$alpineVersion/main/x86_64/libsodium-$libsodiumVersion-r0.apk",
         os.rel / "usr" / "lib" / "libsodium.so.23.3.0" // FIXME Could this change?
       )
     else {

--- a/modules/docs-tests/src/test/scala/sclicheck/GifTests.scala
+++ b/modules/docs-tests/src/test/scala/sclicheck/GifTests.scala
@@ -171,7 +171,7 @@ class GifTests extends munit.FunSuite {
             ttyOpts,
             "-v",
             s"$out:/out",
-            "alpine:3.16.2",
+            s"alpine:${Constants.alpineVersion}",
             "sh",
             "-c",
             "rm -rf /out/* || true; rm -rf /out/.* || true"

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -285,7 +285,7 @@ def buildCsM1Version = Deps.Versions.coursierM1Cli
 // Native library used to encrypt GitHub secrets
 def libsodiumVersion = "1.0.18"
 // Using the libsodium static library from this Alpine version (in the static launcher)
-def alpineVersion = "3.15"
+def alpineVersion = "3.16"
 def ubuntuVersion = "24.04"
 
 object Docker {
@@ -293,9 +293,8 @@ object Docker {
   def muslBuilder =
     s"$customMuslBuilderImageName:latest"
 
-  def testImage = s"ubuntu:$ubuntuVersion"
-  def alpineTestImage =
-    "alpine@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454"
+  def testImage       = s"ubuntu:$ubuntuVersion"
+  def alpineTestImage = s"alpine:$alpineVersion"
   def authProxyTestImage =
     "bahamat/authenticated-proxy@sha256:568c759ac687f93d606866fbb397f39fe1350187b95e648376b971e9d7596e75"
 }

--- a/project/deps.sc
+++ b/project/deps.sc
@@ -286,13 +286,14 @@ def buildCsM1Version = Deps.Versions.coursierM1Cli
 def libsodiumVersion = "1.0.18"
 // Using the libsodium static library from this Alpine version (in the static launcher)
 def alpineVersion = "3.15"
+def ubuntuVersion = "24.04"
 
 object Docker {
   def customMuslBuilderImageName = "scala-cli-base-musl"
   def muslBuilder =
     s"$customMuslBuilderImageName:latest"
 
-  def testImage = "ubuntu:18.04"
+  def testImage = s"ubuntu:$ubuntuVersion"
   def alpineTestImage =
     "alpine@sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454"
   def authProxyTestImage =

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -1,8 +1,15 @@
 import $ivy.`com.goyeau::mill-scalafix::0.3.1`
 import $ivy.`io.github.alexarchambault.mill::mill-native-image::0.1.29`
 
-import $file.deps,
-  deps.{Deps, Docker, alpineVersion, buildCsVersion, buildCsM1Version, libsodiumVersion}
+import $file.deps, deps.{
+  Deps,
+  Docker,
+  alpineVersion,
+  buildCsVersion,
+  buildCsM1Version,
+  libsodiumVersion,
+  ubuntuVersion
+}
 import $file.utils, utils.isArmArchitecture
 
 import com.goyeau.mill.scalafix.ScalafixModule
@@ -305,7 +312,7 @@ trait CliLaunchers extends SbtModule { self =>
     def launcherKind = `base-image`.launcherKind
     def nativeImageDockerParams = Some(
       NativeImage.DockerParams(
-        imageName = "ubuntu:18.04",
+        imageName = s"ubuntu:$ubuntuVersion",
         prepareCommand =
           maybePassNativeImageJpmsOption +
             """apt-get update -q -y &&\
@@ -366,7 +373,7 @@ trait CliLaunchers extends SbtModule { self =>
     def launcherKind = "mostly-static"
     def nativeImageDockerParams = T {
       val baseDockerParams = NativeImage.linuxMostlyStaticParams(
-        "ubuntu:18.04", // TODO Pin that
+        s"ubuntu:$ubuntuVersion",
         s"https://github.com/coursier/coursier/releases/download/v${deps.csDockerVersion}/cs-x86_64-pc-linux.gz"
       )
       val dockerParams = setupLocaleAndOptions(baseDockerParams)

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -242,7 +242,7 @@ trait CliLaunchers extends SbtModule { self =>
         cs,
         "get",
         "--archive",
-        "https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip"
+        s"https://download.libsodium.org/libsodium/releases/libsodium-$libsodiumVersion-stable-msvc.zip"
       ).call()
       val dir = os.Path(dirRes.out.trim(), os.pwd)
       os.copy.over(


### PR DESCRIPTION
- bumps used Ubuntu docker images to `ubuntu:24.04`
- pins Alpine & `libsodium` versions properly
- updates `alpine` to 3.16 
- we can't update `alpine` any higher without adding `.conda` support to `coursier-cache` (but we don't really need to at the moment)