### PR TITLE
Unify `cli` module unit tests with consistent logging, timeouts and other settings

### DIFF
--- a/modules/cli/src/test/scala/cli/tests/ArgSplitterTest.scala
+++ b/modules/cli/src/test/scala/cli/tests/ArgSplitterTest.scala
@@ -2,8 +2,7 @@ package cli.tests
 
 import scala.cli.commands.shared.ArgSplitter
 
-class ArgSplitterTest extends munit.FunSuite {
-
+class ArgSplitterTest extends TestUtil.ScalaCliSuite {
   test("test scalac options are split correctly") {
     val args = List(
       List("-arg", "-other-arg"),

--- a/modules/cli/src/test/scala/cli/tests/CachedBinaryTests.scala
+++ b/modules/cli/src/test/scala/cli/tests/CachedBinaryTests.scala
@@ -1,6 +1,7 @@
 package scala.cli.tests
 
 import bloop.rifle.BloopRifleConfig
+import cli.tests.TestUtil
 import com.eed3si9n.expecty.Expecty.assert as expect
 import os.Path
 
@@ -11,8 +12,7 @@ import scala.build.{Build, BuildThreads, Directories, LocalRepo}
 import scala.cli.internal.CachedBinary
 import scala.util.{Properties, Random}
 
-class CachedBinaryTests extends munit.FunSuite {
-
+class CachedBinaryTests extends TestUtil.ScalaCliSuite {
   val buildThreads: BuildThreads    = BuildThreads.create()
   def bloopConfig: BloopRifleConfig = BloopServer.bloopConfig
 

--- a/modules/cli/src/test/scala/cli/tests/HelpCheck.scala
+++ b/modules/cli/src/test/scala/cli/tests/HelpCheck.scala
@@ -5,8 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import scala.cli.ScalaCliCommands
 import scala.cli.commands.version.Version
 
-class HelpCheck extends munit.FunSuite {
-
+class HelpCheck extends TestUtil.ScalaCliSuite {
   test("help message should be shorter then 80 lines") {
     val scalaCli    = new ScalaCliCommands("scala-cli", "scala-cli", "Scala CLI")
     val helpMessage = scalaCli.help.help(scalaCli.helpFormat)

--- a/modules/cli/src/test/scala/cli/tests/LauncherCliTest.scala
+++ b/modules/cli/src/test/scala/cli/tests/LauncherCliTest.scala
@@ -7,8 +7,7 @@ import scala.build.tests.TestLogger
 import scala.cli.commands.shared.CoursierOptions
 import scala.cli.launcher.LauncherCli
 
-class LauncherCliTest extends munit.FunSuite {
-  override def munitFlakyOK: Boolean = TestUtil.isCI
+class LauncherCliTest extends TestUtil.ScalaCliSuite {
 
   test("resolve nightly version".flaky) {
     val logger          = TestLogger()

--- a/modules/cli/src/test/scala/cli/tests/OptionsCheck.scala
+++ b/modules/cli/src/test/scala/cli/tests/OptionsCheck.scala
@@ -1,10 +1,11 @@
 package scala.cli.tests
 
+import cli.tests.TestUtil
+
 import scala.cli.ScalaCliCommands
 import scala.cli.commands.shared.HasGlobalOptions
 
-class OptionsCheck extends munit.FunSuite {
-
+class OptionsCheck extends TestUtil.ScalaCliSuite {
   for (
     command <-
       new ScalaCliCommands("scala-cli", "scala-cli", "Scala CLI").commands

--- a/modules/cli/src/test/scala/cli/tests/PackageTests.scala
+++ b/modules/cli/src/test/scala/cli/tests/PackageTests.scala
@@ -12,8 +12,7 @@ import scala.build.{BuildThreads, Directories, LocalRepo}
 import scala.cli.commands.package0.Package
 import scala.cli.packaging.Library
 
-class PackageTests extends munit.FunSuite {
-
+class PackageTests extends TestUtil.ScalaCliSuite {
   val buildThreads = BuildThreads.create()
   def bloopConfig  = BloopServer.bloopConfig
 

--- a/modules/cli/src/test/scala/cli/tests/ScalafmtTest.scala
+++ b/modules/cli/src/test/scala/cli/tests/ScalafmtTest.scala
@@ -8,7 +8,7 @@ import scala.build.internal.Constants
 import scala.build.tests.{TestInputs, TestLogger}
 import scala.cli.commands.fmt.{FmtOptions, FmtUtil}
 
-class ScalafmtTests extends munit.FunSuite {
+class ScalafmtTests extends TestUtil.ScalaCliSuite {
   private lazy val defaultScalafmtVersion = Constants.defaultScalafmtVersion
 
   test("readVersionFromFile with non-default scalafmt version") {

--- a/modules/cli/src/test/scala/cli/tests/SetupScalaCLITests.scala
+++ b/modules/cli/src/test/scala/cli/tests/SetupScalaCLITests.scala
@@ -9,8 +9,7 @@ import scala.build.tests.TestInputs
 import scala.cli.ScalaCli
 import scala.jdk.CollectionConverters.{MapHasAsJava, MapHasAsScala}
 
-class SetupScalaCLITests extends munit.FunSuite {
-
+class SetupScalaCLITests extends TestUtil.ScalaCliSuite {
   test(s"should read java properties from file") {
     val key    = "scala-cli"
     val value  = "true"

--- a/modules/cli/src/test/scala/cli/tests/TestUtil.scala
+++ b/modules/cli/src/test/scala/cli/tests/TestUtil.scala
@@ -4,17 +4,52 @@ import coursier.cache.{ArtifactError, FileCache}
 import coursier.util.{Artifact, Task}
 
 import java.io.File
+import java.util.concurrent.TimeUnit
 
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.control.NonFatal
 
 object TestUtil {
+  abstract class ScalaCliSuite extends munit.FunSuite {
+    extension (munitContext: BeforeEach | AfterEach) {
+      def locationAbsolutePath: os.Path =
+        os.Path {
+          (munitContext match {
+            case beforeEach: BeforeEach => beforeEach.test
+            case afterEach: AfterEach   => afterEach.test
+          }).location.path
+        }
+    }
+
+    override def munitTimeout = new FiniteDuration(120, TimeUnit.SECONDS)
+
+    val testStartEndLogger = new Fixture[Unit]("files") {
+      def apply(): Unit = ()
+
+      override def beforeEach(context: BeforeEach): Unit = {
+        val fileName = context.locationAbsolutePath.baseName
+        System.err.println(
+          s">==== ${Console.CYAN}Running '${context.test.name}' from $fileName${Console.RESET}"
+        )
+      }
+
+      override def afterEach(context: AfterEach): Unit = {
+        val fileName = context.locationAbsolutePath.baseName
+        System.err.println(
+          s"X==== ${Console.CYAN}Finishing '${context.test.name}' from $fileName${Console.RESET}"
+        )
+      }
+    }
+
+    override def munitFixtures = List(testStartEndLogger)
+  }
+
   def downloadFile(url: String): Either[ArtifactError, Array[Byte]] = {
     val artifact = Artifact(url).withChanging(true)
     val cache    = FileCache()
 
     val file: Either[ArtifactError, File] = cache.logger.use {
-      try cache.withTtl(0.seconds).file(artifact).run.unsafeRun()(cache.ec)
+      try cache.withTtl(0.seconds).file(artifact).run.unsafeRun()(using cache.ec)
       catch {
         case NonFatal(e) => throw new Exception(e)
       }


### PR DESCRIPTION
This should fix timeouts like https://github.com/VirtusLab/scala-cli/actions/runs/18131801104/job/51600158820#step:9:643
