### PR TITLE
Set Scala 3.7.2 as the latest announced Scala 3 Next

### DIFF
--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -7,16 +7,15 @@ object Cli {
 }
 
 object Scala {
-  def scala212            = "2.12.20"
-  def scala213            = "2.13.16"
-  def scala3LtsPrefix     = "3.3"                  // used for the LTS version tags
-  def scala3Lts           = s"$scala3LtsPrefix.6"  // the LTS version currently used in the build
-  def runnerScala3        = scala3Lts
-  def scala3NextPrefix    = "3.7"
-  def scala3Next          = s"$scala3NextPrefix.2" // the newest/next version of Scala
-  def scala3NextAnnounced =
-    s"$scala3NextPrefix.1" // the newest/next version of Scala that's been announced
-  def scala3NextRc        = "3.7.2-RC2"            // the latest RC version of Scala Next
+  def scala212         = "2.12.20"
+  def scala213         = "2.13.16"
+  def scala3LtsPrefix  = "3.3"                  // used for the LTS version tags
+  def scala3Lts        = s"$scala3LtsPrefix.6"  // the LTS version currently used in the build
+  def runnerScala3     = scala3Lts
+  def scala3NextPrefix = "3.7"
+  def scala3Next       = s"$scala3NextPrefix.2" // the newest/next version of Scala
+  def scala3NextAnnounced   = scala3Next   // the newest/next version of Scala that's been announced
+  def scala3NextRc          = "3.7.2-RC2"  // the latest RC version of Scala Next
   def scala3NextRcAnnounced = scala3NextRc // the latest announced RC version of Scala Next
 
   // The Scala version used to build the CLI itself.


### PR DESCRIPTION
https://github.com/scala/scala3/releases/tag/3.7.2