### PR TITLE
Prevent the REPL from warning about restricted `java.lang.System` API on JDK 24

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -244,16 +244,18 @@ abstract class ScalaCommand[T <: HasGlobalOptions](implicit myParser: Parser[T],
           }
           else if (shared.helpGroups.helpRepl) {
             val initialBuildOptions = buildOptionsOrExit(options)
-            val artifacts     = initialBuildOptions.artifacts(logger, Scope.Main).orExit(logger)
-            val replArtifacts = value {
+            val artifacts        = initialBuildOptions.artifacts(logger, Scope.Main).orExit(logger)
+            val javaVersion: Int = initialBuildOptions.javaHome().value.version
+            val replArtifacts    = value {
               ReplArtifacts.default(
-                scalaParams,
-                artifacts.userDependencies,
-                Nil,
-                logger,
-                buildOptions.finalCache,
-                Nil,
-                None
+                scalaParams = scalaParams,
+                dependencies = artifacts.userDependencies,
+                extraClassPath = Nil,
+                logger = logger,
+                cache = buildOptions.finalCache,
+                repositories = Nil,
+                addScalapy = None,
+                javaVersion = javaVersion
               )
             }
             replArtifacts.replClassPath -> replArtifacts.replMainClass

--- a/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
@@ -452,9 +452,10 @@ object Repl extends ScalaCommand[ReplOptions] with BuildCommandHelpers {
           cache,
           value(options.finalRepositories),
           addScalapy =
-            if (setupPython)
+            if setupPython then
               Some(options.notForBloopOptions.scalaPyVersion.getOrElse(Constants.scalaPyVersion))
-            else None
+            else None,
+          javaVersion = options.javaHome().value.version
         )
       }
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunWithWatchTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunWithWatchTestDefinitions.scala
@@ -1,24 +1,12 @@
 package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
-import os.SubProcess
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.{Duration, DurationInt}
+import scala.cli.integration.TestUtil.ProcOps
+import scala.concurrent.duration.DurationInt
 import scala.util.{Properties, Try}
 
 trait RunWithWatchTestDefinitions { _: RunTestDefinitions =>
-  implicit class ProcOps(proc: SubProcess) {
-    def printStderrUntilRerun(timeout: Duration)(implicit ec: ExecutionContext): Unit = {
-      def rerunWasTriggered(): Boolean = {
-        val stderrOutput = TestUtil.readLine(proc.stderr, ec, timeout)
-        println(stderrOutput)
-        stderrOutput.contains("re-run")
-      }
-      while (!rerunWasTriggered()) Thread.sleep(100L)
-    }
-  }
-
   // TODO make this pass reliably on Mac CI
   if (!Properties.isMac || !TestUtil.isCI) {
     val expectedMessage1 = "Hello"

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -83,7 +83,7 @@ object Java {
   def minimumBloopJava: Int      = 17
   def minimumInternalJava: Int   = 16
   def defaultJava: Int           = minimumBloopJava
-  def mainJavaVersions: Seq[Int] = Seq(8, 11, 17, 21, 23)
+  def mainJavaVersions: Seq[Int] = Seq(8, 11, 17, 21, 23, 24)
   def allJavaVersions: Seq[Int]  =
     (mainJavaVersions ++ Seq(minimumBloopJava, minimumInternalJava, defaultJava)).distinct
 }


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/22756

## What even happens here?
JLine uses some restricted JDK API, which becomes a warning on JDK 24.
https://docs.oracle.com/en/java/javase/24/core/restricted-methods.html

## Why can't we use the approach suggested in the warning?
The API being called can be enabled with `--enable-native-access`, but it is unfortunately only possible via module name.
Which means the call needs to happen in a named module, on the module path. 
The REPL uses a class path, not a module path. The warning suggests `ALL-UNNAMED`, as everything on the classpath doesn't have a named module and thus is just thrown into the catch-all unnamed bin. 
`--enable-native-access=ALL-UNNAMED` is way too broad, as it could cause users to miss legitimate warnings from their code.

## So what do we do instead?
What I do is force JLine on the module path as well as the class path (sigh), let the JVM pick up its default module names from the JAR manifests and then enable the restricted access APIs for those paths only.

## Can this break with a future JLine version bump?
Sure it can.
This is fragile, as we can't really rely on this stuff being unchanged in different JLine versions.
You might notice that the named module defaults in manifests of JLine versions used by Scala 2.13 and Scala 3 REPL differ. 
I added a test, so that we have a sanity check.
The test is a bit hacky too, but what can you do.
Hacky problems require hacky solutions.

## Behaviour examples

### Before
- Scala 3
  ```bash
  scala-cli repl --jvm 24
  # WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
  # WARNING: sun.misc.Unsafe::objectFieldOffset has been called by scala.runtime.LazyVals$ (file:/Users/pchabelski/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.7.1/scala3-library_3-3.7.1.jar)
  # WARNING: Please consider reporting this to the maintainers of class scala.runtime.LazyVals$
  # WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
  # WARNING: A restricted method in java.lang.System has been called
  # WARNING: java.lang.System::load has been called by org.jline.nativ.JLineNativeLoader in an unnamed module (file:/Users/pchabelski/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/jline/jline-native/3.29.0/jline-native-3.29.0.jar)
  # WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
  # WARNING: Restricted methods will be blocked in a future release unless native access is enabled
  # 
  # Welcome to Scala 3.7.1 (24.0.1, Java OpenJDK 64-Bit Server VM).
  # Type in expressions for evaluation. Or try :help.
  #                                                                                                                
  # scala> 
  ```
- Scala 2.13
  ```bash
  scala-cli repl --jvm 24 -S 2.13
  # Welcome to Scala 2.13.16 (OpenJDK 64-Bit Server VM, Java 24.0.1).
  # Type in expressions for evaluation. Or try :help.
  # WARNING: A restricted method in java.lang.System has been called
  # WARNING: java.lang.System::load has been called by org.jline.nativ.JLineNativeLoader in an unnamed module (file:/Users/pchabelski/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/jline/jline/3.27.1/jline-3.27.1-jdk8.jar)
  # WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
  # WARNING: Restricted methods will be blocked in a future release unless native access is enabled
  # 
  # 
  # scala>
  ``` 

### After
- Scala 3
  ```bash
  scala-cli repl --jvm 24
  # WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
  # WARNING: sun.misc.Unsafe::objectFieldOffset has been called by scala.runtime.LazyVals$ (file:/Users/pchabelski/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala3-library_3/3.7.1/scala3-library_3-3.7.1.jar)
  # WARNING: Please consider reporting this to the maintainers of class scala.runtime.LazyVals$
  # WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
  # Welcome to Scala 3.7.1 (24.0.1, Java OpenJDK 64-Bit Server VM).
  # Type in expressions for evaluation. Or try :help.
  #            
  #
  # scala> 
  ``` 
- Scala 2.13
  ```bash
  scala-cli repl --jvm 24 -S 2.13
  # Welcome to Scala 2.13.16 (OpenJDK 64-Bit Server VM, Java 24.0.1).
  # Type in expressions for evaluation. Or try :help.
  # 
  # scala> 
  ```

## Extra context
The remaining warning is tied to https://github.com/scala/scala3/issues/9013 and will be addressed in Scala 3.8 (along with the JDK bump to 17)

cc @sjrd @lrytz