### PR TITLE
Bump Bloop to 2.0.13

### DIFF
--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -133,7 +133,7 @@ object Deps {
     def signingCliJvmVersion              = Java.defaultJava
     def javaSemanticdb                    = "0.10.0"
     def javaClassName                     = "0.1.8"
-    def bloop                             = "2.0.10"
+    def bloop                             = "2.0.13"
     def sbtVersion                        = "1.11.3"
     def mavenVersion                      = "3.8.1"
     def mavenScalaCompilerPluginVersion   = "4.9.1"


### PR DESCRIPTION
https://github.com/scalacenter/bloop/releases/tag/v2.0.13