### PR TITLE
Bump Scala Native to 0.5.9

### DIFF
--- a/modules/build/src/test/scala/scala/build/tests/ScalaNativeUsingDirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ScalaNativeUsingDirectiveTests.scala
@@ -150,6 +150,48 @@ class ScalaNativeUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
     }
   }
 
+  for { directiveKey <- Seq("nativeCCompile", "native-c-compile") }
+    test(s"ScalaNativeOptions for $directiveKey") {
+      val expectedOption1 = "compileOption1"
+      val expectedOption2 = "compileOption2"
+      val inputs          = TestInputs(
+        os.rel / "p.sc" ->
+          s"""//> using $directiveKey $expectedOption1 $expectedOption2
+             |def foo() = println("hello foo")
+             |""".stripMargin
+      )
+
+      inputs.withLoadedBuild(buildOptions, buildThreads, bloopConfig) { (_, _, maybeBuild) =>
+        assert(
+          maybeBuild.options.scalaNativeOptions.cCompileOptions.head == expectedOption1
+        )
+        assert(
+          maybeBuild.options.scalaNativeOptions.cCompileOptions.drop(1).head == expectedOption2
+        )
+      }
+    }
+
+  for { directiveKey <- Seq("nativeCppCompile", "native-cpp-compile") }
+    test(s"ScalaNativeOptions for $directiveKey") {
+      val expectedOption1 = "compileOption1"
+      val expectedOption2 = "compileOption2"
+      val inputs          = TestInputs(
+        os.rel / "p.sc" ->
+          s"""//> using $directiveKey $expectedOption1 $expectedOption2
+             |def foo() = println("hello foo")
+             |""".stripMargin
+      )
+
+      inputs.withLoadedBuild(buildOptions, buildThreads, bloopConfig) { (_, _, maybeBuild) =>
+        assert(
+          maybeBuild.options.scalaNativeOptions.cppCompileOptions.head == expectedOption1
+        )
+        assert(
+          maybeBuild.options.scalaNativeOptions.cppCompileOptions.drop(1).head == expectedOption2
+        )
+      }
+    }
+
   test("ScalaNativeOptions for native-linking and no value") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaNativeOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalaNativeOptions.scala
@@ -56,6 +56,16 @@ final case class ScalaNativeOptions(
     nativeCompile: List[String] = Nil,
 
   @Group(HelpGroup.ScalaNative.toString)
+  @HelpMessage("List of compile options (C files only)")
+  @Tag(tags.should)
+    nativeCCompile: List[String] = Nil,
+
+  @Group(HelpGroup.ScalaNative.toString)
+  @HelpMessage("List of compile options (C++ files only)")
+  @Tag(tags.should)
+    nativeCppCompile: List[String] = Nil,
+
+  @Group(HelpGroup.ScalaNative.toString)
   @Hidden
   @HelpMessage("Use default compile options")
    @Tag(tags.implementation)

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -273,6 +273,8 @@ final case class SharedOptions(
       linkingOptions = nativeLinking,
       linkingDefaults = nativeLinkingDefaults,
       compileOptions = nativeCompile,
+      cCompileOptions = nativeCCompile,
+      cppCompileOptions = nativeCppCompile,
       compileDefaults = nativeCompileDefaults,
       embedResources = embedResources,
       buildTargetStr = nativeTarget,

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaNative.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/ScalaNative.scala
@@ -12,6 +12,8 @@ import scala.cli.commands.SpecificationLevel
 @DirectiveExamples(s"//> using nativeLto full")
 @DirectiveExamples(s"//> using nativeVersion ${Constants.scalaNativeVersion}")
 @DirectiveExamples(s"//> using nativeCompile -flto=thin")
+@DirectiveExamples(s"//> using nativeCCompile -std=c17")
+@DirectiveExamples(s"//> using nativeCppCompile -std=c++17 -fcxx-exceptions")
 @DirectiveExamples(s"//> using nativeLinking -flto=thin")
 @DirectiveExamples(s"//> using nativeClang ./clang")
 @DirectiveExamples(s"//> using nativeClangPP ./clang++")
@@ -31,6 +33,10 @@ import scala.cli.commands.SpecificationLevel
     |`//> using nativeVersion` _value_
     |
     |`//> using nativeCompile` _value1_ _value2_ …
+    |
+    |`//> using nativeCCompile` _value1_ _value2_ …
+    |
+    |`//> using nativeCppCompile` _value1_ _value2_ …
     |
     |`//> using nativeLinking` _value1_ _value2_ …
     |
@@ -59,6 +65,8 @@ final case class ScalaNative(
   nativeLto: Option[String] = None,
   nativeVersion: Option[String] = None,
   nativeCompile: List[String] = Nil,
+  nativeCCompile: List[String] = Nil,
+  nativeCppCompile: List[String] = Nil,
   nativeLinking: List[String] = Nil,
   nativeClang: Option[String] = None,
   @DirectiveName("nativeClangPp")
@@ -74,6 +82,8 @@ final case class ScalaNative(
       ltoStr = nativeLto,
       version = nativeVersion,
       compileOptions = nativeCompile,
+      cCompileOptions = nativeCCompile,
+      cppCompileOptions = nativeCppCompile,
       linkingOptions = nativeLinking,
       clang = nativeClang,
       clangpp = nativeClangPP,

--- a/modules/options/src/main/scala/scala/build/options/ScalaNativeOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaNativeOptions.scala
@@ -36,6 +36,8 @@ final case class ScalaNativeOptions(
   linkingOptions: List[String] = Nil,
   linkingDefaults: Option[Boolean] = None,
   compileOptions: List[String] = Nil,
+  cCompileOptions: List[String] = Nil,
+  cppCompileOptions: List[String] = Nil,
   compileDefaults: Option[Boolean] = None,
   embedResources: Option[Boolean] = None,
   buildTargetStr: Option[String] = None,
@@ -109,6 +111,10 @@ final case class ScalaNativeOptions(
 
   private def compileCliOptions(): List[String] =
     finalCompileOptions().flatMap(option => List("--compile-option", option))
+  private def cCompileCliOptions(): List[String] =
+    cCompileOptions.flatMap(option => List("--c-compile-option", option))
+  private def cppCompileCliOptions(): List[String] =
+    cppCompileOptions.flatMap(option => List("--cpp-compile-option", option))
   private def ltoOptions(): List[String] =
     ltoStr.map(_.trim).filter(_.nonEmpty)
       .map(lto => LTO.apply(lto))
@@ -176,6 +182,8 @@ final case class ScalaNativeOptions(
       clangppCliOption() ++
       linkingCliOptions() ++
       compileCliOptions() ++
+      cCompileCliOptions() ++
+      cppCompileCliOptions() ++
       resourcesCliOptions(resourcesExist) ++
       targetCliOption() ++
       multithreadingCliOption()

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -128,7 +128,7 @@ object Deps {
     def scalaMeta                         = "4.13.9"
     def scalafmt                          = "3.9.10"
     def scalaNative04                     = "0.4.17"
-    def scalaNative05                     = "0.5.8"
+    def scalaNative05                     = "0.5.9"
     def scalaNative                       = scalaNative05
     def maxScalaNativeForToolkit          = scalaNative05
     def maxScalaNativeForTypelevelToolkit = scalaNative04

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1420,7 +1420,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 ### `--native-version`
 
-Set the Scala Native version (0.5.8 by default).
+Set the Scala Native version (0.5.9 by default).
 
 ### `--native-mode`
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1455,6 +1455,14 @@ Use default linking settings
 
 List of compile options
 
+### `--native-c-compile`
+
+List of compile options (C files only)
+
+### `--native-cpp-compile`
+
+List of compile options (C++ files only)
+
 ### `--native-compile-defaults`
 
 [Internal]

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -505,6 +505,10 @@ Add Scala Native options
 
 `//> using nativeCompile` _value1_ _value2_ …
 
+`//> using nativeCCompile` _value1_ _value2_ …
+
+`//> using nativeCppCompile` _value1_ _value2_ …
+
 `//> using nativeLinking` _value1_ _value2_ …
 
 `//> using nativeClang` _value_
@@ -533,6 +537,10 @@ Add Scala Native options
 `//> using nativeVersion 0.5.9`
 
 `//> using nativeCompile -flto=thin`
+
+`//> using nativeCCompile -std=c17`
+
+`//> using nativeCppCompile -std=c++17 -fcxx-exceptions`
 
 `//> using nativeLinking -flto=thin`
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -530,7 +530,7 @@ Add Scala Native options
 
 `//> using nativeLto full`
 
-`//> using nativeVersion 0.5.8`
+`//> using nativeVersion 0.5.9`
 
 `//> using nativeCompile -flto=thin`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -904,6 +904,18 @@ Use default linking settings
 
 List of compile options
 
+### `--native-c-compile`
+
+`SHOULD have` per Scala Runner specification
+
+List of compile options (C files only)
+
+### `--native-cpp-compile`
+
+`SHOULD have` per Scala Runner specification
+
+List of compile options (C++ files only)
+
 ### `--native-compile-defaults`
 
 `IMPLEMENTATION specific` per Scala Runner specification

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -854,7 +854,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 `SHOULD have` per Scala Runner specification
 
-Set the Scala Native version (0.5.8 by default).
+Set the Scala Native version (0.5.9 by default).
 
 ### `--native-mode`
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -346,7 +346,7 @@ Add Scala Native options
 
 `//> using nativeLto full`
 
-`//> using nativeVersion 0.5.8`
+`//> using nativeVersion 0.5.9`
 
 `//> using nativeCompile -flto=thin`
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -321,6 +321,10 @@ Add Scala Native options
 
 `//> using nativeCompile` _value1_ _value2_ …
 
+`//> using nativeCCompile` _value1_ _value2_ …
+
+`//> using nativeCppCompile` _value1_ _value2_ …
+
 `//> using nativeLinking` _value1_ _value2_ …
 
 `//> using nativeClang` _value_
@@ -349,6 +353,10 @@ Add Scala Native options
 `//> using nativeVersion 0.5.9`
 
 `//> using nativeCompile -flto=thin`
+
+`//> using nativeCCompile -std=c17`
+
+`//> using nativeCppCompile -std=c++17 -fcxx-exceptions`
 
 `//> using nativeLinking -flto=thin`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -178,7 +178,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.8 by default).
+Set the Scala Native version (0.5.9 by default).
 
 **--native-mode**
 
@@ -972,7 +972,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.8 by default).
+Set the Scala Native version (0.5.9 by default).
 
 **--native-mode**
 
@@ -1567,7 +1567,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.8 by default).
+Set the Scala Native version (0.5.9 by default).
 
 **--native-mode**
 
@@ -2188,7 +2188,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.8 by default).
+Set the Scala Native version (0.5.9 by default).
 
 **--native-mode**
 
@@ -2828,7 +2828,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.8 by default).
+Set the Scala Native version (0.5.9 by default).
 
 **--native-mode**
 
@@ -3444,7 +3444,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.8 by default).
+Set the Scala Native version (0.5.9 by default).
 
 **--native-mode**
 
@@ -4097,7 +4097,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.8 by default).
+Set the Scala Native version (0.5.9 by default).
 
 **--native-mode**
 
@@ -4810,7 +4810,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.8 by default).
+Set the Scala Native version (0.5.9 by default).
 
 **--native-mode**
 
@@ -5779,7 +5779,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.8 by default).
+Set the Scala Native version (0.5.9 by default).
 
 **--native-mode**
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -200,6 +200,14 @@ Extra options passed to `clang` verbatim during linking
 
 List of compile options
 
+**--native-c-compile**
+
+List of compile options (C files only)
+
+**--native-cpp-compile**
+
+List of compile options (C++ files only)
+
 **--native-target**
 
 Build target type
@@ -994,6 +1002,14 @@ Extra options passed to `clang` verbatim during linking
 
 List of compile options
 
+**--native-c-compile**
+
+List of compile options (C files only)
+
+**--native-cpp-compile**
+
+List of compile options (C++ files only)
+
 **--native-target**
 
 Build target type
@@ -1588,6 +1604,14 @@ Extra options passed to `clang` verbatim during linking
 **--native-compile**
 
 List of compile options
+
+**--native-c-compile**
+
+List of compile options (C files only)
+
+**--native-cpp-compile**
+
+List of compile options (C++ files only)
 
 **--native-target**
 
@@ -2209,6 +2233,14 @@ Extra options passed to `clang` verbatim during linking
 **--native-compile**
 
 List of compile options
+
+**--native-c-compile**
+
+List of compile options (C files only)
+
+**--native-cpp-compile**
+
+List of compile options (C++ files only)
 
 **--native-target**
 
@@ -2850,6 +2882,14 @@ Extra options passed to `clang` verbatim during linking
 
 List of compile options
 
+**--native-c-compile**
+
+List of compile options (C files only)
+
+**--native-cpp-compile**
+
+List of compile options (C++ files only)
+
 **--native-target**
 
 Build target type
@@ -3465,6 +3505,14 @@ Extra options passed to `clang` verbatim during linking
 **--native-compile**
 
 List of compile options
+
+**--native-c-compile**
+
+List of compile options (C files only)
+
+**--native-cpp-compile**
+
+List of compile options (C++ files only)
 
 **--native-target**
 
@@ -4118,6 +4166,14 @@ Extra options passed to `clang` verbatim during linking
 **--native-compile**
 
 List of compile options
+
+**--native-c-compile**
+
+List of compile options (C files only)
+
+**--native-cpp-compile**
+
+List of compile options (C++ files only)
 
 **--native-target**
 
@@ -4831,6 +4887,14 @@ Extra options passed to `clang` verbatim during linking
 **--native-compile**
 
 List of compile options
+
+**--native-c-compile**
+
+List of compile options (C files only)
+
+**--native-cpp-compile**
+
+List of compile options (C++ files only)
 
 **--native-target**
 
@@ -5800,6 +5864,14 @@ Extra options passed to `clang` verbatim during linking
 **--native-compile**
 
 List of compile options
+
+**--native-c-compile**
+
+List of compile options (C files only)
+
+**--native-cpp-compile**
+
+List of compile options (C++ files only)
 
 **--native-target**
 


### PR DESCRIPTION
https://github.com/scala-native/scala-native/releases/tag/v0.5.9
https://scala-native.org/en/latest/changelog/0.5.x/0.5.9.html
Also adds support for https://github.com/scala-native/scala-native-cli/pull/47 / https://github.com/scala-native/scala-native/pull/4418
cc @WojciechMazur 