### PR TITLE
Apply `scalafix` rules to test scope inputs, too

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/compile/Compile.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/compile/Compile.scala
@@ -13,6 +13,7 @@ import scala.cli.commands.setupide.SetupIde
 import scala.cli.commands.shared.{HelpCommandGroup, HelpGroup, SharedOptions}
 import scala.cli.commands.update.Update
 import scala.cli.commands.util.BuildCommandHelpers
+import scala.cli.commands.util.BuildCommandHelpers.*
 import scala.cli.commands.{CommandUtils, ScalaCommand, SpecificationLevel, WatchUtil}
 import scala.cli.config.{ConfigDb, Keys}
 import scala.cli.packaging.Library.fullClassPathMaybeAsJar

--- a/modules/cli/src/main/scala/scala/cli/commands/fix/Fix.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/fix/Fix.scala
@@ -54,6 +54,7 @@ object Fix extends ScalaCommand[FixOptions] {
             ScalafixRules.runRules(
               buildOptions = buildOpts,
               scalafixOptions = options.scalafix,
+              sharedOptions = options.shared,
               inputs = inputs,
               check = options.check,
               compilerMaker = compilerMaker,

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
@@ -37,6 +37,7 @@ import scala.cli.commands.publish.ConfigUtil.*
 import scala.cli.commands.run.Run.orPythonDetectionError
 import scala.cli.commands.shared.{HelpCommandGroup, HelpGroup, MainClassOptions, SharedOptions}
 import scala.cli.commands.util.BuildCommandHelpers
+import scala.cli.commands.util.BuildCommandHelpers.*
 import scala.cli.commands.{CommandUtils, ScalaCommand, WatchUtil}
 import scala.cli.config.{ConfigDb, Keys}
 import scala.cli.errors.ScalaJsLinkingError

--- a/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
@@ -25,6 +25,7 @@ import scala.cli.commands.run.RunMode
 import scala.cli.commands.setupide.SetupIde
 import scala.cli.commands.shared.{HelpCommandGroup, HelpGroup, SharedOptions}
 import scala.cli.commands.update.Update
+import scala.cli.commands.util.BuildCommandHelpers.*
 import scala.cli.commands.util.{BuildCommandHelpers, RunHadoop, RunSpark}
 import scala.cli.commands.{CommandUtils, ScalaCommand, SpecificationLevel, WatchUtil}
 import scala.cli.config.{ConfigDb, Keys}

--- a/modules/cli/src/main/scala/scala/cli/commands/util/BuildCommandHelpers.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/BuildCommandHelpers.scala
@@ -6,7 +6,7 @@ import scala.cli.commands.ScalaCommand
 import scala.cli.commands.shared.SharedOptions
 import scala.cli.commands.util.ScalacOptionsUtil.*
 
-trait BuildCommandHelpers { self: ScalaCommand[_] =>
+trait BuildCommandHelpers { self: ScalaCommand[?] =>
   extension (successfulBuild: Build.Successful) {
     def retainedMainClass(
       logger: Logger,
@@ -17,6 +17,23 @@ trait BuildCommandHelpers { self: ScalaCommand[_] =>
         self.argvOpt.map(_.mkString(" ")).getOrElse(actualFullCommand),
         logger
       )
+  }
+
+  extension (builds: Builds) {
+    def anyBuildCancelled: Boolean = builds.all.exists {
+      case _: Build.Cancelled => true
+      case _                  => false
+    }
+
+    def anyBuildFailed: Boolean = builds.all.exists {
+      case _: Build.Failed => true
+      case _               => false
+    }
+  }
+}
+
+object BuildCommandHelpers {
+  extension (successfulBuild: Build.Successful) {
 
     /** -O -d defaults to --compile-output; if both are defined, --compile-output takes precedence
       */
@@ -33,17 +50,5 @@ trait BuildCommandHelpers { self: ScalaCommand[_] =>
             replaceExisting = true
           )
         }
-  }
-
-  extension (builds: Builds) {
-    def anyBuildCancelled: Boolean = builds.all.exists {
-      case _: Build.Cancelled => true
-      case _                  => false
-    }
-
-    def anyBuildFailed: Boolean = builds.all.exists {
-      case _: Build.Failed => true
-      case _               => false
-    }
   }
 }


### PR DESCRIPTION
Fixes #3640 

The test scope simply wasn't being built for `scalafix`, so no wonder the `semanticdb` files were missing.
There's some follow-up refactoring I'd like to do in a future PR, but for the bugfix itself, this should do the trick.