### PR TITLE
Fix test scope resources to not be added to the main scope

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -778,15 +778,19 @@ object Build {
     val watcher =
       new Watcher(ListBuffer(), threads.fileWatcher, run(), info.foreach(_._1.shutdown()))
 
-    def doWatch(): Unit = {
+    def doWatch(): Unit = either {
+      val (crossSources: CrossSources, inputs0: Inputs) =
+        value(allInputs(inputs, options, logger))
       val elements: Seq[Element] =
-        if res == null then inputs.elements
+        if res == null then inputs0.elements
         else
           res
             .map { builds =>
+              val allResourceDirectories =
+                crossSources.resourceDirs.map(rd => ResourceDirectory(rd.value))
               val mainElems = builds.main.inputs.elements
               val testElems = builds.get(Scope.Test).map(_.inputs.elements).getOrElse(Nil)
-              (mainElems ++ testElems).distinct
+              (mainElems ++ testElems ++ allResourceDirectories).distinct
             }
             .getOrElse(inputs.elements)
       for (elem <- elements) {

--- a/modules/build/src/main/scala/scala/build/CrossSources.scala
+++ b/modules/build/src/main/scala/scala/build/CrossSources.scala
@@ -273,7 +273,10 @@ object CrossSources {
 
     val resourceDirectoriesFromDirectives = {
       val resourceDirsFromCli =
-        allInputs.elements.flatMap { case rd: ResourceDirectory => Some(rd.path); case _ => None }
+        allInputs.elements.flatMap {
+          case rd: ResourceDirectory => Some(rd.path)
+          case _                     => None
+        }
       val resourceDirsFromBuildOptions: Seq[os.Path] =
         buildOptions.flatMap(_.value.classPathOptions.resourcesDir).distinct
       resourceDirsFromBuildOptions
@@ -318,7 +321,7 @@ object CrossSources {
       }
 
     val resourceDirs: Seq[WithBuildRequirements[os.Path]] =
-      resolveResourceDirs(finalInputs, preprocessedSources)
+      resolveResourceDirs(allInputs, preprocessedSources)
 
     lazy val allPathsWithDirectivesByScope: Map[Scope, Seq[(os.Path, Position.File)]] =
       (pathsWithDirectivePositions ++ inMemoryWithDirectivePositions ++ unwrappedScriptsWithDirectivePositions)

--- a/modules/build/src/main/scala/scala/build/CrossSources.scala
+++ b/modules/build/src/main/scala/scala/build/CrossSources.scala
@@ -271,22 +271,8 @@ object CrossSources {
       )
     }).flatten
 
-    val resourceDirectoriesFromDirectives = {
-      val resourceDirsFromCli =
-        allInputs.elements.flatMap {
-          case rd: ResourceDirectory => Some(rd.path)
-          case _                     => None
-        }
-      val resourceDirsFromBuildOptions: Seq[os.Path] =
-        buildOptions.flatMap(_.value.classPathOptions.resourcesDir).distinct
-      resourceDirsFromBuildOptions
-        .filter(!resourceDirsFromCli.contains(_))
-        .map(ResourceDirectory(_))
-    }
-    val finalInputs = allInputs.add(resourceDirectoriesFromDirectives)
-
     val defaultMainElemPath = for {
-      defaultMainElem <- finalInputs.defaultMainClassElement
+      defaultMainElem <- allInputs.defaultMainClassElement
     } yield defaultMainElem.path
 
     val pathsWithDirectivePositions
@@ -296,7 +282,7 @@ object CrossSources {
           val baseReqs0 = baseReqs(d.scopePath)
           WithBuildRequirements(
             d.requirements.fold(baseReqs0)(_ orElse baseReqs0),
-            (d.path, d.path.relativeTo(finalInputs.workspace))
+            (d.path, d.path.relativeTo(allInputs.workspace))
           ) -> d.directivesPositions
       }
     val inMemoryWithDirectivePositions
@@ -382,7 +368,7 @@ object CrossSources {
       buildOptions,
       unwrappedScripts
     )
-    crossSources -> finalInputs
+    crossSources -> allInputs
   }
 
   extension (uri: java.net.URI)

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
@@ -396,7 +396,7 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
           |""".stripMargin
     )
     testInputs.withBuild(baseOptions, buildThreads, bloopConfigOpt, scope = Scope.Main) {
-      (root, _, maybeBuild) =>
+      (_, _, maybeBuild) =>
         val build =
           maybeBuild.toOption.flatMap(_.successfulOpt).getOrElse(sys.error("cannot happen"))
         val resourceDirs = build.sources.resourceDirs

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
@@ -389,6 +389,21 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
         expect(resourceDirs == Seq(path))
     }
   }
+  test("do not include test.resourceDir into sources for main scope") {
+    val testInputs = TestInputs(
+      os.rel / "simple.sc" ->
+        """//> using test.resourceDir foo
+          |""".stripMargin
+    )
+    testInputs.withBuild(baseOptions, buildThreads, bloopConfigOpt, scope = Scope.Main) {
+      (root, _, maybeBuild) =>
+        val build =
+          maybeBuild.toOption.flatMap(_.successfulOpt).getOrElse(sys.error("cannot happen"))
+        val resourceDirs = build.sources.resourceDirs
+
+        expect(resourceDirs.isEmpty)
+    }
+  }
   test("parse boolean for publish.doc") {
     val testInputs = TestInputs(
       os.rel / "simple.sc" ->

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -567,9 +567,9 @@ abstract class RunTestDefinitions
   ): TestInputs =
     TestInputs(
       os.rel / "src" / "proj" / "resources" / "test" / "data" -> resourceContent,
-      os.rel / "src" / "proj" / "Test.scala"                  ->
+      os.rel / "src" / "proj" / "Example.scala"               ->
         s"""$directive
-           |object Test {
+           |object Example {
            |  def main(args: Array[String]): Unit = {
            |    val cl = Thread.currentThread().getContextClassLoader
            |    val is = cl.getResourceAsStream("test/data")
@@ -596,6 +596,22 @@ abstract class RunTestDefinitions
     )
       .fromRoot { root =>
         val res = os.proc(TestUtil.cli, "run", ".").call(cwd = root)
+        expect(res.out.trim() == expectedMessage)
+      }
+  }
+  test("resources via test directive") {
+    val expectedMessage = "hello"
+    resourcesInputs(
+      directive = "//> using test.resourceDirs ./resources",
+      resourceContent = expectedMessage
+    )
+      .fromRoot { root =>
+        val err = os.proc(TestUtil.cli, "run", ".")
+          .call(cwd = root, check = false, stderr = os.Pipe)
+        expect(err.err.trim().contains("java.lang.NullPointerException"))
+        expect(err.exitCode == 1)
+        val res = os.proc(TestUtil.cli, "run", ".", "--test")
+          .call(cwd = root)
         expect(res.out.trim() == expectedMessage)
       }
   }


### PR DESCRIPTION
Supersedes https://github.com/VirtusLab/scala-cli/pull/3879

@btomala I took your commits from #3879 and squashed them, to include the initial part of the fix & tests from your branch.
I will squash the whole thing when this PR gets merged.

TL;DR, what was happening:
- resource directories from the test scope were added to 2 spots unnecessarily
- one of those spots did not respect the scope, which caused the test scope resources to be on the main scope classpath
- the "unnecessary" code adding the resources the second time put them on the elements list of inputs, which was then used to watch those directories under `--watch` (and made them necessary)
  - this is tidied up in the other commit
- I added some more tests to cover some extra scenarios