### PR TITLE
Prepare artifacts in a separate step before they are published to Sonatype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1674,7 +1674,10 @@ jobs:
       env:
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
     - run: ./mill -i ci.setShouldPublish
-    - run: ./mill -i publishSonatype --tasks '{__[],_,test-runner[2.13.16],test-runner[2.12.20],runner[2.13.16],runner[2.12.20]}.publishArtifacts'
+    - name: Prepare artifacts
+      run: ./mill -i '{__[],_,test-runner[2.13.16],test-runner[2.12.20],runner[2.13.16],runner[2.12.20]}.publishArtifacts'
+    - name: Publish to Sonatype
+      run: ./mill -i publishSonatype --tasks '{__[],_,test-runner[2.13.16],test-runner[2.12.20],runner[2.13.16],runner[2.12.20]}.publishArtifacts'
       if: env.SHOULD_PUBLISH == 'true'
       env:
         PGP_PASSWORD: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
Relevant to:
- https://github.com/VirtusLab/scala-cli/issues/3742

It will be silly if this solves it.
I basically want to make sure that all the `publishArtifacts` jobs have finished before we start publishing to Sonatype.