### PR TITLE
Add a suffix to the script file to avoid conflict with library name

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/AmmUtil.scala
+++ b/modules/build/src/main/scala/scala/build/internal/AmmUtil.scala
@@ -13,7 +13,7 @@ object AmmUtil {
       case i  => fileName.take(i)
     }
 
-    (pkg, Name(wrapper))
+    (pkg, Name(s"${wrapper}_scalacli_wrapper"))
   }
 
   def encodeScalaSourcePath(path: Seq[Name]) = path.map(_.backticked).mkString(".")

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
@@ -105,7 +105,7 @@ case object ScriptPreprocessor extends Preprocessor {
         scriptCode,
         inputArgPath.getOrElse(subPath.toString)
       )
-      
+
       val relPath = os.rel / (subPath / os.up) / s"${subPath.last.stripSuffix(".sc")}.scala"
 
       val file = PreprocessedSource.UnwrappedScript(

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
@@ -105,9 +105,8 @@ case object ScriptPreprocessor extends Preprocessor {
         scriptCode,
         inputArgPath.getOrElse(subPath.toString)
       )
-
-      val className = (pkg :+ wrapper).map(_.raw).mkString(".")
-      val relPath   = os.rel / (subPath / os.up) / s"${subPath.last.stripSuffix(".sc")}.scala"
+      
+      val relPath = os.rel / (subPath / os.up) / s"${subPath.last.stripSuffix(".sc")}.scala"
 
       val file = PreprocessedSource.UnwrappedScript(
         originalPath = reportingPath.map((subPath, _)),

--- a/modules/build/src/test/scala/scala/build/tests/ScriptWrapperTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ScriptWrapperTests.scala
@@ -117,12 +117,35 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
         )
         expect(projectDir.size == 1)
         expectClassWrapper(
-          "script1",
+          "script1_scalacli_wrapper",
           projectDir.head / "src_generated" / "main" / "script1.scala"
         )
         expectClassWrapper(
-          "script2",
+          "script2_scalacli_wrapper",
           projectDir.head / "src_generated" / "main" / "script2.scala"
+        )
+    }
+  }
+
+  test(s"run script file properly when file name equals a library name") {
+    val inputs = TestInputs(
+      os.rel / "script1.sc" ->
+        s"""//> using dep "dev.zio::zio:2.1.16"
+           |
+           |import zio.ZIO
+           |""".stripMargin
+    )
+
+    inputs.withBuild(baseOptions, buildThreads, bloopConfigOpt) {
+      (root, _, maybeBuild) =>
+        expect(maybeBuild.orThrow.success)
+        val projectDir = os.list(root / ".scala-build").filter(
+          _.baseName.startsWith(root.baseName + "_")
+        )
+        expect(projectDir.size == 1)
+        expectClassWrapper(
+          "script1_scalacli_wrapper",
+          projectDir.head / "src_generated" / "main" / "script1.scala"
         )
     }
   }
@@ -160,11 +183,11 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
           )
           expect(projectDir.size == 1)
           expectObjectWrapper(
-            "script1",
+            "script1_scalacli_wrapper",
             projectDir.head / "src_generated" / "main" / "script1.scala"
           )
           expectObjectWrapper(
-            "script2",
+            "script2_scalacli_wrapper",
             projectDir.head / "src_generated" / "main" / "script2.scala"
           )
       }
@@ -203,11 +226,11 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
           )
           expect(projectDir.size == 1)
           expectAppWrapper(
-            "script1",
+            "script1_scalacli_wrapper",
             projectDir.head / "src_generated" / "main" / "script1.scala"
           )
           expectAppWrapper(
-            "script2",
+            "script2_scalacli_wrapper",
             projectDir.head / "src_generated" / "main" / "script2.scala"
           )
       }
@@ -249,11 +272,11 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
           expect(projectDir.size == 1)
 
           expectObjectWrapper(
-            "script1",
+            "script1_scalacli_wrapper",
             projectDir.head / "src_generated" / "main" / "script1.scala"
           )
           expectObjectWrapper(
-            "script2",
+            "script2_scalacli_wrapper",
             projectDir.head / "src_generated" / "main" / "script2.scala"
           )
       }


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/3595

Note. Could not add fallaback for the runner name