### PR TITLE
Add support for publishing with Scala CLI to Sonatype Central Portal

### DIFF
--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -115,7 +115,7 @@ object Deps {
     def coursier                          = coursierDefault
     def coursierCli                       = coursierDefault
     def coursierM1Cli                     = coursierDefault
-    def coursierPublish                   = "0.4.0"
+    def coursierPublish                   = "0.4.1"
     def jmh                               = "1.37"
     def jsoniterScalaJava8                = "2.13.5.2"
     def jsoup                             = "1.21.1"

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -129,7 +129,7 @@ object Deps {
     def maxScalaNativeForScalaPy          = scalaNative04
     def maxScalaNativeForMillExport       = scalaNative05
     def scalaPackager                     = "0.1.33"
-    def signingCli                        = "0.2.9"
+    def signingCli                        = "0.2.10"
     def signingCliJvmVersion              = Java.defaultJava
     def javaSemanticdb                    = "0.10.0"
     def javaClassName                     = "0.1.7"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -2192,7 +2192,7 @@ Available in commands:
 ### `--signing-cli-version`
 
 [Internal]
-scala-cli-signing version when running externally (0.2.9 by default)
+scala-cli-signing version when running externally (0.2.10 by default)
 
 ### `--signing-cli-java-arg`
 


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/2771

The actual fix was delivered here:
- https://github.com/coursier/publish/pull/127

Also note that this doesn't cover publishing `*-SNAPSHOT` versions, which are tracked separately here:
- https://github.com/VirtusLab/scala-cli/issues/3777