### PR TITLE
Bump Scala 2.13 to 2.13.17 on the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1593,7 +1593,7 @@ jobs:
     - name: Print version
       run: ./mill -i show project.publish.finalPublishVersion
     - name: Publish to Sonatype Central
-      run: ./mill mill.scalalib.SonatypeCentralPublishModule/ --publishArtifacts '{__[],_,test-runner[2.13.16],test-runner[2.12.20],runner[2.13.16],runner[2.12.20]}.publishArtifacts'
+      run: ./mill mill.scalalib.SonatypeCentralPublishModule/ --publishArtifacts '{__[],_,test-runner[2.13.17],test-runner[2.12.20],runner[2.13.17],runner[2.12.20]}.publishArtifacts'
       if: env.SHOULD_PUBLISH == 'true'
       env:
         MILL_PGP_SECRET_BASE64: ${{ secrets.PGP_SECRET }}


### PR DESCRIPTION
Missed this in https://github.com/VirtusLab/scala-cli/pull/3895:
https://github.com/VirtusLab/scala-cli/actions/runs/18185963018/job/51781629145#step:7:15