### PR TITLE
Ensure publishing to Sonatype runs without parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1674,7 +1674,7 @@ jobs:
       env:
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
     - run: ./mill -i ci.setShouldPublish
-    - run: ./mill -i publishSonatype --tasks '{__[],_,test-runner[2.13.16],test-runner[2.12.20],runner[2.13.16],runner[2.12.20]}.publishArtifacts'
+    - run: ./mill -i -j1 publishSonatype --tasks '{__[],_,test-runner[2.13.16],test-runner[2.12.20],runner[2.13.16],runner[2.12.20]}.publishArtifacts'
       if: env.SHOULD_PUBLISH == 'true'
       env:
         PGP_PASSWORD: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
Relevant to:
- https://github.com/VirtusLab/scala-cli/issues/3742

As suggested in https://discord.com/channels/632150470000902164/940067748103487558/1386702655782387783