### PR TITLE
Migrate from old `coursier` APIs

### DIFF
--- a/modules/build/src/main/scala/scala/build/Project.scala
+++ b/modules/build/src/main/scala/scala/build/Project.scala
@@ -142,9 +142,15 @@ object Project {
   def resolution(
     detailedArtifacts: Seq[(CsDependency, csCore.Publication, csUtil.Artifact, os.Path)]
   ): BloopConfig.Resolution = {
-    val indices = detailedArtifacts.map(_._1.moduleVersion).zipWithIndex.toMap
+    val indices = detailedArtifacts
+      .map { case (dep, _, _, _) => dep.moduleVersionConstraint }
+      .map { case (m, vc) => m -> vc.asString }
+      .zipWithIndex.toMap
     val modules = detailedArtifacts
-      .groupBy(_._1.moduleVersion)
+      .groupBy(_._1.moduleVersionConstraint)
+      .map {
+        case ((m, vc), artifacts) => m -> vc.asString -> artifacts
+      }
       .toVector
       .sortBy { case (modVer, _) => indices.getOrElse(modVer, Int.MaxValue) }
       .iterator

--- a/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/pgp/PgpExternalCommand.scala
@@ -195,13 +195,13 @@ object PgpExternalCommand {
 
       val (_, signingRes) = value {
         scala.build.Artifacts.fetchCsDependencies(
-          Seq(Positioned.none(jvmSigningDep.toCs)),
-          extraRepos,
-          None,
-          Nil,
-          logger,
-          cache,
-          None
+          dependencies = Seq(Positioned.none(jvmSigningDep.toCs)),
+          extraRepositories = extraRepos,
+          forceScalaVersionOpt = None,
+          forcedVersions = Nil,
+          logger = logger,
+          cache = cache,
+          classifiersOpt = None
         )
       }
       val signingClassPath = signingRes.files

--- a/modules/cli/src/main/scala/scala/cli/internal/ScalaJsLinker.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/ScalaJsLinker.scala
@@ -1,8 +1,8 @@
 package scala.cli.internal
 
-import coursier.Repositories
 import coursier.cache.{ArchiveCache, FileCache}
 import coursier.util.Task
+import coursier.{Repositories, VersionConstraint}
 import dependency.*
 import org.scalajs.testing.adapter.TestAdapterInitializer as TAI
 
@@ -71,13 +71,15 @@ object ScalaJsLinker {
           case Right(()) =>
             val (_, linkerRes) = value {
               scala.build.Artifacts.fetchCsDependencies(
-                Seq(Positioned.none(scalaJsCliDep.toCs)),
-                extraRepos,
-                None,
-                forcedVersions.map { case (m, v) => (m.toCs, v) },
-                logger,
-                cache,
-                None
+                dependencies = Seq(Positioned.none(scalaJsCliDep.toCs)),
+                extraRepositories = extraRepos,
+                forceScalaVersionOpt = None,
+                forcedVersions = forcedVersions.map { case (m, v) =>
+                  (m.toCs, VersionConstraint(v))
+                },
+                logger = logger,
+                cache = cache,
+                classifiersOpt = None
               )
             }
             val linkerClassPath = linkerRes.files

--- a/modules/core/src/main/scala/scala/build/CsUtils.scala
+++ b/modules/core/src/main/scala/scala/build/CsUtils.scala
@@ -1,5 +1,5 @@
 package scala.build
 
-import coursier.core.Version
+import coursier.version.Version
 
 extension (s: String) def coursierVersion: Version = Version(s)

--- a/modules/core/src/main/scala/scala/build/errors/CoursierDependencyError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/CoursierDependencyError.scala
@@ -1,0 +1,12 @@
+package scala.build.errors
+
+import coursier.error.DependencyError
+
+import scala.build.Position
+
+class CoursierDependencyError(val underlying: DependencyError, positions: Seq[Position] = Seq.empty)
+    extends BuildException(
+      s"Could not fetch dependency: ${underlying.message}",
+      positions = positions,
+      cause = underlying.getCause
+    )

--- a/modules/core/src/main/scala/scala/build/errors/UnsupportedFeatureError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/UnsupportedFeatureError.scala
@@ -1,0 +1,8 @@
+package scala.build.errors
+
+import scala.build.Position
+
+abstract class UnsupportedFeatureError(
+  val featureDescription: String,
+  override val positions: Seq[Position] = Nil
+) extends BuildException(s"Unsupported feature: $featureDescription")

--- a/modules/core/src/main/scala/scala/build/errors/UnsupportedGradleModuleVariantError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/UnsupportedGradleModuleVariantError.scala
@@ -1,0 +1,12 @@
+package scala.build.errors
+
+import coursier.core.VariantPublication
+
+import scala.build.Position
+
+class UnsupportedGradleModuleVariantError(
+  val variantPublication: VariantPublication,
+  override val positions: Seq[Position] = Nil
+) extends UnsupportedFeatureError(featureDescription =
+      s"Gradle Module variant: ${variantPublication.name} (${variantPublication.url})"
+    )

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Toolkit.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Toolkit.scala
@@ -1,6 +1,6 @@
 package scala.build.preprocessing.directives
 
-import coursier.core.Version
+import coursier.version.Version
 import dependency.*
 
 import scala.build.Positioned

--- a/modules/options/src/main/scala/scala/build/info/ScopedBuildInfo.scala
+++ b/modules/options/src/main/scala/scala/build/info/ScopedBuildInfo.scala
@@ -138,7 +138,7 @@ object ExportDependencyFormat {
     new ExportDependencyFormat(
       dep.module.organization.value,
       ArtifactId(shortDepName, dep.module.name.value),
-      dep.version
+      dep.versionConstraint.asString
     )
   }
 

--- a/modules/options/src/main/scala/scala/build/internal/FetchExternalBinary.scala
+++ b/modules/options/src/main/scala/scala/build/internal/FetchExternalBinary.scala
@@ -3,6 +3,7 @@ package scala.build.internal
 import coursier.cache.{ArchiveCache, ArtifactError, CacheLogger}
 import coursier.error.FetchError
 import coursier.util.{Artifact, Task}
+import coursier.version.VersionConstraint
 
 import java.util.Locale
 
@@ -45,12 +46,12 @@ object FetchExternalBinary {
           .withCache(archiveCache.cache)
           .addDependencies(params.dependencies.map(_.toCs)*)
           .mapResolutionParams { params0 =>
-            params0.addForceVersion(
-              params.forcedVersions.map { case (m, v) => m.toCs -> v }*
+            params0.addForceVersion0(
+              params.forcedVersions.map { case (m, v) => m.toCs -> VersionConstraint(v) }*
             )
           }
-          .addRepositories(params.extraRepos: _*)
-          .run()(archiveCache.cache.ec)
+          .addRepositories(params.extraRepos*)
+          .run()(using archiveCache.cache.ec)
           .map(os.Path(_, os.pwd))
         ExternalBinary.ClassPath(javaCommand(), classPath, params.mainClass)
     }

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -492,7 +492,7 @@ final case class BuildOptions(
     val sortedExtraScalaVersions = scalaOptions0
       .extraScalaVersions
       .toVector
-      .map(coursier.core.Version(_))
+      .map(coursier.version.Version(_))
       .sorted
       .map(_.repr)
       .reverse

--- a/modules/options/src/main/scala/scala/build/options/JavaOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/JavaOptions.scala
@@ -2,7 +2,7 @@ package scala.build.options
 
 import bloop.rifle.VersionUtil.jvmRelease
 import coursier.cache.{ArchiveCache, FileCache}
-import coursier.jvm.{JavaHome, JvmCache, JvmIndex}
+import coursier.jvm.{JavaHome, JvmCache, JvmChannel, JvmIndex}
 import coursier.util.Task
 import dependency.AnyDependency
 
@@ -38,7 +38,7 @@ final case class JavaOptions(
     cache: FileCache[Task],
     verbosity: Int
   ): JavaHome = {
-    val indexUrl  = jvmIndexOpt.getOrElse(JvmIndex.coursierIndexUrl)
+    val indexUrl  = jvmIndexOpt.getOrElse(JvmChannel.gitHubIndexUrl)
     val indexTask = {
       val msg    = if (verbosity > 0) "Downloading JVM index" else ""
       val cache0 = cache.withMessage(msg)
@@ -54,7 +54,7 @@ final case class JavaOptions(
         )
       )
       .withOs(finalJvmIndexOs)
-      .withArchitecture(jvmIndexArch.getOrElse(JvmIndex.defaultArchitecture()))
+      .withArchitecture(jvmIndexArch.getOrElse(JvmChannel.defaultArchitecture()))
     JavaHome().withCache(jvmCache)
   }
 


### PR DESCRIPTION
Follows-up after https://github.com/VirtusLab/scala-cli/pull/3884

This PR gets rid of `coursier` API deprecated between 2.1.24 and 2.1.25-M19 (resulting in a bit of a refactor).
`coursier` 2.1.25-M* also introduces support for Gradle Module variants (more on that can be found here: https://docs.gradle.org/current/userguide/variant_attributes.html)

I'm not sure how useful that'd be in Scala CLI, but for now, I just added a bunch of TODOs and allow the CLI to fail gracefully when a variant is  encountered. Let me know if you're a Gradle Module variant user and would like to have your use case handled by Scala CLI (I'd like to hear of that use case).

Either way, this should get deprecation warnings upon compilation down to reasonable levels.