### PR TITLE
Add missing `using` directive reference docs

### DIFF
--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Benchmarking.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Benchmarking.scala
@@ -16,6 +16,8 @@ import scala.build.{Positioned, options}
 import scala.cli.commands.SpecificationLevel
 
 @DirectiveGroupName("Benchmarking options")
+@DirectiveExamples(s"//> using jmh")
+@DirectiveExamples(s"//> using jmh true")
 @DirectiveExamples(s"//> using jmhVersion ${Constants.jmhVersion}")
 @DirectiveUsage(
   "//> using jmh _value_ | using jmhVersion _value_",

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ComputeVersion.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ComputeVersion.scala
@@ -22,11 +22,8 @@ import scala.cli.commands.SpecificationLevel
 @DirectiveUsage("//> using computeVersion git:tag", "`//> using computeVersion` _method_")
 @DirectiveDescription("Method used to compute the version for BuildInfo")
 @DirectiveLevel(SpecificationLevel.RESTRICTED)
-// format: off
-final case class ComputeVersion(
-    computeVersion: Option[Positioned[String]] = None
-) extends HasBuildOptions {
-  // format: on
+final case class ComputeVersion(computeVersion: Option[Positioned[String]] = None)
+    extends HasBuildOptions {
 
   def buildOptions: Either[BuildException, BuildOptions] = either {
     BuildOptions(

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/CustomJar.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/CustomJar.scala
@@ -26,8 +26,16 @@ import scala.util.{Failure, Success, Try}
 @DirectiveUsage(
   "`//> using jar `_path_ | `//> using jars `_path1_ _path2_ …",
   """`//> using jar` _path_
-    |
     |`//> using jars` _path1_ _path2_ …
+    |
+    |`//> using test.jar` _path_
+    |`//> using test.jars` _path1_ _path2_ …
+    |
+    |`//> using source.jar` _path_
+    |`//> using source.jars` _path1_ _path2_ …
+    |
+    |`//> using test.source.jar` _path_
+    |`//> using test.source.jars` _path1_ _path2_ …
     |""".stripMargin
 )
 @DirectiveDescription("Manually add JAR(s) to the class path")

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Dependency.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Dependency.scala
@@ -19,17 +19,35 @@ import scala.build.preprocessing.directives.DirectiveUtil.*
 import scala.cli.commands.SpecificationLevel
 
 @DirectiveExamples("//> using dep com.lihaoyi::os-lib:0.9.1")
+@DirectiveExamples(
+  "//> using dep tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar"
+)
 @DirectiveExamples("//> using test.dep org.scalatest::scalatest:3.2.10")
 @DirectiveExamples("//> using test.dep org.scalameta::munit:0.7.29")
 @DirectiveExamples(
   "//> using compileOnly.dep com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:2.23.2"
 )
 @DirectiveExamples(
-  "//> using dep tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar"
+  "//> using scalafix.dep com.github.xuwei-k::scalafix-rules:0.5.1"
 )
 @DirectiveUsage(
   "//> using dep org:name:ver | //> using deps org:name:ver org2:name2:ver2",
-  "`//> using dep` _org_`:`name`:`ver"
+  """`//> using dep` _org_`:`name`:`ver
+    |`//> using deps` _org_`:`name`:`ver _org_`:`name`:`ver
+    |`//> using dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
+    |
+    |`//> using test.dep` _org_`:`name`:`ver
+    |`//> using test.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+    |`//> using test.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
+    |
+    |`//> using compileOnly.dep` _org_`:`name`:`ver
+    |`//> using compileOnly.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+    |`//> using compileOnly.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
+    |
+    |`//> using scalafix.dep` _org_`:`name`:`ver
+    |`//> using scalafix.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+    |`//> using scalafix.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
+    |""".stripMargin
 )
 @DirectiveDescription("Add dependencies")
 @DirectiveLevel(SpecificationLevel.MUST)

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Exclude.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Exclude.scala
@@ -22,11 +22,7 @@ import scala.util.Try
 )
 @DirectiveDescription("Exclude sources from the project")
 @DirectiveLevel(SpecificationLevel.SHOULD)
-// format: off
-final case class Exclude(
-  exclude: List[Positioned[String]] = Nil
-) extends HasBuildOptions {
-// format: on
+final case class Exclude(exclude: List[Positioned[String]] = Nil) extends HasBuildOptions {
   def buildOptions: Either[BuildException, BuildOptions] = either {
     BuildOptions(
       internal = InternalOptions(

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavaHome.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavaHome.scala
@@ -16,12 +16,10 @@ import scala.util.Try
 )
 @DirectiveDescription("Sets Java home used to run your application or tests")
 @DirectiveLevel(SpecificationLevel.SHOULD)
-// format: off
 final case class JavaHome(
   javaHome: DirectiveValueParser.WithScopePath[Option[Positioned[String]]] =
     DirectiveValueParser.WithScopePath.empty(None)
 ) extends HasBuildOptions {
-  // format: on
   def buildOptions: Either[BuildException, BuildOptions] = either {
     javaHome.value match {
       case None => BuildOptions()

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavaOptions.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavaOptions.scala
@@ -12,7 +12,12 @@ import scala.cli.commands.SpecificationLevel
 @DirectiveExamples("//> using test.javaOpt -Dsomething=a")
 @DirectiveUsage(
   "//> using javaOpt _options_",
-  "`//> using javaOpt` _options_"
+  """`//> using javaOpt` _options_
+    |`//> using javaOptions` _options_`
+    |
+    |`//> using test.javaOpt` _options_
+    |`//> using test.javaOptions` _options_`
+    |""".stripMargin
 )
 @DirectiveDescription("Add Java options which will be passed when running an application.")
 @DirectiveLevel(SpecificationLevel.MUST)

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavaProps.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavaProps.scala
@@ -14,8 +14,10 @@ import scala.cli.commands.SpecificationLevel
 @DirectiveUsage(
   "//> using javaProp _key=val_",
   """`//> using javaProp` _key=value_
-    |
     |`//> using javaProp` _key_
+    |
+    |`//> using test.javaProp` _key=value_
+    |`//> using test.javaProp` _key_
     |""".stripMargin
 )
 @DirectiveDescription("Add Java properties")

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavacOptions.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavacOptions.scala
@@ -12,7 +12,12 @@ import scala.cli.commands.SpecificationLevel
 @DirectiveExamples("//> using test.javacOpt -source 1.8 -target 1.8")
 @DirectiveUsage(
   "//> using javacOpt _options_",
-  "`//> using javacOpt` _options_"
+  """`//> using javacOpt` _options_
+    |`//> using javacOptions` _options_
+    |
+    |`//> using test.javacOpt` _options_
+    |`//> using test.javacOptions` _options_
+    |""".stripMargin
 )
 @DirectiveDescription("Add Javac options which will be passed when compiling sources.")
 @DirectiveLevel(SpecificationLevel.SHOULD)

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Jvm.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Jvm.scala
@@ -19,11 +19,7 @@ import scala.cli.commands.SpecificationLevel
     "scala-cli uses [coursier](https://get-coursier.io/) to fetch JVMs, so you can use `cs java --available` to list the available JVMs."
 )
 @DirectiveLevel(SpecificationLevel.SHOULD)
-// format: off
-final case class Jvm(
-  jvm: Option[Positioned[String]] = None
-) extends HasBuildOptions {
-  // format: on
+final case class Jvm(jvm: Option[Positioned[String]] = None) extends HasBuildOptions {
   def buildOptions: Either[BuildException, BuildOptions] = {
     val buildOpt = BuildOptions(
       javaOptions = options.JavaOptions(

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/MainClass.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/MainClass.scala
@@ -14,17 +14,9 @@ import scala.cli.commands.SpecificationLevel
 )
 @DirectiveDescription("Specify default main class")
 @DirectiveLevel(SpecificationLevel.MUST)
-// format: off
-final case class MainClass(
-  mainClass: Option[String] = None
-) extends HasBuildOptions {
-  // format: on
-  def buildOptions: Either[BuildException, BuildOptions] = {
-    val buildOpt = BuildOptions(
-      mainClass = mainClass
-    )
-    Right(buildOpt)
-  }
+final case class MainClass(mainClass: Option[String] = None) extends HasBuildOptions {
+  def buildOptions: Either[BuildException, BuildOptions] =
+    Right(BuildOptions(mainClass = mainClass))
 }
 
 object MainClass {

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Packaging.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Packaging.scala
@@ -21,8 +21,13 @@ import scala.cli.commands.SpecificationLevel
 @DirectiveExamples("//> using packaging.packageType assembly")
 @DirectiveExamples("//> using packaging.output foo")
 @DirectiveExamples("//> using packaging.provided org.apache.spark::spark-sql")
-@DirectiveExamples("//> using packaging.dockerFrom openjdk:11")
 @DirectiveExamples("//> using packaging.graalvmArgs --no-fallback")
+@DirectiveExamples("//> using packaging.dockerFrom openjdk:11")
+@DirectiveExamples("//> using packaging.dockerImageTag 1.0.0")
+@DirectiveExamples("//> using packaging.dockerImageRegistry virtuslab")
+@DirectiveExamples("//> using packaging.dockerImageRepository scala-cli")
+@DirectiveExamples("//> using packaging.dockerCmd sh")
+@DirectiveExamples("//> using packaging.dockerCmd node")
 @DirectiveUsage(
   """using packaging.packageType [package type]
     |using packaging.output [destination path]
@@ -32,10 +37,25 @@ import scala.cli.commands.SpecificationLevel
     |using packaging.dockerImageTag [image tag]
     |using packaging.dockerImageRegistry [image registry]
     |using packaging.dockerImageRepository [image repository]
+    |using packaging.dockerCmd [docker command]
     |""".stripMargin,
   """`//> using packaging.packageType` _package-type_
     |
     |`//> using packaging.output` _destination-path_
+    |
+    |`//> using packaging.provided` _module_
+    |
+    |`//> using packaging.graalvmArgs` _args_
+    |
+    |`//> using packaging.dockerFrom` _base-docker-image_
+    |
+    |`//> using packaging.dockerImageTag` _image-tag_
+    |
+    |`//> using packaging.dockerImageRegistry` _image-registry_
+    |
+    |`//> using packaging.dockerImageRepository` _image-repository_
+    |
+    |`//> using packaging.dockerCmd` _docker-command_
     |
     |""".stripMargin
 )

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Packaging.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Packaging.scala
@@ -61,7 +61,6 @@ import scala.cli.commands.SpecificationLevel
 )
 @DirectiveDescription("Set parameters for packaging")
 @DirectiveLevel(SpecificationLevel.RESTRICTED)
-// format: off
 final case class Packaging(
   packageType: Option[Positioned[String]] = None,
   output: Option[String] = None,
@@ -73,7 +72,6 @@ final case class Packaging(
   dockerImageRepository: Option[String] = None,
   dockerCmd: Option[String] = None
 ) extends HasBuildOptions {
-  // format: on
   def buildOptions: Either[BuildException, BuildOptions] = either {
     val maybePackageTypeOpt = packageType
       .map { input =>

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Platform.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Platform.scala
@@ -21,10 +21,12 @@ import scala.cli.commands.SpecificationLevel
 
 @DirectiveGroupName("Platform")
 @DirectiveExamples("//> using platform scala-js")
-@DirectiveExamples("//> using platform jvm scala-native")
+@DirectiveExamples("//> using platforms jvm scala-native")
 @DirectiveUsage(
   "//> using platform (jvm|scala-js|js|scala-native|native)+",
-  "`//> using platform` (`jvm`|`scala-js`|`js`|`scala-native`|`native`)+"
+  """`//> using platform` (`jvm`|`scala-js`|`js`|`scala-native`|`native`)+
+    |`//> using platforms` (`jvm`|`scala-js`|`js`|`scala-native`|`native`)+
+    |""".stripMargin
 )
 @DirectiveDescription("Set the default platform to Scala.js or Scala Native")
 @DirectiveLevel(SpecificationLevel.SHOULD)

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Platform.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Platform.scala
@@ -30,12 +30,10 @@ import scala.cli.commands.SpecificationLevel
 )
 @DirectiveDescription("Set the default platform to Scala.js or Scala Native")
 @DirectiveLevel(SpecificationLevel.SHOULD)
-// format: off
 final case class Platform(
   @DirectiveName("platform")
-    platforms: List[Positioned[String]] = Nil
+  platforms: List[Positioned[String]] = Nil
 ) extends HasBuildOptions {
-  // format: on
 
   private def split(input: String): (String, Option[String]) = {
     val idx = input.indexOf(':')

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Publish.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Publish.scala
@@ -13,14 +13,47 @@ import scala.cli.commands.SpecificationLevel
 @DirectivePrefix("publish.")
 @DirectiveExamples("//> using publish.organization io.github.myself")
 @DirectiveExamples("//> using publish.name my-library")
+@DirectiveExamples("//> using publish.moduleName scala-cli_3")
 @DirectiveExamples("//> using publish.version 0.1.1")
+@DirectiveExamples("//> using publish.url https://github.com/VirtusLab/scala-cli")
+@DirectiveExamples("//> using publish.license MIT")
+@DirectiveExamples("//> using publish.vcs https://github.com/VirtusLab/scala-cli.git")
+@DirectiveExamples("//> using publish.vcs github:VirtusLab/scala-cli")
+@DirectiveExamples("//> using publish.description \"Lorem ipsum dolor sit amet\"")
+@DirectiveExamples("//> using publish.developer alexme|Alex Me|https://alex.me")
+@DirectiveExamples(
+  "//> using publish.developers alexme|Alex Me|https://alex.me Gedochao|Gedo Chao|https://github.com/Gedochao"
+)
+@DirectiveExamples("//> using publish.scalaVersionSuffix _2.13")
+@DirectiveExamples("//> using publish.scalaVersionSuffix _3")
+@DirectiveExamples("//> using publish.scalaPlatformSuffix _sjs1")
+@DirectiveExamples("//> using publish.scalaPlatformSuffix _native0.4")
 @DirectiveUsage(
-  "//> using publish.(organization|name|version) [value]",
+  "//> using publish.[key] [value]",
   """`//> using publish.organization` value
     |
     |`//> using publish.name` value
     |
+    |`//> using publish.moduleName` value
+    |
     |`//> using publish.version` value
+    |
+    |`//> using publish.url` value
+    |
+    |`//> using publish.license` value
+    |
+    |`//> using publish.vcs` value
+    |`//> using publish.scm` value
+    |`//> using publish.versionControl` value
+    |
+    |`//> using publish.description` value
+    |
+    |`//> using publish.developer` value
+    |`//> using publish.developers` value1 value2
+    |
+    |`//> using publish.scalaVersionSuffix` value
+    |
+    |`//> using publish.scalaPlatformSuffix` value
     |
     |""".stripMargin
 )

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Publish.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Publish.scala
@@ -59,7 +59,6 @@ import scala.cli.commands.SpecificationLevel
 )
 @DirectiveDescription("Set parameters for publishing")
 @DirectiveLevel(SpecificationLevel.EXPERIMENTAL)
-// format: off
 final case class Publish(
   organization: Option[Positioned[String]] = None,
   name: Option[Positioned[String]] = None,
@@ -69,14 +68,13 @@ final case class Publish(
   license: Option[Positioned[String]] = None,
   @DirectiveName("scm")
   @DirectiveName("versionControl")
-    vcs: Option[Positioned[String]] = None,
+  vcs: Option[Positioned[String]] = None,
   description: Option[String] = None,
   @DirectiveName("developer")
-    developers: List[Positioned[String]] = Nil,
+  developers: List[Positioned[String]] = Nil,
   scalaVersionSuffix: Option[String] = None,
   scalaPlatformSuffix: Option[String] = None
 ) extends HasBuildOptions {
-  // format: on
   def buildOptions: Either[BuildException, BuildOptions] = either {
 
     val maybeLicense = license

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Repository.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Repository.scala
@@ -19,12 +19,10 @@ import scala.cli.commands.SpecificationLevel
 )
 @DirectiveDescription(Repository.usageMsg)
 @DirectiveLevel(SpecificationLevel.SHOULD)
-// format: off
 final case class Repository(
   @DirectiveName("repository")
-    repositories: List[String] = Nil
+  repositories: List[String] = Nil
 ) extends HasBuildOptions {
-  // format: on
   def buildOptions: Either[BuildException, BuildOptions] = {
     val buildOpt = BuildOptions(
       classPathOptions = ClassPathOptions(

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/RequirePlatform.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/RequirePlatform.scala
@@ -18,12 +18,10 @@ import scala.cli.commands.SpecificationLevel
   "`//> using target.platform` _platform_"
 )
 @DirectiveLevel(SpecificationLevel.EXPERIMENTAL)
-// format: off
 final case class RequirePlatform(
   @DirectiveName("platform")
-    platforms: List[Positioned[String]] = Nil
+  platforms: List[Positioned[String]] = Nil
 ) extends HasBuildRequirements {
-  // format: on
   def buildRequirements: Either[BuildException, BuildRequirements] = either {
     val platformSet = value {
       Platform.parseSpec(platforms.map(_.value).map(options.Platform.normalize)).toRight {

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Resources.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Resources.scala
@@ -15,8 +15,12 @@ import scala.cli.commands.SpecificationLevel
     |
     |//> using resourceDirs _path1_ _path2_ …""".stripMargin,
   """`//> using resourceDir` _path_
+    |`//> using resourceDirs` _path1_ _path2_ …
     |
-    |`//> using resourceDirs` _path1_ _path2_ …""".stripMargin
+    |`//> using test.resourceDir` _path_
+    |`//> using test.resourceDirs` _path1_ _path2_ …
+    |
+    |""".stripMargin
 )
 @DirectiveDescription("Manually add a resource directory to the class path")
 @DirectiveLevel(SpecificationLevel.SHOULD)

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaJs.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaJs.scala
@@ -6,13 +6,29 @@ import scala.build.EitherCps.{either, value}
 import scala.build.Ops.EitherOptOps
 import scala.build.directives.*
 import scala.build.errors.BuildException
+import scala.build.internal.Constants
 import scala.build.options.{BuildOptions, ScalaJsMode, ScalaJsOptions}
 import scala.build.{Positioned, options}
 import scala.cli.commands.SpecificationLevel
 import scala.util.Try
 
 @DirectiveGroupName("Scala.js options")
+@DirectiveExamples(s"//> using jsVersion ${Constants.scalaJsVersion}")
+@DirectiveExamples("//> using jsMode mode")
+@DirectiveExamples("//> using jsNoOpt")
 @DirectiveExamples("//> using jsModuleKind common")
+@DirectiveExamples("//> using jsCheckIr")
+@DirectiveExamples("//> using jsEmitSourceMaps")
+@DirectiveExamples("//> using jsEsModuleImportMap importmap.json")
+@DirectiveExamples("//> using jsSmallModuleForPackage test")
+@DirectiveExamples("//> using jsDom")
+@DirectiveExamples("//> using jsHeader \"#!/usr/bin/env node\n\"")
+@DirectiveExamples("//> using jsAllowBigIntsForLongs")
+@DirectiveExamples("//> using jsAvoidClasses")
+@DirectiveExamples("//> using jsAvoidLetsAndConsts")
+@DirectiveExamples("//> using jsModuleSplitStyleStr smallestmodules")
+@DirectiveExamples("//> using jsEsVersionStr es2017")
+@DirectiveExamples("//> using jsEmitWasm")
 @DirectiveUsage(
   "//> using jsVersion|jsMode|jsModuleKind|… _value_",
   """
@@ -21,32 +37,40 @@ import scala.util.Try
     |`//> using jsMode` _value_
     |
     |`//> using jsNoOpt` _true|false_
+    |`//> using jsNoOpt`
     |
     |`//> using jsModuleKind` _value_
     |
-    |`//> using jsSmallModuleForPackage` _value1_ _value2_ …
-    |
     |`//> using jsCheckIr` _true|false_
+    |`//> using jsCheckIr`
     |
     |`//> using jsEmitSourceMaps` _true|false_
+    |`//> using jsEmitSourceMaps`
+    |
+    |`//> using jsEsModuleImportMap` _value_
+    |
+    |`//> using jsSmallModuleForPackage` _value1_ _value2_ …
     |
     |`//> using jsDom` _true|false_
+    |`//> using jsDom`
     |
     |`//> using jsHeader` _value_
     |
     |`//> using jsAllowBigIntsForLongs` _true|false_
+    |`//> using jsAllowBigIntsForLongs`
     |
     |`//> using jsAvoidClasses` _true|false_
+    |`//> using jsAvoidClasses`
     |
     |`//> using jsAvoidLetsAndConsts` _true|false_
+    |`//> using jsAvoidLetsAndConsts`
     |
     |`//> using jsModuleSplitStyleStr` _value_
     |
     |`//> using jsEsVersionStr` _value_
     |    
     |`//> using jsEmitWasm` _true|false_
-    |
-    |`//> using jsEsModuleImportMap` _value_
+    |`//> using jsEmitWasm`
     |""".stripMargin
 )
 @DirectiveDescription("Add Scala.js options")

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaJs.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaJs.scala
@@ -75,7 +75,6 @@ import scala.util.Try
 )
 @DirectiveDescription("Add Scala.js options")
 @DirectiveLevel(SpecificationLevel.SHOULD)
-// format: off
 final case class ScalaJs(
   jsVersion: Option[String] = None,
   jsMode: Option[String] = None,
@@ -94,7 +93,6 @@ final case class ScalaJs(
   jsEsVersionStr: Option[String] = None,
   jsEmitWasm: Option[Boolean] = None
 ) extends HasBuildOptions {
-  // format: on
   def buildOptions: Either[BuildException, BuildOptions] =
     val scalaJsOptions = ScalaJsOptions(
       version = jsVersion,

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaNative.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaNative.scala
@@ -2,12 +2,25 @@ package scala.build.preprocessing.directives
 
 import scala.build.directives.*
 import scala.build.errors.BuildException
+import scala.build.internal.Constants
 import scala.build.options.{BuildOptions, ScalaNativeOptions}
 import scala.build.{Positioned, options}
 import scala.cli.commands.SpecificationLevel
 
 @DirectiveGroupName("Scala Native options")
-@DirectiveExamples("//> using nativeVersion 0.4.0")
+@DirectiveExamples(s"//> using nativeGc immix")
+@DirectiveExamples(s"//> using nativeMode debug")
+@DirectiveExamples(s"//> using nativeLto full")
+@DirectiveExamples(s"//> using nativeVersion ${Constants.scalaNativeVersion}")
+@DirectiveExamples(s"//> using nativeCompile -flto=thin")
+@DirectiveExamples(s"//> using nativeLinking -flto=thin")
+@DirectiveExamples(s"//> using nativeClang ./clang")
+@DirectiveExamples(s"//> using nativeClangPP ./clang++")
+@DirectiveExamples(s"//> using nativeEmbedResources")
+@DirectiveExamples(s"//> using nativeEmbedResources true")
+@DirectiveExamples(s"//> using nativeTarget library-dynamic")
+@DirectiveExamples(s"//> using nativeMultithreading")
+@DirectiveExamples(s"//> using nativeMultithreading false")
 @DirectiveUsage(
   "//> using nativeGc _value_ | using native-version _value_",
   """`//> using nativeGc` **immix**_|commix|boehm|none_
@@ -25,10 +38,15 @@ import scala.cli.commands.SpecificationLevel
     |`//> using nativeClang` _value_
     |
     |`//> using nativeClangPP` _value_
+    |`//> using nativeClangPp` _value_
     |
     |`//> using nativeEmbedResources` _true|false_
+    |`//> using nativeEmbedResources`
     |
     |`//> using nativeTarget` _application|library-dynamic|library-static_
+    |
+    |`//> using nativeMultithreading` _true|false_
+    |`//> using nativeMultithreading`
     """.stripMargin.trim
 )
 @DirectiveDescription("Add Scala Native options")

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaNative.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaNative.scala
@@ -51,7 +51,6 @@ import scala.cli.commands.SpecificationLevel
 )
 @DirectiveDescription("Add Scala Native options")
 @DirectiveLevel(SpecificationLevel.SHOULD)
-// format: off
 final case class ScalaNative(
   nativeGc: Option[String] = None,
   nativeMode: Option[String] = None,
@@ -61,12 +60,11 @@ final case class ScalaNative(
   nativeLinking: List[String] = Nil,
   nativeClang: Option[String] = None,
   @DirectiveName("nativeClangPp")
-    nativeClangPP: Option[String] = None,
+  nativeClangPP: Option[String] = None,
   nativeEmbedResources: Option[Boolean] = None,
   nativeTarget: Option[String] = None,
   nativeMultithreading: Option[Boolean] = None
 ) extends HasBuildOptions {
-  // format: on
   def buildOptions: Either[BuildException, BuildOptions] = {
     val nativeOptions = ScalaNativeOptions(
       gcStr = nativeGc,

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaVersion.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaVersion.scala
@@ -17,11 +17,9 @@ import scala.cli.commands.SpecificationLevel
 )
 @DirectiveDescription("Set the default Scala version")
 @DirectiveLevel(SpecificationLevel.MUST)
-// format: off
 final case class ScalaVersion(
   scala: List[DirectiveValueParser.MaybeNumericalString] = Nil
 ) extends HasBuildOptions {
-  // format: on
   def buildOptions: Either[BuildException, BuildOptions] =
     scala match {
       case Nil => Right(BuildOptions())

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalacOptions.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalacOptions.scala
@@ -16,21 +16,33 @@ import scala.cli.commands.SpecificationLevel
 
 @DirectiveGroupName("Compiler options")
 @DirectiveExamples("//> using option -Xasync")
-@DirectiveExamples("//> using test.option -Xasync")
 @DirectiveExamples("//> using options -Xasync -Xfatal-warnings")
+@DirectiveExamples("//> using test.option -Xasync")
+@DirectiveExamples("//> using test.options -Xasync -Xfatal-warnings")
 @DirectiveUsage(
   "using option _option_ | using options _option1_ _option2_ …",
-  """`//> using option` _option_
+  """`//> using scalacOption` _option_
+    |`//> using option` _option_
+    |`//> using scalacOptions` _option1_ _option2_ …
+    |`//> using options` _option1_ _option2_ …
     |
-    |`//> using options` _option1_ _option2_ …""".stripMargin
+    |`//> using test.scalacOption` _option_
+    |`//> using test.option` _option_
+    |`//> using test.scalacOptions` _option1_ _option2_ …
+    |`//> using test.options` _option1_ _option2_ …
+    |
+    |""".stripMargin
 )
 @DirectiveDescription("Add Scala compiler options")
 @DirectiveLevel(SpecificationLevel.MUST)
 final case class ScalacOptions(
   @DirectiveName("option")
+  @DirectiveName("scalacOption")
+  @DirectiveName("scalacOptions")
   options: List[Positioned[String]] = Nil,
   @DirectiveName("test.option")
   @DirectiveName("test.options")
+  @DirectiveName("test.scalacOption")
   @DirectiveName("test.scalacOptions")
   testOptions: List[Positioned[String]] = Nil
 ) extends HasBuildOptionsWithRequirements {

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Sources.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Sources.scala
@@ -22,13 +22,11 @@ import scala.util.Try
   "Manually add sources to the project. Does not support chaining, sources are added only once, not recursively."
 )
 @DirectiveLevel(SpecificationLevel.SHOULD)
-// format: off
 final case class Sources(
   @DirectiveName("file")
-    files: DirectiveValueParser.WithScopePath[List[Positioned[String]]] =
-      DirectiveValueParser.WithScopePath.empty(Nil)
+  files: DirectiveValueParser.WithScopePath[List[Positioned[String]]] =
+    DirectiveValueParser.WithScopePath.empty(Nil)
 ) extends HasBuildOptions {
-  // format: on
   def buildOptions: Either[BuildException, BuildOptions] = either {
 
     val paths = files

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Tests.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Tests.scala
@@ -14,12 +14,10 @@ import scala.cli.commands.SpecificationLevel
 )
 @DirectiveDescription("Set the test framework")
 @DirectiveLevel(SpecificationLevel.SHOULD)
-// format: off
 final case class Tests(
   @DirectiveName("test.framework")
   testFramework: Option[String] = None
 ) extends HasBuildOptions {
-  // format: on
   def buildOptions: Either[BuildException, BuildOptions] = {
     val buildOpt = BuildOptions(
       testOptions = TestOptions(

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Toolkit.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Toolkit.scala
@@ -13,12 +13,15 @@ import scala.build.options.*
 import scala.cli.commands.SpecificationLevel
 
 @DirectiveGroupName("Toolkit")
-@DirectiveExamples("//> using toolkit 0.1.0")
+@DirectiveExamples(s"//> using toolkit ${Constants.toolkitDefaultVersion}")
 @DirectiveExamples("//> using toolkit default")
 @DirectiveExamples("//> using test.toolkit default")
 @DirectiveUsage(
   "//> using toolkit _version_",
-  "`//> using toolkit` _version_"
+  """`//> using toolkit` _version_
+    |
+    |//> using test.toolkit` _version_
+    |""".stripMargin
 )
 @DirectiveDescription(
   s"Use a toolkit as dependency (not supported in Scala 2.12), 'default' version for Scala toolkit: ${Constants.toolkitDefaultVersion}, 'default' version for typelevel toolkit: ${Constants.typelevelToolkitDefaultVersion}"

--- a/website/docs/commands/package.md
+++ b/website/docs/commands/package.md
@@ -525,3 +525,12 @@ The using directive allows you to define the image repository.
 ```scala compile power
 //> using packaging.dockerImageRepository scala-cli
 ```
+
+#### packaging.dockerCmd
+
+The using directive allows you to override the executable used to run the application in docker, 
+otherwise it defaults to `sh` for the JVM platform and `node` for the JS platform
+
+```scala compile power
+//> using packaging.dockerCmd node
+```

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -29,16 +29,26 @@ Generate BuildInfo for project
 
 Add Scala compiler options
 
+`//> using scalacOption` _option_
 `//> using option` _option_
-
+`//> using scalacOptions` _option1_ _option2_ …
 `//> using options` _option1_ _option2_ …
+
+`//> using test.scalacOption` _option_
+`//> using test.option` _option_
+`//> using test.scalacOptions` _option1_ _option2_ …
+`//> using test.options` _option1_ _option2_ …
+
+
 
 #### Examples
 `//> using option -Xasync`
 
+`//> using options -Xasync -Xfatal-warnings`
+
 `//> using test.option -Xasync`
 
-`//> using options -Xasync -Xfatal-warnings`
+`//> using test.options -Xasync -Xfatal-warnings`
 
 ### Compiler plugins
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -67,8 +67,16 @@ Method used to compute the version for BuildInfo
 Manually add JAR(s) to the class path
 
 `//> using jar` _path_
-
 `//> using jars` _path1_ _path2_ …
+
+`//> using test.jar` _path_
+`//> using test.jars` _path1_ _path2_ …
+
+`//> using source.jar` _path_
+`//> using source.jars` _path1_ _path2_ …
+
+`//> using test.source.jar` _path_
+`//> using test.source.jars` _path1_ _path2_ …
 
 
 #### Examples

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -14,6 +14,10 @@ Add benchmarking options
 `//> using jmhVersion` _value_
 
 #### Examples
+`//> using jmh`
+
+`//> using jmh true`
+
 `//> using jmhVersion 1.37`
 
 ### BuildInfo

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -195,8 +195,10 @@ Add Java options which will be passed when running an application.
 Add Java properties
 
 `//> using javaProp` _key=value_
-
 `//> using javaProp` _key_
+
+`//> using test.javaProp` _key=value_
+`//> using test.javaProp` _key_
 
 
 #### Examples

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -248,6 +248,20 @@ Set parameters for packaging
 
 `//> using packaging.output` _destination-path_
 
+`//> using packaging.provided` _module_
+
+`//> using packaging.graalvmArgs` _args_
+
+`//> using packaging.dockerFrom` _base-docker-image_
+
+`//> using packaging.dockerImageTag` _image-tag_
+
+`//> using packaging.dockerImageRegistry` _image-registry_
+
+`//> using packaging.dockerImageRepository` _image-repository_
+
+`//> using packaging.dockerCmd` _docker-command_
+
 
 
 #### Examples
@@ -257,9 +271,19 @@ Set parameters for packaging
 
 `//> using packaging.provided org.apache.spark::spark-sql`
 
+`//> using packaging.graalvmArgs --no-fallback`
+
 `//> using packaging.dockerFrom openjdk:11`
 
-`//> using packaging.graalvmArgs --no-fallback`
+`//> using packaging.dockerImageTag 1.0.0`
+
+`//> using packaging.dockerImageRegistry virtuslab`
+
+`//> using packaging.dockerImageRepository scala-cli`
+
+`//> using packaging.dockerCmd sh`
+
+`//> using packaging.dockerCmd node`
 
 ### Platform
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -204,6 +204,11 @@ Add Java properties
 Add Javac options which will be passed when compiling sources.
 
 `//> using javacOpt` _options_
+`//> using javacOptions` _options_
+
+`//> using test.javacOpt` _options_
+`//> using test.javacOptions` _options_
+
 
 #### Examples
 `//> using javacOpt -source 1.8 -target 1.8`

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -99,9 +99,26 @@ Manually add sources to the project. Does not support chaining, sources are adde
 Add dependencies
 
 `//> using dep` _org_`:`name`:`ver
+`//> using deps` _org_`:`name`:`ver _org_`:`name`:`ver
+`//> using dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
+
+`//> using test.dep` _org_`:`name`:`ver
+`//> using test.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+`//> using test.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
+
+`//> using compileOnly.dep` _org_`:`name`:`ver
+`//> using compileOnly.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+`//> using compileOnly.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
+
+`//> using scalafix.dep` _org_`:`name`:`ver
+`//> using scalafix.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+`//> using scalafix.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
+
 
 #### Examples
 `//> using dep com.lihaoyi::os-lib:0.9.1`
+
+`//> using dep tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar`
 
 `//> using test.dep org.scalatest::scalatest:3.2.10`
 
@@ -109,7 +126,7 @@ Add dependencies
 
 `//> using compileOnly.dep com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:2.23.2`
 
-`//> using dep tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar`
+`//> using scalafix.dep com.github.xuwei-k::scalafix-rules:0.5.1`
 
 ### Exclude sources
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -290,11 +290,13 @@ Set parameters for packaging
 Set the default platform to Scala.js or Scala Native
 
 `//> using platform` (`jvm`|`scala-js`|`js`|`scala-native`|`native`)+
+`//> using platforms` (`jvm`|`scala-js`|`js`|`scala-native`|`native`)+
+
 
 #### Examples
 `//> using platform scala-js`
 
-`//> using platform jvm scala-native`
+`//> using platforms jvm scala-native`
 
 ### Publish
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -474,13 +474,42 @@ Add Scala Native options
 `//> using nativeClang` _value_
 
 `//> using nativeClangPP` _value_
+`//> using nativeClangPp` _value_
 
 `//> using nativeEmbedResources` _true|false_
+`//> using nativeEmbedResources`
 
 `//> using nativeTarget` _application|library-dynamic|library-static_
 
+`//> using nativeMultithreading` _true|false_
+`//> using nativeMultithreading`
+
 #### Examples
-`//> using nativeVersion 0.4.0`
+`//> using nativeGc immix`
+
+`//> using nativeMode debug`
+
+`//> using nativeLto full`
+
+`//> using nativeVersion 0.5.7`
+
+`//> using nativeCompile -flto=thin`
+
+`//> using nativeLinking -flto=thin`
+
+`//> using nativeClang ./clang`
+
+`//> using nativeClangPP ./clang++`
+
+`//> using nativeEmbedResources`
+
+`//> using nativeEmbedResources true`
+
+`//> using nativeTarget library-dynamic`
+
+`//> using nativeMultithreading`
+
+`//> using nativeMultithreading false`
 
 ### Scala version
 
@@ -592,8 +621,11 @@ Use a toolkit as dependency (not supported in Scala 2.12), 'default' version for
 
 `//> using toolkit` _version_
 
+//> using test.toolkit` _version_
+
+
 #### Examples
-`//> using toolkit 0.1.0`
+`//> using toolkit 0.7.0`
 
 `//> using toolkit default`
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -507,36 +507,75 @@ Add Scala.js options
 `//> using jsMode` _value_
 
 `//> using jsNoOpt` _true|false_
+`//> using jsNoOpt`
 
 `//> using jsModuleKind` _value_
 
-`//> using jsSmallModuleForPackage` _value1_ _value2_ …
-
 `//> using jsCheckIr` _true|false_
+`//> using jsCheckIr`
 
 `//> using jsEmitSourceMaps` _true|false_
+`//> using jsEmitSourceMaps`
+
+`//> using jsEsModuleImportMap` _value_
+
+`//> using jsSmallModuleForPackage` _value1_ _value2_ …
 
 `//> using jsDom` _true|false_
+`//> using jsDom`
 
 `//> using jsHeader` _value_
 
 `//> using jsAllowBigIntsForLongs` _true|false_
+`//> using jsAllowBigIntsForLongs`
 
 `//> using jsAvoidClasses` _true|false_
+`//> using jsAvoidClasses`
 
 `//> using jsAvoidLetsAndConsts` _true|false_
+`//> using jsAvoidLetsAndConsts`
 
 `//> using jsModuleSplitStyleStr` _value_
 
 `//> using jsEsVersionStr` _value_
     
 `//> using jsEmitWasm` _true|false_
-
-`//> using jsEsModuleImportMap` _value_
+`//> using jsEmitWasm`
 
 
 #### Examples
+`//> using jsVersion 1.18.2`
+
+`//> using jsMode mode`
+
+`//> using jsNoOpt`
+
 `//> using jsModuleKind common`
+
+`//> using jsCheckIr`
+
+`//> using jsEmitSourceMaps`
+
+`//> using jsEsModuleImportMap importmap.json`
+
+`//> using jsSmallModuleForPackage test`
+
+`//> using jsDom`
+
+`//> using jsHeader "#!/usr/bin/env node
+"`
+
+`//> using jsAllowBigIntsForLongs`
+
+`//> using jsAvoidClasses`
+
+`//> using jsAvoidLetsAndConsts`
+
+`//> using jsModuleSplitStyleStr smallestmodules`
+
+`//> using jsEsVersionStr es2017`
+
+`//> using jsEmitWasm`
 
 ### Test framework
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -179,6 +179,11 @@ Sets Java home used to run your application or tests
 Add Java options which will be passed when running an application.
 
 `//> using javaOpt` _options_
+`//> using javaOptions` _options_`
+
+`//> using test.javaOpt` _options_
+`//> using test.javaOptions` _options_`
+
 
 #### Examples
 `//> using javaOpt -Xmx2g -Dsomething=a`

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -433,8 +433,12 @@ Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`
 Manually add a resource directory to the class path
 
 `//> using resourceDir` _path_
-
 `//> using resourceDirs` _path1_ _path2_ …
+
+`//> using test.resourceDir` _path_
+`//> using test.resourceDirs` _path1_ _path2_ …
+
+
 
 #### Examples
 `//> using resourceDir ./resources`

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -243,7 +243,26 @@ Set parameters for publishing
 
 `//> using publish.name` value
 
+`//> using publish.moduleName` value
+
 `//> using publish.version` value
+
+`//> using publish.url` value
+
+`//> using publish.license` value
+
+`//> using publish.vcs` value
+`//> using publish.scm` value
+`//> using publish.versionControl` value
+
+`//> using publish.description` value
+
+`//> using publish.developer` value
+`//> using publish.developers` value1 value2
+
+`//> using publish.scalaVersionSuffix` value
+
+`//> using publish.scalaPlatformSuffix` value
 
 
 
@@ -252,7 +271,31 @@ Set parameters for publishing
 
 `//> using publish.name my-library`
 
+`//> using publish.moduleName scala-cli_3`
+
 `//> using publish.version 0.1.1`
+
+`//> using publish.url https://github.com/VirtusLab/scala-cli`
+
+`//> using publish.license MIT`
+
+`//> using publish.vcs https://github.com/VirtusLab/scala-cli.git`
+
+`//> using publish.vcs github:VirtusLab/scala-cli`
+
+`//> using publish.description "Lorem ipsum dolor sit amet"`
+
+`//> using publish.developer alexme|Alex Me|https://alex.me`
+
+`//> using publish.developers alexme|Alex Me|https://alex.me Gedochao|Gedo Chao|https://github.com/Gedochao`
+
+`//> using publish.scalaVersionSuffix _2.13`
+
+`//> using publish.scalaVersionSuffix _3`
+
+`//> using publish.scalaPlatformSuffix _sjs1`
+
+`//> using publish.scalaPlatformSuffix _native0.4`
 
 ### Publish (CI)
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -297,13 +297,42 @@ Add Scala Native options
 `//> using nativeClang` _value_
 
 `//> using nativeClangPP` _value_
+`//> using nativeClangPp` _value_
 
 `//> using nativeEmbedResources` _true|false_
+`//> using nativeEmbedResources`
 
 `//> using nativeTarget` _application|library-dynamic|library-static_
 
+`//> using nativeMultithreading` _true|false_
+`//> using nativeMultithreading`
+
 #### Examples
-`//> using nativeVersion 0.4.0`
+`//> using nativeGc immix`
+
+`//> using nativeMode debug`
+
+`//> using nativeLto full`
+
+`//> using nativeVersion 0.5.7`
+
+`//> using nativeCompile -flto=thin`
+
+`//> using nativeLinking -flto=thin`
+
+`//> using nativeClang ./clang`
+
+`//> using nativeClangPP ./clang++`
+
+`//> using nativeEmbedResources`
+
+`//> using nativeEmbedResources true`
+
+`//> using nativeTarget library-dynamic`
+
+`//> using nativeMultithreading`
+
+`//> using nativeMultithreading false`
 
 ### Scala.js options
 
@@ -400,8 +429,11 @@ Use a toolkit as dependency (not supported in Scala 2.12), 'default' version for
 
 `//> using toolkit` _version_
 
+//> using test.toolkit` _version_
+
+
 #### Examples
-`//> using toolkit 0.1.0`
+`//> using toolkit 0.7.0`
 
 `//> using toolkit default`
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -226,11 +226,13 @@ Add Javac options which will be passed when compiling sources.
 Set the default platform to Scala.js or Scala Native
 
 `//> using platform` (`jvm`|`scala-js`|`js`|`scala-native`|`native`)+
+`//> using platforms` (`jvm`|`scala-js`|`js`|`scala-native`|`native`)+
+
 
 #### Examples
 `//> using platform scala-js`
 
-`//> using platform jvm scala-native`
+`//> using platforms jvm scala-native`
 
 ### Repository
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -90,8 +90,10 @@ Add Java options which will be passed when running an application.
 Add Java properties
 
 `//> using javaProp` _key=value_
-
 `//> using javaProp` _key_
+
+`//> using test.javaProp` _key=value_
+`//> using test.javaProp` _key_
 
 
 #### Examples

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -125,8 +125,16 @@ Set the default Scala version
 Manually add JAR(s) to the class path
 
 `//> using jar` _path_
-
 `//> using jars` _path1_ _path2_ …
+
+`//> using test.jar` _path_
+`//> using test.jars` _path1_ _path2_ …
+
+`//> using source.jar` _path_
+`//> using source.jars` _path1_ _path2_ …
+
+`//> using test.source.jar` _path_
+`//> using test.source.jars` _path1_ _path2_ …
 
 
 #### Examples

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -203,6 +203,11 @@ Sets Java home used to run your application or tests
 Add Javac options which will be passed when compiling sources.
 
 `//> using javacOpt` _options_
+`//> using javacOptions` _options_
+
+`//> using test.javacOpt` _options_
+`//> using test.javacOptions` _options_
+
 
 #### Examples
 `//> using javacOpt -source 1.8 -target 1.8`

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -15,16 +15,26 @@ Documentation is split into sections in the spirit of RFC keywords (`MUST`, `SHO
 
 Add Scala compiler options
 
+`//> using scalacOption` _option_
 `//> using option` _option_
-
+`//> using scalacOptions` _option1_ _option2_ …
 `//> using options` _option1_ _option2_ …
+
+`//> using test.scalacOption` _option_
+`//> using test.option` _option_
+`//> using test.scalacOptions` _option1_ _option2_ …
+`//> using test.options` _option1_ _option2_ …
+
+
 
 #### Examples
 `//> using option -Xasync`
 
+`//> using options -Xasync -Xfatal-warnings`
+
 `//> using test.option -Xasync`
 
-`//> using options -Xasync -Xfatal-warnings`
+`//> using test.options -Xasync -Xfatal-warnings`
 
 ### Compiler plugins
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -256,8 +256,12 @@ Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`
 Manually add a resource directory to the class path
 
 `//> using resourceDir` _path_
-
 `//> using resourceDirs` _path1_ _path2_ …
+
+`//> using test.resourceDir` _path_
+`//> using test.resourceDirs` _path1_ _path2_ …
+
+
 
 #### Examples
 `//> using resourceDir ./resources`

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -40,9 +40,26 @@ Adds compiler plugins
 Add dependencies
 
 `//> using dep` _org_`:`name`:`ver
+`//> using deps` _org_`:`name`:`ver _org_`:`name`:`ver
+`//> using dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
+
+`//> using test.dep` _org_`:`name`:`ver
+`//> using test.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+`//> using test.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
+
+`//> using compileOnly.dep` _org_`:`name`:`ver
+`//> using compileOnly.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+`//> using compileOnly.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
+
+`//> using scalafix.dep` _org_`:`name`:`ver
+`//> using scalafix.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+`//> using scalafix.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
+
 
 #### Examples
 `//> using dep com.lihaoyi::os-lib:0.9.1`
+
+`//> using dep tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar`
 
 `//> using test.dep org.scalatest::scalatest:3.2.10`
 
@@ -50,7 +67,7 @@ Add dependencies
 
 `//> using compileOnly.dep com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:2.23.2`
 
-`//> using dep tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar`
+`//> using scalafix.dep com.github.xuwei-k::scalafix-rules:0.5.1`
 
 ### Java options
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -74,6 +74,11 @@ Add dependencies
 Add Java options which will be passed when running an application.
 
 `//> using javaOpt` _options_
+`//> using javaOptions` _options_`
+
+`//> using test.javaOpt` _options_
+`//> using test.javaOptions` _options_`
+
 
 #### Examples
 `//> using javaOpt -Xmx2g -Dsomething=a`

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -315,36 +315,75 @@ Add Scala.js options
 `//> using jsMode` _value_
 
 `//> using jsNoOpt` _true|false_
+`//> using jsNoOpt`
 
 `//> using jsModuleKind` _value_
 
-`//> using jsSmallModuleForPackage` _value1_ _value2_ …
-
 `//> using jsCheckIr` _true|false_
+`//> using jsCheckIr`
 
 `//> using jsEmitSourceMaps` _true|false_
+`//> using jsEmitSourceMaps`
+
+`//> using jsEsModuleImportMap` _value_
+
+`//> using jsSmallModuleForPackage` _value1_ _value2_ …
 
 `//> using jsDom` _true|false_
+`//> using jsDom`
 
 `//> using jsHeader` _value_
 
 `//> using jsAllowBigIntsForLongs` _true|false_
+`//> using jsAllowBigIntsForLongs`
 
 `//> using jsAvoidClasses` _true|false_
+`//> using jsAvoidClasses`
 
 `//> using jsAvoidLetsAndConsts` _true|false_
+`//> using jsAvoidLetsAndConsts`
 
 `//> using jsModuleSplitStyleStr` _value_
 
 `//> using jsEsVersionStr` _value_
     
 `//> using jsEmitWasm` _true|false_
-
-`//> using jsEsModuleImportMap` _value_
+`//> using jsEmitWasm`
 
 
 #### Examples
+`//> using jsVersion 1.18.2`
+
+`//> using jsMode mode`
+
+`//> using jsNoOpt`
+
 `//> using jsModuleKind common`
+
+`//> using jsCheckIr`
+
+`//> using jsEmitSourceMaps`
+
+`//> using jsEsModuleImportMap importmap.json`
+
+`//> using jsSmallModuleForPackage test`
+
+`//> using jsDom`
+
+`//> using jsHeader "#!/usr/bin/env node
+"`
+
+`//> using jsAllowBigIntsForLongs`
+
+`//> using jsAvoidClasses`
+
+`//> using jsAvoidLetsAndConsts`
+
+`//> using jsModuleSplitStyleStr smallestmodules`
+
+`//> using jsEsVersionStr es2017`
+
+`//> using jsEmitWasm`
 
 ### Test framework
 


### PR DESCRIPTION
Fixes #3247 

- adds missing examples and syntax in various `using` directives' reference docs
- fixes inconsistent formatting in directives' definitions
- cleans the mess up a lil' bit here and there

Special thanks to @scarf005 and @yadavan88 for reminding me this needs to be cleaned up.