### PR TITLE
Migrate integration tests to Scala 3

### DIFF
--- a/build.mill.scala
+++ b/build.mill.scala
@@ -993,13 +993,13 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
     with ScalaCliScalafixModule {
   override def scalaVersion: T[String] = sv
 
-  def sv: String = Scala.scala213
+  def sv: String = Scala.scala3Lts
 
   def tmpDirBase: T[PathRef] = Task(persistent = true) {
     PathRef(Task.dest / "working-dir")
   }
   override def scalacOptions: T[Seq[String]] = Task {
-    super.scalacOptions() ++ Seq("-Xasync", "-deprecation")
+    super.scalacOptions() ++ Seq("-deprecation")
   }
 
   override def ivyDeps: T[Agg[Dep]] = super.ivyDeps() ++ Agg(
@@ -1015,7 +1015,6 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
       Deps.jsoniterCore,
       Deps.libsodiumjni,
       Deps.pprint,
-      Deps.scalaAsync,
       Deps.slf4jNop,
       Deps.usingDirectives
     )
@@ -1252,7 +1251,7 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
 }
 
 trait CliIntegrationDocker extends SbtModule with ScalaCliPublishModule with HasTests {
-  override def scalaVersion: T[String] = Scala.scala213
+  override def scalaVersion: T[String] = Scala.scala3Lts
   override def ivyDeps: T[Agg[Dep]]    = super.ivyDeps() ++ Agg(
     Deps.osLib
   )

--- a/modules/integration/src/test/scala/scala/cli/integration/BspSuite.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspSuite.scala
@@ -1,9 +1,9 @@
 package scala.cli.integration
 
-import ch.epfl.scala.{bsp4j => b}
+import ch.epfl.scala.bsp4j as b
 import com.eed3si9n.expecty.Expecty.expect
-import com.github.plokhotnyuk.jsoniter_scala.core._
-import com.github.plokhotnyuk.jsoniter_scala.macros._
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+import com.github.plokhotnyuk.jsoniter_scala.macros.*
 import com.google.gson.Gson
 import com.google.gson.internal.LinkedTreeMap
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError
@@ -14,13 +14,13 @@ import java.util.concurrent.{ExecutorService, ScheduledExecutorService}
 import scala.annotation.tailrec
 import scala.cli.integration.BspSuite.{Details, detailsCodec}
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{Await, Future, Promise}
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
-trait BspSuite { _: ScalaCliSuite =>
+trait BspSuite { this: ScalaCliSuite =>
   protected def extraOptions: Seq[String]
   def initParams(root: os.Path): b.InitializeBuildParams =
     new b.InitializeBuildParams(

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTests2Definitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTests2Definitions.scala
@@ -2,7 +2,7 @@ package scala.cli.integration
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait BspTests2Definitions { _: BspTestDefinitions =>
+trait BspTests2Definitions { this: BspTestDefinitions =>
   for {
     useDirectives        <- Seq(true, false)
     (directive, options) <- Seq(

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTests3Definitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTests3Definitions.scala
@@ -2,7 +2,7 @@ package scala.cli.integration
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait BspTests3Definitions { _: BspTestDefinitions =>
+trait BspTests3Definitions { this: BspTestDefinitions =>
   test("BSP class wrapper for Scala 3") {
     val (script1, script2) = "script1.sc" -> "script2.sc"
     val inputs             = TestInputs(

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileScalacCompatTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileScalacCompatTestDefinitions.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import scala.util.Properties
 
 /** For the `run` counterpart, refer to [[RunScalacCompatTestDefinitions]] */
-trait CompileScalacCompatTestDefinitions { _: CompileTestDefinitions =>
+trait CompileScalacCompatTestDefinitions { this: CompileTestDefinitions =>
   if (actualScalaVersion.startsWith("3"))
     test("consecutive -language:* flags are not ignored") {
       val sourceFileName = "example.scala"

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -12,7 +12,7 @@ abstract class CompileTestDefinitions
     with TestScalaVersionArgs
     with CompilerPluginTestDefinitions
     with CompileScalacCompatTestDefinitions
-    with SemanticDbTestDefinitions { _: TestScalaVersion =>
+    with SemanticDbTestDefinitions { this: TestScalaVersion =>
   protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
 
   private lazy val bloopDaemonDir = BloopUtil.bloopDaemonDir {
@@ -576,7 +576,8 @@ abstract class CompileTestDefinitions
         .filter(_.last.endsWith(".class"))
         .filter(os.isFile(_))
         .map(_.relativeTo(outputDir))
-      expect(classFiles.contains(os.rel / "Hello.class"))
+      val path = os.rel / "Hello.class"
+      expect(classFiles.contains(path))
     }
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTests3StableDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTests3StableDefinitions.scala
@@ -4,7 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import java.io.File
 
-trait CompileTests3StableDefinitions { _: CompileTestDefinitions =>
+trait CompileTests3StableDefinitions { this: CompileTestDefinitions =>
   test(s"TASTY processor does not warn about Scala $actualScalaVersion") {
     TestInputs(os.rel / "simple.sc" -> s"""println("Hello")""")
       .fromRoot { root =>

--- a/modules/integration/src/test/scala/scala/cli/integration/CompilerPluginTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompilerPluginTestDefinitions.scala
@@ -4,7 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import scala.cli.integration.util.CompilerPluginUtil
 
-trait CompilerPluginTestDefinitions { _: CompileTestDefinitions =>
+trait CompilerPluginTestDefinitions { this: CompileTestDefinitions =>
   def compilerPluginInputs(pluginName: String, pluginErrorMsg: String): TestInputs =
     if (actualScalaVersion.startsWith("3"))
       CompilerPluginUtil.compilerPluginForScala3(pluginName, pluginErrorMsg)

--- a/modules/integration/src/test/scala/scala/cli/integration/DependencyUpdateTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DependencyUpdateTests.scala
@@ -1,7 +1,7 @@
 package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
-import coursier.core.Version
+import coursier.version.Version
 
 class DependencyUpdateTests extends ScalaCliSuite {
   test("dependency update test") {

--- a/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
@@ -1,12 +1,12 @@
 package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
-import org.jsoup._
+import org.jsoup.*
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 abstract class DocTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
-  _: TestScalaVersion =>
+  this: TestScalaVersion =>
   protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
 
   for {

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportCommonTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportCommonTestDefinitions.scala
@@ -6,7 +6,7 @@ import java.nio.charset.Charset
 
 import scala.util.Properties
 
-trait ExportCommonTestDefinitions { _: ScalaCliSuite & TestScalaVersionArgs =>
+trait ExportCommonTestDefinitions { this: ScalaCliSuite & TestScalaVersionArgs =>
   protected lazy val extraOptions: Seq[String] =
     scalaVersionArgs ++ TestUtil.extraOptions ++ Seq("--suppress-experimental-warning")
 

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportJsonTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportJsonTestDefinitions.scala
@@ -3,7 +3,7 @@ package scala.cli.integration
 import com.eed3si9n.expecty.Expecty.expect
 
 abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
-  _: TestScalaVersion =>
+  this: TestScalaVersion =>
   private def readJson(path: os.ReadablePath): String =
     readJson(os.read(path))
 
@@ -48,35 +48,36 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
 
       val jsonContents = readJson(exportJsonProc.out.text())
 
-      expect(jsonContents ==
+      val expectedJsonContents =
         s"""{
-          |"projectVersion":"1.1.2",
-          |"scalaVersion":"${Constants.scala3Next}",
-          |"platform":"JVM",
-          |"jvmVersion":"adopt:11",
-          |"scopes": {
-          | "main": {
-          |   "sources": ["${withEscapedBackslashes(root / "Main.scala")}"],
-          |   "dependencies": [
-          |     {
-          |       "groupId":"com.lihaoyi",
-          |       "artifactId": {
-          |         "name":"os-lib",
-          |         "fullName": "os-lib_3"
-          |       },
-          |       "version":"0.7.8"
-          |     }
-          |   ],
-          |   "resolvers": [
-          |     "https://repo1.maven.org/maven2",
-          |     "ivy:file:.../local-repo/...",
-          |     "ivy:file:.../.ivy2/local/"
-          |   ]
-          | }
-          |}
-          |,"scalaCliVersion":"1.1.1-SNAPSHOT"
-          |}
-          |""".replaceAll("\\s|\\|", ""))
+           |"projectVersion":"1.1.2",
+           |"scalaVersion":"${Constants.scala3Next}",
+           |"platform":"JVM",
+           |"jvmVersion":"adopt:11",
+           |"scopes": {
+           | "main": {
+           |   "sources": ["${withEscapedBackslashes(root / "Main.scala")}"],
+           |   "dependencies": [
+           |     {
+           |       "groupId":"com.lihaoyi",
+           |       "artifactId": {
+           |         "name":"os-lib",
+           |         "fullName": "os-lib_3"
+           |       },
+           |       "version":"0.7.8"
+           |     }
+           |   ],
+           |   "resolvers": [
+           |     "https://repo1.maven.org/maven2",
+           |     "ivy:file:.../local-repo/...",
+           |     "ivy:file:.../.ivy2/local/"
+           |   ]
+           | }
+           |}
+           |,"scalaCliVersion":"1.1.1-SNAPSHOT"
+           |}
+           |""".replaceAll("\\s|\\|", "")
+      expect(jsonContents == expectedJsonContents)
     }
   }
 
@@ -106,77 +107,78 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
 
       val jsonContents = readJson(exportJsonProc.out.text())
 
-      expect(jsonContents ==
+      val expectedJsonContents =
         s"""{
-          |"scalaVersion":"3.2.2",
-          |"platform":"Native",
-          |"scalaNativeVersion":"${Constants.scalaNativeVersion}",
-          |"scopes": {
-          | "main": {
-          |   "sources": ["${withEscapedBackslashes(root / "Main.scala")}"],
-          |   "scalacOptions":["-Xasync"],
-          |   "scalaCompilerPlugins": [
-          |     {
-          |       "groupId": "org.wartremover",
-          |       "artifactId": {
-          |         "name": "wartremover",
-          |         "fullName": "wartremover_3.2.2"
-          |       },
-          |       "version": "3.0.9"
-          |     }
-          |   ],
-          |   "dependencies": [
-          |     {
-          |       "groupId":"com.lihaoyi",
-          |       "artifactId": {
-          |         "name":"os-lib",
-          |         "fullName": "os-lib_3"
-          |       },
-          |       "version":"0.7.8"
-          |     }
-          |   ],
-          |   "resolvers": [
-          |     "https://repo1.maven.org/maven2",
-          |     "ivy:file:.../local-repo/...",
-          |     "ivy:file:.../.ivy2/local/"
-          |   ]
-          | },
-          | "test": {
-          |   "sources":["${withEscapedBackslashes(root / "unit.test.scala")}"],
-          |   "scalacOptions":["-Xasync"],
-          |   "scalaCompilerPlugins": [
-          |     {
-          |       "groupId": "org.wartremover",
-          |       "artifactId": {
-          |         "name": "wartremover",
-          |         "fullName": "wartremover_3.2.2"
-          |       },
-          |       "version": "3.0.9"
-          |     }
-          |   ],
-          |   "dependencies": [
-          |     {
-          |       "groupId": "com.lihaoyi",
-          |       "artifactId": {
-          |         "name":"os-lib",
-          |         "fullName": "os-lib_3"
-          |       },
-          |       "version": "0.7.8"
-          |     }
-          |   ],
-          |   "resolvers": [
-          |     "https://oss.sonatype.org/content/repositories/snapshots",
-          |     "https://repo1.maven.org/maven2",
-          |     "ivy:file:.../local-repo/...",
-          |     "ivy:file:.../.ivy2/local/"
-          |   ],
-          |   "resourceDirs":["${withEscapedBackslashes(root / "resources")}"],
-          |   "customJarsDecls":["${withEscapedBackslashes(root / "TEST.jar")}"]
-          |  }
-          |}
-          |,"scalaCliVersion":"1.1.1-SNAPSHOT"
-          |}
-          |""".replaceAll("\\s|\\|", ""))
+           |"scalaVersion":"3.2.2",
+           |"platform":"Native",
+           |"scalaNativeVersion":"${Constants.scalaNativeVersion}",
+           |"scopes": {
+           | "main": {
+           |   "sources": ["${withEscapedBackslashes(root / "Main.scala")}"],
+           |   "scalacOptions":["-Xasync"],
+           |   "scalaCompilerPlugins": [
+           |     {
+           |       "groupId": "org.wartremover",
+           |       "artifactId": {
+           |         "name": "wartremover",
+           |         "fullName": "wartremover_3.2.2"
+           |       },
+           |       "version": "3.0.9"
+           |     }
+           |   ],
+           |   "dependencies": [
+           |     {
+           |       "groupId":"com.lihaoyi",
+           |       "artifactId": {
+           |         "name":"os-lib",
+           |         "fullName": "os-lib_3"
+           |       },
+           |       "version":"0.7.8"
+           |     }
+           |   ],
+           |   "resolvers": [
+           |     "https://repo1.maven.org/maven2",
+           |     "ivy:file:.../local-repo/...",
+           |     "ivy:file:.../.ivy2/local/"
+           |   ]
+           | },
+           | "test": {
+           |   "sources":["${withEscapedBackslashes(root / "unit.test.scala")}"],
+           |   "scalacOptions":["-Xasync"],
+           |   "scalaCompilerPlugins": [
+           |     {
+           |       "groupId": "org.wartremover",
+           |       "artifactId": {
+           |         "name": "wartremover",
+           |         "fullName": "wartremover_3.2.2"
+           |       },
+           |       "version": "3.0.9"
+           |     }
+           |   ],
+           |   "dependencies": [
+           |     {
+           |       "groupId": "com.lihaoyi",
+           |       "artifactId": {
+           |         "name":"os-lib",
+           |         "fullName": "os-lib_3"
+           |       },
+           |       "version": "0.7.8"
+           |     }
+           |   ],
+           |   "resolvers": [
+           |     "https://oss.sonatype.org/content/repositories/snapshots",
+           |     "https://repo1.maven.org/maven2",
+           |     "ivy:file:.../local-repo/...",
+           |     "ivy:file:.../.ivy2/local/"
+           |   ],
+           |   "resourceDirs":["${withEscapedBackslashes(root / "resources")}"],
+           |   "customJarsDecls":["${withEscapedBackslashes(root / "TEST.jar")}"]
+           |  }
+           |}
+           |,"scalaCliVersion":"1.1.1-SNAPSHOT"
+           |}
+           |""".replaceAll("\\s|\\|", "")
+      expect(jsonContents == expectedJsonContents)
     }
   }
 
@@ -212,48 +214,48 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
 
       expect(exportJsonProc.out.text().isEmpty)
 
-      val fileContents = readJson(root / "json_dir" / "export.json")
-
-      expect(fileContents ==
+      val fileContents         = readJson(root / "json_dir" / "export.json")
+      val expectedFileContents =
         s"""{
-          |"scalaVersion": "3.1.3",
-          |"platform": "JS",
-          |"scalaJsVersion": "${Constants.scalaJsVersion}",
-          |"jsEsVersion":"es2015",
-          |"scopes": {
-          | "main": {
-          |   "sources": ["${withEscapedBackslashes(root / "Main.scala")}"],
-          |   "scalacOptions": ["-Xasync"],
-          |   "scalaCompilerPlugins": [
-          |     {
-          |       "groupId": "org.wartremover",
-          |       "artifactId": {
-          |         "name": "wartremover",
-          |         "fullName": "wartremover_3.1.3"
-          |       },
-          |       "version": "3.0.9"
-          |     }
-          |   ],
-          |   "dependencies": [
-          |     {
-          |       "groupId": "com.lihaoyi",
-          |       "artifactId": {
-          |         "name": "os-lib",
-          |         "fullName": "os-lib_3"
-          |       },
-          |       "version": "0.7.8"
-          |     }
-          |   ],
-          |   "resolvers": [
-          |     "https://repo1.maven.org/maven2",
-          |     "ivy:file:.../local-repo/...",
-          |     "ivy:file:.../.ivy2/local/"
-          |   ]
-          | }
-          |},
-          |"scalaCliVersion":"1.1.1-SNAPSHOT"
-          |}
-          |""".replaceAll("\\s|\\|", ""))
+           |"scalaVersion": "3.1.3",
+           |"platform": "JS",
+           |"scalaJsVersion": "${Constants.scalaJsVersion}",
+           |"jsEsVersion":"es2015",
+           |"scopes": {
+           | "main": {
+           |   "sources": ["${withEscapedBackslashes(root / "Main.scala")}"],
+           |   "scalacOptions": ["-Xasync"],
+           |   "scalaCompilerPlugins": [
+           |     {
+           |       "groupId": "org.wartremover",
+           |       "artifactId": {
+           |         "name": "wartremover",
+           |         "fullName": "wartremover_3.1.3"
+           |       },
+           |       "version": "3.0.9"
+           |     }
+           |   ],
+           |   "dependencies": [
+           |     {
+           |       "groupId": "com.lihaoyi",
+           |       "artifactId": {
+           |         "name": "os-lib",
+           |         "fullName": "os-lib_3"
+           |       },
+           |       "version": "0.7.8"
+           |     }
+           |   ],
+           |   "resolvers": [
+           |     "https://repo1.maven.org/maven2",
+           |     "ivy:file:.../local-repo/...",
+           |     "ivy:file:.../.ivy2/local/"
+           |   ]
+           | }
+           |},
+           |"scalaCliVersion":"1.1.1-SNAPSHOT"
+           |}
+           |""".replaceAll("\\s|\\|", "")
+      expect(fileContents == expectedFileContents)
 
       val exportToExistingProc = os.proc(
         TestUtil.cli,
@@ -269,9 +271,8 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
         .call(cwd = root, check = false, mergeErrIntoOut = true)
 
       expect(exportToExistingProc.exitCode != 0)
-      expect(
-        exportToExistingProc.out.text().contains(s"Error: ${root / "json_dir"} already exists.")
-      )
+      val jsonDirPath = root / "json_dir"
+      expect(exportToExistingProc.out.text().contains(s"Error: $jsonDirPath already exists."))
     }
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMavenTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMavenTestDefinitions.scala
@@ -2,7 +2,7 @@ package scala.cli.integration
 
 abstract class ExportMavenTestDefinitions extends ScalaCliSuite
     with TestScalaVersionArgs with ExportCommonTestDefinitions with MavenTestHelper {
-  _: TestScalaVersion & MavenLanguageMode =>
+  this: TestScalaVersion & MavenLanguageMode =>
   override def exportCommand(args: String*): os.proc =
     os.proc(
       TestUtil.cli,

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
@@ -9,7 +9,7 @@ abstract class ExportMillTestDefinitions extends ScalaCliSuite
     with TestScalaVersionArgs
     with ExportCommonTestDefinitions
     with ExportScalaOrientedBuildToolsTestDefinitions
-    with MillTestHelper { _: TestScalaVersion =>
+    with MillTestHelper { this: TestScalaVersion =>
   override val prepareTestInputs: TestInputs => TestInputs = _.withMillJvmOpts
 
   override val outputDir: RelPath                    = millOutputDir

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestDefinitions.scala
@@ -3,7 +3,7 @@ package scala.cli.integration
 abstract class ExportSbtTestDefinitions extends ScalaCliSuite
     with TestScalaVersionArgs with ExportCommonTestDefinitions
     with ExportScalaOrientedBuildToolsTestDefinitions with SbtTestHelper {
-  _: TestScalaVersion =>
+  this: TestScalaVersion =>
   override def exportCommand(args: String*): os.proc =
     os.proc(
       TestUtil.cli,

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportScalaOrientedBuildToolsTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportScalaOrientedBuildToolsTestDefinitions.scala
@@ -9,7 +9,7 @@ import java.nio.charset.Charset
   * compile-only dependencies.
   */
 trait ExportScalaOrientedBuildToolsTestDefinitions {
-  _: ExportCommonTestDefinitions & ScalaCliSuite & TestScalaVersionArgs =>
+  this: ExportCommonTestDefinitions & ScalaCliSuite & TestScalaVersionArgs =>
 
   def compileOnlyTest(mainClass: String): Unit = {
     val userName = "John"

--- a/modules/integration/src/test/scala/scala/cli/integration/FixBuiltInRulesTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixBuiltInRulesTestDefinitions.scala
@@ -4,7 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import scala.util.Properties
 
-trait FixBuiltInRulesTestDefinitions { _: FixTestDefinitions =>
+trait FixBuiltInRulesTestDefinitions { this: FixTestDefinitions =>
   test("basic built-in rules") {
     val mainFileName = "Main.scala"
     val inputs       = TestInputs(

--- a/modules/integration/src/test/scala/scala/cli/integration/FixScalafixRulesTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixScalafixRulesTestDefinitions.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import scala.util.Properties
 
 trait FixScalafixRulesTestDefinitions {
-  _: FixTestDefinitions =>
+  this: FixTestDefinitions =>
   protected val scalafixConfFileName: String = ".scalafix.conf"
   protected def scalafixUnusedRuleOption: String
   protected def noCrLf(input: String): String =

--- a/modules/integration/src/test/scala/scala/cli/integration/FixTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixTestDefinitions.scala
@@ -6,7 +6,7 @@ abstract class FixTestDefinitions
     extends ScalaCliSuite
     with TestScalaVersionArgs
     with FixBuiltInRulesTestDefinitions
-    with FixScalafixRulesTestDefinitions { _: TestScalaVersion =>
+    with FixScalafixRulesTestDefinitions { this: TestScalaVersion =>
   val projectFileName           = "project.scala"
   val extraOptions: Seq[String] =
     scalaVersionArgs ++ TestUtil.extraOptions ++ Seq("--suppress-experimental-feature-warning")

--- a/modules/integration/src/test/scala/scala/cli/integration/GitHubTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/GitHubTests.scala
@@ -1,7 +1,7 @@
 package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
-import com.github.plokhotnyuk.jsoniter_scala.core._
+import com.github.plokhotnyuk.jsoniter_scala.core.*
 import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
 import coursier.cache.ArchiveCache
 import coursier.util.Artifact

--- a/modules/integration/src/test/scala/scala/cli/integration/JmhSuite.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/JmhSuite.scala
@@ -1,6 +1,6 @@
 package scala.cli.integration
 
-trait JmhSuite { _: ScalaCliSuite =>
+trait JmhSuite { this: ScalaCliSuite =>
   protected def simpleBenchmarkingInputs(directivesString: String = ""): TestInputs = TestInputs(
     os.rel / "benchmark.scala" ->
       s"""$directivesString

--- a/modules/integration/src/test/scala/scala/cli/integration/LegacyScalaRunnerTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/LegacyScalaRunnerTestDefinitions.scala
@@ -1,7 +1,7 @@
 package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
-trait LegacyScalaRunnerTestDefinitions { _: DefaultTests =>
+trait LegacyScalaRunnerTestDefinitions { this: DefaultTests =>
   test("default to the run sub-command when a script snippet is passed with -e") {
     TestInputs.empty.fromRoot { root =>
       val msg       = "Hello world"

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -9,11 +9,11 @@ import java.util
 import java.util.zip.ZipFile
 
 import scala.cli.integration.TestUtil.removeAnsiColors
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.{Properties, Using}
 
 abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
-  _: TestScalaVersion =>
+  this: TestScalaVersion =>
   protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
   protected lazy val node: String              = TestUtil.fromPath("node").getOrElse("node")
 

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishLocalTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishLocalTestDefinitions.scala
@@ -3,7 +3,7 @@ package scala.cli.integration
 import com.eed3si9n.expecty.Expecty.expect
 
 abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
-  _: TestScalaVersion =>
+  this: TestScalaVersion =>
   protected def extraOptions: Seq[String] =
     scalaVersionArgs ++ TestUtil.extraOptions ++ Seq("--suppress-experimental-feature-warning")
 

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishSetupTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishSetupTests.scala
@@ -6,7 +6,7 @@ import com.virtuslab.using_directives.reporter.ConsoleReporter
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.transport.URIish
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Properties
 import scala.util.matching.Regex
 

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
@@ -6,11 +6,11 @@ import java.io.File
 import java.nio.file.Paths
 import java.util.zip.ZipFile
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Properties
 
 abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
-  _: TestScalaVersion =>
+  this: TestScalaVersion =>
   protected def extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
 
   protected object TestCase {

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplAmmoniteTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplAmmoniteTestDefinitions.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import scala.cli.integration.TestUtil.removeAnsiColors
 import scala.util.Properties
 
-trait ReplAmmoniteTestDefinitions { _: ReplTestDefinitions =>
+trait ReplAmmoniteTestDefinitions { this: ReplTestDefinitions =>
   protected val retrieveScalaVersionCode: String = if (actualScalaVersion.startsWith("2."))
     "scala.util.Properties.versionNumberString"
   else "dotty.tools.dotc.config.Properties.simpleVersionString"

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplAmmoniteTests3StableDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplAmmoniteTests3StableDefinitions.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import scala.util.Properties
 
 trait ReplAmmoniteTests3StableDefinitions {
-  _: ReplTestDefinitions with ReplAmmoniteTestDefinitions =>
+  this: ReplTestDefinitions & ReplAmmoniteTestDefinitions =>
   if (!actualScalaVersion.equals(actualMaxAmmoniteScalaVersion)) {
     lazy val defaultScalaVersionString =
       s" with Scala $actualScalaVersion (the default version, may downgrade)"

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import scala.cli.integration.TestUtil.removeAnsiColors
 
 abstract class ReplTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
-  _: TestScalaVersion =>
+  this: TestScalaVersion =>
   protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
 
   test("dry run (default)") {

--- a/modules/integration/src/test/scala/scala/cli/integration/RunGistTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunGistTestDefinitions.scala
@@ -4,7 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import scala.util.Properties
 
-trait RunGistTestDefinitions { _: RunTestDefinitions =>
+trait RunGistTestDefinitions { this: RunTestDefinitions =>
   def escapedUrls(url: String): String =
     if (Properties.isWin) "\"" + url + "\""
     else url

--- a/modules/integration/src/test/scala/scala/cli/integration/RunJdkTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunJdkTestDefinitions.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import scala.cli.integration.TestUtil.ProcOps
 import scala.util.{Properties, Try}
 
-trait RunJdkTestDefinitions { _: RunTestDefinitions =>
+trait RunJdkTestDefinitions { this: RunTestDefinitions =>
   def canUseScalaInstallationWrapper: Boolean =
     actualScalaVersion.startsWith("3") && actualScalaVersion.split('.').drop(1).head.toInt >= 5
 

--- a/modules/integration/src/test/scala/scala/cli/integration/RunPipedSourcesTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunPipedSourcesTestDefinitions.scala
@@ -4,7 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import scala.util.Properties
 
-trait RunPipedSourcesTestDefinitions { _: RunTestDefinitions =>
+trait RunPipedSourcesTestDefinitions { this: RunTestDefinitions =>
   def piping(): Unit = {
     emptyInputs.fromRoot { root =>
       val cliCmd         = (TestUtil.cli ++ extraOptions).mkString(" ")

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
@@ -4,7 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import scala.cli.integration.TestUtil.removeAnsiColors
 
-trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
+trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
   def simpleJsTestOutput(extraArgs: String*): String = {
     val fileName = "simple.sc"
     val message  = "Hello"
@@ -323,7 +323,8 @@ trait RunScalaJsTestDefinitions { _: RunTestDefinitions =>
         extraOptions
       )
         .call(cwd = root).out.trim()
-      expect(os.exists(absOutDir / "main.wasm"))
+      val path = absOutDir / "main.wasm"
+      expect(os.exists(path))
 
       // TODO : Run WASM using node. Requires node 22.
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import scala.cli.integration.TestUtil.removeAnsiColors
 import scala.util.Properties
 
-trait RunScalaNativeTestDefinitions { _: RunTestDefinitions =>
+trait RunScalaNativeTestDefinitions { this: RunTestDefinitions =>
 
   def simpleNativeScriptCode(
     message: String,

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaPyTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaPyTestDefinitions.scala
@@ -4,7 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import scala.util.Properties
 
-trait RunScalaPyTestDefinitions { _: RunTestDefinitions =>
+trait RunScalaPyTestDefinitions { this: RunTestDefinitions =>
   private def maybeScalapyPrefix =
     if (actualScalaVersion.startsWith("2.13.")) ""
     else "import me.shadaj.scalapy.py" + System.lineSeparator()

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalacCompatTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalacCompatTestDefinitions.scala
@@ -4,12 +4,12 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import java.io.File
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Properties
 
 /** For the `compile` counterpart, refer to [[CompileScalacCompatTestDefinitions]] */
 trait RunScalacCompatTestDefinitions {
-  _: RunTestDefinitions =>
+  this: RunTestDefinitions =>
 
   final val smithyVersion     = "1.50.0"
   private def shutdownBloop() =

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
@@ -7,7 +7,7 @@ import java.io.File
 import scala.cli.integration.TestUtil.normalizeConsoleOutput
 import scala.util.Properties
 
-trait RunScriptTestDefinitions { _: RunTestDefinitions =>
+trait RunScriptTestDefinitions { this: RunTestDefinitions =>
   def simpleScriptTest(ignoreErrors: Boolean = false, extraArgs: Seq[String] = Nil): Unit = {
     val fileName = "simple.sc"
     val message  = "Hello"

--- a/modules/integration/src/test/scala/scala/cli/integration/RunSnippetTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunSnippetTestDefinitions.scala
@@ -2,7 +2,7 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-trait RunSnippetTestDefinitions { _: RunTestDefinitions =>
+trait RunSnippetTestDefinitions { this: RunTestDefinitions =>
   test("correctly run a script snippet") {
     emptyInputs.fromRoot { root =>
       val msg       = "Hello world"

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -7,7 +7,7 @@ import java.nio.charset.Charset
 
 import scala.cli.integration.util.DockerServer
 import scala.io.Codec
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Properties
 
 abstract class RunTestDefinitions
@@ -23,7 +23,7 @@ abstract class RunTestDefinitions
     with RunScalaPyTestDefinitions
     with RunZipTestDefinitions
     with RunJdkTestDefinitions
-    with CoursierScalaInstallationTestHelper { _: TestScalaVersion =>
+    with CoursierScalaInstallationTestHelper { this: TestScalaVersion =>
   protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
   protected val emptyInputs: TestInputs        = TestInputs(os.rel / ".placeholder" -> "")
 
@@ -182,9 +182,8 @@ abstract class RunTestDefinitions
     val url = "https://gist.github.com/alexarchambault/7b4ec20c4033690dd750ffd601e540ec"
     emptyInputs.fromRoot { root =>
       os.proc(TestUtil.cli, extraOptions, escapedUrls(url)).call(cwd = root)
-      expect(
-        !os.exists(root / ".scala-build")
-      ) // virtual source should not create workspace dir in cwd
+      val path = root / ".scala-build"
+      expect(!os.exists(path)) // virtual source should not create workspace dir in cwd
     }
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
@@ -102,10 +102,9 @@ class RunTestsDefault extends RunTestDefinitions
       """//> using dep tabby:tabby:0.2.3,url=https://github.com/bjornregnell/tabby/releases/download/v0.2.3/tabby_3-0.2.3.jar
         |import tabby.Grid
         |@main def main = println(Grid("a", "b", "c")(1, 2, 3))
-        |""".stripMargin).fromRoot {
-      root =>
-        val res = os.proc(TestUtil.cli, "run", extraOptions, inputPath)
-          .call(cwd = root)
+        |""".stripMargin).fromRoot { root =>
+      val res = os.proc(TestUtil.cli, "run", extraOptions, inputPath)
+        .call(cwd = root)
       val out = res.out.trim()
       expect(out.contains("a, b, c"))
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunWithWatchTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunWithWatchTestDefinitions.scala
@@ -6,7 +6,7 @@ import scala.cli.integration.TestUtil.ProcOps
 import scala.concurrent.duration.DurationInt
 import scala.util.{Properties, Try}
 
-trait RunWithWatchTestDefinitions { _: RunTestDefinitions =>
+trait RunWithWatchTestDefinitions { this: RunTestDefinitions =>
   // TODO make this pass reliably on Mac CI
   if (!Properties.isMac || !TestUtil.isCI) {
     val expectedMessage1 = "Hello"
@@ -378,10 +378,11 @@ trait RunWithWatchTestDefinitions { _: RunTestDefinitions =>
           val output1 = TestUtil.readLine(proc.stdout, ec, timeout)
           expect(output1 == expectedMessage1)
           proc.printStderrUntilRerun(timeout)(ec)
-          val Some((resourcePath, newResourceContent)) =
+          val (resourcePath, newResourceContent) =
             resourcesInputs(directive = directive, resourceContent = expectedMessage2)
               .files
               .find(_._1.toString.contains("resources"))
+              .get
           os.write.over(root / resourcePath, newResourceContent)
           val output2 = TestUtil.readLine(proc.stdout, ec, timeout)
           expect(output2 == expectedMessage2)

--- a/modules/integration/src/test/scala/scala/cli/integration/RunZipTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunZipTestDefinitions.scala
@@ -6,7 +6,7 @@ import java.nio.charset.{Charset, StandardCharsets}
 
 import scala.cli.integration.TestInputs.compress
 
-trait RunZipTestDefinitions { _: RunTestDefinitions =>
+trait RunZipTestDefinitions { this: RunTestDefinitions =>
   test("Zip with multiple Scala files") {
     val inputs = TestInputs(
       os.rel / "Hello.scala" ->

--- a/modules/integration/src/test/scala/scala/cli/integration/SemanticDbTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SemanticDbTestDefinitions.scala
@@ -2,7 +2,7 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-trait SemanticDbTestDefinitions { _: CompileTestDefinitions =>
+trait SemanticDbTestDefinitions { this: CompileTestDefinitions =>
   def javaHelloWorld(packageName: String, mainClassName: String): String =
     s"""package $packageName;
        |
@@ -57,9 +57,8 @@ trait SemanticDbTestDefinitions { _: CompileTestDefinitions =>
           .filter(!_.segments.exists(_ == "bloop-internal-classes"))
         expect(semDbFiles.length == 1)
         val semDbFile = semDbFiles.head
-        expect(
-          semDbFile.endsWith(os.rel / "META-INF" / "semanticdb" / "foo" / "Test.java.semanticdb")
-        )
+        val path      = os.rel / "META-INF" / "semanticdb" / "foo" / "Test.java.semanticdb"
+        expect(semDbFile.endsWith(path))
       }
   }
 
@@ -167,17 +166,13 @@ trait SemanticDbTestDefinitions { _: CompileTestDefinitions =>
             .filter(!_.segments.exists(_ == "bloop-internal-classes"))
           expect(semDbFiles.length == 2)
           val semDbFile1 = semDbFiles.find(_.last == s"$sourceFileName1.semanticdb").get
-          expect(
-            semDbFile1.endsWith(
-              os.rel / "META-INF" / "semanticdb" / sourceDir1 / package1 / s"$sourceFileName1.semanticdb"
-            )
-          )
+          val relPath1   =
+            os.rel / "META-INF" / "semanticdb" / sourceDir1 / package1 / s"$sourceFileName1.semanticdb"
+          expect(semDbFile1.endsWith(relPath1))
           val semDbFile2 = semDbFiles.find(_.last == s"$sourceFileName2.semanticdb").get
-          expect(
-            semDbFile2.endsWith(
-              os.rel / "META-INF" / "semanticdb" / sourceDir2 / package2 / s"$sourceFileName2.semanticdb"
-            )
-          )
+          val relPath2   =
+            os.rel / "META-INF" / "semanticdb" / sourceDir2 / package2 / s"$sourceFileName2.semanticdb"
+          expect(semDbFile2.endsWith(relPath2))
         }
       }
   }
@@ -204,11 +199,8 @@ trait SemanticDbTestDefinitions { _: CompileTestDefinitions =>
             .filter(_.last.endsWith(".semanticdb"))
             .filter(!_.segments.exists(_ == "bloop-internal-classes"))
           expect(semDbFiles.length == 1)
-          expect(
-            semDbFiles.head.endsWith(
-              os.rel / "META-INF" / "semanticdb" / "foo" / "Test.sc.semanticdb"
-            )
-          )
+          val relPath = os.rel / "META-INF" / "semanticdb" / "foo" / "Test.sc.semanticdb"
+          expect(semDbFiles.head.endsWith(relPath))
       }
     }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/SparkTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SparkTestDefinitions.scala
@@ -52,7 +52,7 @@ object SparkTestDefinitions {
 }
 
 abstract class SparkTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
-  _: TestScalaVersion =>
+  this: TestScalaVersion =>
   import SparkTestDefinitions.*
 
   protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions

--- a/modules/integration/src/test/scala/scala/cli/integration/SparkTests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SparkTests212.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import java.io.File
 import java.util.Locale
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Properties
 
 class SparkTests212 extends SparkTestDefinitions with Test212 {

--- a/modules/integration/src/test/scala/scala/cli/integration/TestBspClient.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestBspClient.scala
@@ -1,6 +1,6 @@
 package scala.cli.integration
 
-import ch.epfl.scala.{bsp4j => b}
+import ch.epfl.scala.bsp4j as b
 import org.eclipse.lsp4j.jsonrpc
 
 import java.io.{InputStream, OutputStream}

--- a/modules/integration/src/test/scala/scala/cli/integration/TestScalaVersionArgs.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestScalaVersionArgs.scala
@@ -2,7 +2,7 @@ package scala.cli.integration
 
 import scala.annotation.unused
 
-trait TestScalaVersionArgs extends ScalaCliSuite { _: TestScalaVersion =>
+trait TestScalaVersionArgs extends ScalaCliSuite { this: TestScalaVersion =>
   override def group: ScalaCliSuite.TestGroup =
     if (actualScalaVersion.startsWith("2.12.")) ScalaCliSuite.TestGroup.Third
     else if (actualScalaVersion.startsWith("2.13.")) ScalaCliSuite.TestGroup.Second
@@ -20,26 +20,26 @@ trait TestScalaVersionArgs extends ScalaCliSuite { _: TestScalaVersion =>
   lazy val actualScalaVersion: String = scalaVersionOpt.getOrElse(Constants.defaultScala)
 }
 
-sealed trait TestScalaVersion { _: TestScalaVersionArgs =>
+sealed trait TestScalaVersion { this: TestScalaVersionArgs =>
   def scalaVersionOpt: Option[String]
 }
-trait Test213 extends TestScalaVersion { _: TestScalaVersionArgs =>
+trait Test213 extends TestScalaVersion { this: TestScalaVersionArgs =>
   override lazy val scalaVersionOpt: Option[String] = Some(Constants.scala213)
 }
-trait Test212 extends TestScalaVersion { _: TestScalaVersionArgs =>
+trait Test212 extends TestScalaVersion { this: TestScalaVersionArgs =>
   override lazy val scalaVersionOpt: Option[String] = Some(Constants.scala212)
 }
-trait Test3Lts extends TestScalaVersion { _: TestScalaVersionArgs =>
+trait Test3Lts extends TestScalaVersion { this: TestScalaVersionArgs =>
   override lazy val scalaVersionOpt: Option[String] = Some(Constants.scala3Lts)
 }
-trait Test3NextRc extends TestScalaVersion { _: TestScalaVersionArgs =>
+trait Test3NextRc extends TestScalaVersion { this: TestScalaVersionArgs =>
   override lazy val scalaVersionOpt: Option[String] = Some(Constants.scala3NextRc)
 }
 @unused // TestDefault should normally be mixed in instead
-trait Test3Next extends TestScalaVersion { _: TestScalaVersionArgs =>
+trait Test3Next extends TestScalaVersion { this: TestScalaVersionArgs =>
   override lazy val scalaVersionOpt: Option[String] = Some(Constants.scala3Next)
 }
-trait TestDefault extends TestScalaVersion { _: TestScalaVersionArgs =>
+trait TestDefault extends TestScalaVersion { this: TestScalaVersionArgs =>
   // this effectively should make the launcher default to 3.next
   override lazy val scalaVersionOpt: Option[String] = None
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -6,7 +6,7 @@ import scala.annotation.tailrec
 import scala.cli.integration.Constants.munitVersion
 
 abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
-  _: TestScalaVersion =>
+  this: TestScalaVersion =>
   protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
   private val utestVersion                     = "0.8.3"
   private val zioTestVersion                   = "2.1.17"

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{ExecutorService, Executors, ScheduledExecutorService, ThreadFactory}
 import java.util.{Locale, UUID}
 
-import scala.Console._
+import scala.Console.*
 import scala.annotation.tailrec
 import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -426,5 +426,10 @@ object TestUtil {
       versionNumberGroup <- Option(firstMatch.group(1))
       versionInt         <- jvmRelease(versionNumberGroup)
     } yield versionInt
+  }
+
+  extension [T](f: scala.concurrent.Future[T]) {
+    def await: T                         = Await.result(f, Duration.Inf)
+    def awaitWithTimeout(d: Duration): T = Await.result(f, d)
   }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/util/DockerServer.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/util/DockerServer.scala
@@ -5,7 +5,7 @@ package scala.cli.integration.util
 import com.spotify.docker.client.DefaultDockerClient
 import com.spotify.docker.client.messages.{ContainerConfig, HostConfig, PortBinding}
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Try
 
 final case class DockerServer(

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -166,7 +166,7 @@ object Deps {
   def collectionCompat = mvn"org.scala-lang.modules::scala-collection-compat:2.13.0"
   // Force using of 2.13 - is there a better way?
   def coursier             = mvn"io.get-coursier:coursier_2.13:${Versions.coursier}"
-  def coursierArchiveCache = mvn"io.get-coursier::coursier-archive-cache:${Versions.coursier}"
+  def coursierArchiveCache = mvn"io.get-coursier:coursier-archive-cache_2.13:${Versions.coursier}"
     .exclude(("com.github.plokhotnyuk.jsoniter-scala", "*"))
   def coursierCli = mvn"io.get-coursier::coursier-cli:${Versions.coursierCli}"
   def coursierJvm = mvn"io.get-coursier:coursier-jvm_2.13:${Versions.coursier}"
@@ -213,7 +213,6 @@ object Deps {
   def pprint             = mvn"com.lihaoyi::pprint:0.9.3"
   def pythonInterface    = mvn"io.github.alexarchambault.python:interface:0.1.0"
   def pythonNativeLibs   = mvn"ai.kien::python-native-libs:0.2.4"
-  def scalaAsync         = mvn"org.scala-lang.modules::scala-async:1.0.1".exclude("*" -> "*")
   def scalac(sv: String) = mvn"org.scala-lang:scala-compiler:$sv"
   def scalafmtCli        = mvn"org.scalameta:scalafmt-cli_2.13:${Versions.scalafmt}"
   // Force using of 2.13 - is there a better way?


### PR DESCRIPTION
## What was done
- the `integration` module is now fully built with Scala 3.3.7
- `scala-async` syntax has been rewritten with vanilla Scala 3 Futures syntax
- a number of minor workarounds were necessary because of issues with the `expecty` dependency
  - https://github.com/eed3si9n/expecty/issues/212 / https://github.com/com-lihaoyi/os-lib/issues/361
  - https://github.com/eed3si9n/expecty/issues/197 / https://github.com/eed3si9n/expecty/issues/59

## Potential follow-ups
- completely remove `expecty` from the project
  - way out of scope for this PR
  - this was tempting to do here, but requires a project-wide refactor
  - tl;dr we now have the workarounds around the issues mentioned above everywhere, and the library is perhaps more trouble than it is worth
- cross-compile the `integration` module against Scala 3 Next versions
  - this would be a good idea both for dogfooding and in preparation to the 3.9 LTS bump
  - it may be a good idea to finally bump to Mill 1.x, first