### PR TITLE
fix for #3481

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -314,7 +314,13 @@ object ScalaCli {
 
     if (Properties.isWin && System.console() != null && coursier.paths.Util.useJni())
       // Enable ANSI output in Windows terminal
-      coursier.jniutils.WindowsAnsiTerminal.enableAnsiOutput()
+      try
+        coursier.jniutils.WindowsAnsiTerminal.enableAnsiOutput()
+      catch {
+        // ignore error resulting from redirect STDOUT to /dev/null
+        case e: java.io.IOException
+            if Properties.isWin && e.getMessage.contains("GetConsoleMode error 6") =>
+      }
 
     new ScalaCliCommands(progName, baseRunnerName, fullRunnerName)
       .main(scalaCliArgs)

--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -319,7 +319,7 @@ object ScalaCli {
       catch {
         // ignore error resulting from redirect STDOUT to /dev/null
         case e: java.io.IOException
-            if Properties.isWin && e.getMessage.contains("GetConsoleMode error 6") =>
+            if e.getMessage.contains("GetConsoleMode error 6") =>
       }
 
     new ScalaCliCommands(progName, baseRunnerName, fullRunnerName)


### PR DESCRIPTION
This addresses issue #3481.

In Windows, when STDOUT is redirected to `/dev/null` an exception is thrown:
```sh
scala.bat -e "printf("""hello""")" > NUL
```
```scala
java.io.IOException: Error enabling ANSI output: GetConsoleMode error 6
  coursier.jniutils.WindowsAnsiTerminal.enableAnsiOutput(WindowsAnsiTerminal.java:25)
  scala.cli.ScalaCli$.main0(ScalaCli.scala:317)
  scala.cli.ScalaCli$.main(ScalaCli.scala:124)
  scala.cli.ScalaCli.main(ScalaCli.scala)
```

The fix, only in Windows, is to selectively ignore `java.io.IOException` if `getMessage` contains `'GetConsoleMode error 6`.


Error 6 means "invalid handle", and is appropriate since `stdout` redirected to NUL is not a console handle.
Since everything sent to `stdout` is discarded, it shouldn't matter that `Ansi` mode is not enabled.

The documentation for [GetConsoleScreenBufferInfo](https://learn.microsoft.com/en-us/windows/console/getconsolescreenbufferinfo#:~:text=This%20API%20does,on%20ReadConsoleInput.) describes limitations.

Just noticed that the 2nd `isWin` in the exception handling is redundant.