### PR TITLE
Bump `scala-js-cli` to 1.19.0.1

### DIFF
--- a/project/deps.sc
+++ b/project/deps.sc
@@ -34,7 +34,7 @@ object Scala {
   val testRunnerScalaVersions = (runnerScalaVersions ++ allScala3).distinct
 
   def scalaJs    = "1.19.0"
-  def scalaJsCli = scalaJs // this must be compatible with the Scala.js version
+  def scalaJsCli = "1.19.0.1" // this must be compatible with the Scala.js version
 
   private def patchVer(sv: String): Int =
     sv.split('.').drop(2).head.takeWhile(_.isDigit).toInt

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1394,7 +1394,7 @@ Path to the Scala.js linker
 ### `--js-cli-version`
 
 [Internal]
-Scala.js CLI version to use for linking (1.19.0 by default).
+Scala.js CLI version to use for linking (1.19.0.1 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -822,7 +822,7 @@ Path to the Scala.js linker
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Scala.js CLI version to use for linking (1.19.0 by default).
+Scala.js CLI version to use for linking (1.19.0.1 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -424,7 +424,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.19.0 by default).
+Scala.js CLI version to use for linking (1.19.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -1206,7 +1206,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.19.0 by default).
+Scala.js CLI version to use for linking (1.19.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -1807,7 +1807,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.19.0 by default).
+Scala.js CLI version to use for linking (1.19.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -2438,7 +2438,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.19.0 by default).
+Scala.js CLI version to use for linking (1.19.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -3078,7 +3078,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.19.0 by default).
+Scala.js CLI version to use for linking (1.19.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -3676,7 +3676,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.19.0 by default).
+Scala.js CLI version to use for linking (1.19.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -4352,7 +4352,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.19.0 by default).
+Scala.js CLI version to use for linking (1.19.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -5038,7 +5038,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.19.0 by default).
+Scala.js CLI version to use for linking (1.19.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -6007,7 +6007,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.19.0 by default).
+Scala.js CLI version to use for linking (1.19.0.1 by default).
 
 **--js-cli-java-arg**
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-js-cli/releases/tag/v1.19.0.1