### PR TITLE
Make `test-fish-shell`, `test-hypothetical-sbt-export` and `bloop-memory-footprint` required for publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1651,6 +1651,9 @@ jobs:
       - vc-redist
       - format
       - checks
+      - test-fish-shell
+      - test-hypothetical-sbt-export
+      - bloop-memory-footprint
       - reference-doc
       - docs-tests
     if: github.event_name == 'push' && github.repository == 'VirtusLab/scala-cli'
@@ -1730,6 +1733,9 @@ jobs:
       - vc-redist
       - format
       - checks
+      - test-fish-shell
+      - test-hypothetical-sbt-export
+      - bloop-memory-footprint
       - reference-doc
       - generate-linux-arm64-native-launcher
       - publish


### PR DESCRIPTION
It was theoretically possible to make a release with those 3 jobs failing.