### PR TITLE
Ensure `publish` actually fails on a failed upload

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
@@ -13,7 +13,7 @@ abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersio
   _: TestScalaVersion =>
   protected def extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
 
-  private object TestCase {
+  protected object TestCase {
     val expectedMessage    = "Hello"
     val org                = "org.virtuslab.scalacli.test"
     val name               = "simple"


### PR DESCRIPTION
Fixes #3852

Added a very dumb test for when the upload to Sonatype should fail.
It's not exactly the same case as in the issue, but we'd have to set up a mock server to mimic a reaction to 403.