### PR TITLE
Bump `python-native-libs` to 0.2.5 (was 0.2.4)

### DIFF
--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -213,7 +213,7 @@ object Deps {
   def osLib              = mvn"com.lihaoyi::os-lib:0.11.5"
   def pprint             = mvn"com.lihaoyi::pprint:0.9.3"
   def pythonInterface    = mvn"io.github.alexarchambault.python:interface:0.1.0"
-  def pythonNativeLibs   = mvn"ai.kien::python-native-libs:0.2.4"
+  def pythonNativeLibs   = mvn"ai.kien::python-native-libs:0.2.5"
   def scalac(sv: String) = mvn"org.scala-lang:scala-compiler:$sv"
   def scala3Graal = mvn"org.virtuslab.scala-cli::scala3-graal:${Cli.scala3GraalLegacyVersion}"
   def scala3GraalProcessor =


### PR DESCRIPTION
https://github.com/scalapy/python-native-libs/releases/tag/v0.2.5
Of note, this bumps the dependency's Scala version from 3.0.2 to 3.3.7, which in the (JDK 24+ related) future should unblock keeping ScalaPy support