### PR TITLE
Print artifacts' version when publishing Scala CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1673,8 +1673,12 @@ jobs:
       run: .github/scripts/gpg-setup.sh
       env:
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
-    - run: ./mill -i ci.setShouldPublish
-    - run: ./mill mill.scalalib.SonatypeCentralPublishModule/ --publishArtifacts '{__[],_,test-runner[2.13.16],test-runner[2.12.20],runner[2.13.16],runner[2.12.20]}.publishArtifacts'
+    - name: Set publish flag
+      run: ./mill -i ci.setShouldPublish
+    - name: Print version
+      run: ./mill -i show project.publish.finalPublishVersion
+    - name: Publish to Sonatype Central
+      run: ./mill mill.scalalib.SonatypeCentralPublishModule/ --publishArtifacts '{__[],_,test-runner[2.13.16],test-runner[2.12.20],runner[2.13.16],runner[2.12.20]}.publishArtifacts'
       if: env.SHOULD_PUBLISH == 'true'
       env:
         MILL_PGP_SECRET_BASE64: ${{ secrets.PGP_SECRET }}


### PR DESCRIPTION
Just a sanity check, as the publishing logic we're testing doesn't actually print it.