### PR TITLE
Add more tests for URLs in using file directives

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/RunGistTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunGistTestDefinitions.scala
@@ -9,54 +9,63 @@ trait RunGistTestDefinitions { _: RunTestDefinitions =>
     if (Properties.isWin) "\"" + url + "\""
     else url
 
-  protected val scalaScriptUrl =
-    "https://gist.github.com/alexarchambault/f972d941bc4a502d70267cfbbc4d6343/raw/b0285fa0305f76856897517b06251970578565af/test.sc"
-  protected val scalaScriptMessage = "Hello from GitHub Gist"
-
-  test("Script URL") {
-    emptyInputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, escapedUrls(scalaScriptUrl))
-        .call(cwd = root)
-        .out.trim()
-      expect(output == scalaScriptMessage)
-    }
-  }
-
-  test("Scala URL") {
-    val url =
-      "https://gist.github.com/alexarchambault/f972d941bc4a502d70267cfbbc4d6343/raw/2691c01984c9249936a625a42e29a822a357b0f6/Test.scala"
-    val message = "Hello from Scala GitHub Gist"
-    emptyInputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, escapedUrls(url))
-        .call(cwd = root)
-        .out.trim()
-      expect(output == message)
-    }
-  }
-
-  test("Java URL") {
-    val url =
-      "https://gist.github.com/alexarchambault/f972d941bc4a502d70267cfbbc4d6343/raw/2691c01984c9249936a625a42e29a822a357b0f6/Test.java"
-    val message = "Hello from Java GitHub Gist"
-    emptyInputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, extraOptions, escapedUrls(url))
-        .call(cwd = root)
-        .out.trim()
-      expect(output == message)
-    }
-  }
-
-  test("Github Gists Script URL") {
-    TestUtil.retryOnCi() {
+  for {
+    useFileDirective <- Seq(true, false)
+    useFileDirectiveMessage = if (useFileDirective) " (//> using file)" else ""
+  } {
+    def testInputs(url: String) =
+      if (useFileDirective) TestInputs(os.rel / "input.scala" -> s"//> using file $url")
+      else emptyInputs
+    def args(url: String) = if (useFileDirective) Seq(".") else Seq(escapedUrls(url))
+    test(s"Script URL$useFileDirectiveMessage") {
       val url =
-        "https://gist.github.com/alexarchambault/7b4ec20c4033690dd750ffd601e540ec"
-      val message = "Hello"
-      emptyInputs.fromRoot { root =>
-        val output = os.proc(TestUtil.cli, extraOptions, escapedUrls(url))
+        "https://gist.github.com/alexarchambault/f972d941bc4a502d70267cfbbc4d6343/raw/b0285fa0305f76856897517b06251970578565af/test.sc"
+      val expectedMessage = "Hello from GitHub Gist"
+      testInputs(url).fromRoot { root =>
+        val output = os.proc(TestUtil.cli, "run", extraOptions, args(url))
+          .call(cwd = root)
+          .out.trim()
+        expect(output == expectedMessage)
+      }
+    }
+
+    test(s"Scala URL$useFileDirectiveMessage") {
+      val url =
+        "https://gist.github.com/alexarchambault/f972d941bc4a502d70267cfbbc4d6343/raw/2691c01984c9249936a625a42e29a822a357b0f6/Test.scala"
+      val message = "Hello from Scala GitHub Gist"
+      testInputs(url).fromRoot { root =>
+        val output = os.proc(TestUtil.cli, extraOptions, args(url))
           .call(cwd = root)
           .out.trim()
         expect(output == message)
       }
     }
+
+    test(s"Java URL$useFileDirectiveMessage") {
+      val url =
+        "https://gist.github.com/alexarchambault/f972d941bc4a502d70267cfbbc4d6343/raw/2691c01984c9249936a625a42e29a822a357b0f6/Test.java"
+      val message = "Hello from Java GitHub Gist"
+      testInputs(url).fromRoot { root =>
+        val output = os.proc(TestUtil.cli, extraOptions, args(url))
+          .call(cwd = root)
+          .out.trim()
+        expect(output == message)
+      }
+    }
+
+    if (!useFileDirective) // TODO: add support for gists in using file directives
+      test(s"Github Gists Script URL$useFileDirectiveMessage") {
+        TestUtil.retryOnCi() {
+          val url =
+            "https://gist.github.com/alexarchambault/7b4ec20c4033690dd750ffd601e540ec"
+          val message = "Hello"
+          testInputs(url).fromRoot { root =>
+            val output = os.proc(TestUtil.cli, extraOptions, args(url))
+              .call(cwd = root)
+              .out.trim()
+            expect(output == message)
+          }
+        }
+      }
   }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
@@ -111,17 +111,6 @@ class RunTestsDefault extends RunTestDefinitions
     }
   }
 
-  test("using file + http[s] link directive") {
-    val inputPath = os.rel / "usingFileLinkExample.scala"
-    TestInputs(inputPath -> s"//> using file $scalaScriptUrl\n").fromRoot {
-      root =>
-        val res = os.proc(TestUtil.cli, "run", extraOptions, inputPath)
-          .call(cwd = root)
-        val out = res.out.trim()
-        expect(out == scalaScriptMessage)
-    }
-  }
-
   for {
     suppressDeprecatedWarnings <- Seq(true, false)
     suppressByConfig           <- if (suppressDeprecatedWarnings) Seq(true, false) else Seq(false)


### PR DESCRIPTION
- follow up to https://github.com/VirtusLab/scala-cli/pull/3681
- this mostly refactors the existing remote sources tests to run both directly and via the `//> using file` directive