### PR TITLE
Switch publishing to Sonatype Central to not use a bundle

### DIFF
--- a/build.mill.scala
+++ b/build.mill.scala
@@ -1349,16 +1349,16 @@ def publishSonatype(tasks: mill.main.Tasks[PublishModule.PublishData]) = Task.Co
     s"""Tasks producing artifacts to be included in the bundle:
        |  ${taskNames.mkString("\n  ")}""".stripMargin
   )
-  val pv = finalPublishVersion()
-  System.err.println(s"Publish version: $pv")
-  val bundleName = s"$organization-$ghName-$pv"
-  System.err.println(s"Publishing bundle: $bundleName")
+//  val pv = finalPublishVersion()
+//  System.err.println(s"Publish version: $pv")
+//  val bundleName = s"$organization-$ghName-$pv"
+//  System.err.println(s"Publishing bundle: $bundleName")
   publish.publishSonatype(
     data = define.Target.sequence(tasks.value)(),
     log = Task.ctx().log,
     workspace = Task.workspace,
     env = Task.env,
-    bundleName = bundleName
+    bundleName = None
   )
 }
 

--- a/project/publish/package.mill.scala
+++ b/project/publish/package.mill.scala
@@ -158,7 +158,7 @@ def publishSonatype(
   log: mill.api.Logger,
   workspace: os.Path,
   env: Map[String, String],
-  bundleName: String
+  bundleName: Option[String] = None
 ): Unit = {
   val credentials = SonatypeCredentials(
     username = sys.env("SONATYPE_USERNAME"),
@@ -206,8 +206,11 @@ def publishSonatype(
   )
   val publishingType = if (isRelease) PublishingType.AUTOMATIC else PublishingType.USER_MANAGED
   System.err.println(s"Publishing type: $publishingType")
-  val finalBundleName = if (bundleName.nonEmpty) Some(bundleName) else None
-  System.err.println(s"Final bundle name: $finalBundleName")
+  val finalBundleName = bundleName.filter(_.nonEmpty)
+  finalBundleName match {
+    case Some(bn) => System.err.println(s"Final bundle name: $bn")
+    case _        => System.err.println("No bundle name provided")
+  }
   publisher.publishAll(
     publishingType = publishingType,
     singleBundleName = finalBundleName,


### PR DESCRIPTION
Relevant to:

https://github.com/VirtusLab/scala-cli/issues/3742

As suggested in https://discord.com/channels/632150470000902164/940067748103487558/1386709263522463935

This is likely borked, as when testing with mock credentials on my local machine, the publishing does not fail... 😐 