### PR TITLE
Add `--no-fallback` to graalvm native-image configuration

### DIFF
--- a/project/settings/package.mill.scala
+++ b/project/settings/package.mill.scala
@@ -165,7 +165,7 @@ trait CliLaunchers extends SbtModule { self =>
         if (usesDocker) s"/data/$staticLibDirName"
         else staticLibDir().path.toString
       super.nativeImageOptions() ++ Seq(
-         "--no-fallback",
+        "--no-fallback",
         s"-H:IncludeResources=$localRepoResourcePath",
         s"-H:IncludeResources=$launcherTypeResourcePath",
         s"-H:IncludeResources=$defaultFilesResourcePath/.*",

--- a/project/settings/package.mill.scala
+++ b/project/settings/package.mill.scala
@@ -165,6 +165,7 @@ trait CliLaunchers extends SbtModule { self =>
         if (usesDocker) s"/data/$staticLibDirName"
         else staticLibDir().path.toString
       super.nativeImageOptions() ++ Seq(
+         "--no-fallback",
         s"-H:IncludeResources=$localRepoResourcePath",
         s"-H:IncludeResources=$launcherTypeResourcePath",
         s"-H:IncludeResources=$defaultFilesResourcePath/.*",


### PR DESCRIPTION
For some reason some of the recent versions of scala runner has been built as a fallback native image, meaning it does require a jvm to run. This can be verified fairly easily (this was ran on Mac OS X):

```bash
FAKE=$(mktemp -d)       
printf '#!/bin/sh\nexit 127\n' >"$FAKE/java"
chmod +x "$FAKE/java"
SC_DIR=$(dirname "$(which scala-cli)")   # where scala-cli lives

# we launch a subshell with a poisoned PATH - the java command is overwritten even if it's present in /usr/bin
/usr/bin/env -i \
  PATH="$FAKE:$SC_DIR:/usr/bin:/bin" \
  HOME="$HOME" TERM="$TERM" PS1='[nojvm]$ ' \
  bash --noprofile --norc
```

This yields something like this on my machine (where both `scala` and `scala-cli` are installed via homebrew):
```bash
λ bash 
bash-5.3$ FAKE=$(mktemp -d)
bash-5.3$ chmod +x "$FAKE/java"
chmod: /var/folders/h7/h89zxhb91zdbjq1r_pk9d__r0000gn/T/tmp.VlgMjTODjU/java: No such file or directory
bash-5.3$ printf '#!/bin/sh\nexit 127\n' >"$FAKE/java"
bash-5.3$ chmod +x "$FAKE/java"
bash-5.3$ SC_DIR=$(dirname "$(which scala-cli)")   # where scala-cli lives
bash-5.3$ /usr/bin/env -i   PATH="$FAKE:$SC_DIR:/usr/bin:/bin"   HOME="$HOME" TERM="$TERM" PS1='[nojvm]$ '   bash --noprofile --norc
[nojvm]$ scala version
[nojvm]$ echo "$?"
127
[nojvm]$ scala-cli version
Scala CLI version: 1.8.4
Scala version (default): 3.7.1
[nojvm]$
exit
bash-5.3$
exit

λ scala version 
NOTE: Picked up JDK_JAVA_OPTIONS: --sun-misc-unsafe-memory-access=allow
Scala code runner version: 1.8.4
Scala version (default): 3.7.2
```

Notice the jvm picking up my env var JDK_JAVA_OPTIONS! `scala` crashes in the sanitized shell as the overwritten java command just exits with exit code 127.

We should demand from native-image to build true native binaries instead of fallback images as fallbacks use the jvm that is available on users machine (in PATH to be precise) and that can lead to compatibility issues.
  