### PR TITLE
Automatically add the new Sonatype Central Portal snapshots repository when snapshots are expected to be used

### DIFF
--- a/modules/build/src/main/scala/scala/build/Bloop.scala
+++ b/modules/build/src/main/scala/scala/build/Bloop.scala
@@ -3,6 +3,7 @@ package scala.build
 import bloop.rifle.{BloopRifleConfig, BuildServer}
 import ch.epfl.scala.bsp4j
 import coursier.cache.FileCache
+import coursier.maven.MavenRepository
 import coursier.util.Task
 import dependency.parser.ModuleParser
 import dependency.{AnyDependency, DependencyLike, ScalaParameters, ScalaVersion}
@@ -81,7 +82,8 @@ object Bloop {
           Seq(Positioned.none(dep)),
           Seq(
             coursier.Repositories.sonatype("snapshots"),
-            coursier.Repositories.sonatypeS01("snapshots")
+            coursier.Repositories.sonatypeS01("snapshots"),
+            MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
           ),
           Some(params),
           logger,

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -1,9 +1,10 @@
 package scala.build.tests
 
 import com.eed3si9n.expecty.Expecty.assert as expect
-import coursier.Repositories
+import coursier.{Repositories, Repository}
 import coursier.cache.FileCache
 import coursier.core.Version
+import coursier.maven.MavenRepository
 import dependency.ScalaParameters
 
 import scala.build.Ops.*
@@ -444,10 +445,13 @@ class BuildOptionsTests extends TestUtil.ScalaCliBuildSuite {
           .getOrElse(sys.error("cannot happen"))
         val repositories = build.options.finalRepositories.orThrow
 
-        expect(repositories.length == 3)
+        expect(repositories.length == 4)
         expect(repositories.contains(Repositories.sonatype("snapshots")))
         expect(repositories.contains(Repositories.sonatypeS01("snapshots")))
         expect(repositories.contains(Repositories.central))
+        expect(repositories.contains(
+          MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
+        ))
     }
   }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalCommand.scala
@@ -2,6 +2,7 @@ package scala.cli.commands.pgp
 
 import coursier.Repositories
 import coursier.cache.{ArchiveCache, FileCache}
+import coursier.maven.MavenRepository
 import coursier.util.Task
 import dependency.*
 
@@ -185,7 +186,10 @@ object PgpExternalCommand {
     if (signingCliOptions.forceJvm.getOrElse(false)) {
       val extraRepos =
         if (version.endsWith("SNAPSHOT"))
-          Seq(Repositories.sonatype("snapshots"))
+          Seq(
+            Repositories.sonatype("snapshots"),
+            MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
+          )
         else
           Nil
 

--- a/modules/cli/src/main/scala/scala/cli/internal/ScalaJsLinker.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/ScalaJsLinker.scala
@@ -2,6 +2,7 @@ package scala.cli.internal
 
 import coursier.Repositories
 import coursier.cache.{ArchiveCache, FileCache}
+import coursier.maven.MavenRepository
 import coursier.util.Task
 import dependency.*
 import org.scalajs.testing.adapter.TestAdapterInitializer as TAI
@@ -58,7 +59,10 @@ object ScalaJsLinker {
 
         val extraRepos =
           if (scalaJsVersion.endsWith("SNAPSHOT") || scalaJsCliVersion.endsWith("SNAPSHOT"))
-            Seq(Repositories.sonatype("snapshots"))
+            Seq(
+              Repositories.sonatype("snapshots"),
+              MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
+            )
           else
             Nil
 

--- a/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
@@ -3,6 +3,7 @@ package scala.cli.launcher
 import coursier.Repositories
 import coursier.cache.FileCache
 import coursier.core.Version
+import coursier.maven.MavenRepository
 import coursier.util.{Artifact, Task}
 import dependency.*
 
@@ -22,7 +23,11 @@ object LauncherCli {
     val cache           = CoursierOptions().coursierCache(logger.coursierLogger(""))
     val scalaVersion    = options.cliScalaVersion.getOrElse(scalaCliScalaVersion(version))
     val scalaParameters = ScalaParameters(scalaVersion)
-    val snapshotsRepo   = Seq(Repositories.central, Repositories.sonatype("snapshots"))
+    val snapshotsRepo   = Seq(
+      Repositories.central,
+      Repositories.sonatype("snapshots"),
+      MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
+    )
 
     val cliVersion: String =
       if (version == "nightly") resolveNightlyScalaCliVersion(cache, scalaParameters) else version

--- a/modules/options/src/main/scala/scala/build/Artifacts.scala
+++ b/modules/options/src/main/scala/scala/build/Artifacts.scala
@@ -3,6 +3,7 @@ package scala.build
 import coursier.cache.FileCache
 import coursier.core.{Classifier, Module, ModuleName, Organization, Repository, Version}
 import coursier.error.ResolutionError
+import coursier.maven.MavenRepository
 import coursier.util.Task
 import coursier.{Dependency as CsDependency, Fetch, Resolution, core as csCore, util as csUtil}
 import dependency.*
@@ -164,7 +165,10 @@ object Artifacts {
       val hasSnapshots = jvmTestRunnerDependencies.exists(_.version.endsWith("SNAPSHOT")) ||
         scalaArtifactsParamsOpt.flatMap(_.scalaNativeCliVersion).exists(_.endsWith("SNAPSHOT"))
       if (hasSnapshots)
-        Seq(coursier.Repositories.sonatype("snapshots"))
+        Seq(
+          coursier.Repositories.sonatype("snapshots"),
+          MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
+        )
       else
         Nil
     }
@@ -427,7 +431,10 @@ object Artifacts {
           if addJvmRunner0 then {
             val maybeSnapshotRepo =
               if runnerVersion.endsWith("SNAPSHOT") then
-                Seq(coursier.Repositories.sonatype("snapshots"))
+                Seq(
+                  coursier.Repositories.sonatype("snapshots"),
+                  MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
+                )
               else Nil
             val runnerVersion0 =
               if shouldUseLegacyRunners then {

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -1,6 +1,7 @@
 package scala.build.options
 import coursier.cache.{ArchiveCache, FileCache}
 import coursier.core.{Repository, Version}
+import coursier.maven.MavenRepository
 import coursier.parse.RepositoryParser
 import coursier.util.{Artifact, Task}
 import dependency.*
@@ -261,7 +262,8 @@ final case class BuildOptions(
       then
         Seq(
           coursier.Repositories.sonatype("snapshots"),
-          coursier.Repositories.sonatypeS01("snapshots")
+          coursier.Repositories.sonatypeS01("snapshots"),
+          MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
         )
       else Nil
     val extraRepositories = classPathOptions.extraRepositories.filterNot(_ == "snapshots")

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -299,7 +299,8 @@ object Docker {
 def customRepositories =
   Seq(
     coursier.Repositories.sonatype("snapshots"),
-    coursier.MavenRepository("https://s01.oss.sonatype.org/content/repositories/snapshots")
+    coursier.MavenRepository("https://s01.oss.sonatype.org/content/repositories/snapshots"),
+    coursier.MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
     // Uncomment for local development
     // coursier.LocalRepositories.Dangerous.maven2Local
   )


### PR DESCRIPTION
Fixes #3785 
Extracted out of https://github.com/VirtusLab/scala-cli/pull/3786