### PR TITLE
Fix formatting in directives' reference docs

### DIFF
--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/CustomJar.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/CustomJar.scala
@@ -26,15 +26,19 @@ import scala.util.{Failure, Success, Try}
 @DirectiveUsage(
   "`//> using jar `_path_ | `//> using jars `_path1_ _path2_ …",
   """`//> using jar` _path_
+    |
     |`//> using jars` _path1_ _path2_ …
     |
     |`//> using test.jar` _path_
+    |
     |`//> using test.jars` _path1_ _path2_ …
     |
     |`//> using source.jar` _path_
+    |
     |`//> using source.jars` _path1_ _path2_ …
     |
     |`//> using test.source.jar` _path_
+    |
     |`//> using test.source.jars` _path1_ _path2_ …
     |""".stripMargin
 )

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Dependency.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Dependency.scala
@@ -33,19 +33,27 @@ import scala.cli.commands.SpecificationLevel
 @DirectiveUsage(
   "//> using dep org:name:ver | //> using deps org:name:ver org2:name2:ver2",
   """`//> using dep` _org_`:`name`:`ver
+    |
     |`//> using deps` _org_`:`name`:`ver _org_`:`name`:`ver
+    |
     |`//> using dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
     |
     |`//> using test.dep` _org_`:`name`:`ver
+    |
     |`//> using test.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+    |
     |`//> using test.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
     |
     |`//> using compileOnly.dep` _org_`:`name`:`ver
+    |
     |`//> using compileOnly.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+    |
     |`//> using compileOnly.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
     |
     |`//> using scalafix.dep` _org_`:`name`:`ver
+    |
     |`//> using scalafix.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+    |
     |`//> using scalafix.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
     |""".stripMargin
 )

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavaProps.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavaProps.scala
@@ -14,9 +14,11 @@ import scala.cli.commands.SpecificationLevel
 @DirectiveUsage(
   "//> using javaProp _key=val_",
   """`//> using javaProp` _key=value_
+    |
     |`//> using javaProp` _key_
     |
     |`//> using test.javaProp` _key=value_
+    |
     |`//> using test.javaProp` _key_
     |""".stripMargin
 )

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavacOptions.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/JavacOptions.scala
@@ -13,9 +13,11 @@ import scala.cli.commands.SpecificationLevel
 @DirectiveUsage(
   "//> using javacOpt _options_",
   """`//> using javacOpt` _options_
+    |
     |`//> using javacOptions` _options_
     |
     |`//> using test.javacOpt` _options_
+    |
     |`//> using test.javacOptions` _options_
     |""".stripMargin
 )

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Platform.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Platform.scala
@@ -25,6 +25,7 @@ import scala.cli.commands.SpecificationLevel
 @DirectiveUsage(
   "//> using platform (jvm|scala-js|js|scala-native|native)+",
   """`//> using platform` (`jvm`|`scala-js`|`js`|`scala-native`|`native`)+
+    |
     |`//> using platforms` (`jvm`|`scala-js`|`js`|`scala-native`|`native`)+
     |""".stripMargin
 )

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Publish.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Publish.scala
@@ -43,12 +43,15 @@ import scala.cli.commands.SpecificationLevel
     |`//> using publish.license` value
     |
     |`//> using publish.vcs` value
+    |
     |`//> using publish.scm` value
+    |
     |`//> using publish.versionControl` value
     |
     |`//> using publish.description` value
     |
     |`//> using publish.developer` value
+    |
     |`//> using publish.developers` value1 value2
     |
     |`//> using publish.scalaVersionSuffix` value

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Resources.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Resources.scala
@@ -15,9 +15,11 @@ import scala.cli.commands.SpecificationLevel
     |
     |//> using resourceDirs _path1_ _path2_ …""".stripMargin,
   """`//> using resourceDir` _path_
+    |
     |`//> using resourceDirs` _path1_ _path2_ …
     |
     |`//> using test.resourceDir` _path_
+    |
     |`//> using test.resourceDirs` _path1_ _path2_ …
     |
     |""".stripMargin

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaJs.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaJs.scala
@@ -37,14 +37,17 @@ import scala.util.Try
     |`//> using jsMode` _value_
     |
     |`//> using jsNoOpt` _true|false_
+    |
     |`//> using jsNoOpt`
     |
     |`//> using jsModuleKind` _value_
     |
     |`//> using jsCheckIr` _true|false_
+    |
     |`//> using jsCheckIr`
     |
     |`//> using jsEmitSourceMaps` _true|false_
+    |
     |`//> using jsEmitSourceMaps`
     |
     |`//> using jsEsModuleImportMap` _value_
@@ -52,17 +55,21 @@ import scala.util.Try
     |`//> using jsSmallModuleForPackage` _value1_ _value2_ …
     |
     |`//> using jsDom` _true|false_
+    |
     |`//> using jsDom`
     |
     |`//> using jsHeader` _value_
     |
     |`//> using jsAllowBigIntsForLongs` _true|false_
+    |
     |`//> using jsAllowBigIntsForLongs`
     |
     |`//> using jsAvoidClasses` _true|false_
+    |
     |`//> using jsAvoidClasses`
     |
     |`//> using jsAvoidLetsAndConsts` _true|false_
+    |
     |`//> using jsAvoidLetsAndConsts`
     |
     |`//> using jsModuleSplitStyleStr` _value_
@@ -70,6 +77,7 @@ import scala.util.Try
     |`//> using jsEsVersionStr` _value_
     |    
     |`//> using jsEmitWasm` _true|false_
+    |
     |`//> using jsEmitWasm`
     |""".stripMargin
 )

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaNative.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaNative.scala
@@ -38,14 +38,17 @@ import scala.cli.commands.SpecificationLevel
     |`//> using nativeClang` _value_
     |
     |`//> using nativeClangPP` _value_
+    |
     |`//> using nativeClangPp` _value_
     |
     |`//> using nativeEmbedResources` _true|false_
+    |
     |`//> using nativeEmbedResources`
     |
     |`//> using nativeTarget` _application|library-dynamic|library-static_
     |
     |`//> using nativeMultithreading` _true|false_
+    |
     |`//> using nativeMultithreading`
     """.stripMargin.trim
 )

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalacOptions.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalacOptions.scala
@@ -22,13 +22,19 @@ import scala.cli.commands.SpecificationLevel
 @DirectiveUsage(
   "using option _option_ | using options _option1_ _option2_ …",
   """`//> using scalacOption` _option_
+    |
     |`//> using option` _option_
+    |
     |`//> using scalacOptions` _option1_ _option2_ …
+    |
     |`//> using options` _option1_ _option2_ …
     |
     |`//> using test.scalacOption` _option_
+    |
     |`//> using test.option` _option_
+    |
     |`//> using test.scalacOptions` _option1_ _option2_ …
+    |
     |`//> using test.options` _option1_ _option2_ …
     |
     |""".stripMargin

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -34,13 +34,19 @@ Generate BuildInfo for project
 Add Scala compiler options
 
 `//> using scalacOption` _option_
+
 `//> using option` _option_
+
 `//> using scalacOptions` _option1_ _option2_ …
+
 `//> using options` _option1_ _option2_ …
 
 `//> using test.scalacOption` _option_
+
 `//> using test.option` _option_
+
 `//> using test.scalacOptions` _option1_ _option2_ …
+
 `//> using test.options` _option1_ _option2_ …
 
 
@@ -81,15 +87,19 @@ Method used to compute the version for BuildInfo
 Manually add JAR(s) to the class path
 
 `//> using jar` _path_
+
 `//> using jars` _path1_ _path2_ …
 
 `//> using test.jar` _path_
+
 `//> using test.jars` _path1_ _path2_ …
 
 `//> using source.jar` _path_
+
 `//> using source.jars` _path1_ _path2_ …
 
 `//> using test.source.jar` _path_
+
 `//> using test.source.jars` _path1_ _path2_ …
 
 
@@ -121,19 +131,27 @@ Manually add sources to the project. Does not support chaining, sources are adde
 Add dependencies
 
 `//> using dep` _org_`:`name`:`ver
+
 `//> using deps` _org_`:`name`:`ver _org_`:`name`:`ver
+
 `//> using dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
 
 `//> using test.dep` _org_`:`name`:`ver
+
 `//> using test.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+
 `//> using test.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
 
 `//> using compileOnly.dep` _org_`:`name`:`ver
+
 `//> using compileOnly.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+
 `//> using compileOnly.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
 
 `//> using scalafix.dep` _org_`:`name`:`ver
+
 `//> using scalafix.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+
 `//> using scalafix.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
 
 
@@ -209,9 +227,11 @@ Add Java options which will be passed when running an application.
 Add Java properties
 
 `//> using javaProp` _key=value_
+
 `//> using javaProp` _key_
 
 `//> using test.javaProp` _key=value_
+
 `//> using test.javaProp` _key_
 
 
@@ -225,9 +245,11 @@ Add Java properties
 Add Javac options which will be passed when compiling sources.
 
 `//> using javacOpt` _options_
+
 `//> using javacOptions` _options_
 
 `//> using test.javacOpt` _options_
+
 `//> using test.javacOptions` _options_
 
 
@@ -304,6 +326,7 @@ Set parameters for packaging
 Set the default platform to Scala.js or Scala Native
 
 `//> using platform` (`jvm`|`scala-js`|`js`|`scala-native`|`native`)+
+
 `//> using platforms` (`jvm`|`scala-js`|`js`|`scala-native`|`native`)+
 
 
@@ -329,12 +352,15 @@ Set parameters for publishing
 `//> using publish.license` value
 
 `//> using publish.vcs` value
+
 `//> using publish.scm` value
+
 `//> using publish.versionControl` value
 
 `//> using publish.description` value
 
 `//> using publish.developer` value
+
 `//> using publish.developers` value1 value2
 
 `//> using publish.scalaVersionSuffix` value
@@ -447,9 +473,11 @@ Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`
 Manually add a resource directory to the class path
 
 `//> using resourceDir` _path_
+
 `//> using resourceDirs` _path1_ _path2_ …
 
 `//> using test.resourceDir` _path_
+
 `//> using test.resourceDirs` _path1_ _path2_ …
 
 
@@ -478,14 +506,17 @@ Add Scala Native options
 `//> using nativeClang` _value_
 
 `//> using nativeClangPP` _value_
+
 `//> using nativeClangPp` _value_
 
 `//> using nativeEmbedResources` _true|false_
+
 `//> using nativeEmbedResources`
 
 `//> using nativeTarget` _application|library-dynamic|library-static_
 
 `//> using nativeMultithreading` _true|false_
+
 `//> using nativeMultithreading`
 
 #### Examples
@@ -540,14 +571,17 @@ Add Scala.js options
 `//> using jsMode` _value_
 
 `//> using jsNoOpt` _true|false_
+
 `//> using jsNoOpt`
 
 `//> using jsModuleKind` _value_
 
 `//> using jsCheckIr` _true|false_
+
 `//> using jsCheckIr`
 
 `//> using jsEmitSourceMaps` _true|false_
+
 `//> using jsEmitSourceMaps`
 
 `//> using jsEsModuleImportMap` _value_
@@ -555,17 +589,21 @@ Add Scala.js options
 `//> using jsSmallModuleForPackage` _value1_ _value2_ …
 
 `//> using jsDom` _true|false_
+
 `//> using jsDom`
 
 `//> using jsHeader` _value_
 
 `//> using jsAllowBigIntsForLongs` _true|false_
+
 `//> using jsAllowBigIntsForLongs`
 
 `//> using jsAvoidClasses` _true|false_
+
 `//> using jsAvoidClasses`
 
 `//> using jsAvoidLetsAndConsts` _true|false_
+
 `//> using jsAvoidLetsAndConsts`
 
 `//> using jsModuleSplitStyleStr` _value_
@@ -573,6 +611,7 @@ Add Scala.js options
 `//> using jsEsVersionStr` _value_
     
 `//> using jsEmitWasm` _true|false_
+
 `//> using jsEmitWasm`
 
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -16,13 +16,19 @@ Documentation is split into sections in the spirit of RFC keywords (`MUST`, `SHO
 Add Scala compiler options
 
 `//> using scalacOption` _option_
+
 `//> using option` _option_
+
 `//> using scalacOptions` _option1_ _option2_ …
+
 `//> using options` _option1_ _option2_ …
 
 `//> using test.scalacOption` _option_
+
 `//> using test.option` _option_
+
 `//> using test.scalacOptions` _option1_ _option2_ …
+
 `//> using test.options` _option1_ _option2_ …
 
 
@@ -50,19 +56,27 @@ Adds compiler plugins
 Add dependencies
 
 `//> using dep` _org_`:`name`:`ver
+
 `//> using deps` _org_`:`name`:`ver _org_`:`name`:`ver
+
 `//> using dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
 
 `//> using test.dep` _org_`:`name`:`ver
+
 `//> using test.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+
 `//> using test.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
 
 `//> using compileOnly.dep` _org_`:`name`:`ver
+
 `//> using compileOnly.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+
 `//> using compileOnly.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
 
 `//> using scalafix.dep` _org_`:`name`:`ver
+
 `//> using scalafix.deps` _org_`:`name`:`ver _org_`:`name`:`ver
+
 `//> using scalafix.dependencies` _org_`:`name`:`ver _org_`:`name`:`ver
 
 
@@ -100,9 +114,11 @@ Add Java options which will be passed when running an application.
 Add Java properties
 
 `//> using javaProp` _key=value_
+
 `//> using javaProp` _key_
 
 `//> using test.javaProp` _key=value_
+
 `//> using test.javaProp` _key_
 
 
@@ -142,15 +158,19 @@ Set the default Scala version
 Manually add JAR(s) to the class path
 
 `//> using jar` _path_
+
 `//> using jars` _path1_ _path2_ …
 
 `//> using test.jar` _path_
+
 `//> using test.jars` _path1_ _path2_ …
 
 `//> using source.jar` _path_
+
 `//> using source.jars` _path1_ _path2_ …
 
 `//> using test.source.jar` _path_
+
 `//> using test.source.jars` _path1_ _path2_ …
 
 
@@ -220,9 +240,11 @@ Sets Java home used to run your application or tests
 Add Javac options which will be passed when compiling sources.
 
 `//> using javacOpt` _options_
+
 `//> using javacOptions` _options_
 
 `//> using test.javacOpt` _options_
+
 `//> using test.javacOptions` _options_
 
 
@@ -236,6 +258,7 @@ Add Javac options which will be passed when compiling sources.
 Set the default platform to Scala.js or Scala Native
 
 `//> using platform` (`jvm`|`scala-js`|`js`|`scala-native`|`native`)+
+
 `//> using platforms` (`jvm`|`scala-js`|`js`|`scala-native`|`native`)+
 
 
@@ -266,9 +289,11 @@ Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`
 Manually add a resource directory to the class path
 
 `//> using resourceDir` _path_
+
 `//> using resourceDirs` _path1_ _path2_ …
 
 `//> using test.resourceDir` _path_
+
 `//> using test.resourceDirs` _path1_ _path2_ …
 
 
@@ -297,14 +322,17 @@ Add Scala Native options
 `//> using nativeClang` _value_
 
 `//> using nativeClangPP` _value_
+
 `//> using nativeClangPp` _value_
 
 `//> using nativeEmbedResources` _true|false_
+
 `//> using nativeEmbedResources`
 
 `//> using nativeTarget` _application|library-dynamic|library-static_
 
 `//> using nativeMultithreading` _true|false_
+
 `//> using nativeMultithreading`
 
 #### Examples
@@ -344,14 +372,17 @@ Add Scala.js options
 `//> using jsMode` _value_
 
 `//> using jsNoOpt` _true|false_
+
 `//> using jsNoOpt`
 
 `//> using jsModuleKind` _value_
 
 `//> using jsCheckIr` _true|false_
+
 `//> using jsCheckIr`
 
 `//> using jsEmitSourceMaps` _true|false_
+
 `//> using jsEmitSourceMaps`
 
 `//> using jsEsModuleImportMap` _value_
@@ -359,17 +390,21 @@ Add Scala.js options
 `//> using jsSmallModuleForPackage` _value1_ _value2_ …
 
 `//> using jsDom` _true|false_
+
 `//> using jsDom`
 
 `//> using jsHeader` _value_
 
 `//> using jsAllowBigIntsForLongs` _true|false_
+
 `//> using jsAllowBigIntsForLongs`
 
 `//> using jsAvoidClasses` _true|false_
+
 `//> using jsAvoidClasses`
 
 `//> using jsAvoidLetsAndConsts` _true|false_
+
 `//> using jsAvoidLetsAndConsts`
 
 `//> using jsModuleSplitStyleStr` _value_
@@ -377,6 +412,7 @@ Add Scala.js options
 `//> using jsEsVersionStr` _value_
     
 `//> using jsEmitWasm` _true|false_
+
 `//> using jsEmitWasm`
 
 


### PR DESCRIPTION
A follow-up to https://github.com/VirtusLab/scala-cli/pull/3608, where I messed some of the formatting and now the doc looks off.