### PR TITLE
Fix version string of published artifacts

### DIFF
--- a/build.mill.scala
+++ b/build.mill.scala
@@ -8,7 +8,7 @@ import build.ci.publishVersion
 import build.project.deps
 import deps.{Cli, Deps, Docker, InternalDeps, Java, Scala, TestDeps}
 import build.project.publish
-import publish.{ScalaCliPublishModule, ghName, ghOrg, organization}
+import publish.{ScalaCliPublishModule, finalPublishVersion, ghName, ghOrg, organization}
 import build.project.settings
 import settings.{
   CliLaunchers,
@@ -1344,7 +1344,7 @@ object `local-repo` extends LocalRepo {
 
 // Helper CI commands
 def publishSonatype(tasks: mill.main.Tasks[PublishModule.PublishData]) = Task.Command {
-  val pv = publishVersion()
+  val pv = finalPublishVersion()
   System.err.println(s"Publish version: $pv")
   val bundleName = s"$organization-$ghName-$pv"
   System.err.println(s"Publishing bundle: $bundleName")


### PR DESCRIPTION
```scala
[1734] Publish version: ci.publishVersion
[1734] Publishing bundle: org.virtuslab.scala-cli-scala-cli-ci.publishVersion
[1734/1734] =============== publishSonatype --tasks...2.20]}.publishArtifacts =============== 180s
[1734] publishSonatype 19s
[1734/1734, 1 failed] =============== publishSonatype --...}.publishArtifacts =============== 191s
1 tasks failed
publishSonatype java.lang.RuntimeException: Failed to publish org.virtuslab.scala-cli-scala-cli-ci.publishVersion to Sonatype Central
    mill.scalalib.SonatypeCentralPublisher.publishFile(SonatypeCentralPublisher.scala:106)
    mill.scalalib.SonatypeCentralPublisher.$anonfun$publishAll$8(SonatypeCentralPublisher.scala:80)
    mill.scalalib.SonatypeCentralPublisher.$anonfun$publishAll$8$adapted(SonatypeCentralPublisher.scala:69)
    scala.Option.fold(Option.scala:263)
    mill.scalalib.SonatypeCentralPublisher.publishAll(SonatypeCentralPublisher.scala:69)
    build_.project.publish.package_.publishSonatype(package.mill.scala:208)
    build_.package_.$anonfun$publishSonatype$2(build.mill.scala:1356)
    scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
```
It seems I used the wrong function to generate the version for artifacts bundle.
hopefully that's the only reason for the publishing to be failing.