### PR TITLE
Suggest using ivy2Local in the documentation

### DIFF
--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Repository.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Repository.scala
@@ -8,6 +8,7 @@ import scala.cli.commands.SpecificationLevel
 @DirectiveGroupName("Repository")
 @DirectiveExamples("//> using repository jitpack")
 @DirectiveExamples("//> using repository sonatype:snapshots")
+@DirectiveExamples("//> using repository ivy2Local")
 @DirectiveExamples("//> using repository m2Local")
 @DirectiveExamples(
   "//> using repository https://maven-central.storage-download.googleapis.com/maven2"
@@ -38,5 +39,5 @@ object Repository {
   val usageMsg =
     """Add repositories for dependency resolution.
       |
-      |Accepts predefined repositories supported by Coursier (like `sonatype:snapshots` or `m2Local`) or a URL of the root of Maven repository""".stripMargin
+      |Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`, `ivy2Local` or `m2Local`) or a URL of the root of Maven repository""".stripMargin
 }

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -300,7 +300,7 @@ Aliases: `-r`, `--repo`
 
 Add repositories for dependency resolution.
 
-Accepts predefined repositories supported by Coursier (like `sonatype:snapshots` or `m2Local`) or a URL of the root of Maven repository
+Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`, `ivy2Local` or `m2Local`) or a URL of the root of Maven repository
 
 ### `--compiler-plugin`
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -457,7 +457,7 @@ Enable Python support
 
 Add repositories for dependency resolution.
 
-Accepts predefined repositories supported by Coursier (like `sonatype:snapshots` or `m2Local`) or a URL of the root of Maven repository
+Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`, `ivy2Local` or `m2Local`) or a URL of the root of Maven repository
 
 `//> using repository` _repository_
 
@@ -465,6 +465,8 @@ Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`
 `//> using repository jitpack`
 
 `//> using repository sonatype:snapshots`
+
+`//> using repository ivy2Local`
 
 `//> using repository m2Local`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -244,7 +244,7 @@ Aliases: `-r`, `--repo`
 
 Add repositories for dependency resolution.
 
-Accepts predefined repositories supported by Coursier (like `sonatype:snapshots` or `m2Local`) or a URL of the root of Maven repository
+Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`, `ivy2Local` or `m2Local`) or a URL of the root of Maven repository
 
 ### `--compiler-plugin`
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -273,7 +273,7 @@ Set the default platform to Scala.js or Scala Native
 
 Add repositories for dependency resolution.
 
-Accepts predefined repositories supported by Coursier (like `sonatype:snapshots` or `m2Local`) or a URL of the root of Maven repository
+Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`, `ivy2Local` or `m2Local`) or a URL of the root of Maven repository
 
 `//> using repository` _repository_
 
@@ -281,6 +281,8 @@ Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`
 `//> using repository jitpack`
 
 `//> using repository sonatype:snapshots`
+
+`//> using repository ivy2Local`
 
 `//> using repository m2Local`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -216,7 +216,7 @@ Enable/disable Scala Native multithreading support
 
 Add repositories for dependency resolution.
 
-Accepts predefined repositories supported by Coursier (like `sonatype:snapshots` or `m2Local`) or a URL of the root of Maven repository
+Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`, `ivy2Local` or `m2Local`) or a URL of the root of Maven repository
 
 Aliases: `-r` ,`--repo`
 
@@ -1010,7 +1010,7 @@ Enable/disable Scala Native multithreading support
 
 Add repositories for dependency resolution.
 
-Accepts predefined repositories supported by Coursier (like `sonatype:snapshots` or `m2Local`) or a URL of the root of Maven repository
+Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`, `ivy2Local` or `m2Local`) or a URL of the root of Maven repository
 
 Aliases: `-r` ,`--repo`
 
@@ -1605,7 +1605,7 @@ Enable/disable Scala Native multithreading support
 
 Add repositories for dependency resolution.
 
-Accepts predefined repositories supported by Coursier (like `sonatype:snapshots` or `m2Local`) or a URL of the root of Maven repository
+Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`, `ivy2Local` or `m2Local`) or a URL of the root of Maven repository
 
 Aliases: `-r` ,`--repo`
 
@@ -2226,7 +2226,7 @@ Enable/disable Scala Native multithreading support
 
 Add repositories for dependency resolution.
 
-Accepts predefined repositories supported by Coursier (like `sonatype:snapshots` or `m2Local`) or a URL of the root of Maven repository
+Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`, `ivy2Local` or `m2Local`) or a URL of the root of Maven repository
 
 Aliases: `-r` ,`--repo`
 
@@ -2866,7 +2866,7 @@ Enable/disable Scala Native multithreading support
 
 Add repositories for dependency resolution.
 
-Accepts predefined repositories supported by Coursier (like `sonatype:snapshots` or `m2Local`) or a URL of the root of Maven repository
+Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`, `ivy2Local` or `m2Local`) or a URL of the root of Maven repository
 
 Aliases: `-r` ,`--repo`
 
@@ -3482,7 +3482,7 @@ Enable/disable Scala Native multithreading support
 
 Add repositories for dependency resolution.
 
-Accepts predefined repositories supported by Coursier (like `sonatype:snapshots` or `m2Local`) or a URL of the root of Maven repository
+Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`, `ivy2Local` or `m2Local`) or a URL of the root of Maven repository
 
 Aliases: `-r` ,`--repo`
 
@@ -4135,7 +4135,7 @@ Enable/disable Scala Native multithreading support
 
 Add repositories for dependency resolution.
 
-Accepts predefined repositories supported by Coursier (like `sonatype:snapshots` or `m2Local`) or a URL of the root of Maven repository
+Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`, `ivy2Local` or `m2Local`) or a URL of the root of Maven repository
 
 Aliases: `-r` ,`--repo`
 
@@ -4848,7 +4848,7 @@ Enable/disable Scala Native multithreading support
 
 Add repositories for dependency resolution.
 
-Accepts predefined repositories supported by Coursier (like `sonatype:snapshots` or `m2Local`) or a URL of the root of Maven repository
+Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`, `ivy2Local` or `m2Local`) or a URL of the root of Maven repository
 
 Aliases: `-r` ,`--repo`
 
@@ -5817,7 +5817,7 @@ Enable/disable Scala Native multithreading support
 
 Add repositories for dependency resolution.
 
-Accepts predefined repositories supported by Coursier (like `sonatype:snapshots` or `m2Local`) or a URL of the root of Maven repository
+Accepts predefined repositories supported by Coursier (like `sonatype:snapshots`, `ivy2Local` or `m2Local`) or a URL of the root of Maven repository
 
 Aliases: `-r` ,`--repo`
 


### PR DESCRIPTION
The `ivy2Local` repository is useful when you want to use `scala-cli` for scripting a larger application built locally with `sbt`.