### PR TITLE
Bump `scala-packager` to 0.2.1 & enable adding extra directories to a docker image

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
@@ -684,7 +684,7 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
       tag = Some(tag),
       exec = exec,
       dockerExecutable = None,
-      extraDirectories = Seq.empty
+      extraDirectories = packageOptions.dockerOptions.extraDirectories.map(_.toNIO)
     )
 
     val appPath = os.temp.dir(prefix = "scala-cli-docker") / "app"

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
@@ -683,7 +683,8 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
       repository = repository,
       tag = Some(tag),
       exec = exec,
-      dockerExecutable = None
+      dockerExecutable = None,
+      extraDirectories = Seq.empty
     )
 
     val appPath = os.temp.dir(prefix = "scala-cli-docker") / "app"

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
@@ -219,7 +219,8 @@ final case class PackageOptions(
             imageRepository = packager.dockerImageRepository,
             imageTag = packager.dockerImageTag,
             cmd = packager.dockerCmd,
-            isDockerEnabled = Some(docker)
+            isDockerEnabled = Some(docker),
+            extraDirectories = packager.dockerExtraDirectories.map(os.Path(_, os.pwd))
           ),
           nativeImageOptions = NativeImageOptions(
             graalvmJvmId = packager.graalvmJvmId.map(_.trim).filter(_.nonEmpty),

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/PackagerOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/PackagerOptions.scala
@@ -138,6 +138,11 @@ final case class PackagerOptions(
   )
   @Tag(tags.restricted)
   dockerCmd: Option[String] = None,
+  
+  @Group(HelpGroup.Docker.toString)
+  @HelpMessage("Extra directories to be added to the docker image")
+  @Tag(tags.restricted)
+  dockerExtraDirectories: List[String] = Nil,
 
   @Group(HelpGroup.NativeImage.toString)
   @HelpMessage(s"GraalVM Java major version to use to build GraalVM native images (${Constants.defaultGraalVMJavaVersion} by default)")

--- a/modules/directives/src/main/scala/scala/build/errors/WrongDirectoryPathError.scala
+++ b/modules/directives/src/main/scala/scala/build/errors/WrongDirectoryPathError.scala
@@ -1,0 +1,7 @@
+package scala.build.errors
+
+class WrongDirectoryPathError(cause: Throwable) extends BuildException(
+      message = s"""The directory path argument in the using directives at could not be found!
+                   |${cause.getLocalizedMessage}""".stripMargin,
+      cause = cause
+    )

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -1130,13 +1130,14 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
         s"""//> using toolkit default
            |
            |object Smth extends App {
-           |  val file =
-           |    os.list(os.pwd)
-           |      .filter(os.isFile)
-           |      .filter(_.endsWith(os.rel / "$extraFileName"))
-           |      .head
-           |  val contents = os.read(file).trim()
-           |  println(contents)
+           |  val content = 
+           |   os.walk(os.pwd)
+           |     .filter(os.isFile)
+           |     .filter(_.endsWith(os.rel / "$extraFileName"))
+           |     .headOption
+           |     .map(file => os.read(file).trim())
+           |     .getOrElse("No matching files found")
+           |  println(content)
            |}
            |""".stripMargin,
       extraFilePath -> expectedOutput

--- a/modules/options/src/main/scala/scala/build/options/packaging/DockerOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/packaging/DockerOptions.scala
@@ -8,7 +8,8 @@ final case class DockerOptions(
   imageRepository: Option[String] = None,
   imageTag: Option[String] = None,
   cmd: Option[String] = None,
-  isDockerEnabled: Option[Boolean] = None
+  isDockerEnabled: Option[Boolean] = None,
+  extraDirectories: Seq[os.Path] = Nil
 )
 
 object DockerOptions {

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -134,7 +134,7 @@ object Deps {
     def maxScalaNativeForTypelevelToolkit = scalaNative04
     def maxScalaNativeForScalaPy          = scalaNative04
     def maxScalaNativeForMillExport       = scalaNative05
-    def scalaPackager                     = "0.2.0"
+    def scalaPackager                     = "0.2.1"
     def signingCli                        = "0.2.11"
     def signingCliJvmVersion              = Java.defaultJava
     def javaSemanticdb                    = "0.10.0"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -972,6 +972,10 @@ The image tag; the default tag is `latest`
 
 Allows to override the executable used to run the application in docker, otherwise it defaults to sh for the JVM platform and node for the JS platform
 
+### `--docker-extra-directories`
+
+Extra directories to be added to the docker image
+
 ### `--graalvm-java-version`
 
 GraalVM Java major version to use to build GraalVM native images (17 by default)

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -300,6 +300,9 @@ Set parameters for packaging
 
 `//> using packaging.dockerCmd` _docker-command_
 
+`//> using packaging.dockerExtraDirectories` _directories_
+`//> using packaging.dockerExtraDirectory` _directory_
+
 
 
 #### Examples
@@ -322,6 +325,10 @@ Set parameters for packaging
 `//> using packaging.dockerCmd sh`
 
 `//> using packaging.dockerCmd node`
+
+`//> using packaging.dockerExtraDirectories path/to/directory1 path/to/directory2`
+
+`//> using packaging.dockerExtraDirectory path/to/directory`
 
 ### Platform
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-packager/releases/tag/v0.2.1
cc @btomala 

This integrates with the changes in https://github.com/VirtusLab/scala-packager/pull/250 and adds the `--docker-extra-directories` flag for the `package` sub-command.