### PR TITLE
Run `test` sub-command integration tests on default JVM settings

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -7,14 +7,8 @@ import scala.cli.integration.Constants.munitVersion
 
 abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
   _: TestScalaVersion =>
-  protected val jvmOptions: Seq[String] =
-    // seems munit requires this with Scala 3
-    if (actualScalaVersion.startsWith("3.")) Seq("--jvm", "11")
-    else Nil
-  protected lazy val baseExtraOptions: Seq[String] = TestUtil.extraOptions ++ jvmOptions
-  private lazy val extraOptions: Seq[String]       = scalaVersionArgs ++ baseExtraOptions
-
-  private val utestVersion = "0.8.3"
+  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
+  private val utestVersion                     = "0.8.3"
 
   def successfulTestInputs(directivesString: String =
     s"//> using dep org.scalameta::munit::$munitVersion"): TestInputs = TestInputs(

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
@@ -32,11 +32,11 @@ class TestTestsDefault extends TestTestDefinitions with TestDefault {
     )
 
     inputs.fromRoot { root =>
-      val compileRes = os.proc(TestUtil.cli, "compile", "--print-class-path", baseExtraOptions, ".")
+      val compileRes = os.proc(TestUtil.cli, "compile", "--print-class-path", extraOptions, ".")
         .call(cwd = root)
       val cp = compileRes.out.trim().split(File.pathSeparator)
       expect(cp.length == 1) // only class dir, no scala JARs
-      os.proc(TestUtil.cli, "test", baseExtraOptions, ".")
+      os.proc(TestUtil.cli, "test", extraOptions, ".")
         .call(cwd = root, stdout = os.Inherit)
     }
   }


### PR DESCRIPTION
`munit` should handle Java 17 by now, I think.