### PR TITLE
fix for 3725, 3752, 3766 and 3769

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/AmmUtil.scala
+++ b/modules/build/src/main/scala/scala/build/internal/AmmUtil.scala
@@ -18,7 +18,7 @@ object AmmUtil {
 
   def encodeScalaSourcePath(path: Seq[Name]) = path.map(_.backticked).mkString(".")
 
-  def normalizeNewlines(s: String)(using newLine: String = lineSeparator): String =
+  def normalizeNewlines(s: String): String =
     s.replace("\r", "")
 
   lazy val lineSeparator: String = "\n"

--- a/modules/build/src/main/scala/scala/build/internal/AmmUtil.scala
+++ b/modules/build/src/main/scala/scala/build/internal/AmmUtil.scala
@@ -18,5 +18,8 @@ object AmmUtil {
 
   def encodeScalaSourcePath(path: Seq[Name]) = path.map(_.backticked).mkString(".")
 
-  def normalizeNewlines(s: String) = s.replace("\r", "").replace("\n", System.lineSeparator())
+  def normalizeNewlines(s: String)(using newLine: String = lineSeparator): String =
+    s.replace("\r", "")
+
+  lazy val lineSeparator: String = "\n"
 }

--- a/modules/build/src/main/scala/scala/build/internal/markdown/MarkdownCodeWrapper.scala
+++ b/modules/build/src/main/scala/scala/build/internal/markdown/MarkdownCodeWrapper.scala
@@ -115,15 +115,15 @@ object MarkdownCodeWrapper {
       val fence: MarkdownCodeBlock = snippets(index)
       val classOpener: String      =
         if (index == 0)
-          s"object ${scopeObjectName(scopeIndex)} {${System.lineSeparator()}" // first snippet needs to open a class
+          s"object ${scopeObjectName(scopeIndex)} {${AmmUtil.lineSeparator}" // first snippet needs to open a class
         else if (fence.resetScope)
-          s"}; object ${scopeObjectName(scopeIndex)} {${System.lineSeparator()}" // if scope is being reset, close previous class and open a new one
-        else System.lineSeparator()
+          s"}; object ${scopeObjectName(scopeIndex)} {${AmmUtil.lineSeparator}" // if scope is being reset, close previous class and open a new one
+        else AmmUtil.lineSeparator
       val nextScopeIndex = if index == 0 || fence.resetScope then scopeIndex + 1 else scopeIndex
-      val newAcc         = acc + (System.lineSeparator() * (fence.startLine - line - 1)) // padding
+      val newAcc         = acc + (AmmUtil.lineSeparator * (fence.startLine - line - 1)) // padding
         .:++(classOpener) // new class opening (if applicable)
         .:++(fence.body) // snippet body
-        .:++(System.lineSeparator()) // padding in place of closing backticks
+        .:++(AmmUtil.lineSeparator) // padding in place of closing backticks
       generateMainScalaLines(
         snippets = snippets,
         index = index + 1,
@@ -154,9 +154,9 @@ object MarkdownCodeWrapper {
     if index >= snippets.length then acc
     else {
       val fence: MarkdownCodeBlock = snippets(index)
-      val newAcc = acc + (System.lineSeparator() * (fence.startLine - line)) // padding
+      val newAcc = acc + (AmmUtil.lineSeparator * (fence.startLine - line)) // padding
         .:++(fence.body) // snippet body
-        .:++(System.lineSeparator()) // padding in place of closing backticks
+        .:++(AmmUtil.lineSeparator) // padding in place of closing backticks
       generateRawScalaLines(snippets, index + 1, fence.endLine + 1, newAcc)
     }
 }

--- a/modules/build/src/main/scala/scala/build/internal/markdown/MarkdownOpenFence.scala
+++ b/modules/build/src/main/scala/scala/build/internal/markdown/MarkdownOpenFence.scala
@@ -39,7 +39,8 @@ case class MarkdownOpenFence(
     val start: Int               = tickStartLine + 1
     val bodyLines: Array[String] = lines.slice(start, tickEndLine)
     val body                     = bodyLines.mkString("\n")
-    val (bodyWithNoSheBang, _)   = SheBang.ignoreSheBangLines(body)
+
+    val (bodyWithNoSheBang, _, _) = SheBang.ignoreSheBangLines(body)
     MarkdownCodeBlock(
       info.split("\\s+").toList, // strip info by whitespaces
       bodyWithNoSheBang,

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScalaPreprocessor.scala
@@ -171,7 +171,8 @@ case object ScalaPreprocessor extends Preprocessor {
     allowRestrictedFeatures: Boolean,
     suppressWarningOptions: SuppressWarningOptions
   )(using ScalaCliInvokeData): Either[BuildException, Option[ProcessingOutput]] = either {
-    val (contentWithNoShebang, _)                = SheBang.ignoreSheBangLines(content)
+    val (contentWithNoShebang, _, _) = SheBang.ignoreSheBangLines(content)
+
     val extractedDirectives: ExtractedDirectives = value(ExtractedDirectives.from(
       contentChars = contentWithNoShebang.toCharArray,
       path = path,
@@ -210,7 +211,7 @@ case object ScalaPreprocessor extends Preprocessor {
       logger
     )
 
-    val (content0, isSheBang)                          = SheBang.ignoreSheBangLines(content)
+    val (content0, isSheBang, _)                       = SheBang.ignoreSheBangLines(content)
     val preprocessedDirectives: PreprocessedDirectives =
       value(DirectivesPreprocessor(
         path,

--- a/modules/build/src/main/scala/scala/build/preprocessing/SheBang.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/SheBang.scala
@@ -1,38 +1,47 @@
 package scala.build.preprocessing
 
-import scala.util.matching.Regex
-
 object SheBang {
-  private val sheBangRegex: Regex = s"""(^(#!.*(\\X)?)+(\\X*!#.*)?)""".r
+  def isShebangScript(content: String): Boolean = content.startsWith("#!")
 
-  def isShebangScript(content: String): Boolean = sheBangRegex.unanchored.matches(content)
-
-  /** Returns the shebang section and the content without the shebang section */
-  def partitionOnShebangSection(content: String): (String, String) =
+  def partitionOnShebangSection(content: String): (String, String, String) =
     if (content.startsWith("#!")) {
-      val regexMatch = sheBangRegex.findFirstMatchIn(content)
-      regexMatch match {
-        case Some(firstMatch) =>
-          (firstMatch.toString(), content.replaceFirst(firstMatch.toString(), ""))
-        case None => ("", content)
+      val splitIndex = content.indexOf("\n!#") match {
+        case -1 =>
+          val eolIndex = content.indexOf("\n")
+          content.drop(eolIndex + 1) match {
+            case s if s.startsWith("#!") =>
+              eolIndex + s.indexOf("\n") + 1 // skip over #! nix-shell line
+            case _ =>
+              eolIndex + 1
+          }
+        case index =>
+          var i = index + 1
+          while (i < content.length && content(i) != '\n') i += 1
+          i + 1 // split at start of subsequent line
       }
+      val newLine: String = content.drop(splitIndex - 2).take(2) match {
+        case CRLF => CRLF
+        case _    => "\n"
+      }
+      val (header, body) = content.splitAt(splitIndex)
+      (header, body, newLine)
     }
     else
-      ("", content)
+      ("", content, lineSeparator(content))
 
-  def ignoreSheBangLines(content: String): (String, Boolean) =
-    if (content.startsWith("#!")) {
-      val regexMatch = sheBangRegex.findFirstMatchIn(content)
-      regexMatch match {
-        case Some(firstMatch) =>
-          content.replace(
-            firstMatch.toString(),
-            System.lineSeparator() * firstMatch.toString().split(System.lineSeparator()).length
-          ) -> true
-        case None => (content, false)
-      }
-    }
+  def ignoreSheBangLines(content: String): (String, Boolean, String) =
+    if (content.startsWith("#!"))
+      val (header, body, newLine) = partitionOnShebangSection(content)
+      val blankHeader             = newLine * (header.split("\\R", -1).length - 1)
+      (s"$blankHeader$body", true, newLine)
     else
-      (content, false)
+      (content, false, lineSeparator(content))
+
+  def lineSeparator(content: String): String = content.indexOf(CRLF) match {
+    case -1 => "\n"
+    case _  => CRLF
+  }
+
+  private final val CRLF: String = "\r\n"
 
 }

--- a/modules/build/src/test/scala/scala/build/tests/ActionableDiagnosticTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ActionableDiagnosticTests.scala
@@ -23,6 +23,8 @@ class ActionableDiagnosticTests extends TestUtil.ScalaCliBuildSuite {
   )
   val buildThreads = BuildThreads.create()
 
+  def path2url(p: os.Path): String = p.toIO.toURI.toURL.toString
+
   test("using outdated os-lib") {
     val dependencyOsLib = "com.lihaoyi::os-lib:0.7.8"
     val testInputs      = TestInputs(
@@ -160,7 +162,7 @@ class ActionableDiagnosticTests extends TestUtil.ScalaCliBuildSuite {
     )
     val withRepoBuildOptions = baseOptions.copy(
       classPathOptions =
-        baseOptions.classPathOptions.copy(extraRepositories = Seq(s"file:${repoTmpDir.toString}"))
+        baseOptions.classPathOptions.copy(extraRepositories = Seq(path2url(repoTmpDir)))
     )
     testInputs.withBuild(withRepoBuildOptions, buildThreads, None, actionableDiagnostics = true) {
       (_, _, maybeBuild) =>
@@ -222,7 +224,7 @@ class ActionableDiagnosticTests extends TestUtil.ScalaCliBuildSuite {
     val withRepoBuildOptions = baseOptions.copy(
       classPathOptions =
         baseOptions.classPathOptions.copy(extraRepositories =
-          Seq(s"file:${repoTmpDir.toString.replace('\\', '/')}")
+          Seq(path2url(repoTmpDir))
         )
     )
     testInputs.withBuild(withRepoBuildOptions, buildThreads, None, actionableDiagnostics = true) {

--- a/modules/build/src/test/scala/scala/build/tests/SourceGeneratorTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/SourceGeneratorTests.scala
@@ -54,6 +54,7 @@ class SourceGeneratorTests extends TestUtil.ScalaCliBuildSuite {
         "val scalaCliVersion = Some\\(\"[^\"]*\"\\)",
         "val scalaCliVersion = Some\\(\"1.1.1-SNAPSHOT\"\\)"
       )
+      .replaceAll("\\\\", "\\")
       .linesWithSeparators
       .filterNot(_.stripLeading().startsWith("/**"))
       .mkString

--- a/modules/build/src/test/scala/scala/build/tests/TestUtil.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestUtil.scala
@@ -92,5 +92,11 @@ object TestUtil {
       )
   }
 
+  def c2s(c: Char): String = c match {
+    case '\r' => "\\r"
+    case '\n' => "\\n"
+    case s    => s"$s"
+  }
+
   lazy val cs = Constants.cs
 }

--- a/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownCodeBlockTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownCodeBlockTests.scala
@@ -66,6 +66,30 @@ class MarkdownCodeBlockTests extends TestUtil.ScalaCliBuildSuite {
       )
     val Right(Seq(actualResult: MarkdownCodeBlock)) =
       MarkdownCodeBlock.findCodeBlocks(os.sub / "Example.md", markdown)
+    showDiffs(actualResult, expectedResult)
+    expect(actualResult == expectedResult)
+  }
+
+  test("end-of-shebang token allowed in scala code") {
+    val code     = """println("Hello !#")""".stripMargin
+    val markdown =
+      s"""# Some snippet
+         |
+         |```scala
+         |#!/usr/bin/env -S scala-cli shebang
+         |$code
+         |```
+         |""".stripMargin
+    val expectedResult =
+      MarkdownCodeBlock(
+        info = PlainScalaInfo,
+        body = "\n" + code,
+        startLine = 3,
+        endLine = 4
+      )
+    val Right(Seq(actualResult: MarkdownCodeBlock)) =
+      MarkdownCodeBlock.findCodeBlocks(os.sub / "Example.md", markdown)
+    showDiffs(actualResult, expectedResult)
     expect(actualResult == expectedResult)
   }
 
@@ -114,6 +138,7 @@ class MarkdownCodeBlockTests extends TestUtil.ScalaCliBuildSuite {
       )
     val Right(Seq(actualResult: MarkdownCodeBlock)) =
       MarkdownCodeBlock.findCodeBlocks(os.sub / "Example.md", markdown)
+    showDiffs(actualResult, expectedResult)
     expect(actualResult == expectedResult)
   }
 
@@ -209,4 +234,16 @@ class MarkdownCodeBlockTests extends TestUtil.ScalaCliBuildSuite {
     expect(actualError.positions == expectedError.positions)
     expect(actualError.message == expectedError.message)
   }
+
+  def showDiffs(actual: MarkdownCodeBlock, expect: MarkdownCodeBlock): Unit = {
+    if actual != expect then
+      for (((a, b), i) <- (actual.body zip expect.body).zipWithIndex)
+        if (a != b) {
+          val aa = TestUtil.c2s(a)
+          val bb = TestUtil.c2s(b)
+          System.err.printf("== index %d: [%s]!=[%s]\n", i, aa, bb)
+        }
+      System.err.printf("actual[%s]\nexpect[%s]\n", actual, expect)
+  }
+
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/fix/BuiltInRules.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/fix/BuiltInRules.scala
@@ -30,7 +30,7 @@ object BuiltInRules extends CommandHelpers {
         .exists(_.nameAliases.contains(directiveTestPrefix + strictDirective.key))
   }
 
-  private val newLine: String = System.lineSeparator()
+  private val newLine: String = scala.build.internal.AmmUtil.lineSeparator
 
   def runRules(
     inputs: Inputs,
@@ -191,7 +191,7 @@ object BuiltInRules extends CommandHelpers {
     val logger = loggingUtilities.logger
 
     val fromPaths = sources.paths.map { (path, _) =>
-      val (_, content) = SheBang.partitionOnShebangSection(os.read(path))
+      val (_, content, _) = SheBang.partitionOnShebangSection(os.read(path))
       logger.debug(s"Extracting directives from ${loggingUtilities.relativePath(path)}")
       ExtractedDirectives.from(
         contentChars = content.toCharArray,
@@ -220,7 +220,7 @@ object BuiltInRules extends CommandHelpers {
           }
       }
 
-      val (_, contentWithNoShebang) = SheBang.partitionOnShebangSection(content)
+      val (_, contentWithNoShebang, _) = SheBang.partitionOnShebangSection(content)
 
       ExtractedDirectives.from(
         contentChars = contentWithNoShebang.toCharArray,
@@ -298,7 +298,8 @@ object BuiltInRules extends CommandHelpers {
   ): Unit = {
     position match {
       case Some(Position.File(Right(path), _, _, offset)) =>
-        val (shebangSection, strippedContent) = SheBang.partitionOnShebangSection(os.read(path))
+        val (shebangSection, strippedContent, newLine) =
+          SheBang.partitionOnShebangSection(os.read(path))
 
         def ignoreOrAddNewLine(str: String) = if str.isBlank then "" else str + newLine
 

--- a/modules/core/src/main/scala/scala/build/internals/CodeWrapper.scala
+++ b/modules/core/src/main/scala/scala/build/internals/CodeWrapper.scala
@@ -24,7 +24,11 @@ abstract class CodeWrapper {
     val (topWrapper, bottomWrapper) =
       apply(code, pkgName, indexedWrapperName, extraCode0, scriptPath)
 
-    val nl                            = System.lineSeparator()
+    // match lineSeparator to existing code
+    val nl = code.indexOf("\n") match {
+      case n if n > 0 && code(n - 1) == '\r' => System.lineSeparator()
+      case _                                 => "\n"
+    }
     val (topWrapper0, bottomWrapper0) =
       (
         topWrapper + "/*<script>*/" + nl,

--- a/modules/docs-tests/src/main/scala/sclicheck/sclicheck.scala
+++ b/modules/docs-tests/src/main/scala/sclicheck/sclicheck.scala
@@ -262,7 +262,7 @@ def checkFile(file: os.Path, options: Options): Unit =
         if !shouldAlignContent(file) then prefixLines.mkString("")
         else prefixLines.mkString("", "", s"$fakeLineMarker\n" * c.line)
 
-      os.write.over(file, code.mkString(prefix, "\n", ""), createFolders = true)
+      os.write.over(file, codeLines.mkString(prefix, "\n", ""), createFolders = true)
 
     def run(cmd: os.proc): Int =
       val res = cmd.call(


### PR DESCRIPTION
The `Regex` that is used to partition the `shebang` section from script code is too permissive.
The end marker must appear as the first 2 characters of the line it appears on.

The cause of bug #3725 is that the `partitionShebangSection` grabs part of the scala code [here](https://github.com/VirtusLab/scala-cli/blob/bb9c9f8fe1b5980439e253bd48edffd613abdeb9/modules/build/src/main/scala/scala/build/preprocessing/SheBang.scala#L13).
The fix is to require that the `Regex` substring `!#` is anchored at the beginning of a line.