### PR TITLE
Retry docs' tests on the CI

### DIFF
--- a/modules/docs-tests/src/test/scala/sclicheck/DocTests.scala
+++ b/modules/docs-tests/src/test/scala/sclicheck/DocTests.scala
@@ -38,7 +38,7 @@ class DocTests extends munit.FunSuite {
     md <- inputs
   }
     test(s"$tpe ${md.toString.stripSuffix(".md")}") {
-      checkFile(dir / md, options)
+      TestUtil.retryOnCi()(checkFile(dir / md, options))
     }
 
 }

--- a/modules/docs-tests/src/test/scala/sclicheck/TestUtil.scala
+++ b/modules/docs-tests/src/test/scala/sclicheck/TestUtil.scala
@@ -1,6 +1,10 @@
 package sclicheck
 
+import scala.annotation.tailrec
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
 object TestUtil {
+  val isCI: Boolean = System.getenv("CI") != null
 
   def withTmpDir[T](prefix: String)(f: os.Path => T): T = {
     val tmpDir = os.temp.dir(prefix = prefix)
@@ -20,4 +24,36 @@ object TestUtil {
       sys.error("SCLICHECK_SCALA_CLI not set")
     }
 
+  def retry[T](
+    maxAttempts: Int = 3,
+    waitDuration: FiniteDuration = 5.seconds
+  )(
+    run: => T
+  ): T = {
+    @tailrec
+    def helper(count: Int): T =
+      try run
+      catch {
+        case t: Throwable =>
+          if (count >= maxAttempts) {
+            System.err.println(s"$maxAttempts attempts failed, caught $t. Giving up.")
+            throw new Exception(t)
+          }
+          else {
+            val remainingAttempts = maxAttempts - count
+            System.err.println(
+              s"Caught $t, $remainingAttempts attempts remaining, trying again in $waitDuration…"
+            )
+            Thread.sleep(waitDuration.toMillis)
+            System.err.println(s"Trying attempt $count out of $maxAttempts...")
+            helper(count + 1)
+          }
+      }
+
+    helper(1)
+  }
+
+  def retryOnCi[T](maxAttempts: Int = 3, waitDuration: FiniteDuration = 5.seconds)(
+    run: => T
+  ): T = retry(if (isCI) maxAttempts else 1, waitDuration)(run)
 }


### PR DESCRIPTION
A whole bunch of docs' tests relies on fetching nightlies or particular versions of stuff, which tends to be flaky at times. This should make it slightly more reliable.
Also, mental note to do a refactor of test utils and maybe extract them to a dedicated module, as the retry logic is now duplicated in a couple spots in the codebase.