### PR TITLE
Bump `java-class-name` to 0.1.6

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -148,7 +148,7 @@ object Deps {
     def signingCli                        = "0.2.6"
     def signingCliJvmVersion              = Java.defaultJava
     def javaSemanticdb                    = "0.10.0"
-    def javaClassName                     = "0.1.4"
+    def javaClassName                     = "0.1.6"
     def bloop                             = "2.0.10"
     def sbtVersion                        = "1.10.11"
     def mavenVersion                      = "3.8.1"


### PR DESCRIPTION
https://github.com/VirtusLab/java-class-name/releases/tag/v0.1.6