### PR TITLE
Temporarily tag CLI docker image tests as flaky

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
@@ -409,7 +409,8 @@ class NativePackagerTests extends ScalaCliSuite {
     ((Properties.isMac || Properties.isWin) && !TestUtil.isCI)
 
   if (hasDocker) {
-    test("building docker image") {
+    // TODO: restore this test when `registry-1.docker.io` is stable again
+    test("building docker image".flaky) {
       TestUtil.retryOnCi() {
         runTest()
       }

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -1161,13 +1161,15 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
   }
 
   if (Properties.isLinux) {
-    test("pass java options to docker") {
+    // TODO: restore this test when `registry-1.docker.io` is stable again
+    test("pass java options to docker".flaky) {
       TestUtil.retryOnCi() {
         javaOptionsDockerTest()
       }
     }
 
-    test("pass extra directory to docker") {
+    // TODO: restore this test when `registry-1.docker.io` is stable again
+    test("pass extra directory to docker".flaky) {
       TestUtil.retryOnCi() {
         dockerWithExtraDirsTest()
       }


### PR DESCRIPTION
```
[136] Exception in thread "main" com.google.cloud.tools.jib.registry.RegistryErrorException: Tried to pull image manifest for registry-1.docker.io/library/openjdk:17-slim but failed because: registry returned error code 404; possible causes include invalid or wrong reference. Actual error output follows:
[136] {"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown","detail":"unknown tag=17-slim"}]}
[136] 
[136] 
[136] 	at com.google.cloud.tools.jib.registry.RegistryErrorExceptionBuilder.build(RegistryErrorExceptionBuilder.java:101)
...
```
`registry-1.docker.io` seems to be down and these tests are blocking the CI, so I'm temporarily tagging them as flaky.

relevant:
- https://github.com/VirtusLab/scala-cli/pull/3936#issuecomment-3485411909