### PR TITLE
add test case for not having test.resourceDir in main scope

### DIFF
--- a/modules/build/src/main/scala/scala/build/CrossSources.scala
+++ b/modules/build/src/main/scala/scala/build/CrossSources.scala
@@ -271,19 +271,8 @@ object CrossSources {
       )
     }).flatten
 
-    val resourceDirectoriesFromDirectives = {
-      val resourceDirsFromCli =
-        allInputs.elements.flatMap { case rd: ResourceDirectory => Some(rd.path); case _ => None }
-      val resourceDirsFromBuildOptions: Seq[os.Path] =
-        buildOptions.flatMap(_.value.classPathOptions.resourcesDir).distinct
-      resourceDirsFromBuildOptions
-        .filter(!resourceDirsFromCli.contains(_))
-        .map(ResourceDirectory(_))
-    }
-    val finalInputs = allInputs.add(resourceDirectoriesFromDirectives)
-
     val defaultMainElemPath = for {
-      defaultMainElem <- finalInputs.defaultMainClassElement
+      defaultMainElem <- allInputs.defaultMainClassElement
     } yield defaultMainElem.path
 
     val pathsWithDirectivePositions
@@ -293,7 +282,7 @@ object CrossSources {
           val baseReqs0 = baseReqs(d.scopePath)
           WithBuildRequirements(
             d.requirements.fold(baseReqs0)(_ orElse baseReqs0),
-            (d.path, d.path.relativeTo(finalInputs.workspace))
+            (d.path, d.path.relativeTo(allInputs.workspace))
           ) -> d.directivesPositions
       }
     val inMemoryWithDirectivePositions
@@ -318,7 +307,7 @@ object CrossSources {
       }
 
     val resourceDirs: Seq[WithBuildRequirements[os.Path]] =
-      resolveResourceDirs(finalInputs, preprocessedSources)
+      resolveResourceDirs(allInputs, preprocessedSources)
 
     lazy val allPathsWithDirectivesByScope: Map[Scope, Seq[(os.Path, Position.File)]] =
       (pathsWithDirectivePositions ++ inMemoryWithDirectivePositions ++ unwrappedScriptsWithDirectivePositions)
@@ -379,7 +368,7 @@ object CrossSources {
       buildOptions,
       unwrappedScripts
     )
-    crossSources -> finalInputs
+    crossSources -> allInputs
   }
 
   extension (uri: java.net.URI)

--- a/modules/build/src/main/scala/scala/build/CrossSources.scala
+++ b/modules/build/src/main/scala/scala/build/CrossSources.scala
@@ -271,8 +271,22 @@ object CrossSources {
       )
     }).flatten
 
+    val resourceDirectoriesFromDirectives = {
+      val resourceDirsFromCli =
+        allInputs.elements.flatMap {
+          case rd: ResourceDirectory => Some(rd.path)
+          case _                     => None
+        }
+      val resourceDirsFromBuildOptions: Seq[os.Path] =
+        buildOptions.flatMap(_.value.classPathOptions.resourcesDir).distinct
+      resourceDirsFromBuildOptions
+        .filter(!resourceDirsFromCli.contains(_))
+        .map(ResourceDirectory(_))
+    }
+    val finalInputs = allInputs.add(resourceDirectoriesFromDirectives)
+
     val defaultMainElemPath = for {
-      defaultMainElem <- allInputs.defaultMainClassElement
+      defaultMainElem <- finalInputs.defaultMainClassElement
     } yield defaultMainElem.path
 
     val pathsWithDirectivePositions
@@ -282,7 +296,7 @@ object CrossSources {
           val baseReqs0 = baseReqs(d.scopePath)
           WithBuildRequirements(
             d.requirements.fold(baseReqs0)(_ orElse baseReqs0),
-            (d.path, d.path.relativeTo(allInputs.workspace))
+            (d.path, d.path.relativeTo(finalInputs.workspace))
           ) -> d.directivesPositions
       }
     val inMemoryWithDirectivePositions
@@ -368,7 +382,7 @@ object CrossSources {
       buildOptions,
       unwrappedScripts
     )
-    crossSources -> allInputs
+    crossSources -> finalInputs
   }
 
   extension (uri: java.net.URI)

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
@@ -230,11 +230,9 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
           |""".stripMargin
       ) { (build, isTestScope) =>
         val resourcesDirs = build.options.classPathOptions.resourcesDir
-        val sourcesResourcesDirs = build.successfulOpt.get.sources.resourceDirs
         expect(resourcesDirs.exists(_.last == "mainResources"))
         val hasTestResources = resourcesDirs.exists(_.last == "testResources")
         expect(if isTestScope then hasTestResources else !hasTestResources)
-        expect(resourcesDirs.toSet == sourcesResourcesDirs.toSet)
       }
     }
     test(s"resolve test scope toolkit dependency correctly when building for ${scope.name} scope") {

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
@@ -230,9 +230,11 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
           |""".stripMargin
       ) { (build, isTestScope) =>
         val resourcesDirs = build.options.classPathOptions.resourcesDir
+        val sourcesResourcesDirs = build.successfulOpt.get.sources.resourceDirs
         expect(resourcesDirs.exists(_.last == "mainResources"))
         val hasTestResources = resourcesDirs.exists(_.last == "testResources")
         expect(if isTestScope then hasTestResources else !hasTestResources)
+        expect(resourcesDirs.toSet == sourcesResourcesDirs.toSet)
       }
     }
     test(s"resolve test scope toolkit dependency correctly when building for ${scope.name} scope") {

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
@@ -389,6 +389,21 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
         expect(resourceDirs == Seq(path))
     }
   }
+  test("do not include test.resourceDir into sources for main scope") {
+    val testInputs = TestInputs(
+      os.rel / "simple.sc" ->
+        """//> using test.resourceDir foo
+          |""".stripMargin
+    )
+    testInputs.withBuild(baseOptions, buildThreads, bloopConfigOpt, scope = Scope.Main) {
+      (root, _, maybeBuild) =>
+        val build =
+          maybeBuild.toOption.flatMap(_.successfulOpt).getOrElse(sys.error("cannot happen"))
+        val resourceDirs = build.sources.resourceDirs
+
+        expect(resourceDirs.isEmpty)
+    }
+  }
   test("parse boolean for publish.doc") {
     val testInputs = TestInputs(
       os.rel / "simple.sc" ->


### PR DESCRIPTION
I found that the resource from the directive `test.resourceDir` is added to the classpath in the main scope. It should be only in the test scope.

I thought that was an easy fix, so I tried to do so. However, I failed. I'm opening a PR with a test case for this. I'm happy to fix it if you could give me some guidance on where to look.