### PR TITLE
Fix publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1674,7 +1674,7 @@ jobs:
       env:
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
     - run: ./mill -i ci.setShouldPublish
-    - run: ./mill -i publishSonatype '{__[],_,test-runner[2.13.16],test-runner[2.12.20],runner[2.13.16],runner[2.12.20]}.publishArtifacts'
+    - run: ./mill -i publishSonatype --tasks '{__[],_,test-runner[2.13.16],test-runner[2.12.20],runner[2.13.16],runner[2.12.20]}.publishArtifacts'
       if: env.SHOULD_PUBLISH == 'true'
       env:
         PGP_PASSWORD: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
🤦 
```scala
Run ./mill -i publishSonatype '{__[],_,test-runner[2.13.16],test-runner[2.12.20],runner[2.13.16],runner[2.12.20]}.publishArtifacts'
=============== publishSonatype {__[],_,test-run...nner[2.12.20]}.publishArtifacts ===============
[62/65] =============== publishSonatype {__[],_,te...2.[12](https://github.com/VirtusLab/scala-cli/actions/runs/15429197304/job/43428644197#step:6:13).20]}.publishArtifacts =============== 3s
Missing argument: --tasks <tasks>
Unknown argument: "{__[],_,test-runner[2.[13](https://github.com/VirtusLab/scala-cli/actions/runs/15429197304/job/43428644197#step:6:14).16],test-runner[2.12.20],runner[2.13.16],runner[2.12.20]}.publishArtifacts"
Expected Signature: publishSonatype
  --tasks <tasks>
  ```

This should do the trick.