### PR TITLE
Fix `fmt` to format the `project.scala` configuration file as any other Scala input

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/fmt/Fmt.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/fmt/Fmt.scala
@@ -4,7 +4,7 @@ import caseapp.*
 import caseapp.core.help.HelpFormat
 import dependency.*
 
-import scala.build.input.{Inputs, Script, SourceScalaFile}
+import scala.build.input.{Inputs, ProjectScalaFile, Script, SourceScalaFile}
 import scala.build.internal.{Constants, ExternalBinaryParams, FetchExternalBinary, Runner}
 import scala.build.options.BuildOptions
 import scala.build.{Logger, Sources}
@@ -44,14 +44,11 @@ object Fmt extends ScalaCommand[FmtOptions] {
 
     // TODO If no input is given, just pass '.' to scalafmt?
     val (sourceFiles, workspace, _) =
-      if (args.all.isEmpty)
-        (Seq(os.pwd), os.pwd, None)
+      if args.all.isEmpty then (Seq(os.pwd), os.pwd, None)
       else {
         val i = options.shared.inputs(args.all).orExit(logger)
-        val s = i.sourceFiles().collect {
-          case sc: Script          => sc.path
-          case sc: SourceScalaFile => sc.path
-        }
+        type FormattableSourceFile = Script | SourceScalaFile | ProjectScalaFile
+        val s = i.sourceFiles().collect { case sc: FormattableSourceFile => sc.path }
         (s, i.workspace, Some(i))
       }
     CurrentParams.workspaceOpt = Some(workspace)

--- a/modules/integration/src/test/scala/scala/cli/integration/FmtTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FmtTests.scala
@@ -216,4 +216,20 @@ class FmtTests extends ScalaCliSuite {
       expect(fmtVersionHelp.contains(s"(${Constants.defaultScalafmtVersion} by default)"))
     }
   }
+
+  test("project.scala gets formatted correctly, as any other input") {
+    val projectFileName = "project.scala"
+    TestInputs(
+      os.rel / projectFileName -> simpleInputsUnformattedContent,
+      os.rel / confFileName ->
+        s"""|version = "${Constants.defaultScalafmtVersion}"
+            |runner.dialect = scala3
+            |""".stripMargin
+    )
+      .fromRoot { root =>
+        os.proc(TestUtil.cli, "fmt", ".").call(cwd = root)
+        val updatedContent = noCrLf(os.read(root / projectFileName))
+        expect(updatedContent == expectedSimpleInputsFormattedContent)
+      }
+  }
 }


### PR DESCRIPTION
It seems `fmt` has been skipping over `project.scala` while formatting.