### PR TITLE
Run all found test frameworks, rather than just one

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
@@ -273,7 +273,7 @@ object Test extends ScalaCommand[TestOptions] {
     if classPath0.exists(_.contains("zio-test")) && !classPath0.exists(_.contains("zio-test-sbt"))
     then {
       val parentInspector = new AsmTestRunner.ParentInspector(classPath)
-      Runner.frameworkNames(classPath, parentInspector) match {
+      Runner.frameworkNames(classPath, parentInspector, logger) match {
         case Right(f) => f.headOption
         case Left(_) =>
           logger.message(

--- a/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
@@ -248,7 +248,7 @@ object Test extends ScalaCommand[TestOptions] {
         val testOnly = build.options.testOptions.testOnly
 
         val extraArgs =
-          (if (requireTests) Seq("--require-tests") else Nil) ++
+          (if requireTests then Seq("--require-tests") else Nil) ++
             build.options.internal.verbosity.map(v => s"--verbosity=$v") ++
             testFrameworkOpt0.map(fw => s"--test-framework=$fw").toSeq ++
             testOnly.map(to => s"--test-only=$to").toSeq ++

--- a/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
@@ -266,16 +266,15 @@ object Test extends ScalaCommand[TestOptions] {
     }
   }
 
-  def findTestFramework(classPath: Seq[Path], logger: Logger): Option[String] = {
+  private def findTestFramework(classPath: Seq[Path], logger: Logger): Option[String] = {
     val classPath0 = classPath.map(_.toString)
 
     // https://github.com/VirtusLab/scala-cli/issues/426
-    if (
-      classPath0.exists(_.contains("zio-test")) && !classPath0.exists(_.contains("zio-test-sbt"))
-    ) {
+    if classPath0.exists(_.contains("zio-test")) && !classPath0.exists(_.contains("zio-test-sbt"))
+    then {
       val parentInspector = new AsmTestRunner.ParentInspector(classPath)
-      Runner.frameworkName(classPath, parentInspector) match {
-        case Right(f) => Some(f)
+      Runner.frameworkNames(classPath, parentInspector) match {
+        case Right(f) => f.headOption
         case Left(_) =>
           logger.message(
             s"zio-test found in the class path, zio-test-sbt should be added to run zio tests with $fullRunnerName."
@@ -283,8 +282,7 @@ object Test extends ScalaCommand[TestOptions] {
           None
       }
     }
-    else
-      None
+    else None
   }
 
 }

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/JsonProjectDescriptor.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/JsonProjectDescriptor.scala
@@ -13,7 +13,6 @@ import java.nio.file.Path
 import scala.build.errors.BuildException
 import scala.build.info.{BuildInfo, ScopedBuildInfo}
 import scala.build.internal.Constants
-import scala.build.internal.Runner.frameworkName
 import scala.build.options.{BuildOptions, Scope}
 import scala.build.testrunner.AsmTestRunner
 import scala.build.{Logger, Positioned, Sources}

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/MavenProjectDescriptor.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/MavenProjectDescriptor.scala
@@ -10,7 +10,7 @@ import java.nio.file.Path
 
 import scala.build.errors.BuildException
 import scala.build.internal.Constants
-import scala.build.internal.Runner.frameworkName
+import scala.build.internal.Runner.frameworkNames
 import scala.build.options.{BuildOptions, Platform, Scope, ShadowingSeq}
 import scala.build.testrunner.AsmTestRunner
 import scala.build.{Logger, Positioned, Sources}

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/MillProjectDescriptor.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/MillProjectDescriptor.scala
@@ -149,7 +149,7 @@ final case class MillProjectDescriptor(
     }
     val parentInspector = new AsmTestRunner.ParentInspector(testClassPath)
     val frameworkName0 = options.testOptions.frameworkOpt.orElse {
-      frameworkNames(testClassPath, parentInspector).toOption
+      frameworkNames(testClassPath, parentInspector, logger).toOption
         .flatMap(_.headOption) // TODO: handle multiple frameworks here
     }
 

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/MillProjectDescriptor.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/MillProjectDescriptor.scala
@@ -9,7 +9,7 @@ import java.nio.file.Path
 
 import scala.build.errors.BuildException
 import scala.build.internal.Constants
-import scala.build.internal.Runner.frameworkName
+import scala.build.internal.Runner.frameworkNames
 import scala.build.options.{BuildOptions, Platform, ScalaJsOptions, ScalaNativeOptions, Scope}
 import scala.build.testrunner.AsmTestRunner
 import scala.build.{Logger, Sources}
@@ -149,7 +149,8 @@ final case class MillProjectDescriptor(
     }
     val parentInspector = new AsmTestRunner.ParentInspector(testClassPath)
     val frameworkName0 = options.testOptions.frameworkOpt.orElse {
-      frameworkName(testClassPath, parentInspector).toOption
+      frameworkNames(testClassPath, parentInspector).toOption
+        .flatMap(_.headOption) // TODO: handle multiple frameworks here
     }
 
     val testFrameworkDecls = frameworkName0 match {

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/SbtProjectDescriptor.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/SbtProjectDescriptor.scala
@@ -10,7 +10,7 @@ import java.nio.file.Path
 
 import scala.build.errors.BuildException
 import scala.build.internal.Constants
-import scala.build.internal.Runner.frameworkName
+import scala.build.internal.Runner.frameworkNames
 import scala.build.options.{
   BuildOptions,
   Platform,
@@ -262,7 +262,8 @@ final case class SbtProjectDescriptor(
 
     val parentInspector = new AsmTestRunner.ParentInspector(testClassPath)
     val frameworkName0 = options.testOptions.frameworkOpt.orElse {
-      frameworkName(testClassPath, parentInspector).toOption
+      frameworkNames(testClassPath, parentInspector).toOption
+        .flatMap(_.headOption) // TODO: handle multiple frameworks here
     }
 
     val testFrameworkSettings = frameworkName0 match {

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/SbtProjectDescriptor.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/SbtProjectDescriptor.scala
@@ -262,7 +262,7 @@ final case class SbtProjectDescriptor(
 
     val parentInspector = new AsmTestRunner.ParentInspector(testClassPath)
     val frameworkName0 = options.testOptions.frameworkOpt.orElse {
-      frameworkNames(testClassPath, parentInspector).toOption
+      frameworkNames(testClassPath, parentInspector, logger).toOption
         .flatMap(_.headOption) // TODO: handle multiple frameworks here
     }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -936,7 +936,10 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
                |}
                |""".stripMargin
         ).fromRoot { root =>
-          val r = os.proc(TestUtil.cli, "test", extraOptions, ".", platformOptions).call(cwd = root)
+          val r =
+            os.proc(TestUtil.cli, "test", extraOptions, ".", platformOptions, "-v", "-v").call(cwd =
+              root
+            )
           val output = r.out.trim()
           expect(output.nonEmpty)
           expectedMessages.foreach { expectedMessage =>

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -513,7 +513,7 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
               Seq("--native-version", "0.4.17")
             else Nil
           val baseRes =
-            os.proc(TestUtil.cli, "test", extraOptions, platformArgs, scalaTestExtraArgs, ".", "-v")
+            os.proc(TestUtil.cli, "test", extraOptions, platformArgs, scalaTestExtraArgs, ".")
               .call(cwd = root, check = false)
           if (baseRes.exitCode != 0) {
             println(baseRes.out.text())
@@ -814,8 +814,8 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
   for {
     platformOptions <- Seq(
       Nil, // JVM
-      Seq("--native")
-      // TODO: Seq("--js")
+      Seq("--native"),
+      Seq("--js")
     )
     platformDescription = platformOptions.headOption.map(o => s" ($o)").getOrElse(" (JVM)")
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -9,6 +9,7 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
   _: TestScalaVersion =>
   protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
   private val utestVersion                     = "0.8.3"
+  private val zioTestVersion                   = "2.1.17"
 
   def successfulTestInputs(directivesString: String =
     s"//> using dep org.scalameta::munit::$munitVersion"): TestInputs = TestInputs(
@@ -811,6 +812,35 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
     }
   }
 
+  test(s"zio-test warning when zio-test-sbt was not passed") {
+    TestUtil.retryOnCi() {
+      val expectedMessage = "Hello from zio"
+      TestInputs(os.rel / "Zio.test.scala" ->
+        s"""//> using test.dep dev.zio::zio-test::$zioTestVersion
+           |import zio._
+           |import zio.test._
+           |
+           |object SimpleSpec extends ZIOSpecDefault {
+           |  override def spec: Spec[TestEnvironment with Scope, Any] =
+           |    suite("SimpleSpec")(
+           |      test("print hello and assert true") {
+           |        for {
+           |          _ <- Console.printLine("$expectedMessage")
+           |        } yield assertTrue(true)
+           |      }
+           |    )
+           |}
+           |""".stripMargin).fromRoot { root =>
+        val r = os.proc(TestUtil.cli, "test", ".", extraOptions)
+          .call(cwd = root, check = false, stderr = os.Pipe)
+        expect(r.exitCode == 1)
+        val expectedWarning =
+          "zio-test found in the class path, zio-test-sbt should be added to run zio tests"
+        expect(r.err.trim().contains(expectedWarning))
+      }
+    }
+  }
+
   for {
     platformOptions <- Seq(
       Nil, // JVM
@@ -818,59 +848,103 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
       Seq("--js")
     )
     platformDescription = platformOptions.headOption.map(o => s" ($o)").getOrElse(" (JVM)")
-  }
-    test(s"multiple test frameworks$platformDescription") {
-      val scalatestMessage = "Hello from ScalaTest"
-      val munitMessage     = "Hello from Munit"
-      val utestMessage     = "Hello from utest"
-      TestInputs(
-        os.rel / "project.scala" ->
-          s"""//> using test.dep org.scalatest::scalatest::3.2.19
-             |//> using test.dep org.scalameta::munit::$munitVersion
-             |//> using dep com.lihaoyi::utest::$utestVersion
-             |""".stripMargin,
-        os.rel / "scalatest.test.scala" ->
-          s"""import org.scalatest.flatspec.AnyFlatSpec
+  } {
+    test(s"zio-test$platformDescription") {
+      TestUtil.retryOnCi() {
+        val expectedMessage = "Hello from zio"
+        TestInputs(os.rel / "Zio.test.scala" ->
+          s"""//> using test.dep dev.zio::zio-test::$zioTestVersion
+             |//> using test.dep dev.zio::zio-test-sbt::$zioTestVersion
+             |import zio._
+             |import zio.test._
              |
-             |class ScalaTestSpec extends AnyFlatSpec {
-             |    "example" should "work" in {
-             |      assertResult(1)(1)
-             |      println("$scalatestMessage")
-             |    }
+             |object SimpleSpec extends ZIOSpecDefault {
+             |  override def spec: Spec[TestEnvironment with Scope, Any] =
+             |    suite("SimpleSpec")(
+             |      test("print hello and assert true") {
+             |        for {
+             |          _ <- Console.printLine("$expectedMessage")
+             |        } yield assertTrue(true)
+             |      }
+             |    )
              |}
-             |""".stripMargin,
-        os.rel / "munit.test.scala" ->
-          s"""import munit.FunSuite
-             |
-             |class Munit extends FunSuite {
-             |  test("foo") {
-             |    assert(2 + 2 == 4)
-             |    println("$munitMessage")
-             |  }
-             |}
-             |""".stripMargin,
-        os.rel / "utest.test.scala" ->
-          s"""import utest._
-             |
-             |object MyTests extends TestSuite {
-             |  val tests = Tests {
-             |    test("foo") {
-             |      assert(2 + 2 == 4)
-             |      println("$utestMessage")
-             |    }
-             |  }
-             |}""".stripMargin
-      ).fromRoot { root =>
-        val r = os.proc(TestUtil.cli, "test", extraOptions, ".", platformOptions).call(cwd = root)
-        val output = r.out.trim()
-        expect(output.nonEmpty)
-        expect(output.contains(scalatestMessage))
-        expect(countSubStrings(output, scalatestMessage) == 1)
-        expect(output.contains(munitMessage))
-        expect(countSubStrings(output, munitMessage) == 1)
-        expect(output.contains(utestMessage))
-        expect(countSubStrings(output, utestMessage) == 1)
-        println(output)
+             |""".stripMargin).fromRoot { root =>
+          val r = os.proc(TestUtil.cli, "test", ".", extraOptions, platformOptions).call(cwd = root)
+          val output = r.out.trim()
+          expect(output.contains(expectedMessage))
+          expect(countSubStrings(output, expectedMessage) == 1)
+        }
       }
     }
+
+    test(s"multiple test frameworks$platformDescription") {
+      TestUtil.retryOnCi() {
+        val expectedMessages @ Seq(scalatestMessage, munitMessage, utestMessage, zioMessage) =
+          Seq("Hello from ScalaTest", "Hello from Munit", "Hello from utest", "Hello from zio")
+        TestInputs(
+          os.rel / "project.scala" ->
+            s"""//> using test.dep org.scalatest::scalatest::3.2.19
+               |//> using test.dep org.scalameta::munit::$munitVersion
+               |//> using dep com.lihaoyi::utest::$utestVersion
+               |//> using test.dep dev.zio::zio-test::$zioTestVersion
+               |//> using test.dep dev.zio::zio-test-sbt::$zioTestVersion
+               |""".stripMargin,
+          os.rel / "scalatest.test.scala" ->
+            s"""import org.scalatest.flatspec.AnyFlatSpec
+               |
+               |class ScalaTestSpec extends AnyFlatSpec {
+               |    "example" should "work" in {
+               |      assertResult(1)(1)
+               |      println("$scalatestMessage")
+               |    }
+               |}
+               |""".stripMargin,
+          os.rel / "munit.test.scala" ->
+            s"""import munit.FunSuite
+               |
+               |class Munit extends FunSuite {
+               |  test("foo") {
+               |    assert(2 + 2 == 4)
+               |    println("$munitMessage")
+               |  }
+               |}
+               |""".stripMargin,
+          os.rel / "utest.test.scala" ->
+            s"""import utest._
+               |
+               |object MyTests extends TestSuite {
+               |  val tests = Tests {
+               |    test("foo") {
+               |      assert(2 + 2 == 4)
+               |      println("$utestMessage")
+               |    }
+               |  }
+               |}""".stripMargin,
+          os.rel / "Zio.test.scala" ->
+            s"""import zio._
+               |import zio.test._
+               |
+               |object SimpleSpec extends ZIOSpecDefault {
+               |  override def spec: Spec[TestEnvironment with Scope, Any] =
+               |    suite("SimpleSpec")(
+               |      test("print hello and assert true") {
+               |        for {
+               |          _ <- Console.printLine("$zioMessage")
+               |        } yield assertTrue(true)
+               |      }
+               |    )
+               |}
+               |""".stripMargin
+        ).fromRoot { root =>
+          val r = os.proc(TestUtil.cli, "test", extraOptions, ".", platformOptions).call(cwd = root)
+          val output = r.out.trim()
+          expect(output.nonEmpty)
+          expectedMessages.foreach { expectedMessage =>
+            expect(output.contains(expectedMessage))
+            expect(countSubStrings(output, expectedMessage) == 1)
+          }
+        }
+      }
+    }
+  }
 }

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
@@ -1,7 +1,7 @@
 package scala.build.testrunner
 
 import org.objectweb.asm
-import sbt.testing._
+import sbt.testing.{Logger => _, _}
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
 import java.nio.charset.StandardCharsets
@@ -206,7 +206,6 @@ object AsmTestRunner {
     parentInspector: ParentInspector
   ): List[String] = {
     val preferredClassesByteCode = preferredClasses
-      .iterator
       .map(_.replace('.', '/'))
       .flatMap { name =>
         findInClassPath(classPath, name + ".class")
@@ -215,7 +214,7 @@ object AsmTestRunner {
             (name, () => openStream())
           }
       }
-    (preferredClassesByteCode ++ listClassesByteCode(classPath, true))
+    (preferredClassesByteCode.iterator ++ listClassesByteCode(classPath, true))
       .flatMap {
         case (moduleInfo, _) if moduleInfo.contains("module-info") => Iterator.empty
         case (name, is) =>
@@ -233,6 +232,7 @@ object AsmTestRunner {
           else
             Iterator.empty
       }
+      .take(math.max(preferredClassesByteCode.length, 1))
       .toList
   }
 

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
@@ -1,6 +1,6 @@
 package scala.build.testrunner
 
-import sbt.testing.{Logger => SbtTestLogger, _}
+import sbt.testing.{Logger => _, _}
 
 import java.lang.annotation.Annotation
 import java.lang.reflect.Modifier

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
@@ -9,6 +9,7 @@ import java.util.ServiceLoader
 import java.util.regex.Pattern
 
 import scala.annotation.tailrec
+import scala.build.testrunner.FrameworkUtils._
 import scala.jdk.CollectionConverters._
 
 object DynamicTestRunner {
@@ -237,14 +238,11 @@ object DynamicTestRunner {
           loop(seq, Set.empty, Vector.empty)
         }
 
-        def getFrameworkDescription(f: Framework): String =
-          s"${f.name()} (${Option(f.getClass.getCanonicalName).getOrElse(f.toString)})"
-
         val foundFrameworkServices = findFrameworkServices(classLoader)
         if (foundFrameworkServices.nonEmpty)
           logger.debug(
             s"""Found test framework services:
-               |  - ${foundFrameworkServices.map(getFrameworkDescription).mkString("\n  - ")}
+               |  - ${foundFrameworkServices.map(_.description).mkString("\n  - ")}
                |""".stripMargin
           )
 
@@ -253,7 +251,7 @@ object DynamicTestRunner {
         if (foundFrameworks.nonEmpty)
           logger.debug(
             s"""Found test frameworks:
-               |  - ${foundFrameworks.map(getFrameworkDescription).mkString("\n  - ")}
+               |  - ${foundFrameworks.map(_.description).mkString("\n  - ")}
                |""".stripMargin
           )
 
@@ -261,7 +259,7 @@ object DynamicTestRunner {
         if (distinctFrameworks.nonEmpty)
           logger.debug(
             s"""Distinct test frameworks found (by framework name):
-               |  - ${distinctFrameworks.map(getFrameworkDescription).mkString("\n  - ")}
+               |  - ${distinctFrameworks.map(_.description).mkString("\n  - ")}
                |""".stripMargin
           )
 
@@ -277,7 +275,7 @@ object DynamicTestRunner {
         if (finalFrameworks.nonEmpty)
           logger.log(
             s"""Final list of test frameworks found:
-               |  - ${finalFrameworks.map(getFrameworkDescription).mkString("\n  - ")}
+               |  - ${finalFrameworks.map(_.description).mkString("\n  - ")}
                |""".stripMargin
           )
 
@@ -285,7 +283,7 @@ object DynamicTestRunner {
         if (skippedInheritedFrameworks.nonEmpty)
           logger.log(
             s"""The following test frameworks have been filtered out, as they're being inherited from by others:
-               |  - ${skippedInheritedFrameworks.map(getFrameworkDescription).mkString("\n  - ")}
+               |  - ${skippedInheritedFrameworks.map(_.description).mkString("\n  - ")}
                |""".stripMargin
           )
 

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
@@ -2,149 +2,12 @@ package scala.build.testrunner
 
 import sbt.testing.{Logger => _, _}
 
-import java.lang.annotation.Annotation
-import java.lang.reflect.Modifier
-import java.nio.file.{Files, Path}
-import java.util.ServiceLoader
 import java.util.regex.Pattern
 
 import scala.annotation.tailrec
 import scala.build.testrunner.FrameworkUtils._
-import scala.jdk.CollectionConverters._
 
 object DynamicTestRunner {
-
-  // adapted from https://github.com/com-lihaoyi/mill/blob/ab4d61a50da24fb7fac97c4453dd8a770d8ac62b/scalalib/src/Lib.scala#L156-L172
-  private def matchFingerprints(
-    loader: ClassLoader,
-    cls: Class[_],
-    fingerprints: Array[Fingerprint]
-  ): Option[Fingerprint] = {
-    val isModule               = cls.getName.endsWith("$")
-    val publicConstructorCount = cls.getConstructors.count(c => Modifier.isPublic(c.getModifiers))
-    val noPublicConstructors   = publicConstructorCount == 0
-    val definitelyNoTests = Modifier.isAbstract(cls.getModifiers) ||
-      cls.isInterface ||
-      publicConstructorCount > 1 ||
-      isModule != noPublicConstructors
-    if (definitelyNoTests)
-      None
-    else
-      fingerprints.find {
-        case f: SubclassFingerprint =>
-          f.isModule == isModule &&
-          loader.loadClass(f.superclassName())
-            .isAssignableFrom(cls)
-
-        case f: AnnotatedFingerprint =>
-          val annotationCls = loader.loadClass(f.annotationName())
-            .asInstanceOf[Class[Annotation]]
-          f.isModule == isModule && (
-            cls.isAnnotationPresent(annotationCls) ||
-            cls.getDeclaredMethods.exists(_.isAnnotationPresent(annotationCls)) ||
-            cls.getMethods.exists { m =>
-              m.isAnnotationPresent(annotationCls) &&
-              Modifier.isPublic(m.getModifiers())
-            }
-          )
-      }
-  }
-
-  def listClasses(classPathEntry: Path, keepJars: Boolean): Iterator[String] =
-    if (Files.isDirectory(classPathEntry)) {
-      var stream: java.util.stream.Stream[Path] = null
-      try {
-        stream = Files.walk(classPathEntry, Int.MaxValue)
-        stream
-          .iterator
-          .asScala
-          .filter(_.getFileName.toString.endsWith(".class"))
-          .map(classPathEntry.relativize(_))
-          .map { p =>
-            val count = p.getNameCount
-            (0 until count).map(p.getName).mkString(".")
-          }
-          .map(_.stripSuffix(".class"))
-          .toVector // fully consume stream before closing it
-          .iterator
-      }
-      finally if (stream != null) stream.close()
-    }
-    else if (keepJars && Files.isRegularFile(classPathEntry)) {
-      import java.util.zip._
-      var zf: ZipFile = null
-      try {
-        zf = new ZipFile(classPathEntry.toFile)
-        zf.entries
-          .asScala
-          // FIXME Check if these are files too
-          .filter(_.getName.endsWith(".class"))
-          .map(ent => ent.getName.stripSuffix(".class").replace("/", "."))
-          .toVector // full consume ZipFile before closing it
-          .iterator
-      }
-      finally if (zf != null) zf.close()
-    }
-    else Iterator.empty
-
-  def listClasses(classPath: Seq[Path], keepJars: Boolean): Iterator[String] =
-    classPath.iterator.flatMap(listClasses(_, keepJars))
-
-  def findFrameworkServices(loader: ClassLoader): Seq[Framework] =
-    ServiceLoader.load(classOf[Framework], loader)
-      .iterator()
-      .asScala
-      .toSeq
-
-  def loadFramework(
-    loader: ClassLoader,
-    className: String
-  ): Framework = {
-    val cls         = loader.loadClass(className)
-    val constructor = cls.getConstructor()
-    constructor.newInstance().asInstanceOf[Framework]
-  }
-
-  def findFrameworks(
-    classPath: Seq[Path],
-    loader: ClassLoader,
-    preferredClasses: Seq[String]
-  ): Seq[Framework] = {
-    val frameworkCls = classOf[Framework]
-    (preferredClasses.iterator ++ listClasses(classPath, true))
-      .flatMap { name =>
-        val it: Iterator[Class[_]] =
-          try Iterator(loader.loadClass(name))
-          catch {
-            case _: ClassNotFoundException | _: UnsupportedClassVersionError | _: NoClassDefFoundError | _: IncompatibleClassChangeError =>
-              Iterator.empty
-          }
-        it
-      }
-      .flatMap { cls =>
-        def isAbstract = Modifier.isAbstract(cls.getModifiers)
-        def publicConstructorCount =
-          cls.getConstructors.count { c =>
-            Modifier.isPublic(c.getModifiers) && c.getParameterCount() == 0
-          }
-        val it: Iterator[Class[_]] =
-          if (frameworkCls.isAssignableFrom(cls) && !isAbstract && publicConstructorCount == 1)
-            Iterator(cls)
-          else
-            Iterator.empty
-        it
-      }
-      .flatMap { cls =>
-        try {
-          val constructor = cls.getConstructor()
-          Iterator(constructor.newInstance().asInstanceOf[Framework])
-        }
-        catch {
-          case _: NoSuchMethodException => Iterator.empty
-        }
-      }
-      .toSeq
-  }
 
   /** Based on junit-interface [GlobFilter.
     * compileGlobPattern](https://github.com/sbt/junit-interface/blob/f8c6372ed01ce86f15393b890323d96afbe6d594/src/main/java/com/novocode/junit/GlobFilter.java#L37)
@@ -223,71 +86,10 @@ object DynamicTestRunner {
       .map(loadFramework(classLoader, _))
       .map(Seq(_))
       .getOrElse {
-        // needed for Scala 2.12
-        def distinctBy[A, B](seq: Seq[A])(f: A => B): Seq[A] = {
-          @annotation.tailrec
-          def loop(remaining: Seq[A], seen: Set[B], acc: Vector[A]): Vector[A] =
-            if (remaining.isEmpty) acc
-            else {
-              val head = remaining.head
-              val tail = remaining.tail
-              val key  = f(head)
-              if (seen(key)) loop(tail, seen, acc)
-              else loop(tail, seen + key, acc :+ head)
-            }
-          loop(seq, Set.empty, Vector.empty)
-        }
-
-        val foundFrameworkServices = findFrameworkServices(classLoader)
-        if (foundFrameworkServices.nonEmpty)
-          logger.debug(
-            s"""Found test framework services:
-               |  - ${foundFrameworkServices.map(_.description).mkString("\n  - ")}
-               |""".stripMargin
-          )
-
-        val foundFrameworks =
-          findFrameworks(classPath0, classLoader, TestRunner.commonTestFrameworks)
-        if (foundFrameworks.nonEmpty)
-          logger.debug(
-            s"""Found test frameworks:
-               |  - ${foundFrameworks.map(_.description).mkString("\n  - ")}
-               |""".stripMargin
-          )
-
-        val distinctFrameworks = distinctBy(foundFrameworkServices ++ foundFrameworks)(_.name())
-        if (distinctFrameworks.nonEmpty)
-          logger.debug(
-            s"""Distinct test frameworks found (by framework name):
-               |  - ${distinctFrameworks.map(_.description).mkString("\n  - ")}
-               |""".stripMargin
-          )
-
-        val finalFrameworks =
-          distinctFrameworks
-            .filter(f1 =>
-              !distinctFrameworks
-                .filter(_ != f1)
-                .exists(f2 =>
-                  f1.getClass.isAssignableFrom(f2.getClass)
-                )
-            )
-        if (finalFrameworks.nonEmpty)
-          logger.log(
-            s"""Final list of test frameworks found:
-               |  - ${finalFrameworks.map(_.description).mkString("\n  - ")}
-               |""".stripMargin
-          )
-
-        val skippedInheritedFrameworks = distinctFrameworks.diff(finalFrameworks)
-        if (skippedInheritedFrameworks.nonEmpty)
-          logger.log(
-            s"""The following test frameworks have been filtered out, as they're being inherited from by others:
-               |  - ${skippedInheritedFrameworks.map(_.description).mkString("\n  - ")}
-               |""".stripMargin
-          )
-
-        finalFrameworks match {
+        getFrameworksToRun(
+          frameworkServices = findFrameworkServices(classLoader),
+          frameworks = findFrameworks(classPath0, classLoader, TestRunner.commonTestFrameworks)
+        )(logger) match {
           case f if f.nonEmpty     => f
           case _ if verbosity >= 2 => sys.error("No test framework found")
           case _ =>

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/FrameworkUtils.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/FrameworkUtils.scala
@@ -1,0 +1,11 @@
+package scala.build.testrunner
+
+import sbt.testing.Framework
+
+object FrameworkUtils {
+  implicit class TestFrameworkOps(val framework: Framework) {
+    def description: String =
+      s"${framework.name()} (${Option(framework.getClass.getCanonicalName).getOrElse(framework.toString)})"
+  }
+
+}

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/FrameworkUtils.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/FrameworkUtils.scala
@@ -1,11 +1,223 @@
 package scala.build.testrunner
 
-import sbt.testing.Framework
+import sbt.testing.{AnnotatedFingerprint, Fingerprint, Framework, SubclassFingerprint}
+
+import java.lang.annotation.Annotation
+import java.lang.reflect.Modifier
+import java.nio.file.{Files, Path}
+import java.util.ServiceLoader
+
+import scala.jdk.CollectionConverters._
 
 object FrameworkUtils {
+  // needed for Scala 2.12
+  def distinctBy[A, B](seq: Seq[A])(f: A => B): Seq[A] = {
+    @annotation.tailrec
+    def loop(remaining: Seq[A], seen: Set[B], acc: Vector[A]): Vector[A] =
+      if (remaining.isEmpty) acc
+      else {
+        val head = remaining.head
+        val tail = remaining.tail
+        val key  = f(head)
+        if (seen(key)) loop(tail, seen, acc)
+        else loop(tail, seen + key, acc :+ head)
+      }
+
+    loop(seq, Set.empty, Vector.empty)
+  }
+
   implicit class TestFrameworkOps(val framework: Framework) {
     def description: String =
       s"${framework.name()} (${Option(framework.getClass.getCanonicalName).getOrElse(framework.toString)})"
   }
 
+  def getFrameworksToRun(allFrameworks: Seq[Framework])(logger: Logger): Seq[Framework] = {
+    val distinctFrameworks = distinctBy(allFrameworks)(_.name())
+    if (distinctFrameworks.nonEmpty)
+      logger.debug(
+        s"""Distinct test frameworks found (by framework name):
+           |  - ${distinctFrameworks.map(_.description).mkString("\n  - ")}
+           |""".stripMargin
+      )
+
+    val finalFrameworks =
+      distinctFrameworks
+        .filter(f1 =>
+          !distinctFrameworks
+            .filter(_ != f1)
+            .exists(f2 =>
+              f1.getClass.isAssignableFrom(f2.getClass)
+            )
+        )
+    if (finalFrameworks.nonEmpty)
+      logger.log(
+        s"""Final list of test frameworks found:
+           |  - ${finalFrameworks.map(_.description).mkString("\n  - ")}
+           |""".stripMargin
+      )
+
+    val skippedInheritedFrameworks = distinctFrameworks.diff(finalFrameworks)
+    if (skippedInheritedFrameworks.nonEmpty)
+      logger.log(
+        s"""The following test frameworks have been filtered out, as they're being inherited from by others:
+           |  - ${skippedInheritedFrameworks.map(_.description).mkString("\n  - ")}
+           |""".stripMargin
+      )
+
+    finalFrameworks
+  }
+
+  def getFrameworksToRun(
+    frameworkServices: Seq[Framework],
+    frameworks: Seq[Framework]
+  )(logger: Logger): Seq[Framework] = {
+    if (frameworkServices.nonEmpty)
+      logger.debug(
+        s"""Found test framework services:
+           |  - ${frameworkServices.map(_.description).mkString("\n  - ")}
+           |""".stripMargin
+      )
+    if (frameworks.nonEmpty)
+      logger.debug(
+        s"""Found test frameworks:
+           |  - ${frameworks.map(_.description).mkString("\n  - ")}
+           |""".stripMargin
+      )
+
+    getFrameworksToRun(allFrameworks = frameworkServices ++ frameworks)(logger)
+  }
+
+  def listClasses(classPath: Seq[Path], keepJars: Boolean): Iterator[String] =
+    classPath.iterator.flatMap(listClasses(_, keepJars))
+
+  def listClasses(classPathEntry: Path, keepJars: Boolean): Iterator[String] =
+    if (Files.isDirectory(classPathEntry)) {
+      var stream: java.util.stream.Stream[Path] = null
+      try {
+        stream = Files.walk(classPathEntry, Int.MaxValue)
+        stream
+          .iterator
+          .asScala
+          .filter(_.getFileName.toString.endsWith(".class"))
+          .map(classPathEntry.relativize)
+          .map { p =>
+            val count = p.getNameCount
+            (0 until count).map(p.getName).mkString(".")
+          }
+          .map(_.stripSuffix(".class"))
+          .toVector // fully consume stream before closing it
+          .iterator
+      }
+      finally if (stream != null) stream.close()
+    }
+    else if (keepJars && Files.isRegularFile(classPathEntry)) {
+      import java.util.zip._
+      var zf: ZipFile = null
+      try {
+        zf = new ZipFile(classPathEntry.toFile)
+        zf.entries
+          .asScala
+          // FIXME Check if these are files too
+          .filter(_.getName.endsWith(".class"))
+          .map(ent => ent.getName.stripSuffix(".class").replace("/", "."))
+          .toVector // full consume ZipFile before closing it
+          .iterator
+      }
+      finally if (zf != null) zf.close()
+    }
+    else Iterator.empty
+
+  def findFrameworkServices(loader: ClassLoader): Seq[Framework] =
+    ServiceLoader.load(classOf[Framework], loader)
+      .iterator()
+      .asScala
+      .toSeq
+
+  def loadFramework(
+    loader: ClassLoader,
+    className: String
+  ): Framework = {
+    val cls         = loader.loadClass(className)
+    val constructor = cls.getConstructor()
+    constructor.newInstance().asInstanceOf[Framework]
+  }
+
+  def findFrameworks(
+    classPath: Seq[Path],
+    loader: ClassLoader,
+    preferredClasses: Seq[String]
+  ): Seq[Framework] = {
+    val frameworkCls = classOf[Framework]
+    (preferredClasses.iterator ++ listClasses(classPath, true))
+      .flatMap { name =>
+        val it: Iterator[Class[_]] =
+          try Iterator(loader.loadClass(name))
+          catch {
+            case _: ClassNotFoundException | _: UnsupportedClassVersionError | _: NoClassDefFoundError | _: IncompatibleClassChangeError =>
+              Iterator.empty
+          }
+        it
+      }
+      .flatMap { cls =>
+        def isAbstract = Modifier.isAbstract(cls.getModifiers)
+
+        def publicConstructorCount =
+          cls.getConstructors.count { c =>
+            Modifier.isPublic(c.getModifiers) && c.getParameterCount == 0
+          }
+
+        val it: Iterator[Class[_]] =
+          if (frameworkCls.isAssignableFrom(cls) && !isAbstract && publicConstructorCount == 1)
+            Iterator(cls)
+          else
+            Iterator.empty
+        it
+      }
+      .flatMap { cls =>
+        try {
+          val constructor = cls.getConstructor()
+          Iterator(constructor.newInstance().asInstanceOf[Framework])
+        }
+        catch {
+          case _: NoSuchMethodException => Iterator.empty
+        }
+      }
+      .toSeq
+  }
+
+  // adapted from https://github.com/com-lihaoyi/mill/blob/ab4d61a50da24fb7fac97c4453dd8a770d8ac62b/scalalib/src/Lib.scala#L156-L172
+  def matchFingerprints(
+    loader: ClassLoader,
+    cls: Class[_],
+    fingerprints: Array[Fingerprint]
+  ): Option[Fingerprint] = {
+    val isModule               = cls.getName.endsWith("$")
+    val publicConstructorCount = cls.getConstructors.count(c => Modifier.isPublic(c.getModifiers))
+    val noPublicConstructors   = publicConstructorCount == 0
+    val definitelyNoTests = Modifier.isAbstract(cls.getModifiers) ||
+      cls.isInterface ||
+      publicConstructorCount > 1 ||
+      isModule != noPublicConstructors
+    if (definitelyNoTests)
+      None
+    else
+      fingerprints.find {
+        case f: SubclassFingerprint =>
+          f.isModule == isModule &&
+          loader.loadClass(f.superclassName())
+            .isAssignableFrom(cls)
+
+        case f: AnnotatedFingerprint =>
+          val annotationCls = loader.loadClass(f.annotationName())
+            .asInstanceOf[Class[Annotation]]
+          f.isModule == isModule && (
+            cls.isAnnotationPresent(annotationCls) ||
+            cls.getDeclaredMethods.exists(_.isAnnotationPresent(annotationCls)) ||
+            cls.getMethods.exists { m =>
+              m.isAnnotationPresent(annotationCls) &&
+              Modifier.isPublic(m.getModifiers)
+            }
+          )
+      }
+  }
 }

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/Logger.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/Logger.scala
@@ -1,0 +1,21 @@
+package scala.build.testrunner
+
+import java.io.PrintStream
+
+class Logger(val verbosity: Int, out: PrintStream) {
+  def error(message: String): Unit = out.println(message)
+
+  def message(message: => String): Unit = if (verbosity >= 0) out.println(message)
+
+  def log(message: => String): Unit = if (verbosity >= 1) out.println(message)
+  def log(message: => String, debugMessage: => String): Unit =
+    if (verbosity >= 2) out.println(debugMessage)
+    else if (verbosity >= 1) out.println(message)
+
+  def debug(message: => String): Unit = if (verbosity >= 2) out.println(message)
+}
+
+object Logger {
+  def apply(verbosity: Int, out: PrintStream) = new Logger(verbosity, out)
+  def apply(verbosity: Int)                   = new Logger(verbosity, out = System.err)
+}

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/TestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/TestRunner.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable
 
 object TestRunner {
 
-  def commonTestFrameworks = Seq(
+  def commonTestFrameworks: Seq[String] = Seq(
     "munit.Framework",
     "utest.runner.Framework",
     "org.scalacheck.ScalaCheckFramework"
@@ -51,19 +51,15 @@ object TestRunner {
 
     val logger: SbtTestLogger =
       new SbtTestLogger {
-        def error(msg: String)   = out.println(msg)
-        def warn(msg: String)    = out.println(msg)
-        def info(msg: String)    = out.println(msg)
-        def debug(msg: String)   = out.println(msg)
-        def trace(t: Throwable)  = t.printStackTrace(out)
-        def ansiCodesSupported() = true
+        def error(msg: String): Unit      = out.println(msg)
+        def warn(msg: String): Unit       = out.println(msg)
+        def info(msg: String): Unit       = out.println(msg)
+        def debug(msg: String): Unit      = out.println(msg)
+        def trace(t: Throwable): Unit     = t.printStackTrace(out)
+        def ansiCodesSupported(): Boolean = true
       }
 
-    val eventHandler: EventHandler =
-      new EventHandler {
-        def handle(event: Event) =
-          events.append(event)
-      }
+    val eventHandler: EventHandler = (event: Event) => events.append(event)
 
     while (tasks.nonEmpty) {
       val task     = tasks.dequeue()

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/TestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/TestRunner.scala
@@ -1,6 +1,6 @@
 package scala.build.testrunner
 
-import sbt.testing._
+import sbt.testing.{Logger => SbtTestLogger, _}
 
 import java.io.{File, PrintStream}
 import java.nio.file.{Path, Paths}
@@ -49,8 +49,8 @@ object TestRunner {
 
     val events = mutable.Buffer.empty[Event]
 
-    val logger: Logger =
-      new Logger {
+    val logger: SbtTestLogger =
+      new SbtTestLogger {
         def error(msg: String)   = out.println(msg)
         def warn(msg: String)    = out.println(msg)
         def info(msg: String)    = out.println(msg)

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/TestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/TestRunner.scala
@@ -12,7 +12,12 @@ object TestRunner {
   def commonTestFrameworks: Seq[String] = Seq(
     "munit.Framework",
     "utest.runner.Framework",
-    "org.scalacheck.ScalaCheckFramework"
+    "org.scalacheck.ScalaCheckFramework",
+    "zio.test.sbt.ZTestFramework",
+    "org.scalatest.tools.Framework",
+    "com.novocode.junit.JUnitFramework",
+    "org.scalajs.junit.JUnitFramework",
+    "weaver.framework.CatsEffect"
   )
 
   def classPath(loader: ClassLoader): Seq[Path] = {

--- a/project/settings.sc
+++ b/project/settings.sc
@@ -556,6 +556,8 @@ trait HasTests extends SbtModule {
 
     def repositoriesTask =
       T.task(super.repositoriesTask() ++ deps.customRepositories)
+
+    override def testFramework: T[String] = super.testFramework
   }
 }
 


### PR DESCRIPTION
Fixes #3620 

What this does:
- on the JVM, all test frameworks should be detected and ran automatically
- on Scala Native & Scala.js platforms, all recognised test frameworks should be detected and ran automatically
  - unknown (non-recognised) and custom test frameworks are limited to 1 at a time, and not together with others; this is due to deep-searches for unknown test frameworks being very time-consuming;
  - this is still a straight-up upgrade over the past behaviour, when a single test framework would be run at all times.
- the `--test-framework` CLI option and `//> using testFramework` using directive work as before, where **only** the specified test framework is to be run
  - note that this gives the best performance, particularly for Scala Native & Scala.js tests, as this effectively skips test framework detection and runs with what is passed

Potential future follow-ups:
- handle multiple test frameworks on `SBT`/`Mill` export: https://github.com/VirtusLab/scala-cli/issues/3634
- expand the `--test-framework` CLI option and `//> using testFramework` directive to accept multiple values, allowing to preconfigure multiple frameworks and skipping detection: https://github.com/VirtusLab/scala-cli/issues/3632
- add a deep search flag, which would allow someone to actually deep search for test frameworks on Scala Native & Scala.js, if they really care to and don't mind the long loading times (not sure how many use cases that'd have, but it doesn't hurt to add a flag)
- add a `--print-test-frameworks` flag, similar to `--print-classpath`, to make it easier to find what test frameworks are available in the project: https://github.com/VirtusLab/scala-cli/issues/3633
- add a global config for preconfiguring more recognised test frameworks