### PR TITLE
fix for 3789

### DIFF
--- a/modules/build/src/main/scala/scala/build/input/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/input/Inputs.scala
@@ -222,6 +222,8 @@ object Inputs {
     ).flatten
   }
 
+  lazy val scalaHashbang = "#!.*scala.*".r
+
   def validateArgs(
     args: Seq[String],
     cwd: os.Path,
@@ -237,6 +239,7 @@ object Inputs {
         lazy val subPath         = path.subRelativeTo(dir)
         lazy val stdinOpt0       = stdinOpt
         lazy val content         = os.read.bytes(path)
+        lazy val firstline       = new String(content.takeWhile(_ != '\n')).trim
         lazy val fullProgramCall = programInvokeData.progName +
           s"${
               if programInvokeData.subCommand == SubCommand.Default then ""
@@ -275,7 +278,8 @@ object Inputs {
         }
         else if path.last == Constants.projectFileName then
           Right(Seq(ProjectScalaFile(dir, subPath)))
-        else if arg.endsWith(".sc") then Right(Seq(Script(dir, subPath, Some(arg))))
+        else if arg.endsWith(".sc") || scalaHashbang.matches(firstline) then
+          Right(Seq(Script(dir, subPath, Some(arg))))
         else if arg.endsWith(".scala") then Right(Seq(SourceScalaFile(dir, subPath)))
         else if arg.endsWith(".java") then Right(Seq(JavaFile(dir, subPath)))
         else if arg.endsWith(".jar") then Right(Seq(JarFile(dir, subPath)))

--- a/modules/build/src/main/scala/scala/build/input/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/input/Inputs.scala
@@ -234,13 +234,12 @@ object Inputs {
   )(using programInvokeData: ScalaCliInvokeData): Seq[Either[String, Seq[Element]]] =
     args.zipWithIndex.map {
       case (arg, idx) =>
-        lazy val path      = os.Path(arg, cwd)
-        lazy val dir       = path / os.up
-        lazy val subPath   = path.subRelativeTo(dir)
-        lazy val stdinOpt0 = stdinOpt
-        lazy val content   = os.read.bytes(path)
-        lazy val firstline =
-          if os.isDir(path) then "" else new String(content.takeWhile(_ != '\n')).trim
+        lazy val path            = os.Path(arg, cwd)
+        lazy val dir             = path / os.up
+        lazy val subPath         = path.subRelativeTo(dir)
+        lazy val stdinOpt0       = stdinOpt
+        lazy val content         = os.read.bytes(path)
+        lazy val firstline       = new String(content.takeWhile(_ != '\n')).trim
         lazy val fullProgramCall = programInvokeData.progName +
           s"${
               if programInvokeData.subCommand == SubCommand.Default then ""
@@ -279,7 +278,7 @@ object Inputs {
         }
         else if path.last == Constants.projectFileName then
           Right(Seq(ProjectScalaFile(dir, subPath)))
-        else if arg.endsWith(".sc") || scalaHashbang.matches(firstline) then
+        else if arg.endsWith(".sc") || isShebangScript(String(content)) then
           Right(Seq(Script(dir, subPath, Some(arg))))
         else if arg.endsWith(".scala") then Right(Seq(SourceScalaFile(dir, subPath)))
         else if arg.endsWith(".java") then Right(Seq(JavaFile(dir, subPath)))

--- a/modules/build/src/main/scala/scala/build/input/Inputs.scala
+++ b/modules/build/src/main/scala/scala/build/input/Inputs.scala
@@ -234,12 +234,13 @@ object Inputs {
   )(using programInvokeData: ScalaCliInvokeData): Seq[Either[String, Seq[Element]]] =
     args.zipWithIndex.map {
       case (arg, idx) =>
-        lazy val path            = os.Path(arg, cwd)
-        lazy val dir             = path / os.up
-        lazy val subPath         = path.subRelativeTo(dir)
-        lazy val stdinOpt0       = stdinOpt
-        lazy val content         = os.read.bytes(path)
-        lazy val firstline       = new String(content.takeWhile(_ != '\n')).trim
+        lazy val path      = os.Path(arg, cwd)
+        lazy val dir       = path / os.up
+        lazy val subPath   = path.subRelativeTo(dir)
+        lazy val stdinOpt0 = stdinOpt
+        lazy val content   = os.read.bytes(path)
+        lazy val firstline =
+          if os.isDir(path) then "" else new String(content.takeWhile(_ != '\n')).trim
         lazy val fullProgramCall = programInvokeData.progName +
           s"${
               if programInvokeData.subCommand == SubCommand.Default then ""


### PR DESCRIPTION
This PR recognizes valid scala scripts without an extension, based on the presence of a hash-bang line, regardless of the terminal type.    It prevents rejecting a run from a Windows CMD.EXE terminal.
