### PR TITLE
Check formatting with Scala CLI, rather than the `scalafmt` launcher itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1512,10 +1512,7 @@ jobs:
         fetch-depth: 0
         submodules: true
     - uses: VirtusLab/scala-cli-setup@v1
-      with:
-        jvm: "temurin:17"
-        apps: scalafmt:3.0.0
-    - run: scalafmt --check
+    - run: scala-cli fmt . --check
 
   reference-doc:
     timeout-minutes: 15


### PR DESCRIPTION
It'd actually make sense to dogfood the `fmt` sub-command here, so.