### PR TITLE
Add tests for the current behaviour of `--cross`

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestsDefault.scala
@@ -1,4 +1,15 @@
 package scala.cli.integration
 
 class CompileTestsDefault extends CompileTestDefinitions with CompileTests3StableDefinitions
-    with TestDefault
+    with TestDefault {
+  test(
+    s"compile --cross $actualScalaVersion with ${Constants.scala213} and ${Constants.scala212}"
+  ) {
+    val crossVersions = Seq(actualScalaVersion, Constants.scala213, Constants.scala212)
+    simpleInputs
+      .add(os.rel / "project.scala" -> s"//> using scala ${crossVersions.mkString(" ")}")
+      .fromRoot { root =>
+        os.proc(TestUtil.cli, "compile", ".", "--cross", "--power", extraOptions).call(cwd = root)
+      }
+  }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -1356,59 +1356,20 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
       packageDescription = packageOpts.headOption.getOrElse("bootstrap")
     } {
       test(s"package with main method in test scope ($packageDescription)") {
-        val mainClass         = "TestScopeMain"
-        val testScopeFileName = s"$mainClass.test.scala"
-        val message           = "Hello"
-        val outputFile        = mainClass + extension
-        TestInputs(
-          os.rel / "Messages.scala" -> s"""object Messages { val msg = "$message" }""",
-          os.rel / testScopeFileName -> s"""object $mainClass extends App { println(Messages.msg) }"""
-        ).fromRoot { root =>
-          os.proc(
-            TestUtil.cli,
-            "--power",
-            "package",
-            "--test",
-            extraOptions,
-            ".",
-            packageOpts
-          )
-            .call(cwd = root)
-          val outputFilePath = root / outputFile
-          expect(os.isFile(outputFilePath))
-          val output =
-            if (packageDescription == libraryArg)
-              os.proc(TestUtil.cli, "run", outputFilePath).call(cwd = root).out.trim()
-            else if (packageDescription == jsArg)
-              os.proc(node, outputFilePath).call(cwd = root).out.trim()
-            else {
-              expect(Files.isExecutable(outputFilePath.toNIO))
-              TestUtil.maybeUseBash(outputFilePath)(cwd = root).out.trim()
-            }
-          expect(output == message)
-        }
-      }
-
-      if (actualScalaVersion == Constants.scala3Next)
-        test(s"package ($packageDescription, --cross)") {
-          val crossDirective =
-            s"//> using scala $actualScalaVersion ${Constants.scala213} ${Constants.scala212}"
-          val mainClass  = "TestScopeMain"
-          val mainFile   = s"$mainClass.scala"
-          val message    = "Hello"
-          val outputFile = mainClass + extension
+        TestUtil.retryOnCi() {
+          val mainClass         = "TestScopeMain"
+          val testScopeFileName = s"$mainClass.test.scala"
+          val message           = "Hello"
+          val outputFile        = mainClass + extension
           TestInputs(
-            os.rel / "Messages.scala" ->
-              s"""$crossDirective
-                 |object Messages { val msg = "$message" }""".stripMargin,
-            os.rel / mainFile ->
-              s"""object $mainClass extends App { println(Messages.msg) }""".stripMargin
+            os.rel / "Messages.scala" -> s"""object Messages { val msg = "$message" }""",
+            os.rel / testScopeFileName -> s"""object $mainClass extends App { println(Messages.msg) }"""
           ).fromRoot { root =>
             os.proc(
               TestUtil.cli,
               "--power",
               "package",
-              "--cross",
+              "--test",
               extraOptions,
               ".",
               packageOpts
@@ -1426,6 +1387,49 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
                 TestUtil.maybeUseBash(outputFilePath)(cwd = root).out.trim()
               }
             expect(output == message)
+          }
+        }
+      }
+
+      if (actualScalaVersion == Constants.scala3Next)
+        test(s"package ($packageDescription, --cross)") {
+          TestUtil.retryOnCi() {
+            val crossDirective =
+              s"//> using scala $actualScalaVersion ${Constants.scala213} ${Constants.scala212}"
+            val mainClass  = "TestScopeMain"
+            val mainFile   = s"$mainClass.scala"
+            val message    = "Hello"
+            val outputFile = mainClass + extension
+            TestInputs(
+              os.rel / "Messages.scala" ->
+                s"""$crossDirective
+                   |object Messages { val msg = "$message" }""".stripMargin,
+              os.rel / mainFile ->
+                s"""object $mainClass extends App { println(Messages.msg) }""".stripMargin
+            ).fromRoot { root =>
+              os.proc(
+                TestUtil.cli,
+                "--power",
+                "package",
+                "--cross",
+                extraOptions,
+                ".",
+                packageOpts
+              )
+                .call(cwd = root)
+              val outputFilePath = root / outputFile
+              expect(os.isFile(outputFilePath))
+              val output =
+                if (packageDescription == libraryArg)
+                  os.proc(TestUtil.cli, "run", outputFilePath).call(cwd = root).out.trim()
+                else if (packageDescription == jsArg)
+                  os.proc(node, outputFilePath).call(cwd = root).out.trim()
+                else {
+                  expect(Files.isExecutable(outputFilePath.toNIO))
+                  TestUtil.maybeUseBash(outputFilePath)(cwd = root).out.trim()
+                }
+              expect(output == message)
+            }
           }
         }
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishLocalTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishLocalTestsDefault.scala
@@ -1,3 +1,50 @@
 package scala.cli.integration
 
-class PublishLocalTestsDefault extends PublishLocalTestDefinitions with TestDefault
+import com.eed3si9n.expecty.Expecty.expect
+
+class PublishLocalTestsDefault extends PublishLocalTestDefinitions with TestDefault {
+  test(
+    s"publish local --cross $actualScalaVersion with ${Constants.scala213} and ${Constants.scala212}"
+  ) {
+    val expectedMessage = "Hello"
+    val crossVersions   = Seq(actualScalaVersion, Constants.scala213, Constants.scala212)
+    PublishTestInputs.inputs(message = expectedMessage, crossVersions = Some(crossVersions))
+      .fromRoot { root =>
+        os.proc(
+          TestUtil.cli,
+          "--power",
+          "publish",
+          "local",
+          ".",
+          extraOptions,
+          "--cross"
+        )
+          .call(cwd = root)
+        def publishedDep(scalaVersionSuffix: String) =
+          s"${PublishTestInputs.testOrg}:${PublishTestInputs.testName}_$scalaVersionSuffix:$testPublishVersion"
+        val r3 =
+          os.proc(TestUtil.cli, "run", "--dep", publishedDep("3"), extraOptions).call(cwd = root)
+        expect(r3.out.trim() == expectedMessage)
+        val r213 = os.proc(
+          TestUtil.cli,
+          "run",
+          "--dep",
+          publishedDep("2.13"),
+          "-S",
+          Constants.scala213,
+          extraOptions
+        ).call(cwd = root)
+        expect(r213.out.trim() == expectedMessage)
+        val r212 = os.proc(
+          TestUtil.cli,
+          "run",
+          "--dep",
+          publishedDep("2.12"),
+          "-S",
+          Constants.scala212,
+          extraOptions
+        ).call(cwd = root)
+        expect(r212.out.trim() == expectedMessage)
+      }
+  }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
@@ -162,27 +162,29 @@ class RunTestsDefault extends RunTestDefinitions
     test(
       s"run --cross $platformDesc $actualScalaVersion, ${Constants.scala213} and ${Constants.scala212} ($scopeDesc scope)"
     ) {
-      TestInputs {
-        os.rel / fileName ->
-          s"""//> using scala $actualScalaVersion ${Constants.scala213} ${Constants.scala212}
-             |object Main extends App {
-             |  println("$expectedMessage")
-             |}
-             |""".stripMargin
-      }.fromRoot { root =>
-        val r =
-          os.proc(
-            TestUtil.cli,
-            "run",
-            ".",
-            "--cross",
-            "--power",
-            extraOptions,
-            scopeOptions,
-            platformOptions
-          )
-            .call(cwd = root)
-        expect(r.out.trim() == expectedMessage)
+      TestUtil.retryOnCi() {
+        TestInputs {
+          os.rel / fileName ->
+            s"""//> using scala $actualScalaVersion ${Constants.scala213} ${Constants.scala212}
+               |object Main extends App {
+               |  println("$expectedMessage")
+               |}
+               |""".stripMargin
+        }.fromRoot { root =>
+          val r =
+            os.proc(
+              TestUtil.cli,
+              "run",
+              ".",
+              "--cross",
+              "--power",
+              extraOptions,
+              scopeOptions,
+              platformOptions
+            )
+              .call(cwd = root)
+          expect(r.out.trim() == expectedMessage)
+        }
       }
     }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -12,7 +12,7 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
     if (actualScalaVersion.startsWith("3.")) Seq("--jvm", "11")
     else Nil
   protected lazy val baseExtraOptions: Seq[String] = TestUtil.extraOptions ++ jvmOptions
-  private lazy val extraOptions: Seq[String]       = scalaVersionArgs ++ baseExtraOptions
+  protected lazy val extraOptions: Seq[String]     = scalaVersionArgs ++ baseExtraOptions
 
   private val utestVersion = "0.8.3"
 


### PR DESCRIPTION
This adds missing, rudimentary tests for the workings of the (still experimental) `--cross` command line option with various Scala CLI sub-commands which support it.
- `run` cross-compiles against provided versions, but only runs the first of them, as per #3590 
- `test` runs tests for each of the cross-compiled versions
- `package` cross-compiles against provided versions, but only packages for the first of them, as per https://github.com/VirtusLab/scala-cli/issues/3591
- `publish` and `publish local` actually cross-publish for each of the provided versions.

Adding these tests to prevent changing these behaviours by accident, as I did in https://github.com/VirtusLab/scala-cli/pull/3538