### PR TITLE
Drop Scala 2 in `runner`, `test-runner` and `tasty-lib` modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1593,7 +1593,7 @@ jobs:
     - name: Print version
       run: ./mill -i show project.publish.finalPublishVersion
     - name: Publish to Sonatype Central
-      run: ./mill mill.scalalib.SonatypeCentralPublishModule/ --publishArtifacts '{__[],_,test-runner[2.13.17],test-runner[2.12.20],runner[2.13.17],runner[2.12.20]}.publishArtifacts'
+      run: ./mill mill.scalalib.SonatypeCentralPublishModule/ --publishArtifacts '{__[],_}.publishArtifacts'
       if: env.SHOULD_PUBLISH == 'true'
       env:
         MILL_PGP_SECRET_BASE64: ${{ secrets.PGP_SECRET }}

--- a/build.mill.scala
+++ b/build.mill.scala
@@ -105,10 +105,9 @@ object directives extends Cross[Directives](Scala.scala3MainVersions)
 object core           extends Cross[Core](Scala.scala3MainVersions) with CrossScalaDefaultToInternal
 object `build-module` extends Cross[Build](Scala.scala3MainVersions)
     with CrossScalaDefaultToInternal
-object runner        extends Cross[Runner](Scala.runnerScalaVersions) with CrossScalaDefaultToRunner
-object `test-runner` extends Cross[TestRunner](Scala.testRunnerScalaVersions)
-    with CrossScalaDefaultToRunner
-object `tasty-lib` extends Cross[TastyLib](Scala.all) with CrossScalaDefaultToInternal
+object runner        extends Runner
+object `test-runner` extends TestRunner
+object `tasty-lib`   extends Cross[TastyLib](Scala.all) with CrossScalaDefaultToInternal
 // Runtime classes used within native image on Scala 3 replacing runtime from Scala
 object `scala3-runtime` extends Cross[Scala3Runtime](Scala.scala3MainVersions)
     with CrossScalaDefaultToInternal
@@ -437,16 +436,16 @@ trait Core extends ScalaCliCrossSbtModule
   def constantsFile: T[PathRef] = Task(persistent = true) {
     val dir                 = Task.dest / "constants"
     val dest                = dir / "Constants.scala"
-    val testRunnerMainClass = `test-runner`(Scala.runnerScala3)
+    val testRunnerMainClass = `test-runner`
       .mainClass()
       .getOrElse(sys.error("No main class defined for test-runner"))
-    val runnerMainClass = build.runner(Scala.runnerScala3)
+    val runnerMainClass = build.runner
       .mainClass()
       .getOrElse(sys.error("No main class defined for runner"))
     val detailedVersionValue =
       if (`local-repo`.developingOnStubModules) s"""Some("${vcsState()}")"""
       else "None"
-    val testRunnerOrganization = `test-runner`(Scala.runnerScala3)
+    val testRunnerOrganization = `test-runner`
       .pomSettings()
       .organization
     val code =
@@ -466,14 +465,15 @@ trait Core extends ScalaCliCrossSbtModule
          |  def scalaNativeVersion = "${Deps.Versions.scalaNative}"
          |
          |  def testRunnerOrganization = "$testRunnerOrganization"
-         |  def testRunnerModuleName = "${`test-runner`(Scala.runnerScala3).artifactName()}"
-         |  def testRunnerVersion = "${`test-runner`(Scala.runnerScala3).publishVersion()}"
+         |  def testRunnerModuleName = "${`test-runner`.artifactName()}"
+         |  def testRunnerVersion = "${`test-runner`.publishVersion()}"
          |  def testRunnerMainClass = "$testRunnerMainClass"
          |
-         |  def runnerOrganization = "${build.runner(Scala.runnerScala3).pomSettings().organization}"
-         |  def runnerModuleName = "${build.runner(Scala.runnerScala3).artifactName()}"
-         |  def runnerVersion = "${build.runner(Scala.runnerScala3).publishVersion()}"
-         |  def runnerLegacyVersion = "${Cli.runnerLegacyVersion}"
+         |  def runnerOrganization = "${build.runner.pomSettings().organization}"
+         |  def runnerModuleName = "${build.runner.artifactName()}"
+         |  def runnerVersion = "${build.runner.publishVersion()}"
+         |  def runnerScala30LegacyVersion = "${Cli.runnerScala30LegacyVersion}"
+         |  def runnerScala2LegacyVersion = "${Cli.runnerScala2LegacyVersion}"
          |  def runnerMainClass = "$runnerMainClass"
          |
          |  def semanticDbPluginOrganization = "${Deps.semanticDbScalac.dep.module.organization
@@ -744,7 +744,7 @@ trait Build extends ScalaCliCrossSbtModule
     options(crossScalaVersion),
     directives(crossScalaVersion),
     `scala-cli-bsp`,
-    `test-runner`(crossScalaVersion),
+    `test-runner`,
     `tasty-lib`(crossScalaVersion)
   )
   override def scalacOptions: T[Seq[String]] = Task {
@@ -1095,7 +1095,8 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
            |  def ammoniteVersion              = "${Deps.ammonite.dep.versionConstraint.asString}"
            |  def defaultGraalVMJavaVersion    = "${deps.graalVmJavaVersion}"
            |  def defaultGraalVMVersion        = "${deps.graalVmVersion}"
-           |  def runnerLegacyVersion          = "${Cli.runnerLegacyVersion}"
+           |  def runnerScala30LegacyVersion   = "${Cli.runnerScala30LegacyVersion}"
+           |  def runnerScala2LegacyVersion    = "${Cli.runnerScala2LegacyVersion}"
            |  def scalaPyVersion               = "${Deps.scalaPy.dep.versionConstraint.asString}"
            |  def scalaPyMaxScalaNative        = "${Deps.Versions.maxScalaNativeForScalaPy}"
            |  def bloopVersion                 = "${Deps.bloopRifle.dep.versionConstraint.asString}"
@@ -1275,19 +1276,19 @@ trait CliIntegrationDocker extends SbtModule with ScalaCliPublishModule with Has
   )
 }
 
-trait Runner extends ScalaCliCrossSbtModule
+trait Runner extends SbtModule
     with ScalaCliPublishModule
-    with ScalaCliScalafixLegacyModule {
-  override def crossScalaVersion: String     = crossValue
+    with ScalaCliScalafixModule {
+  override def scalaVersion: T[String]       = Scala.scala3Lts
   override def scalacOptions: T[Seq[String]] = Task {
-    super.scalacOptions() ++ Seq("-release", "8")
+    super.scalacOptions() ++ Seq("-release", "8", "-deprecation")
   }
   override def mainClass: T[Option[String]] = Some("scala.cli.runner.Runner")
   override def sources: T[Seq[PathRef]]     = Task.Sources {
     val scala3DirNames =
-      if (crossScalaVersion.startsWith("3.")) {
+      if (scalaVersion().startsWith("3.")) {
         val name =
-          if (crossScalaVersion.contains("-RC")) "scala-3-unstable"
+          if (scalaVersion().contains("-RC")) "scala-3-unstable"
           else "scala-3-stable"
         Seq(name)
       }
@@ -1298,12 +1299,12 @@ trait Runner extends ScalaCliCrossSbtModule
   }
 }
 
-trait TestRunner extends ScalaCliCrossSbtModule
+trait TestRunner extends SbtModule
     with ScalaCliPublishModule
-    with ScalaCliScalafixLegacyModule {
-  override def crossScalaVersion: String     = crossValue
+    with ScalaCliScalafixModule {
+  override def scalaVersion: T[String]       = Scala.scala3Lts
   override def scalacOptions: T[Seq[String]] = Task {
-    super.scalacOptions() ++ Seq("-release", "8")
+    super.scalacOptions() ++ Seq("-release", "8", "-deprecation")
   }
   override def ivyDeps: T[Agg[Dep]] = super.ivyDeps() ++ Agg(
     Deps.asm,
@@ -1345,12 +1346,9 @@ object `local-repo` extends LocalRepo {
    */
   def developingOnStubModules = false
 
-  override def stubsModules: Seq[PublishLocalNoFluff] =
-    for {
-      sv   <- Scala.runnerScalaVersions
-      proj <- Seq(runner, `test-runner`)
-    } yield proj(sv)
-  override def version: T[String] = runner(Scala.runnerScala3).publishVersion()
+  override def stubsModules: Seq[PublishLocalNoFluff] = Seq(runner, `test-runner`)
+
+  override def version: T[String] = runner.publishVersion()
 }
 
 // Helper CI commands

--- a/build.mill.scala
+++ b/build.mill.scala
@@ -107,7 +107,8 @@ object `build-module` extends Cross[Build](Scala.scala3MainVersions)
     with CrossScalaDefaultToInternal
 object runner        extends Runner
 object `test-runner` extends TestRunner
-object `tasty-lib`   extends Cross[TastyLib](Scala.all) with CrossScalaDefaultToInternal
+object `tasty-lib`   extends Cross[TastyLib](Scala.scala3MainVersions)
+    with CrossScalaDefaultToInternal
 // Runtime classes used within native image on Scala 3 replacing runtime from Scala
 object `scala3-runtime` extends Cross[Scala3Runtime](Scala.scala3MainVersions)
     with CrossScalaDefaultToInternal
@@ -1316,7 +1317,7 @@ trait TestRunner extends SbtModule
 
 trait TastyLib extends ScalaCliCrossSbtModule
     with ScalaCliPublishModule
-    with ScalaCliScalafixLegacyModule {
+    with ScalaCliScalafixModule {
   override def crossScalaVersion: String = crossValue
   def constantsFile: T[PathRef]          = Task(persistent = true) {
     val dir  = Task.dest / "constants"

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTests213.scala
@@ -44,20 +44,23 @@ class CompileTests213 extends CompileTestDefinitions with Test213 {
            |  }
            |}""".stripMargin
     ).fromRoot { root =>
-      val result = os.proc(TestUtil.cli, "test", ".").call(
+      val result = os.proc(TestUtil.cli, "test", ".", extraOptions).call(
         cwd = root,
         check = false,
         mergeErrIntoOut = true
       )
-      val separator = if (Properties.isWin) "\\" else "/"
+      val separator           = if (Properties.isWin) "\\" else "/"
+      val graalVmVersion      = Constants.defaultGraalVMJavaVersion
+      val legacyRunnerVersion = Constants.runnerScala2LegacyVersion
+      val ltsPrefix           = Constants.scala3LtsPrefix
 
       val expectedOutput =
-        s"""|Compiling project (Scala ${Constants.scala213}, JVM (${Constants
-             .defaultGraalVMJavaVersion}))
-            |Compiled project (Scala ${Constants.scala213}, JVM (${Constants
-             .defaultGraalVMJavaVersion}))
-            |Compiling project (test, Scala ${Constants.scala213}, JVM (${Constants
-             .defaultGraalVMJavaVersion}))
+        s"""|Compiling project (Scala $actualScalaVersion, JVM ($graalVmVersion))
+            |Compiled project (Scala $actualScalaVersion, JVM ($graalVmVersion))
+            |[warn] Scala $actualScalaVersion is no longer supported by the test-runner module.
+            |[warn] Defaulting to a legacy test-runner module version: $legacyRunnerVersion.
+            |[warn] To use the latest test-runner, upgrade Scala to at least $ltsPrefix.
+            |Compiling project (test, Scala $actualScalaVersion, JVM ($graalVmVersion))
             |[info] .${separator}Test.test.scala:6:5
             |[info] scala.Predef.ArrowAssoc[Int](1).->[String]("test")
             |[info] scala.Predef.ArrowAssoc[Int](1).->[String]("test")
@@ -71,8 +74,7 @@ class CompileTests213 extends CompileTestDefinitions with Test213 {
             |[error] example error message
             |[error]     Scala2Example.macroMethod(1 -> "test")
             |[error]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            |Error compiling project (test, Scala ${Constants.scala213}, JVM (${Constants
-             .defaultGraalVMJavaVersion}))
+            |Error compiling project (test, Scala $actualScalaVersion, JVM ($graalVmVersion))
             |Compilation failed
             |""".stripMargin
 

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -2426,7 +2426,11 @@ abstract class RunTestDefinitions
         val res = os.proc(TestUtil.cli, "run", ".", "--runner", extraOptions)
           .call(cwd = root, stderr = os.Pipe)
         expect(res.out.trim() == expectedMessage)
-        expect(!res.err.trim().contains(legacyRunnerWarning))
+        val legacyWarningCheck = {
+          val check = res.err.trim().contains(legacyRunnerWarning)
+          if (actualScalaVersion.startsWith("2")) check else !check
+        }
+        expect(legacyWarningCheck)
       }
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
@@ -192,7 +192,7 @@ class RunTestsDefault extends RunTestDefinitions
     scalaVersion <- TestUtil.legacyScalaVersionsOnePerMinor
     expectedMessage = "Hello, world!"
     expectedWarning =
-      s"Defaulting to a legacy runner module version: ${Constants.runnerLegacyVersion}"
+      s"Defaulting to a legacy runner module version: ${Constants.runnerScala30LegacyVersion}"
   }
     test(
       s"run a simple hello world with the runner module on the classpath and Scala $scalaVersion (legacy)"

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTests212.scala
@@ -1,3 +1,34 @@
 package scala.cli.integration
 
-class TestTests212 extends TestTestDefinitions with Test212
+import com.eed3si9n.expecty.Expecty.expect
+
+import scala.cli.integration.TestUtil.StringOps
+
+class TestTests212 extends TestTestDefinitions with Test212 {
+  test(s"run a simple test with Scala $actualScalaVersion (legacy)") {
+    val expectedMessage = "Hello, world!"
+    TestInputs(os.rel / "example.test.scala" ->
+      s"""//> using dep com.novocode:junit-interface:0.11
+         |import org.junit.Test
+         |
+         |class MyTests {
+         |  @Test
+         |  def foo(): Unit = {
+         |    assert(2 + 2 == 4)
+         |    println("$expectedMessage")
+         |  }
+         |}
+         |""".stripMargin).fromRoot { root =>
+      val expectedWarning =
+        s"Defaulting to a legacy test-runner module version: ${Constants.runnerScala2LegacyVersion}"
+      val res =
+        os.proc(TestUtil.cli, "test", ".", extraOptions)
+          .call(cwd = root, stderr = os.Pipe)
+      val out = res.out.trim()
+      expect(out.contains(expectedMessage))
+      val err = res.err.trim()
+      expect(err.contains(expectedWarning))
+      expect(err.countOccurrences(expectedWarning) == 1)
+    }
+  }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTests213.scala
@@ -1,3 +1,35 @@
 package scala.cli.integration
 
-class TestTests213 extends TestTestDefinitions with Test213
+import com.eed3si9n.expecty.Expecty.expect
+
+import scala.cli.integration.TestUtil.StringOps
+
+class TestTests213 extends TestTestDefinitions with Test213 {
+  test(s"run a simple test with Scala $actualScalaVersion (legacy)") {
+    val expectedMessage = "Hello, world!"
+    TestInputs(os.rel / "example.test.scala" ->
+      s"""//> using dep com.novocode:junit-interface:0.11
+         |import org.junit.Test
+         |
+         |class MyTests {
+         |  @Test
+         |  def foo(): Unit = {
+         |    assert(2 + 2 == 4)
+         |    println("$expectedMessage")
+         |  }
+         |}
+         |""".stripMargin).fromRoot { root =>
+      val expectedWarning =
+        s"Defaulting to a legacy test-runner module version: ${Constants.runnerScala2LegacyVersion}"
+      val res =
+        os.proc(TestUtil.cli, "test", ".", extraOptions)
+          .call(cwd = root, stderr = os.Pipe)
+      val out = res.out.trim()
+      expect(out.contains(expectedMessage))
+      val err = res.err.trim()
+      expect(err.contains(expectedWarning))
+      expect(err.countOccurrences(expectedWarning) == 1)
+    }
+  }
+
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
@@ -72,7 +72,7 @@ class TestTestsDefault extends TestTestDefinitions with TestDefault {
     scalaVersion <- TestUtil.legacyScalaVersionsOnePerMinor
     expectedMessage = "Hello, world!"
     expectedWarning =
-      s"Defaulting to a legacy test-runner module version: ${Constants.runnerLegacyVersion}"
+      s"Defaulting to a legacy test-runner module version: ${Constants.runnerScala30LegacyVersion}"
   }
     test(s"run a simple test with Scala $scalaVersion (legacy)") {
       TestInputs(os.rel / "example.test.scala" ->

--- a/modules/options/src/main/scala/scala/build/Artifacts.scala
+++ b/modules/options/src/main/scala/scala/build/Artifacts.scala
@@ -146,12 +146,18 @@ object Artifacts {
       scalaVersion = scalaParams.scalaVersion
     } yield scalaVersion).getOrElse(defaultScalaVersion)
 
-    val shouldUseLegacyRunners =
+    val shouldUseLegacyScala3Runners =
       scalaVersion.startsWith("3") &&
       scalaVersion.coursierVersion < s"$scala3LtsPrefix.0".coursierVersion
+    val shouldUseLegacyScala2Runners = scalaVersion.startsWith("2")
+    val shouldUseLegacyRunners       = shouldUseLegacyScala2Runners || shouldUseLegacyScala3Runners
 
     val jvmTestRunnerDependencies =
       if addJvmTestRunner then {
+        val runnerLegacyVersion =
+          if scalaVersion.startsWith("3")
+          then runnerScala30LegacyVersion
+          else runnerScala2LegacyVersion
         val testRunnerVersion0 =
           if shouldUseLegacyRunners then {
             logger.message(
@@ -471,6 +477,10 @@ object Artifacts {
               else Nil
             val runnerVersion0 =
               if shouldUseLegacyRunners then {
+                val runnerLegacyVersion =
+                  if shouldUseLegacyScala3Runners
+                  then runnerScala30LegacyVersion
+                  else runnerScala2LegacyVersion
                 logger.message(
                   s"""$warnPrefix Scala $scalaVersion is no longer supported by the runner module.
                      |$warnPrefix Defaulting to a legacy runner module version: $runnerLegacyVersion.

--- a/modules/runner/src/main/scala/scala/cli/runner/StackTracePrinter.scala
+++ b/modules/runner/src/main/scala/scala/cli/runner/StackTracePrinter.scala
@@ -97,10 +97,8 @@ final case class StackTracePrinter(
 }
 
 object StackTracePrinter {
-
   lazy val coloredStackTraces: Boolean =
     sys.props.get("scala.colored-stack-traces")
       .map(_.toLowerCase(Locale.ROOT))
       .forall(_ == "true")
-
 }

--- a/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyBuffer.scala
+++ b/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyBuffer.scala
@@ -59,7 +59,7 @@ class TastyBuffer(initialSize: Int) {
   /** Like writeNat, but for longs. Note that the binary representation of LongNat is identical to
     * Nat if the long value is in the range Int.MIN_VALUE to Int.MAX_VALUE.
     */
-  def writeLongNat(x: Long): Unit = {
+  private def writeLongNat(x: Long): Unit = {
     def writePrefix(x: Long): Unit = {
       val y = x >>> 7
       if (y != 0L) writePrefix(y)
@@ -79,7 +79,7 @@ class TastyBuffer(initialSize: Int) {
   def getNat(at: Addr): Int = getLongNat(at).toInt
 
   /** The long natural number at address `at` */
-  def getLongNat(at: Addr): Long = {
+  private def getLongNat(at: Addr): Long = {
     var b   = 0L
     var x   = 0L
     var idx = at.index

--- a/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyReader.scala
+++ b/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyReader.scala
@@ -16,14 +16,14 @@ package scala.build.tastylib
 
 import java.io.OutputStream
 
-import scala.build.tastylib.TastyBuffer._
+import scala.build.tastylib.TastyBuffer.*
 import scala.collection.mutable
 
 class TastyReader(val bytes: Array[Byte], val start: Int, val end: Int, val base: Int = 0) {
 
   def this(bytes: Array[Byte]) = this(bytes, 0, bytes.length)
 
-  private[this] var bp: Int = start
+  private var bp: Int = start
 
   def pos: Int                  = bp
   def read: TastyReader.Bytes   = TastyReader.Bytes(bytes, start, bp)
@@ -50,7 +50,7 @@ class TastyReader(val bytes: Array[Byte], val start: Int, val end: Int, val base
   def readNat(): Int = readLongNat().toInt
   def readInt(): Int = readLongInt().toInt
 
-  def readLongNat(): Long = {
+  private def readLongNat(): Long = {
     var b = 0L
     var x = 0L
     while ({
@@ -62,7 +62,7 @@ class TastyReader(val bytes: Array[Byte], val start: Int, val end: Int, val base
     x
   }
 
-  def readLongInt(): Long = {
+  private def readLongInt(): Long = {
     var b       = bytes(bp)
     var x: Long = (b << 1).toByte >> 1
     bp += 1
@@ -95,6 +95,7 @@ class TastyReader(val bytes: Array[Byte], val start: Int, val end: Int, val base
   }
 
   def doUntil(end: Addr)(op: => Unit): Unit = {
+    // noinspection LoopVariableNotUpdated
     while (bp < index(end)) op
     assert(bp == index(end))
   }

--- a/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyUnpickler.scala
+++ b/modules/tasty-lib/src/main/scala/scala/build/tastylib/TastyUnpickler.scala
@@ -16,14 +16,14 @@ package scala.build.tastylib
 
 import scala.build.tastylib.TastyBuffer.NameRef
 import scala.build.tastylib.TastyFormat.NameTags
-import scala.build.tastylib.TastyName._
+import scala.build.tastylib.TastyName.*
 import scala.build.tastylib.TastyReader.Bytes
 import scala.collection.mutable
 
 object TastyUnpickler {
 
   final class NameTable {
-    private[this] val names = new mutable.ArrayBuffer[(Option[TastyName], Bytes)]
+    private val names = new mutable.ArrayBuffer[(Option[TastyName], Bytes)]
     def add(
       name: Option[TastyName],
       bytes: Bytes
@@ -39,7 +39,7 @@ import TastyUnpickler._
 
 private class TastyUnpickler(reader: TastyReader) { self =>
 
-  private[this] val nameTable = new NameTable
+  private val nameTable = new NameTable
 
   def nameAtRef: NameTable = nameTable
 

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
@@ -1,14 +1,14 @@
 package scala.build.testrunner
 
 import org.objectweb.asm
-import sbt.testing.{Logger => _, _}
+import sbt.testing.{Logger as _, *}
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 object AsmTestRunner {
 
@@ -38,11 +38,11 @@ object AsmTestRunner {
           parents
       }
 
-    def allParents(className: String): Stream[String] = {
+    def allParents(className: String): LazyList[String] = {
 
-      def helper(done: Set[String], todo: List[String]): Stream[String] =
+      def helper(done: Set[String], todo: List[String]): LazyList[String] =
         todo match {
-          case Nil    => Stream.empty
+          case Nil    => LazyList.empty
           case h :: t =>
             if (done(h)) helper(done, t)
             else h #:: helper(done + h, parents(h).toList ::: t)
@@ -97,7 +97,7 @@ object AsmTestRunner {
       }
   }
 
-  def listClassesByteCode(
+  private def listClassesByteCode(
     classPathEntry: Path,
     keepJars: Boolean
   ): Iterator[(String, () => InputStream)] =
@@ -153,13 +153,13 @@ object AsmTestRunner {
     }
     else Iterator.empty
 
-  def listClassesByteCode(
+  private def listClassesByteCode(
     classPath: Seq[Path],
     keepJars: Boolean
   ): Iterator[(String, () => InputStream)] =
     classPath.iterator.flatMap(listClassesByteCode(_, keepJars))
 
-  def findInClassPath(classPathEntry: Path, name: String): Option[Array[Byte]] =
+  private def findInClassPath(classPathEntry: Path, name: String): Option[Array[Byte]] =
     if (Files.isDirectory(classPathEntry)) {
       val p = classPathEntry.resolve(name)
       if (Files.isRegularFile(p)) Some(Files.readAllBytes(p))
@@ -190,7 +190,7 @@ object AsmTestRunner {
     }
     else None
 
-  def findInClassPath(classPath: Seq[Path], name: String): Iterator[Array[Byte]] =
+  private def findInClassPath(classPath: Seq[Path], name: String): Iterator[Array[Byte]] =
     classPath
       .iterator
       .flatMap(findInClassPath(_, name).iterator)
@@ -329,7 +329,7 @@ object AsmTestRunner {
       ).toArray
 
     val runner       = framework.runner(Array(), Array(), classLoader)
-    val initialTasks = runner.tasks(taskDefs0)
+    val initialTasks = runner.tasks(taskDefs0).toSeq
     val events       = TestRunner.runTasks(initialTasks, out)
 
     val doneMsg = runner.done()

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
@@ -1,11 +1,11 @@
 package scala.build.testrunner
 
-import sbt.testing.{Logger => _, _}
+import sbt.testing.{Logger as _, *}
 
 import java.util.regex.Pattern
 
 import scala.annotation.tailrec
-import scala.build.testrunner.FrameworkUtils._
+import scala.build.testrunner.FrameworkUtils.*
 
 object DynamicTestRunner {
 
@@ -134,7 +134,7 @@ object DynamicTestRunner {
                 new TaskDef(cls.getName.stripSuffix("$"), fp, false, Array(new SuiteSelector))
             }
             .toVector
-          val initialTasks = runner.tasks(taskDefs.toArray)
+          val initialTasks = runner.tasks(taskDefs.toArray).toSeq
           val events       = TestRunner.runTasks(initialTasks, out)
           val failed       = events.exists { ev =>
             ev.status == Status.Error ||

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/FrameworkUtils.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/FrameworkUtils.scala
@@ -7,7 +7,7 @@ import java.lang.reflect.Modifier
 import java.nio.file.{Files, Path}
 import java.util.ServiceLoader
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 object FrameworkUtils {
   // needed for Scala 2.12

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/TestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/TestRunner.scala
@@ -1,6 +1,6 @@
 package scala.build.testrunner
 
-import sbt.testing.{Logger => SbtTestLogger, _}
+import sbt.testing.{Logger as SbtTestLogger, *}
 
 import java.io.{File, PrintStream}
 import java.nio.file.{Path, Paths}
@@ -21,8 +21,8 @@ object TestRunner {
   )
 
   def classPath(loader: ClassLoader): Seq[Path] = {
-    def helper(loader: ClassLoader): Stream[Path] =
-      if (loader == null) Stream.empty
+    def helper(loader: ClassLoader): LazyList[Path] =
+      if (loader == null) LazyList.empty
       else {
         val paths = loader match {
           case u: java.net.URLClassLoader =>
@@ -32,14 +32,14 @@ object TestRunner {
                   Seq(Paths.get(url.toURI).toAbsolutePath)
                 case _ => Nil // FIXME Warn about this
               }
-              .toStream
+              .to(LazyList)
           case cl if cl.getClass.getName == "jdk.internal.loader.ClassLoaders$AppClassLoader" =>
             // Required with JDK-11
             sys.props.getOrElse("java.class.path", "")
               .split(File.pathSeparator)
-              .toStream
+              .to(LazyList)
               .map(Paths.get(_))
-          case _ => Stream.empty // FIXME Warn about this
+          case _ => LazyList.empty // FIXME Warn about this
         }
         paths #::: helper(loader.getParent)
       }

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -3,7 +3,9 @@ import mill._
 import scalalib._
 
 object Cli {
-  def runnerLegacyVersion = "1.7.1" // last runner version to support pre-LTS Scala 3 versions
+  def runnerScala30LegacyVersion =
+    "1.7.1" // last runner version to support pre-LTS Scala 3 versions
+  def runnerScala2LegacyVersion = "1.9.1" // last runner version to support pre-Scala-3 versions
 }
 
 object Scala {
@@ -30,8 +32,7 @@ object Scala {
   val allScala3           = Seq(scala3Lts, scala3Next, scala3NextAnnounced, scala3NextRc).distinct
   val all                 = (allScala2 ++ allScala3 ++ defaults).distinct
   val scala3MainVersions  = (defaults ++ allScala3).distinct
-  val runnerScalaVersions = runnerScala3 +: allScala2
-  val testRunnerScalaVersions = (runnerScalaVersions ++ allScala3).distinct
+  val runnerScalaVersions = Seq(runnerScala3, scala213)
 
   def scalaJs    = "1.20.1"
   def scalaJsCli = scalaJs // this must be compatible with the Scala.js version


### PR DESCRIPTION
- this is a follow-up to https://github.com/VirtusLab/scala-cli/pull/3650
- even though it [was mentioned in Scala CLI v1.8.0 release notes that we'd stop](https://github.com/VirtusLab/scala-cli/releases/tag/v1.8.0), we kept releasing `runner` and `test-runner` modules for Scala 2.12 and 2.13 (even though we did bump Scala 3 version used to the 3.3 LTS)
- with this change, we are effectively freezing these 2 modules at 1.9.1; no further development is predicted to happen there, as no Scala 2.14 version is predicted to be coming
- using the runners with Scala 2 will keep on working, of course, but the newest developments and improvements will no longer be available for those versions (not that much development is happening there); future Scala CLI releases will fall back to 1.9.1 for those modules.
- an appropriate warning will get printed when the runners are used with Scala 2
  - I might do a follow-up with a a flag/config for silencing the warning (out of scope for this PR)
<img width="1368" height="191" alt="image" src="https://github.com/user-attachments/assets/2b480a91-cebf-414b-9520-15f1c3a1ddb0" />
