### PR TITLE
Add support for the `--repl-quit-after-init` REPL option

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
@@ -407,20 +407,15 @@ object Repl extends ScalaCommand[ReplOptions] with BuildCommandHelpers {
       extraProps: Map[String, String] = Map.empty
     ): Unit = {
       val isAmmonite = replArtifacts.replMainClass.startsWith("ammonite")
-      if replArgs.exists(_.noDashPrefixes == ScalacOptions.replInitScript) then
-        scalaParams.scalaVersion match
-          case _ if isAmmonite =>
+      if isAmmonite then
+        replArgs
+          .map(_.noDashPrefixes)
+          .filter(ScalacOptions.replExecuteScriptOptions.contains)
+          .foreach(arg =>
             logger.message(
-              "The '--repl-init-script' option is not supported with Ammonite. Did you mean to use '--ammonite-arg'?"
+              s"The '--$arg' option is not supported with Ammonite. Did you mean to use '--ammonite-arg -c' to execute a script?"
             )
-          case s
-              if s.coursierVersion < "3.6.4-RC1".coursierVersion &&
-              s.coursierVersion < "3.6.4".coursierVersion &&
-              s.coursierVersion < "3.6.4-RC1-bin-20250109-a50a1e4-NIGHTLY".coursierVersion =>
-            logger.message(
-              "The '--repl-init-script option' is only supported starting with Scala 3.6.4 and onwards."
-            )
-          case _ => ()
+          )
       if dryRun then logger.message("Dry run, not running REPL.")
       else {
         val depClassPathArgs: Seq[String] =

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
@@ -48,8 +48,10 @@ object ScalacOptions {
   val YScriptRunnerOption               = "Yscriptrunner"
   private val scalacOptionsPurePrefixes = Set("V", "W", "X", "Y")
   private val scalacOptionsPrefixes     = Set("P") ++ scalacOptionsPurePrefixes
-  val replInitScript                    = "repl-init-script"
-  private val replAliasedOptions        = Set(replInitScript)
+  val replExecuteScriptOptions @ Seq(replInitScript, replQuitAfterInit) =
+    Seq("repl-init-script", "repl-quit-after-init")
+  private val replAliasedOptions      = Set(replInitScript)
+  private val replNoArgAliasedOptions = Set(replQuitAfterInit)
   private val scalacAliasedOptions = // these options don't require being passed after -O and accept an arg
     Set(
       "bootclasspath",
@@ -104,7 +106,7 @@ object ScalacOptions {
       "preview",
       "uniqid",
       "unique-id"
-    )
+    ) ++ replNoArgAliasedOptions
 
   /** This includes all the scalac options which disregard inputs and print a help and/or context
     * message instead.


### PR DESCRIPTION
Follow-up for 3.7 after:
- https://github.com/scala/scala3/pull/22636

Also a pre-requirement for:
- https://github.com/VirtusLab/scala-cli/issues/3210