### PR TITLE
Bump `scalafmt` to 3.9.10

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.9.9"
+version = "3.9.10"
 
 align.preset = more
 maxColumn = 100

--- a/modules/integration/src/test/scala/scala/cli/integration/InstallAndUninstallCompletionsTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/InstallAndUninstallCompletionsTests.scala
@@ -10,8 +10,8 @@ class InstallAndUninstallCompletionsTests extends ScalaCliSuite {
   val bashRcFile: String = ".bashrc"
   val fishRcFile: String = "config.fish"
   val rcContent: String  = s"""
-                             |dummy line
-                             |dummy line""".stripMargin
+                              |dummy line
+                              |dummy line""".stripMargin
   val testInputs: TestInputs = TestInputs(
     os.rel / zshRcFile                       -> rcContent,
     os.rel / bashRcFile                      -> rcContent,

--- a/modules/integration/src/test/scala/scala/cli/integration/MillTestHelper.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/MillTestHelper.scala
@@ -10,8 +10,8 @@ trait MillTestHelper {
 
   protected val millJvmOptsFileName: String = ".mill-jvm-opts"
   protected val millJvmOptsContent: String  = """-Xmx512m
-                                               |-Xms128m
-                                               |""".stripMargin
+                                                |-Xms128m
+                                                |""".stripMargin
 
   protected val millDefaultProjectName = "project"
 

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -120,7 +120,7 @@ object Deps {
     def jsoniterScalaJava8                = "2.13.5.2"
     def jsoup                             = "1.21.2"
     def scalaMeta                         = "4.13.9"
-    def scalafmt                          = "3.9.9"
+    def scalafmt                          = "3.9.10"
     def scalaNative04                     = "0.4.17"
     def scalaNative05                     = "0.5.8"
     def scalaNative                       = scalaNative05

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -501,7 +501,7 @@ Pass a global dialect for scalafmt. This overrides whatever value is configured 
 
 Aliases: `--fmt-version`
 
-Pass scalafmt version before running it (3.9.9 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
+Pass scalafmt version before running it (3.9.10 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
 
 ## Global suppress warning options
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -370,7 +370,7 @@ Aliases: `--fmt-version`
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Pass scalafmt version before running it (3.9.9 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
+Pass scalafmt version before running it (3.9.10 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
 
 ## Global suppress warning options
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -3948,7 +3948,7 @@ Aliases: `--dialect`
 
 **--scalafmt-version**
 
-Pass scalafmt version before running it (3.9.9 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
+Pass scalafmt version before running it (3.9.10 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
 
 Aliases: `--fmt-version`
 


### PR DESCRIPTION
https://github.com/scalameta/scalafmt/releases/tag/v3.9.10
https://github.com/VirtusLab/scalafmt-native-image/releases/tag/v3.9.10