### PR TITLE
Bump `coursier` to 2.1.25-M19

### DIFF
--- a/.github/scripts/build-linux-aarch64.sh
+++ b/.github/scripts/build-linux-aarch64.sh
@@ -6,7 +6,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
 mkdir -p artifacts
 mkdir -p utils
-cp "$(cs get https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.24/cs-aarch64-pc-linux.gz --archive)" utils/cs
+cp "$(cs get https://github.com/coursier/coursier/releases/download/v2.1.25-M19/cs-aarch64-pc-linux.gz --archive)" utils/cs
 chmod +x utils/cs
 
 cp "$DIR/build-linux-aarch64-from-docker.sh" utils/

--- a/.github/scripts/get-latest-cs.sh
+++ b/.github/scripts/get-latest-cs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-CS_VERSION="2.1.24"
+CS_VERSION="2.1.25-M19"
 
 DIR="$(cs get --archive "https://github.com/coursier/coursier/releases/download/v$CS_VERSION/cs-x86_64-pc-win32.zip")"
 

--- a/build.mill.scala
+++ b/build.mill.scala
@@ -515,6 +515,7 @@ trait Core extends ScalaCliCrossSbtModule
          |  def typelevelToolkitDefaultVersion = "${Deps.typelevelToolkitVersion}"
          |  def typelevelToolkitMaxScalaNative = "${Deps.Versions.maxScalaNativeForTypelevelToolkit}"
          |
+         |  def minimumLauncherJavaVersion = ${Java.minimumJavaLauncherJava}
          |  def minimumBloopJavaVersion = ${Java.minimumBloopJava}
          |  def minimumInternalJavaVersion = ${Java.minimumInternalJava}
          |  def defaultJavaVersion = ${Java.defaultJava}
@@ -881,6 +882,7 @@ trait Cli extends CrossSbtModule with ProtoBuildModule with CliLaunchers
          |object Constants {
          |  def defaultScalaVersion = "${Scala.defaultUser}"
          |  def defaultJavaVersion = ${Java.defaultJava}
+         |  def minimumLauncherJavaVersion = ${Java.minimumJavaLauncherJava}
          |  def minimumBloopJavaVersion = ${Java.minimumBloopJava}
          |  def scalaJsVersion = "${Scala.scalaJs}"
          |  def scalaJsCliVersion = "${Scala.scalaJsCli}"
@@ -1061,6 +1063,7 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
            |  def cliVersion                   = "${publishVersion()}"
            |  def allJavaVersions              = Seq(${Java.allJavaVersions.sorted.mkString(", ")})
            |  def bspVersion                   = "${Deps.bsp4j.dep.versionConstraint.asString}"
+           |  def minimumLauncherJavaVersion   = ${Java.minimumJavaLauncherJava}
            |  def bloopMinimumJvmVersion       = ${Java.minimumBloopJava}
            |  def minimumInternalJvmVersion    = ${Java.minimumInternalJava}
            |  def defaultJvmVersion            = ${Java.defaultJava}

--- a/build.mill.scala
+++ b/build.mill.scala
@@ -2,7 +2,7 @@ package build
 
 import $packages._
 import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`
-import $ivy.`io.get-coursier::coursier-launcher:2.1.24`
+import $ivy.`io.get-coursier::coursier-launcher:2.1.25-M19`
 import $ivy.`io.github.alexarchambault.mill::mill-native-image-upload:0.1.31-1`
 import build.ci.publishVersion
 import build.project.deps
@@ -130,6 +130,7 @@ object `scala-cli-bsp` extends JavaModule with ScalaCliPublishModule {
 object integration extends CliIntegration {
   object test extends IntegrationScalaTests {
     override def ivyDeps: T[Loose.Agg[Dep]] = super.ivyDeps() ++ Seq(
+      Deps.coursierArchiveCache,
       Deps.jgit,
       Deps.jsoup
     )

--- a/mill
+++ b/mill
@@ -2,7 +2,7 @@
 
 # Adapted from
 
-coursier_version="2.1.24"
+coursier_version="2.1.25-M19"
 COMMAND=$@
 
 # necessary for Windows various shell environments
@@ -17,9 +17,8 @@ if [ "$(expr substr $(uname -s) 1 5 2>/dev/null)" == "Linux" ]; then
   fi
   cache_base="$HOME/.cache/coursier/v1"
 elif [ "$(uname)" == "Darwin" ]; then
-  # TODO: remove once coursier-m1 and coursier mainline are merged
   if [ "$(uname -p)" == "arm" ]; then 
-    cs_url="https://github.com/VirtusLab/coursier-m1/releases/download/v$coursier_version/cs-aarch64-apple-darwin.gz"
+    cs_url="https://github.com/coursier/coursier/releases/download/v$coursier_version/cs-aarch64-apple-darwin.gz"
   else 
     cs_url="https://github.com/coursier/coursier/releases/download/v$coursier_version/cs-x86_64-apple-darwin.gz"
   fi

--- a/modules/build/src/main/scala/scala/build/Directories.scala
+++ b/modules/build/src/main/scala/scala/build/Directories.scala
@@ -1,8 +1,8 @@
 package scala.build
 
-import coursier.cache.shaded.dirs.ProjectDirectories
-import coursier.cache.shaded.dirs.impl.Windows
-import coursier.cache.shaded.dirs.jni.WindowsJni
+import coursier.paths.shaded.dirs.ProjectDirectories
+import coursier.paths.shaded.dirs.impl.Windows
+import coursier.paths.shaded.dirs.jni.WindowsJni
 
 import java.util.function.Supplier
 

--- a/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
+++ b/modules/cli/src/main/scala/scala/cli/ScalaCli.scala
@@ -272,7 +272,18 @@ object ScalaCli {
             val newArgs = powerArgs ++ finalScalaRunnerArgs ++ args0
             LauncherCli.runAndExit(ver, launcherOpts, newArgs)
           case _ if
-                javaMajorVersion < Constants.minimumBloopJavaVersion
+                javaMajorVersion < Constants.minimumLauncherJavaVersion
+                && sys.props.get("scala-cli.kind").exists(_.startsWith("jvm")) =>
+            System.err.println(
+              s"[${Console.RED}error${Console.RESET}] Java $javaMajorVersion is not supported with this Scala CLI (JVM) launcher."
+            )
+            System.err.println(
+              s"[${Console.RED}error${Console.RESET}] Please upgrade to at least Java ${Constants.minimumLauncherJavaVersion} or use a native Scala CLI launcher instead."
+            )
+            sys.exit(1)
+          case _ if
+                javaMajorVersion >= Constants.minimumLauncherJavaVersion
+                && javaMajorVersion < Constants.minimumBloopJavaVersion
                 && sys.props.get("scala-cli.kind").exists(_.startsWith("jvm")) =>
             JavaLauncherCli.runAndExit(args)
           case None =>

--- a/modules/docs-tests/src/main/scala/sclicheck/sclicheck.scala
+++ b/modules/docs-tests/src/main/scala/sclicheck/sclicheck.scala
@@ -207,7 +207,7 @@ def checkFile(file: os.Path, options: Options): Unit =
     createHelperScript(options.scalaCliCommand, "scala-cli")
     createHelperScript(options.scalaCliCommand, "scala")
     val coursierCliDep =
-      s"${Constants.coursierOrg}:${Constants.coursierCliModule}:${Constants.coursierCliVersion}"
+      s"${Constants.coursierOrg}:${Constants.coursierCliModule}_3:${Constants.coursierCliVersion}"
     createHelperScript(
       options.scalaCliCommand ++ Seq(
         "run",

--- a/modules/docs-tests/src/test/scala/sclicheck/DocTests.scala
+++ b/modules/docs-tests/src/test/scala/sclicheck/DocTests.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 
 class DocTests extends munit.FunSuite {
-  override def munitTimeout = new FiniteDuration(480, TimeUnit.SECONDS)
+  override def munitTimeout = new FiniteDuration(600, TimeUnit.SECONDS)
   case class DocTestEntry(name: String, path: os.Path, depth: Int = Int.MaxValue)
 
   val docsRootPath: os.Path      = os.Path(sys.env("MILL_WORKSPACE_ROOT")) / "website" / "docs"

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -2258,9 +2258,10 @@ abstract class BspTestDefinitions extends ScalaCliSuite
         )
           .fromRoot { root =>
             withLauncher(root) { launcher =>
+              val jvmIndex = if (TestUtil.isJvmCli) Constants.minimumLauncherJavaVersion else 8
               val javaHome =
                 os.Path(
-                  os.proc(TestUtil.cs, "java-home", "--jvm", "zulu:8").call().out.trim(),
+                  os.proc(TestUtil.cs, "java-home", "--jvm", jvmIndex).call().out.trim(),
                   os.pwd
                 )
               os.proc(launcher, "setup-ide", scriptName, extraOptions)

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportJsonTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportJsonTestDefinitions.scala
@@ -11,8 +11,8 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
     json
       .replaceAll("\\s", "")
       .replaceAll(
-        "ivy:file:[^\"]*(scalacli|ScalaCli)[^\"]*/local-repo[^\"]*",
-        "ivy:file:.../scalacli/local-repo/..."
+        "ivy:file:[^\"]*/local-repo/[^\"]*",
+        "ivy:file:.../local-repo/..."
       )
       .replaceAll(
         "ivy:file:[^\"]*\\.ivy2/local[^\"]*",
@@ -70,7 +70,7 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
           |   ],
           |   "resolvers": [
           |     "https://repo1.maven.org/maven2",
-          |     "ivy:file:.../scalacli/local-repo/...",
+          |     "ivy:file:.../local-repo/...",
           |     "ivy:file:.../.ivy2/local/"
           |   ]
           | }
@@ -139,7 +139,7 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
           |   ],
           |   "resolvers": [
           |     "https://repo1.maven.org/maven2",
-          |     "ivy:file:.../scalacli/local-repo/...",
+          |     "ivy:file:.../local-repo/...",
           |     "ivy:file:.../.ivy2/local/"
           |   ]
           | }], [
@@ -170,7 +170,7 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
           |   "resolvers": [
           |     "https://oss.sonatype.org/content/repositories/snapshots",
           |     "https://repo1.maven.org/maven2",
-          |     "ivy:file:.../scalacli/local-repo/...",
+          |     "ivy:file:.../local-repo/...",
           |     "ivy:file:.../.ivy2/local/"
           |   ],
           |   "resourceDirs":["${withEscapedBackslashes(root / "resources")}"],
@@ -250,7 +250,7 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
           |   ],
           |   "resolvers": [
           |     "https://repo1.maven.org/maven2",
-          |     "ivy:file:.../scalacli/local-repo/...",
+          |     "ivy:file:.../local-repo/...",
           |     "ivy:file:.../.ivy2/local/"
           |   ]
           | }

--- a/modules/integration/src/test/scala/scala/cli/integration/InstallAndUninstallCompletionsTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/InstallAndUninstallCompletionsTests.scala
@@ -1,7 +1,7 @@
 package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
-import coursier.cache.shaded.dirs.ProjectDirectories
+import coursier.paths.shaded.dirs.ProjectDirectories
 
 import scala.util.Properties
 

--- a/modules/integration/src/test/scala/scala/cli/integration/RunJdkTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunJdkTestDefinitions.scala
@@ -12,7 +12,7 @@ trait RunJdkTestDefinitions { _: RunTestDefinitions =>
   for {
     javaVersion <-
       if (!TestUtil.isJvmCli) Constants.allJavaVersions
-      else Constants.allJavaVersions.filter(_ >= 11)
+      else Constants.allJavaVersions.filter(_ >= Constants.minimumLauncherJavaVersion)
     index = javaVersion
     useScalaInstallationWrapper <-
       if (canUseScalaInstallationWrapper) Seq(false, true) else Seq(false)

--- a/modules/integration/src/test/scala/scala/cli/integration/RunJdkTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunJdkTestDefinitions.scala
@@ -6,20 +6,14 @@ import scala.cli.integration.TestUtil.ProcOps
 import scala.util.{Properties, Try}
 
 trait RunJdkTestDefinitions { _: RunTestDefinitions =>
-  def javaIndex(javaVersion: Int): String =
-    // TODO just passing the version number on arm64 should be enough, needs a fix in cs
-    if (
-      (Properties.isMac && TestUtil.isM1 && (javaVersion < 11 || javaVersion == 16)) || javaVersion == 25
-    )
-      s"zulu:$javaVersion"
-    else javaVersion.toString
-
   def canUseScalaInstallationWrapper: Boolean =
     actualScalaVersion.startsWith("3") && actualScalaVersion.split('.').drop(1).head.toInt >= 5
 
   for {
-    javaVersion <- Constants.allJavaVersions
-    index = javaIndex(javaVersion)
+    javaVersion <-
+      if (!TestUtil.isJvmCli) Constants.allJavaVersions
+      else Constants.allJavaVersions.filter(_ >= 11)
+    index = javaVersion
     useScalaInstallationWrapper <-
       if (canUseScalaInstallationWrapper) Seq(false, true) else Seq(false)
     launcherString = if (useScalaInstallationWrapper) "coursier scala installation" else "Scala CLI"

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
@@ -864,20 +864,23 @@ trait RunScriptTestDefinitions { _: RunTestDefinitions =>
 
   test("verify drive-relative JAVA_HOME works") {
     TestUtil.retryOnCi() {
-      val java8Home =
-        os.Path(os.proc(TestUtil.cs, "java-home", "--jvm", "zulu:8").call().out.trim(), os.pwd)
+      val jvmIndex =
+        if (TestUtil.isJvmCli) Constants.minimumLauncherJavaVersion
+        else 8
+      val oldJavaHome =
+        os.Path(os.proc(TestUtil.cs, "java-home", "--jvm", jvmIndex).call().out.trim(), os.pwd)
 
       val dr = os.Path.driveRoot
 
       // forward slash is legal in `Windows`
-      val javaHome = java8Home.toString.replace('\\', '/')
+      val javaHome = oldJavaHome.toString.replace('\\', '/')
       expect(javaHome.drop(dr.length).startsWith("/"))
 
       val sysPath: String = System.getenv("PATH").replace('\\', '/')
       val newPath: String = s"$javaHome/bin" + File.pathSeparator + sysPath
 
       val extraEnv = Map(
-        "JAVA_HOME" -> java8Home.toString,
+        "JAVA_HOME" -> oldJavaHome.toString,
         "PATH"      -> newPath
       )
 

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -122,7 +122,15 @@ object TestUtil {
     removeAnsiColors(result.toString).trim().linesIterator.filterNot { str =>
       // these lines are not stable and can easily change
       val shouldNotContain =
-        Set("Starting compilation server", "hint", "Download", "Result of", "Checking", "Checked")
+        Set(
+          "Starting compilation server",
+          "hint",
+          "Download",
+          "Result of",
+          "Checking",
+          "Checked",
+          "Failed to download"
+        )
       shouldNotContain.exists(str.contains)
     }.mkString(System.lineSeparator())
 

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -80,12 +80,18 @@ object Scala {
 }
 
 object Java {
-  def minimumBloopJava: Int      = 17
-  def minimumInternalJava: Int   = 16
-  def defaultJava: Int           = minimumBloopJava
+  def minimumJavaLauncherJava  = 11
+  def minimumBloopJava: Int    = 17
+  def minimumInternalJava: Int = 16
+  def defaultJava: Int         = minimumBloopJava
+  def cliKeyJavaVersions       = Seq(
+    minimumBloopJava,
+    minimumInternalJava,
+    defaultJava,
+    minimumJavaLauncherJava
+  ).distinct
   def mainJavaVersions: Seq[Int] = Seq(8, 11, 17, 21, 23, 24, 25)
-  def allJavaVersions: Seq[Int]  =
-    (mainJavaVersions ++ Seq(minimumBloopJava, minimumInternalJava, defaultJava)).distinct
+  def allJavaVersions: Seq[Int]  = (mainJavaVersions ++ cliKeyJavaVersions).distinct
 }
 
 // Dependencies used in integration test fixtures
@@ -160,8 +166,9 @@ object Deps {
   // Force using of 2.13 - is there a better way?
   def coursier             = mvn"io.get-coursier:coursier_2.13:${Versions.coursier}"
   def coursierArchiveCache = mvn"io.get-coursier::coursier-archive-cache:${Versions.coursier}"
-  def coursierCli          = mvn"io.get-coursier:coursier-cli_2.13:${Versions.coursierCli}"
-  def coursierJvm          = mvn"io.get-coursier:coursier-jvm_2.13:${Versions.coursier}"
+    .exclude(("com.github.plokhotnyuk.jsoniter-scala", "*"))
+  def coursierCli = mvn"io.get-coursier:coursier-cli_2.13:${Versions.coursierCli}"
+  def coursierJvm = mvn"io.get-coursier:coursier-jvm_2.13:${Versions.coursier}"
     .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-core_2.13"))
     .exclude("io.get-coursier" -> "dependency_2.13")
   def coursierLauncher = mvn"io.get-coursier:coursier-launcher_2.13:${Versions.coursier}"

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -138,7 +138,7 @@ object Deps {
     def signingCliJvmVersion              = Java.defaultJava
     def javaSemanticdb                    = "0.10.0"
     def javaClassName                     = "0.1.8"
-    def bloop                             = "2.0.14-39-1864805c-SNAPSHOT"
+    def bloop                             = "2.0.15"
     def sbtVersion                        = "1.11.4"
     def mavenVersion                      = "3.8.1"
     def mavenScalaCompilerPluginVersion   = "4.9.1"

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -167,7 +167,7 @@ object Deps {
   def coursier             = mvn"io.get-coursier:coursier_2.13:${Versions.coursier}"
   def coursierArchiveCache = mvn"io.get-coursier::coursier-archive-cache:${Versions.coursier}"
     .exclude(("com.github.plokhotnyuk.jsoniter-scala", "*"))
-  def coursierCli = mvn"io.get-coursier:coursier-cli_2.13:${Versions.coursierCli}"
+  def coursierCli = mvn"io.get-coursier::coursier-cli:${Versions.coursierCli}"
   def coursierJvm = mvn"io.get-coursier:coursier-jvm_2.13:${Versions.coursier}"
     .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-core_2.13"))
     .exclude("io.get-coursier" -> "dependency_2.13")

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -111,10 +111,9 @@ object Deps {
     def ammoniteForScala3Lts = ammonite
     def argonautShapeless    = "1.3.1"
     // jni-utils version may need to be sync-ed when bumping the coursier version
-    def coursierDefault                   = "2.1.24"
+    def coursierDefault                   = "2.1.25-M19"
     def coursier                          = coursierDefault
     def coursierCli                       = coursierDefault
-    def coursierM1Cli                     = coursierDefault
     def coursierPublish                   = "0.4.3"
     def jmh                               = "1.37"
     def jsoniterScalaJava8                = "2.13.5.2"
@@ -133,7 +132,7 @@ object Deps {
     def signingCliJvmVersion              = Java.defaultJava
     def javaSemanticdb                    = "0.10.0"
     def javaClassName                     = "0.1.8"
-    def bloop                             = "2.0.13"
+    def bloop                             = "2.0.14-39-1864805c-SNAPSHOT"
     def sbtVersion                        = "1.11.4"
     def mavenVersion                      = "3.8.1"
     def mavenScalaCompilerPluginVersion   = "4.9.1"
@@ -159,9 +158,10 @@ object Deps {
   def caseApp          = mvn"com.github.alexarchambault::case-app:2.1.0"
   def collectionCompat = mvn"org.scala-lang.modules::scala-collection-compat:2.13.0"
   // Force using of 2.13 - is there a better way?
-  def coursier    = mvn"io.get-coursier:coursier_2.13:${Versions.coursier}"
-  def coursierCli = mvn"io.get-coursier:coursier-cli_2.13:${Versions.coursierCli}"
-  def coursierJvm = mvn"io.get-coursier:coursier-jvm_2.13:${Versions.coursier}"
+  def coursier             = mvn"io.get-coursier:coursier_2.13:${Versions.coursier}"
+  def coursierArchiveCache = mvn"io.get-coursier::coursier-archive-cache:${Versions.coursier}"
+  def coursierCli          = mvn"io.get-coursier:coursier-cli_2.13:${Versions.coursierCli}"
+  def coursierJvm          = mvn"io.get-coursier:coursier-jvm_2.13:${Versions.coursier}"
     .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-core_2.13"))
     .exclude("io.get-coursier" -> "dependency_2.13")
   def coursierLauncher = mvn"io.get-coursier:coursier-launcher_2.13:${Versions.coursier}"
@@ -170,7 +170,7 @@ object Deps {
   def coursierProxySetup = mvn"io.get-coursier:coursier-proxy-setup:${Versions.coursier}"
   def coursierPublish    = mvn"io.get-coursier.publish::publish:${Versions.coursierPublish}"
     .exclude(("org.scala-lang.modules", "scala-collection-compat_2.13"))
-    .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-core_3"))
+    .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-core_2.13"))
   def dependency    = mvn"io.get-coursier::dependency:0.3.2"
   def dockerClient  = mvn"com.spotify:docker-client:8.16.0"
   def expecty       = mvn"com.eed3si9n.expecty::expecty:0.17.0"
@@ -277,8 +277,7 @@ def graalVmJvmId       = s"graalvm-java$graalVmJavaVersion:$graalVmVersion"
 
 def csDockerVersion = Deps.Versions.coursierCli
 
-def buildCsVersion   = Deps.Versions.coursierCli
-def buildCsM1Version = Deps.Versions.coursierM1Cli
+def buildCsVersion = Deps.Versions.coursierCli
 
 // Native library used to encrypt GitHub secrets
 def libsodiumVersion = "1.0.18"

--- a/project/settings/package.mill.scala
+++ b/project/settings/package.mill.scala
@@ -6,7 +6,6 @@ import deps.{
   Deps,
   Docker,
   alpineVersion,
-  buildCsM1Version,
   buildCsVersion,
   libsodiumVersion,
   ubuntuVersion
@@ -63,7 +62,7 @@ def fromPath(name: String): String =
 def cs: T[String] = Task(persistent = true) {
   val arch      = sys.props.getOrElse("os.arch", "").toLowerCase(Locale.ROOT)
   val ext       = if (Properties.isWin) ".exe" else ""
-  val csVersion = if (arch == "aarch64" && Properties.isMac) buildCsM1Version else buildCsVersion
+  val csVersion = buildCsVersion
   val dest      = Task.dest / s"cs-$csVersion$ext"
 
   def downloadOpt(): Option[String] = {
@@ -85,11 +84,11 @@ def cs: T[String] = Task(persistent = true) {
       case "aarch64" =>
         if (Properties.isLinux)
           Some(
-            s"https://github.com/VirtusLab/coursier-m1/releases/download/v$csVersion/cs-aarch64-pc-linux.gz"
+            s"https://github.com/coursier/coursier/releases/download/v$csVersion/cs-aarch64-pc-linux.gz"
           )
         else if (Properties.isMac)
           Some(
-            s"https://github.com/VirtusLab/coursier-m1/releases/download/v$csVersion/cs-aarch64-apple-darwin.gz"
+            s"https://github.com/coursier/coursier/releases/download/v$csVersion/cs-aarch64-apple-darwin.gz"
           )
         else None
       case _ =>

--- a/website/docs/release_notes.md
+++ b/website/docs/release_notes.md
@@ -2647,7 +2647,7 @@ to Java 8.
 This is no longer the case. Scala CLI will now automatically download Java 17 for Bloop in such a situation 
 (and still use the JVM from `JAVA_HOME` for running the code, while Bloop runs on 17).
 
-```bash
+```bash ignore
 scala-cli --power bloop exit 
 # Stopped Bloop server.  
 export JAVA_HOME=$(cs java-home --jvm zulu:8)


### PR DESCRIPTION
https://github.com/coursier/coursier/releases/tag/v2.1.25-M19

Past attempts at 2.1.25:
- https://github.com/VirtusLab/scala-cli/pull/3578

Blockers:
- https://github.com/coursier/coursier/issues/3342

Required:
- https://github.com/coursier/coursier/pull/3343 or https://github.com/coursier/coursier/pull/3505
- https://github.com/scalacenter/bloop/pull/2747