### PR TITLE
Fix flaky `build-macros[_].test.testNegativeCompilation`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
         retention-days: 2
     - name: Cross compile everything
       run: ./mill -i '__[_].compile'
+    - name: Build macros negative compilation tests
+      run: ./mill -i build-macros[_].test.testNegativeCompilation
     - name: Unit tests
       run: ./mill -i unitTests
     - name: Convert Mill test reports to JUnit XML format

--- a/build.mill.scala
+++ b/build.mill.scala
@@ -313,19 +313,11 @@ trait BuildMacros extends ScalaCliCrossSbtModule
   }
 
   object test extends ScalaCliTests {
-
-    // Is there a better way to add task dependency to test?
-    def test(args: String*): Command[(String, Seq[TestResult])] = Task.Command {
-      val res = super.test(args: _*)()
-      testNegativeCompilation()()
-      res
-    }
-
     def scalacOptions: Target[Seq[String]] = Task {
       super.scalacOptions() ++ asyncScalacOptions(scalaVersion())
     }
 
-    def testNegativeCompilation(): Command[Unit] = Task.Command {
+    def testNegativeCompilation(): Command[Unit] = Task.Command(exclusive = true) {
       val base          = Task.workspace / "modules" / "build-macros" / "src"
       val negativeTests = Seq(
         "MismatchedLeft.scala" -> Seq(


### PR DESCRIPTION
It seems that `build-macros[_].test.testNegativeCompilation` has been flaky because of Mill 0.12 running stuff in parallel, unless explicitly stated otherwise.
We used to run it within the `unitTests` task.
I now explicitly mark it as non-parallel and run it in a separate step on the CI.

The flaky failure itself is failing with a timeout from `bloop-rifle`:
```scala
[0842] Exception in thread "main" java.util.concurrent.TimeoutException: Future timed out after [30 seconds]
[0842] 	at scala.concurrent.impl.Promise$DefaultPromise.tryAwait0(Promise.scala:248)
[0842] 	at scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:261)
[0842] 	at scala.concurrent.Await$.$anonfun$result$1(package.scala:201)
[0842] 	at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:62)
[0842] 	at scala.concurrent.Await$.result(package.scala:124)
[0842] 	at bloop.rifle.internal.Operations$.timeout(Operations.scala:534)
[0842] 	at bloop.rifle.internal.Operations$.about(Operations.scala:503)
[0842] 	at bloop.rifle.BloopRifle$.getCurrentBloopVersion(BloopRifle.scala:158)
[0842] 	at bloop.rifle.BloopServer$.ensureBloopRunning(BloopServer.scala:84)
[0842] 	at bloop.rifle.BloopServer$.bsp(BloopServer.scala:156)
[0842] 	at bloop.rifle.BloopServer$.buildServer(BloopServer.scala:186)
[0842] 	at scala.build.compiler.BloopCompilerMaker.$anonfun$1$$anonfun$1(BloopCompilerMaker.scala:56)
[0842] 	at scala.build.package$package$.helper$1(package.scala:16)
[0842] 	at scala.build.package$package$.retry(package.scala:29)
[0842] 	at scala.build.compiler.BloopCompilerMaker.$anonfun$1(BloopCompilerMaker.scala:58)
[0842] 	at scala.build.compiler.BloopCompiler.<init>(BloopCompiler.scala:15)
[0842] 	at scala.build.compiler.BloopCompilerMaker.$anonfun$2(BloopCompilerMaker.scala:60)
[0842] 	at scala.util.Try$.apply(Try.scala:217)
[0842] 	at scala.build.compiler.BloopCompilerMaker.create(BloopCompilerMaker.scala:60)
[0842] 	at scala.build.compiler.ScalaCompilerMaker.withCompiler(ScalaCompilerMaker.scala:34)
[0842] 	at scala.build.compiler.ScalaCompilerMaker.withCompiler$(ScalaCompilerMaker.scala:9)
[0842] 	at scala.build.compiler.BloopCompilerMaker.withCompiler(BloopCompilerMaker.scala:14)
[0842] 	at scala.build.Build$.build$$anonfun$3(Build.scala:635)
[0842] 	at scala.build.EitherCps$Helper.apply(EitherCps.scala:19)
[0842] 	at scala.build.Build$.build(Build.scala:610)
[0842] 	at scala.cli.commands.compile.Compile$.runCommand(Compile.scala:136)
[0842] 	at scala.cli.commands.compile.Compile$.runCommand(Compile.scala:39)
[0842] 	at scala.cli.commands.ScalaCommand.run(ScalaCommand.scala:401)
[0842] 	at scala.cli.commands.ScalaCommand.run(ScalaCommand.scala:382)
[0842] 	at caseapp.core.app.CaseApp.main(CaseApp.scala:166)
[0842] 	at scala.cli.commands.ScalaCommand.main(ScalaCommand.scala:367)
[0842] 	at caseapp.core.app.CommandsEntryPoint.main(CommandsEntryPoint.scala:370)
[0842] 	at scala.cli.ScalaCliCommands.main(ScalaCliCommands.scala:125)
[0842] 	at scala.cli.ScalaCli$.main0(ScalaCli.scala:320)
[0842] 	at scala.cli.ScalaCli$.main(ScalaCli.scala:124)
[0842] 	at scala.cli.ScalaCli.main(ScalaCli.scala)
```

The timeout seems to be this one: https://github.com/scalacenter/bloop/blame/9eb13aecc872f8d77a9e9ed5d10cbecacf207bd4/bloop-rifle/src/main/scala/bloop/rifle/internal/Operations.scala#L502 
(it's been there for a long time)