### PR TITLE
Don't prepend shell scripts for CLI bootstrapped fatJARs

### DIFF
--- a/build.mill.scala
+++ b/build.mill.scala
@@ -72,6 +72,8 @@ object cliBootstrapped extends ScalaCliPublishModule {
 
   import mill.scalalib.Assembly
 
+  override def prependShellScript: T[String] = Task("")
+
   override def mainClass: Target[Option[String]] = Some("scala.cli.ScalaCli")
 
   override def assemblyRules: Seq[Assembly.Rule] = Seq(


### PR DESCRIPTION
Perhaps the one and only fix for:
- https://github.com/VirtusLab/scala-cli/issues/3742