### PR TITLE
Cross compile the `runner` and `test-runner` modules against Scala 3 Next versions

### DIFF
--- a/build.mill.scala
+++ b/build.mill.scala
@@ -1261,22 +1261,14 @@ trait CliIntegrationDocker extends SbtModule with ScalaCliPublishModule with Has
 trait Runner extends SbtModule
     with ScalaCliPublishModule
     with ScalaCliScalafixModule {
-  override def scalaVersion: T[String]       = Scala.scala3Lts
+  override def scalaVersion: T[String]       = Scala.runnerScala3
   override def scalacOptions: T[Seq[String]] = Task {
     super.scalacOptions() ++ Seq("-release", "8", "-deprecation")
   }
   override def mainClass: T[Option[String]] = Some("scala.cli.runner.Runner")
   override def sources: T[Seq[PathRef]]     = Task.Sources {
-    val scala3DirNames =
-      if (scalaVersion().startsWith("3.")) {
-        val name =
-          if (scalaVersion().contains("-RC")) "scala-3-unstable"
-          else "scala-3-stable"
-        Seq(name)
-      }
-      else
-        Nil
-    val extraDirs = scala3DirNames.map(name => PathRef(moduleDir / "src" / "main" / name))
+    val scala3DirName = if (scalaVersion().contains("-RC")) "scala-3-unstable" else "scala-3-stable"
+    val extraDirs     = Seq(PathRef(moduleDir / "src" / "main" / scala3DirName))
     super.sources() ++ extraDirs
   }
 }
@@ -1284,7 +1276,7 @@ trait Runner extends SbtModule
 trait TestRunner extends SbtModule
     with ScalaCliPublishModule
     with ScalaCliScalafixModule {
-  override def scalaVersion: T[String]       = Scala.scala3Lts
+  override def scalaVersion: T[String]       = Scala.runnerScala3
   override def scalacOptions: T[Seq[String]] = Task {
     super.scalacOptions() ++ Seq("-release", "8", "-deprecation")
   }

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -32,7 +32,7 @@ object Scala {
   val allScala3           = Seq(scala3Lts, scala3Next, scala3NextAnnounced, scala3NextRc).distinct
   val all                 = (allScala2 ++ allScala3 ++ defaults).distinct
   val scala3MainVersions  = (defaults ++ allScala3).distinct
-  val runnerScalaVersions = Seq(runnerScala3, scala3MainVersions).distinct
+  val runnerScalaVersions = (Seq(runnerScala3) ++ scala3MainVersions).distinct
 
   def scalaJs    = "1.20.1"
   def scalaJsCli = scalaJs // this must be compatible with the Scala.js version

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -32,7 +32,7 @@ object Scala {
   val allScala3           = Seq(scala3Lts, scala3Next, scala3NextAnnounced, scala3NextRc).distinct
   val all                 = (allScala2 ++ allScala3 ++ defaults).distinct
   val scala3MainVersions  = (defaults ++ allScala3).distinct
-  val runnerScalaVersions = Seq(runnerScala3, scala213)
+  val runnerScalaVersions = Seq(runnerScala3, scala3MainVersions).distinct
 
   def scalaJs    = "1.20.1"
   def scalaJsCli = scalaJs // this must be compatible with the Scala.js version


### PR DESCRIPTION
We will still publish `runner` and `test-runner` with Scala 3.3 LTS.
In the foreseeable future, those'd be the only modules to remain on 3.3 LTS when we bump to 3.9 LTS.
We should, however, ensure they can build successfully on the newest versions, just like any other piece of the CLI (if only to make the 3.9 LTS bump that wee bit smoother).