### PR TITLE
`fix` sub-command tweaks

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/compile/Compile.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/compile/Compile.scala
@@ -102,6 +102,7 @@ object Compile extends ScalaCommand[CompileOptions] with BuildCommandHelpers {
         configDb.get(Keys.actions).getOrElse(None)
       )
 
+    val shouldBuildTestScope = options.shared.scope.test.getOrElse(false)
     if (options.watch.watchMode) {
       val watcher = Build.watch(
         inputs,
@@ -110,7 +111,7 @@ object Compile extends ScalaCommand[CompileOptions] with BuildCommandHelpers {
         None,
         logger,
         crossBuilds = cross,
-        buildTests = options.shared.scope.test,
+        buildTests = shouldBuildTestScope,
         partial = None,
         actionableDiagnostics = actionableDiagnostics,
         postAction = () => WatchUtil.printWatchMessage()
@@ -129,7 +130,7 @@ object Compile extends ScalaCommand[CompileOptions] with BuildCommandHelpers {
         None,
         logger,
         crossBuilds = cross,
-        buildTests = options.shared.scope.test,
+        buildTests = shouldBuildTestScope,
         partial = None,
         actionableDiagnostics = actionableDiagnostics
       )

--- a/modules/cli/src/main/scala/scala/cli/commands/dependencyupdate/DependencyUpdate.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/dependencyupdate/DependencyUpdate.scala
@@ -25,7 +25,7 @@ object DependencyUpdate extends ScalaCommand[DependencyUpdateOptions] {
     args: RemainingArgs,
     logger: Logger
   ): Unit = {
-    if options.shared.scope.test then
+    if options.shared.scope.test.nonEmpty then
       logger.message(
         s"""$warnPrefix Including the test scope does not change the behaviour of this command. 
            |$warnPrefix Test dependencies are updated regardless.""".stripMargin

--- a/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
@@ -52,7 +52,7 @@ object Doc extends ScalaCommand[DocOptions] {
         configDb.get(Keys.actions).getOrElse(None)
       )
 
-    val withTestScope = options.shared.scope.test
+    val withTestScope = options.shared.scope.test.getOrElse(false)
     Build.build(
       inputs,
       initialBuildOptions,

--- a/modules/cli/src/main/scala/scala/cli/commands/export0/Export.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/export0/Export.scala
@@ -136,7 +136,7 @@ object Export extends ScalaCommand[ExportOptions] {
   override def sharedOptions(opts: ExportOptions): Option[SharedOptions] = Some(opts.shared)
 
   override def runCommand(options: ExportOptions, args: RemainingArgs, logger: Logger): Unit = {
-    if options.shared.scope.test then {
+    if options.shared.scope.test.nonEmpty then {
       logger.error(
         s"""Including the test scope sources together with the main scope is currently not supported.
            |Note that test scope sources will still be exported as per the output build tool tests definition demands.""".stripMargin

--- a/modules/cli/src/main/scala/scala/cli/commands/fix/ScalafixRules.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/fix/ScalafixRules.scala
@@ -56,10 +56,6 @@ object ScalafixRules extends CommandHelpers {
         )
       else buildOptions
 
-    val scalaVersion =
-      buildOptions.scalaParams.orExit(logger).map(_.scalaVersion)
-        .getOrElse(Constants.defaultScalaVersion)
-
     val shouldBuildTestScope = sharedOptions.scope.test.getOrElse(true)
     if !shouldBuildTestScope then
       logger.message(
@@ -88,6 +84,13 @@ object ScalafixRules extends CommandHelpers {
         val scalacOptions =
           successfulBuilds.headOption.toSeq
             .flatMap(_.options.scalaOptions.scalacOptions.toSeq.map(_.value.value))
+
+        val scalaVersion = {
+          for {
+            b           <- successfulBuilds.headOption
+            scalaParams <- b.scalaParams
+          } yield scalaParams.scalaVersion
+        }.getOrElse(Constants.defaultScalaVersion)
 
         either {
           val artifacts =

--- a/modules/cli/src/main/scala/scala/cli/commands/fix/ScalafixRules.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/fix/ScalafixRules.scala
@@ -10,6 +10,7 @@ import scala.build.compiler.ScalaCompilerMaker
 import scala.build.errors.BuildException
 import scala.build.input.{Inputs, ScalaCliInvokeData}
 import scala.build.internal.{Constants, Runner}
+import scala.build.internals.ConsoleUtils.ScalaCliConsole.warnPrefix
 import scala.build.options.{BuildOptions, Scope}
 import scala.build.{Build, Logger, Os, ScalafixArtifacts}
 import scala.cli.commands.fix.ScalafixOptions
@@ -32,11 +33,28 @@ object ScalafixRules extends CommandHelpers {
     actionableDiagnostics: Option[Boolean],
     logger: Logger
   )(using ScalaCliInvokeData): Either[BuildException, Int] = {
-    val buildOptionsWithSemanticDb = buildOptions.copy(scalaOptions =
-      buildOptions.scalaOptions.copy(semanticDbOptions =
-        buildOptions.scalaOptions.semanticDbOptions.copy(generateSemanticDbs = Some(true))
-      )
-    )
+    sharedOptions.semanticDbOptions.semanticDb match {
+      case Some(false) =>
+        logger.message(
+          s"""$warnPrefix SemanticDB files' generation was explicitly set to false.
+             |$warnPrefix Some scalafix rules require .semanticdb files and may not work properly."""
+            .stripMargin
+        )
+      case Some(true) =>
+        logger.debug("SemanticDB files' generation enabled.")
+      case None =>
+        logger.debug("Defaulting SemanticDB files' generation to true, to satisfy scalafix needs.")
+    }
+    val buildOptionsWithSemanticDb =
+      if buildOptions.scalaOptions.semanticDbOptions.generateSemanticDbs.isEmpty then
+        buildOptions.copy(scalaOptions =
+          buildOptions.scalaOptions.copy(semanticDbOptions =
+            buildOptions.scalaOptions.semanticDbOptions.copy(generateSemanticDbs =
+              Some(true)
+            )
+          )
+        )
+      else buildOptions
 
     val scalaVersion =
       buildOptions.scalaParams.orExit(logger).map(_.scalaVersion)

--- a/modules/cli/src/main/scala/scala/cli/commands/fix/ScalafixRules.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/fix/ScalafixRules.scala
@@ -60,6 +60,13 @@ object ScalafixRules extends CommandHelpers {
       buildOptions.scalaParams.orExit(logger).map(_.scalaVersion)
         .getOrElse(Constants.defaultScalaVersion)
 
+    val shouldBuildTestScope = sharedOptions.scope.test.getOrElse(true)
+    if !shouldBuildTestScope then
+      logger.message(
+        s"""$warnPrefix Building test scope was explicitly disabled.
+           |$warnPrefix Some scalafix rules may not work correctly with test scope inputs."""
+          .stripMargin
+      )
     val res = Build.build(
       inputs,
       buildOptionsWithSemanticDb,
@@ -67,7 +74,7 @@ object ScalafixRules extends CommandHelpers {
       None,
       logger,
       crossBuilds = false,
-      buildTests = true,
+      buildTests = shouldBuildTestScope,
       partial = None,
       actionableDiagnostics = actionableDiagnostics
     )

--- a/modules/cli/src/main/scala/scala/cli/commands/fmt/Fmt.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/fmt/Fmt.scala
@@ -43,7 +43,7 @@ object Fmt extends ScalaCommand[FmtOptions] {
   override def runCommand(options: FmtOptions, args: RemainingArgs, logger: Logger): Unit = {
     val buildOptions = buildOptionsOrExit(options)
 
-    if options.shared.scope.test then
+    if options.shared.scope.test.nonEmpty then
       logger.message(
         s"""$warnPrefix Including the test scope does not change the behaviour of this command. 
            |$warnPrefix Test scope inputs are formatted, regardless.""".stripMargin

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
@@ -88,7 +88,7 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
         configDb.get(Keys.actions).getOrElse(None)
       )
 
-    val withTestScope = options.shared.scope.test
+    val withTestScope = options.shared.scope.test.getOrElse(false)
     if options.watch.watchMode then {
       var expectedModifyEpochSecondOpt = Option.empty[Long]
       val watcher = Build.watch(

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -266,7 +266,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
       () => configDb,
       options.mainClass,
       dummy = options.sharedPublish.dummy,
-      buildTests = options.shared.scope.test
+      buildTests = options.shared.scope.test.getOrElse(false)
     )
   }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
@@ -86,7 +86,7 @@ object PublishLocal extends ScalaCommand[PublishLocalOptions] {
       configDb = () => ConfigDb.empty, // shouldn't be used, no need of repo credentials here
       mainClassOptions = options.mainClass,
       dummy = options.sharedPublish.dummy,
-      buildTests = options.shared.scope.test
+      buildTests = options.shared.scope.test.getOrElse(false)
     )
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
@@ -190,10 +190,11 @@ object Repl extends ScalaCommand[ReplOptions] with BuildCommandHelpers {
         configDb.get(Keys.actions).getOrElse(None)
       )
 
+    val shouldBuildTestScope = options.shared.scope.test.getOrElse(false)
     if (inputs.isEmpty) {
       val allArtifacts =
         Seq(initialBuildOptions.artifacts(logger, Scope.Main).orExit(logger)) ++
-          (if options.shared.scope.test
+          (if shouldBuildTestScope
            then Seq(initialBuildOptions.artifacts(logger, Scope.Test).orExit(logger))
            else Nil)
       // synchronizing, so that multiple presses to enter (handled by WatchUtil.waitForCtrlC)
@@ -224,7 +225,7 @@ object Repl extends ScalaCommand[ReplOptions] with BuildCommandHelpers {
         None,
         logger,
         crossBuilds = cross,
-        buildTests = options.shared.scope.test,
+        buildTests = shouldBuildTestScope,
         partial = None,
         actionableDiagnostics = actionableDiagnostics,
         postAction = () => WatchUtil.printWatchMessage()
@@ -252,7 +253,7 @@ object Repl extends ScalaCommand[ReplOptions] with BuildCommandHelpers {
           None,
           logger,
           crossBuilds = cross,
-          buildTests = options.shared.scope.test,
+          buildTests = shouldBuildTestScope,
           partial = None,
           actionableDiagnostics = actionableDiagnostics
         )

--- a/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
@@ -233,6 +233,7 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
         configDb.get(Keys.actions).getOrElse(None)
       )
 
+    val shouldBuildTestScope = options.shared.scope.test.getOrElse(false)
     if options.sharedRun.watch.watchMode then {
 
       /** A handle to the Runner process, used to kill the process if it's still alive when a change
@@ -258,7 +259,7 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
         docCompilerMakerOpt = None,
         logger = logger,
         crossBuilds = cross,
-        buildTests = options.shared.scope.test,
+        buildTests = shouldBuildTestScope,
         partial = None,
         actionableDiagnostics = actionableDiagnostics,
         postAction = () =>
@@ -331,7 +332,7 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
         None,
         logger,
         crossBuilds = cross,
-        buildTests = options.shared.scope.test,
+        buildTests = shouldBuildTestScope,
         partial = None,
         actionableDiagnostics = actionableDiagnostics
       )

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScopeOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScopeOptions.scala
@@ -12,7 +12,7 @@ case class ScopeOptions(
   @Name("testScope")
   @Name("withTestScope")
   @Name("withTest")
-  test: Boolean = false
+  test: Option[Boolean] = None
 )
 object ScopeOptions {
   implicit lazy val parser: Parser[ScopeOptions] = Parser.derive


### PR DESCRIPTION
Some tweaks on `fix` sub-command behaviour
- it will now respect the `--test` command line flag
  - `scalafix` rules may require `.semanticdb` files for test scope inputs, so the `fix` sub-command defaults to build the test scope as well (unlike other sub-commands)
  - however, if `--test=false` is explicitly passed, Scala CLI will now warn about it, but respect the option (and skip building the test scope, rather than silently ignore it as before)
- it will now respect the `--semanticdb` flag
  - `scalafix` rules may require `.semanticdb` files for various rules, so the `fix` sub-command defaults to generate them as well (unlike other sub-commands)
  - however, if `--test=false` is explicitly passed, Scala CLI will now warn about it, but respect the option (and skip SemanticDB,  rather than silently ignore it, as before)
- Scala CLI will now pass the correct Scala version to scalafix, when the scala version was defined in a using directive
- misc refactoring to achieve the above 