### PR TITLE
Adjust Scala CLI nightly version resolution for the new Maven Central Snapshots repository

### DIFF
--- a/modules/build/src/main/scala/scala/build/Bloop.scala
+++ b/modules/build/src/main/scala/scala/build/Bloop.scala
@@ -3,7 +3,6 @@ package scala.build
 import bloop.rifle.{BloopRifleConfig, BuildServer}
 import ch.epfl.scala.bsp4j
 import coursier.cache.FileCache
-import coursier.maven.MavenRepository
 import coursier.util.Task
 import dependency.parser.ModuleParser
 import dependency.{AnyDependency, DependencyLike, ScalaParameters, ScalaVersion}
@@ -83,7 +82,7 @@ object Bloop {
           Seq(
             coursier.Repositories.sonatype("snapshots"),
             coursier.Repositories.sonatypeS01("snapshots"),
-            MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
+            SonatypeUtils.snapshotsRepository
           ),
           Some(params),
           logger,

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -26,9 +26,7 @@ import scala.build.options.{
   ScalacOpt,
   ShadowingSeq
 }
-import scala.build.{Build, BuildThreads, LocalRepo}
-import scala.build.Directories
-import scala.build.Positioned
+import scala.build.{Build, BuildThreads, Directories, LocalRepo, Positioned, SonatypeUtils}
 import scala.build.tests.util.BloopServer
 import scala.concurrent.duration.DurationInt
 import scala.build.internal.Regexes.scala3LtsRegex
@@ -449,9 +447,7 @@ class BuildOptionsTests extends TestUtil.ScalaCliBuildSuite {
         expect(repositories.contains(Repositories.sonatype("snapshots")))
         expect(repositories.contains(Repositories.sonatypeS01("snapshots")))
         expect(repositories.contains(Repositories.central))
-        expect(repositories.contains(
-          MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
-        ))
+        expect(repositories.contains(SonatypeUtils.snapshotsRepository))
     }
   }
 

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalCommand.scala
@@ -2,7 +2,6 @@ package scala.cli.commands.pgp
 
 import coursier.Repositories
 import coursier.cache.{ArchiveCache, FileCache}
-import coursier.maven.MavenRepository
 import coursier.util.Task
 import dependency.*
 
@@ -19,7 +18,7 @@ import scala.build.internal.{
   FetchExternalBinary,
   Runner
 }
-import scala.build.{Logger, Positioned, options as bo}
+import scala.build.{Logger, Positioned, SonatypeUtils, options as bo}
 import scala.cli.ScalaCli
 import scala.cli.commands.shared.{CoursierOptions, SharedJvmOptions}
 import scala.cli.commands.util.JvmUtils
@@ -185,13 +184,12 @@ object PgpExternalCommand {
 
     if (signingCliOptions.forceJvm.getOrElse(false)) {
       val extraRepos =
-        if (version.endsWith("SNAPSHOT"))
+        if version.endsWith("SNAPSHOT") then
           Seq(
             Repositories.sonatype("snapshots"),
-            MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
+            SonatypeUtils.snapshotsRepository
           )
-        else
-          Nil
+        else Nil
 
       val (_, signingRes) = value {
         scala.build.Artifacts.fetchCsDependencies(

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/RepoParams.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/RepoParams.scala
@@ -10,9 +10,9 @@ import java.net.URI
 import java.util.concurrent.ScheduledExecutorService
 
 import scala.build.EitherCps.{either, value}
-import scala.build.Logger
 import scala.build.errors.BuildException
 import scala.build.internals.ConsoleUtils.ScalaCliConsole.warnPrefix
+import scala.build.{Logger, SonatypeUtils}
 import scala.cli.commands.util.ScalaCliSttpBackend
 
 final case class RepoParams(
@@ -53,10 +53,10 @@ final case class RepoParams(
 
 object RepoParams {
   private val sonatypeOssrhStagingApiBase = "https://ossrh-staging-api.central.sonatype.com"
-  private val sonatypeSnapshotsBase = "https://central.sonatype.com/repository/maven-snapshots/"
-  private val sonatypeLegacyBase    = "https://oss.sonatype.org"
-  private val sonatypeS01LegacyBase = "https://s01.oss.sonatype.org"
-  private def sonatypeHosts: Seq[String] =
+  private val sonatypeSnapshotsBase       = s"${SonatypeUtils.snapshotsRepositoryUrl}/"
+  private val sonatypeLegacyBase          = "https://oss.sonatype.org"
+  private val sonatypeS01LegacyBase       = "https://s01.oss.sonatype.org"
+  private def sonatypeHosts: Seq[String]  =
     Seq(
       sonatypeLegacyBase,
       sonatypeSnapshotsBase,

--- a/modules/cli/src/main/scala/scala/cli/internal/ScalaJsLinker.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/ScalaJsLinker.scala
@@ -2,7 +2,6 @@ package scala.cli.internal
 
 import coursier.Repositories
 import coursier.cache.{ArchiveCache, FileCache}
-import coursier.maven.MavenRepository
 import coursier.util.Task
 import dependency.*
 import org.scalajs.testing.adapter.TestAdapterInitializer as TAI
@@ -14,7 +13,7 @@ import scala.build.errors.{BuildException, ScalaJsLinkingError}
 import scala.build.internal.Util.{DependencyOps, ModuleOps}
 import scala.build.internal.{ExternalBinaryParams, FetchExternalBinary, Runner, ScalaJsLinkerConfig}
 import scala.build.options.scalajs.ScalaJsLinkerOptions
-import scala.build.{Logger, Positioned}
+import scala.build.{Logger, Positioned, SonatypeUtils}
 import scala.io.Source
 import scala.util.Properties
 
@@ -58,13 +57,13 @@ object ScalaJsLinker {
         )
 
         val extraRepos =
-          if (scalaJsVersion.endsWith("SNAPSHOT") || scalaJsCliVersion.endsWith("SNAPSHOT"))
+          if scalaJsVersion.endsWith("SNAPSHOT") || scalaJsCliVersion.endsWith("SNAPSHOT")
+          then
             Seq(
               Repositories.sonatype("snapshots"),
-              MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
+              SonatypeUtils.snapshotsRepository
             )
-          else
-            Nil
+          else Nil
 
         options.finalUseJvm match {
           case Right(()) =>

--- a/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/launcher/LauncherCli.scala
@@ -3,7 +3,6 @@ package scala.cli.launcher
 import coursier.Repositories
 import coursier.cache.FileCache
 import coursier.core.Version
-import coursier.maven.MavenRepository
 import coursier.util.{Artifact, Task}
 import dependency.*
 
@@ -11,15 +10,13 @@ import scala.build.internal.CsLoggerUtil.CsCacheExtensions
 import scala.build.internal.{Constants, OsLibc, Runner}
 import scala.build.options.ScalaVersionUtil.fileWithTtl0
 import scala.build.options.{BuildOptions, JavaOptions}
-import scala.build.{Artifacts, Os, Positioned}
+import scala.build.{Artifacts, Os, Positioned, SonatypeUtils}
 import scala.cli.ScalaCli
 import scala.cli.commands.shared.{CoursierOptions, LoggingOptions}
 import scala.xml.XML
 
 object LauncherCli {
-
   def runAndExit(version: String, options: LauncherOptions, remainingArgs: Seq[String]): Nothing = {
-
     val logger          = LoggingOptions().logger
     val cache           = CoursierOptions().coursierCache(logger.coursierLogger(""))
     val scalaVersion    = options.cliScalaVersion.getOrElse(scalaCliScalaVersion(version))
@@ -27,21 +24,23 @@ object LauncherCli {
     val snapshotsRepo   = Seq(
       Repositories.central,
       Repositories.sonatype("snapshots"),
-      MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
+      SonatypeUtils.snapshotsRepository
     )
 
     val cliVersion: String =
-      if (version == "nightly") resolveNightlyScalaCliVersion(cache, scalaParameters) else version
+      if version == "nightly"
+      then resolveNightlyScalaCliVersion(cache, scalaParameters.scalaBinaryVersion)
+      else version
     val scalaCliDependency = Seq(dep"org.virtuslab.scala-cli::cli:$cliVersion")
 
     val fetchedScalaCli =
       Artifacts.fetchAnyDependencies(
-        scalaCliDependency.map(Positioned.none),
-        snapshotsRepo,
-        Some(scalaParameters),
-        logger,
-        cache.withMessage(s"Fetching ${ScalaCli.fullRunnerName} $cliVersion"),
-        None
+        dependencies = scalaCliDependency.map(Positioned.none),
+        extraRepositories = snapshotsRepo,
+        paramsOpt = Some(scalaParameters),
+        logger = logger,
+        cache = cache.withMessage(s"Fetching ${ScalaCli.fullRunnerName} $cliVersion"),
+        classifiersOpt = None
       ) match {
         case Right(value) => value
         case Left(value)  =>
@@ -50,8 +49,7 @@ object LauncherCli {
       }
 
     val scalaCli = fetchedScalaCli.fullDetailedArtifacts.collect {
-      case (_, _, _, Some(f)) =>
-        os.Path(f, os.pwd)
+      case (_, _, _, Some(f)) => os.Path(f, os.pwd)
     }
 
     val buildOptions = BuildOptions(
@@ -62,12 +60,12 @@ object LauncherCli {
 
     val exitCode =
       Runner.runJvm(
-        buildOptions.javaHome().value.javaCommand,
-        buildOptions.javaOptions.javaOpts.toSeq.map(_.value.value),
-        scalaCli,
-        "scala.cli.ScalaCli",
-        remainingArgs,
-        logger,
+        javaCommand = buildOptions.javaHome().value.javaCommand,
+        javaArgs = buildOptions.javaOptions.javaOpts.toSeq.map(_.value.value),
+        classPath = scalaCli,
+        mainClass = "scala.cli.ScalaCli",
+        args = remainingArgs,
+        logger = logger,
         allowExecve = true
       ).waitFor()
 
@@ -75,33 +73,30 @@ object LauncherCli {
   }
 
   def scalaCliScalaVersion(cliVersion: String): String =
-    if (cliVersion == "nightly") Constants.defaultScalaVersion
-    else if (Version(cliVersion) <= Version("0.1.2")) Constants.defaultScala212Version
-    else if (Version(cliVersion) <= Version("0.1.4")) Constants.defaultScala213Version
+    if cliVersion == "nightly" then Constants.defaultScalaVersion
+    else if Version(cliVersion) <= Version("0.1.2") then Constants.defaultScala212Version
+    else if Version(cliVersion) <= Version("0.1.4") then Constants.defaultScala213Version
     else Constants.defaultScalaVersion
 
   def resolveNightlyScalaCliVersion(
     cache: FileCache[Task],
-    scalaParameters: ScalaParameters
+    scalaBinaryVersion: String
   ): String = {
-    val snapshotRepoUrl =
-      s"https://central.sonatype.com/repository/maven-snapshots/org/virtuslab/scala-cli/cli_${scalaParameters.scalaBinaryVersion}/"
-    val mavenMetadataUrl = s"$snapshotRepoUrl/maven-metadata.xml"
+    val cliSubPath       = s"org/virtuslab/scala-cli/cli_$scalaBinaryVersion"
+    val mavenMetadataUrl = s"${SonatypeUtils.snapshotsRepositoryUrl}/$cliSubPath/maven-metadata.xml"
     val artifact         = Artifact(mavenMetadataUrl).withChanging(true)
     cache.fileWithTtl0(artifact) match {
       case Left(_) =>
         System.err.println(s"Unable to find nightly ${ScalaCli.fullRunnerName} version")
         sys.exit(1)
-      case Right(f) =>
-        val metadataXml = os.read(os.Path(f, Os.pwd))
-        val parsed      = XML.loadString(metadataXml)
-        val rawVersions = (parsed \ "versioning" \ "versions" \ "version")
-          .map(_.text)
-        val versions = rawVersions.map(Version(_))
-        if versions.isEmpty then sys.error(s"No versions found in $snapshotRepoUrl (locally at $f)")
+      case Right(mavenMetadataXml) =>
+        val metadataXmlContent = os.read(os.Path(mavenMetadataXml, Os.pwd))
+        val parsed             = XML.loadString(metadataXmlContent)
+        val rawVersions        = (parsed \ "versioning" \ "versions" \ "version").map(_.text)
+        val versions           = rawVersions.map(Version(_))
+        if versions.isEmpty
+        then sys.error(s"No versions found in $mavenMetadataUrl (locally at $mavenMetadataXml)")
         else versions.max.repr
     }
-
   }
-
 }

--- a/modules/cli/src/test/scala/cli/tests/LauncherCliTest.scala
+++ b/modules/cli/src/test/scala/cli/tests/LauncherCliTest.scala
@@ -15,7 +15,8 @@ class LauncherCliTest extends munit.FunSuite {
     val cache           = CoursierOptions().coursierCache(logger.coursierLogger(""))
     val scalaParameters = ScalaParameters(Constants.defaultScalaVersion)
 
-    val nightlyCliVersion = LauncherCli.resolveNightlyScalaCliVersion(cache, scalaParameters)
+    val nightlyCliVersion =
+      LauncherCli.resolveNightlyScalaCliVersion(cache, scalaParameters.scalaBinaryVersion)
     expect(nightlyCliVersion.endsWith("-SNAPSHOT"))
   }
 

--- a/modules/core/src/main/scala/scala/build/SonatypeUtils.scala
+++ b/modules/core/src/main/scala/scala/build/SonatypeUtils.scala
@@ -1,0 +1,8 @@
+package scala.build
+
+import coursier.maven.MavenRepository
+
+object SonatypeUtils {
+  lazy val snapshotsRepositoryUrl = "https://central.sonatype.com/repository/maven-snapshots"
+  lazy val snapshotsRepository    = MavenRepository(snapshotsRepositoryUrl)
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/VersionTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/VersionTests.scala
@@ -27,6 +27,24 @@ class VersionTests extends ScalaCliSuite {
     }
   }
 
+  // given the 30 days snapshot retention, this may prove unreliable on the CI
+  // but might still be valuable for local testing
+  test("CLI nightly on new Maven Central Snapshots repo".flaky) {
+    TestInputs.empty.fromRoot {
+      root =>
+        val res =
+          os.proc(
+            TestUtil.cli,
+            "--cli-version",
+            "nightly",
+            "version",
+            "--cli-version"
+          )
+            .call(cwd = root)
+        expect(res.out.trim().coursierVersion >= "1.8.4".coursierVersion)
+    }
+  }
+
 }
 
 object VersionTests {

--- a/modules/options/src/main/scala/scala/build/Artifacts.scala
+++ b/modules/options/src/main/scala/scala/build/Artifacts.scala
@@ -3,7 +3,6 @@ package scala.build
 import coursier.cache.FileCache
 import coursier.core.{Classifier, Module, ModuleName, Organization, Repository, Version}
 import coursier.error.ResolutionError
-import coursier.maven.MavenRepository
 import coursier.util.Task
 import coursier.{Dependency as CsDependency, Fetch, Resolution, core as csCore, util as csUtil}
 import dependency.*
@@ -164,13 +163,12 @@ object Artifacts {
     val maybeSnapshotRepo = {
       val hasSnapshots = jvmTestRunnerDependencies.exists(_.version.endsWith("SNAPSHOT")) ||
         scalaArtifactsParamsOpt.flatMap(_.scalaNativeCliVersion).exists(_.endsWith("SNAPSHOT"))
-      if (hasSnapshots)
+      if hasSnapshots then
         Seq(
           coursier.Repositories.sonatype("snapshots"),
-          MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
+          SonatypeUtils.snapshotsRepository
         )
-      else
-        Nil
+      else Nil
     }
 
     val allExtraRepositories =
@@ -433,7 +431,7 @@ object Artifacts {
               if runnerVersion.endsWith("SNAPSHOT") then
                 Seq(
                   coursier.Repositories.sonatype("snapshots"),
-                  MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
+                  SonatypeUtils.snapshotsRepository
                 )
               else Nil
             val runnerVersion0 =

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -1,7 +1,6 @@
 package scala.build.options
 import coursier.cache.{ArchiveCache, FileCache}
 import coursier.core.{Repository, Version}
-import coursier.maven.MavenRepository
 import coursier.parse.RepositoryParser
 import coursier.util.{Artifact, Task}
 import dependency.*
@@ -21,7 +20,7 @@ import scala.build.internal.Regexes.scala3NightlyNicknameRegex
 import scala.build.internal.{Constants, OsLibc, Util}
 import scala.build.internals.EnvVar
 import scala.build.options.validation.BuildOptionsRule
-import scala.build.{Artifacts, Logger, Os, Position, Positioned}
+import scala.build.{Artifacts, Logger, Os, Position, Positioned, SonatypeUtils}
 import scala.collection.immutable.Seq
 import scala.concurrent.Await
 import scala.concurrent.duration.*
@@ -263,7 +262,7 @@ final case class BuildOptions(
         Seq(
           coursier.Repositories.sonatype("snapshots"),
           coursier.Repositories.sonatypeS01("snapshots"),
-          MavenRepository("https://central.sonatype.com/repository/maven-snapshots")
+          SonatypeUtils.snapshotsRepository
         )
       else Nil
     val extraRepositories = classPathOptions.extraRepositories.filterNot(_ == "snapshots")


### PR DESCRIPTION
fixes https://github.com/VirtusLab/scala-cli/issues/3742

```bash
scala-cli --cli-version nightly version 
# Scala CLI version: 1.8.4-20-g9136c9b3a-SNAPSHOT
# Scala version (default): 3.7.2
```