### PR TITLE
Ensure `Coursier` logger gets initialized while downloading JVMs

### DIFF
--- a/modules/core/src/main/scala/scala/build/internals/CsLoggerUtil.scala
+++ b/modules/core/src/main/scala/scala/build/internals/CsLoggerUtil.scala
@@ -36,6 +36,7 @@ object CsLoggerUtil {
                 ()
               )
             )
+            updatedLogger.init()
             cache.withLogger(updatedLogger)
           }
           else cache


### PR DESCRIPTION
Fixes #3949 
kudos for @lbialy for helping to find this magic one-line fix