### PR TITLE
Add support for the new Scala 3.8 REPL

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTests3NextRc.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTests3NextRc.scala
@@ -1,3 +1,25 @@
 package scala.cli.integration
 
-class ReplTests3NextRc extends ReplTestDefinitions with Test3NextRc
+import com.eed3si9n.expecty.Expecty.expect
+
+class ReplTests3NextRc extends ReplTestDefinitions with Test3NextRc {
+  test("run hello world from the 3.8 REPL") {
+    TestInputs.empty.fromRoot { root =>
+      val expectedMessage = "1337"
+      val code            = s"""println($expectedMessage)"""
+      val r               = os.proc(
+        TestUtil.cli,
+        "repl",
+        "--repl-quit-after-init",
+        "--repl-init-script",
+        code,
+        "-S",
+        // TODO: switch this test to 3.8.0-RC1 once it's out
+        "3.8.0-RC1-bin-20251104-b83b3d9-NIGHTLY",
+        TestUtil.extraOptions
+      )
+        .call(cwd = root)
+      expect(r.out.trim() == expectedMessage)
+    }
+  }
+}


### PR DESCRIPTION
This adds support for the new `scala3-repl` artifact introduced in Scala `3.8.0-RC1-bin-20251101-389483e-NIGHTLY`.
cc @hamzaremmal

```bash
scala-cli repl -S 3.nightly
# Welcome to Scala 3.8.0-RC1-bin-20251104-b83b3d9-NIGHTLY-git-b83b3d9 (23.0.1, Java OpenJDK 64-Bit Server VM).
# Type in expressions for evaluation. Or try :help.
#                                                                                                                  
# scala> 
```