### PR TITLE
Introduce source generator directives

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -919,6 +919,9 @@ object Build {
     val semanticDbSourceRoot =
       options.scalaOptions.semanticDbOptions.semanticDbSourceRoot.getOrElse(inputs.workspace)
 
+    val sourceGenerators =
+      options.sourceGeneratorOptions.configs.values.toList.filter(_.command.nonEmpty)
+
     val scalaCompilerParamsOpt = artifacts.scalaOpt match {
       case Some(scalaArtifacts) =>
         val params = value(options.scalaParams).getOrElse {
@@ -1056,7 +1059,8 @@ object Build {
       resourceDirs = sources.resourceDirs,
       scope = scope,
       javaHomeOpt = Option(options.javaHomeLocation().value),
-      javacOptions = javacOptions.toList
+      javacOptions = javacOptions.toList,
+      generators = Some(sourceGenerators).filter(_.nonEmpty)
     )
     project
   }

--- a/modules/build/src/main/scala/scala/build/preprocessing/directives/DirectivesPreprocessingUtils.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/directives/DirectivesPreprocessingUtils.scala
@@ -31,6 +31,7 @@ object DirectivesPreprocessingUtils {
       directives.ScalaJs.handler,
       directives.ScalaNative.handler,
       directives.ScalaVersion.handler,
+      directives.SourceGenerator.handler,
       directives.Sources.handler,
       directives.Tests.handler
     ).map(_.mapE(_.buildOptions))

--- a/modules/core/src/main/scala/scala/build/errors/UnnamedKeyError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/UnnamedKeyError.scala
@@ -1,0 +1,6 @@
+package scala.build.errors
+
+import scala.build.Position
+
+final class UnnamedKeyError(val key: String)
+    extends BuildException(s"Expected key $key to be named")

--- a/modules/directives/src/main/scala/scala/build/errors/NotADirectoryError.scala
+++ b/modules/directives/src/main/scala/scala/build/errors/NotADirectoryError.scala
@@ -1,0 +1,9 @@
+package scala.build.errors
+
+import scala.build.Position
+
+class NotADirectoryError(path: String, positions: Seq[Position])
+    extends BuildException(
+      message = s"Expected a directory at '$path'".stripMargin,
+      positions = positions
+    )

--- a/modules/directives/src/main/scala/scala/build/errors/NotAFileError.scala
+++ b/modules/directives/src/main/scala/scala/build/errors/NotAFileError.scala
@@ -1,0 +1,9 @@
+package scala.build.errors
+
+import scala.build.Position
+
+class NotAFileError(path: String, positions: Seq[Position])
+    extends BuildException(
+      message = s"Expected a file at '$path'".stripMargin,
+      positions = positions
+    )

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/DirectiveHandler.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/DirectiveHandler.scala
@@ -4,7 +4,6 @@ import com.virtuslab.using_directives.custom.model.{EmptyValue, Value}
 
 import java.util.Locale
 
-import scala.build.Logger
 import scala.build.Ops.*
 import scala.build.directives.*
 import scala.build.errors.{
@@ -16,6 +15,7 @@ import scala.build.errors.{
   UsingDirectiveWrongValueTypeError
 }
 import scala.build.preprocessing.Scoped
+import scala.build.{Logger, Named}
 import scala.cli.commands.SpecificationLevel
 import scala.deriving.*
 import scala.quoted.{_, given}
@@ -105,8 +105,11 @@ object DirectiveHandler {
         w.init.mkString :: pascalCaseSplit(w.last :: tail)
     }
 
+  private def excludeNamed(s: String): String =
+    Named.fromKey(s).value
+
   def normalizeName(s: String): String = {
-    val elems = s.split('-')
+    val elems = excludeNamed(s).split('-')
     (elems.head +: elems.tail.map(_.capitalize)).mkString
   }
 

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/SourceGenerator.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/SourceGenerator.scala
@@ -1,0 +1,114 @@
+package scala.build.preprocessing.directives
+
+import java.nio.file.Paths
+
+import scala.build.EitherCps.{either, value}
+import scala.build.Ops.*
+import scala.build.directives.*
+import scala.build.errors.{
+  BuildException,
+  CompositeBuildException,
+  NotADirectoryError,
+  NotAFileError,
+  WrongSourcePathError
+}
+import scala.build.options.{
+  BuildOptions,
+  InternalOptions,
+  SourceGeneratorConfig,
+  SourceGeneratorOptions
+}
+import scala.build.preprocessing.ScopePath
+import scala.build.{Named, Positioned}
+import scala.cli.commands.SpecificationLevel
+import scala.util.Try
+
+@DirectiveGroupName("Source generators")
+@DirectivePrefix("sourceGenerator.")
+@DirectiveExamples("//> using sourceGenerator.[hello].input ${.}/in")
+@DirectiveExamples("//> using sourceGenerator.[hello].output ${.}/out")
+@DirectiveExamples("//> using sourceGenerator.[hello].glob *.txt")
+@DirectiveExamples("//> using sourceGenerator.[hello].command python ${.}/gen/hello.py")
+@DirectiveExamples("//> using sourceGenerator.[hello].unmanaged ${.}/gen/hello.py")
+@DirectiveUsage(
+  """using sourceGenerator.[name].input <directory>
+    |using sourceGenerator.[name].output <directory>
+    |using sourceGenerator.[name].glob <globs>
+    |using sourceGenerator.[name].command <command>
+    |using sourceGenerator.[name].unmanaged <files>
+    |""".stripMargin,
+  """`//> using sourceGenerator.[`_name_`].input` _directory_
+    |
+    |`//> using sourceGenerator.[`_name_`].output` _directory_
+    |
+    |`//> using sourceGenerator.[`_name_`].glob` _glob_
+    |
+    |`//> using sourceGenerator.[`_name_`].globs` _glob1_ _glob2_ …
+    |
+    |`//> using sourceGenerator.[`_name_`].command` _command_
+    |
+    |`//> using sourceGenerator.[`_name_`].unmanaged` _file_
+    |
+    |`//> using sourceGenerator.[`_name_`].unmanaged` _file1_ _file2_ …
+    |
+    |""".stripMargin
+)
+@DirectiveDescription("Configure source generators")
+@DirectiveLevel(SpecificationLevel.EXPERIMENTAL)
+final case class SourceGenerator(
+  command: Named[List[String]] = Named.none(Nil),
+  input: Named[DirectiveValueParser.WithScopePath[Option[Positioned[String]]]] =
+    Named.none(DirectiveValueParser.WithScopePath.empty(None)),
+  output: Named[DirectiveValueParser.WithScopePath[Option[Positioned[String]]]] =
+    Named.none(DirectiveValueParser.WithScopePath.empty(None)),
+  @DirectiveName("globs")
+  glob: Named[List[String]] = Named.none(Nil),
+  unmanaged: Named[DirectiveValueParser.WithScopePath[List[Positioned[String]]]] =
+    Named.none(DirectiveValueParser.WithScopePath.empty(Nil))
+) extends HasBuildOptions {
+
+  private def resolve(cwd: ScopePath, s: Positioned[String]): Either[BuildException, os.Path] =
+    for {
+      root <- Directive.osRoot(cwd, s.positions.headOption)
+      res <- Try(os.Path(s.value, root)).toEither
+        .left.map(new WrongSourcePathError(s.value, _, s.positions))
+    } yield res
+
+  private def resolveDir(
+    path: DirectiveValueParser.WithScopePath[Option[Positioned[String]]]
+  ): Either[BuildException, Option[os.Path]] =
+    path.value.map { s =>
+      resolve(path.scopePath, s)
+        .filterOrElse(os.isDir(_), new NotADirectoryError(s.value, s.positions))
+    }.sequence
+
+  private def resolveFiles(
+    path: DirectiveValueParser.WithScopePath[List[Positioned[String]]]
+  ): Either[BuildException, List[os.Path]] =
+    path.value.map { s =>
+      resolve(path.scopePath, s)
+        .filterOrElse(os.isFile(_), new NotAFileError(s.value, s.positions))
+    }.sequence
+      .left.map(CompositeBuildException(_))
+      .map(_.toList)
+
+  def buildOptions: Either[BuildException, BuildOptions] = either {
+    val configs =
+      Seq[Named[SourceGeneratorConfig]](
+        command.map(v => SourceGeneratorConfig(command = v)),
+        input.map(v => SourceGeneratorConfig(inputDir = value(resolveDir(v)))),
+        output.map(v => SourceGeneratorConfig(outputDir = value(resolveDir(v)))),
+        glob.map(v => SourceGeneratorConfig(glob = v)),
+        unmanaged.map(v => SourceGeneratorConfig(unmanaged = value(resolveFiles(v))))
+      ).flatten.toMap
+
+    val options =
+      BuildOptions(sourceGeneratorOptions = SourceGeneratorOptions(configs = configs))
+
+    options
+  }
+}
+
+object SourceGenerator {
+  val handler: DirectiveHandler[SourceGenerator] = DirectiveHandler.derive
+}

--- a/modules/options/src/main/scala/scala/build/Named.scala
+++ b/modules/options/src/main/scala/scala/build/Named.scala
@@ -1,0 +1,34 @@
+package scala.build
+
+import scala.util.matching.Regex
+
+final case class Named[+T](
+  name: Option[String],
+  value: T
+) {
+  def map[U](f: T => U): Named[U] =
+    copy(value = f(value))
+
+  def entry: Option[(String, T)] =
+    name.map(n => n -> value)
+}
+
+object Named {
+  private val NameRegex: Regex = "^\\[\\w+\\]$".r
+
+  def apply[T](name: String, value: T): Named[T] = Named(Some(name), value)
+
+  def none[T](value: T): Named[T] =
+    Named(None, value)
+
+  given [T]: Conversion[Named[T], IterableOnce[(String, T)]] =
+    named => named.entry
+
+  def fromKey(key: String): Named[String] = {
+    val parts = key.split('.')
+    val name  = parts.find(NameRegex.matches)
+    val rest  = parts.filterNot(name.contains)
+
+    Named(name, rest.mkString("."))
+  }
+}

--- a/modules/options/src/main/scala/scala/build/options/SourceGeneratorConfig.scala
+++ b/modules/options/src/main/scala/scala/build/options/SourceGeneratorConfig.scala
@@ -1,0 +1,13 @@
+package scala.build.options
+
+final case class SourceGeneratorConfig(
+  inputDir: Option[os.Path] = None,
+  outputDir: Option[os.Path] = None,
+  unmanaged: List[os.Path] = Nil,
+  glob: List[String] = Nil,
+  command: List[String] = Nil
+)
+
+object SourceGeneratorConfig {
+  implicit val monoid: ConfigMonoid[SourceGeneratorConfig] = ConfigMonoid.derive
+}

--- a/modules/options/src/main/scala/scala/build/options/SourceGeneratorOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/SourceGeneratorOptions.scala
@@ -3,7 +3,8 @@ package scala.build.options
 final case class SourceGeneratorOptions(
   useBuildInfo: Option[Boolean] = None,
   projectVersion: Option[String] = None,
-  computeVersion: Option[ComputeVersion] = None
+  computeVersion: Option[ComputeVersion] = None,
+  configs: Map[String, SourceGeneratorConfig] = Map.empty
 )
 
 object SourceGeneratorOptions {

--- a/modules/options/src/test/scala/scala/build/options/ConfigMonoidTest.scala
+++ b/modules/options/src/test/scala/scala/build/options/ConfigMonoidTest.scala
@@ -3,7 +3,8 @@ package scala.build.options
 case class Inner(
   foo: Boolean = false,
   bar: Seq[String] = Nil,
-  baz: Set[Double] = Set()
+  baz: Set[Double] = Set(),
+  qux: Map[String, Boolean] = Map()
 )
 
 object Inner {
@@ -53,5 +54,17 @@ class ConfigMonoidTest extends munit.FunSuite {
     assertEquals(Outer.monoid.orElse(outer1, outer2).name, Some("o1"))
     assertEquals(Outer.monoid.orElse(outer2, outer1).name, Some("o2"))
 
+  }
+
+  test("Merging maps") {
+    val inner1 = Inner(qux = Map("k1" -> false, "k3" -> true))
+    val inner2 = Inner(qux = Map("k2" -> true, "k3" -> false))
+
+    assertEquals(Map("k1" -> false, "k3" -> true), Inner.monoid.orElse(inner1, Inner()).qux)
+    assertEquals(Map("k2" -> true, "k3" -> false), Inner.monoid.orElse(inner2, Inner()).qux)
+    assertEquals(
+      Map("k1" -> false, "k2" -> true, "k3" -> true),
+      Inner.monoid.orElse(inner1, inner2).qux
+    )
   }
 }

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -416,6 +416,37 @@ Add Scala.js options
 #### Examples
 `//> using jsModuleKind common`
 
+### Source generators
+
+Configure source generators
+
+`//> using sourceGenerator.[`_name_`].input` _directory_
+
+`//> using sourceGenerator.[`_name_`].output` _directory_
+
+`//> using sourceGenerator.[`_name_`].glob` _glob_
+
+`//> using sourceGenerator.[`_name_`].globs` _glob1_ _glob2_ …
+
+`//> using sourceGenerator.[`_name_`].command` _command_
+
+`//> using sourceGenerator.[`_name_`].unmanaged` _file_
+
+`//> using sourceGenerator.[`_name_`].unmanaged` _file1_ _file2_ …
+
+
+
+#### Examples
+`//> using sourceGenerator.[hello].input ${.}/in`
+
+`//> using sourceGenerator.[hello].output ${.}/out`
+
+`//> using sourceGenerator.[hello].glob *.txt`
+
+`//> using sourceGenerator.[hello].command python ${.}/gen/hello.py`
+
+`//> using sourceGenerator.[hello].unmanaged ${.}/gen/hello.py`
+
 ### Test framework
 
 Set the test framework


### PR DESCRIPTION
This PR aims to add support for source generators in scala-cli, addressing #610 and providing an alternative approach to https://github.com/VirtusLab/scala-cli/pull/3033.

Source generators can be configured using "named" directives. This allows for multiple generators to be configured independently and provides a clean way to specify inputs, outputs, and other parameters.

The approach can be further improved to include standard predefined generators (ex: scalapb, smithy4s), which would require only minimal configuration.

## Features

- Named source generator configurations using the new `[name]` syntax
- Arbitrary command execution with cached results
- Support for both relative and absolute paths
- Input and output location defaults to the current directory if not specified

## Example

```scala
//> using sourceGenerator.[hello].input     in
//> using sourceGenerator.[hello].output    out
//> using sourceGenerator.[hello].glob      *.txt
//> using sourceGenerator.[hello].command   python ${.}/hello.py
//> using sourceGenerator.[hello].unmanaged hello.py
```

A full example showcasing all possibilities can be found [here](https://github.com/Mee-Tree/scala-cli-sourcegen).

## Known Issues

- Execution order for multiple generators is undefined
- Incremental compilation is not working
- No tests
- Metals triggers the generator multiple times on save
- Metals doesn't work with the scalapb generator in the full example (likely due to the generator's source code being in the same project)


Please let me know if you have feedback about this implementation or any of the known issues.