### PR TITLE
Bump Ammonite to 3.0.3

### DIFF
--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -71,10 +71,10 @@ object Scala {
       .distinct
       .filter(minorVer(_) < minorVer(scala3Lts))
 
-  def maxAmmoniteScala212Version                    = scala212
-  def maxAmmoniteScala213Version                    = "2.13.16"
-  def maxAmmoniteScala3Version                      = "3.6.3"
-  def maxAmmoniteScala3LtsVersion                   = "3.3.5"
+  def maxAmmoniteScala212Version                    = "2.12.20"
+  def maxAmmoniteScala213Version                    = "2.13.17"
+  def maxAmmoniteScala3Version                      = "3.7.3"
+  def maxAmmoniteScala3LtsVersion                   = "3.3.7"
   lazy val listMaxAmmoniteScalaVersion: Seq[String] =
     Seq(maxAmmoniteScala212Version, maxAmmoniteScala213Version, maxAmmoniteScala3Version)
 }
@@ -113,7 +113,7 @@ object InternalDeps {
 
 object Deps {
   object Versions {
-    def ammonite             = "3.0.2"
+    def ammonite             = "3.0.3"
     def ammoniteForScala3Lts = ammonite
     def argonautShapeless    = "1.3.1"
     // jni-utils version may need to be sync-ed when bumping the coursier version

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1246,7 +1246,7 @@ Use Ammonite (instead of the default Scala REPL)
 
 Aliases: `--ammonite-ver`
 
-Set the Ammonite version (3.0.2 by default)
+Set the Ammonite version (3.0.3 by default)
 
 ### `--ammonite-arg`
 


### PR DESCRIPTION
https://github.com/com-lihaoyi/Ammonite/releases/tag/3.0.3
This also bumps the max Scala versions for ammonite to 2.13.17/3.3.7/3.7.3