### PR TITLE
Increase CI timeout for integration tests to 150 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         fish -c './mill __.compile'
 
   jvm-bootstrapped-tests:
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -99,7 +99,7 @@ jobs:
           path: test-report.xml
 
   jvm-tests-1:
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
@@ -124,7 +124,7 @@ jobs:
         path: test-report.xml
 
   jvm-tests-2:
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
@@ -149,7 +149,7 @@ jobs:
         path: test-report.xml
 
   jvm-tests-3:
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
@@ -174,7 +174,7 @@ jobs:
         path: test-report.xml
 
   jvm-tests-4:
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -199,7 +199,7 @@ jobs:
           path: test-report.xml
 
   jvm-tests-5:
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -251,7 +251,7 @@ jobs:
 
   native-linux-tests-1:
     needs: generate-linux-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
@@ -284,7 +284,7 @@ jobs:
 
   native-linux-tests-2:
     needs: generate-linux-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
@@ -317,7 +317,7 @@ jobs:
 
   native-linux-tests-3:
     needs: generate-linux-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
@@ -350,7 +350,7 @@ jobs:
 
   native-linux-tests-4:
     needs: generate-linux-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -383,7 +383,7 @@ jobs:
 
   native-linux-tests-5:
     needs: generate-linux-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -467,7 +467,7 @@ jobs:
 
   native-macos-tests-1:
     needs: generate-macos-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: "macOS-15-intel"
     steps:
     - uses: actions/checkout@v5
@@ -502,7 +502,7 @@ jobs:
 
   native-macos-tests-5:
     needs: generate-macos-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: "macOS-15-intel"
     steps:
       - uses: actions/checkout@v5
@@ -565,7 +565,7 @@ jobs:
 
   native-macos-m1-tests-1:
     needs: generate-macos-m1-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: "macOS-15"
     steps:
       - uses: actions/checkout@v5
@@ -600,7 +600,7 @@ jobs:
 
   native-macos-m1-tests-2:
     needs: generate-macos-m1-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: "macOS-15"
     steps:
       - uses: actions/checkout@v5
@@ -635,7 +635,7 @@ jobs:
 
   native-macos-m1-tests-3:
     needs: generate-macos-m1-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: "macOS-15"
     steps:
       - uses: actions/checkout@v5
@@ -670,7 +670,7 @@ jobs:
 
   native-macos-m1-tests-4:
     needs: generate-macos-m1-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: "macOS-15"
     steps:
       - uses: actions/checkout@v5
@@ -705,7 +705,7 @@ jobs:
 
   native-macos-m1-tests-5:
     needs: generate-macos-m1-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: "macOS-15"
     steps:
       - uses: actions/checkout@v5
@@ -771,7 +771,7 @@ jobs:
 
   native-windows-tests-1:
     needs: generate-windows-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: "windows-2025"
     steps:
     - uses: actions/checkout@v5
@@ -812,7 +812,7 @@ jobs:
 
   native-windows-tests-2:
     needs: generate-windows-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: "windows-2025"
     steps:
     - uses: actions/checkout@v5
@@ -853,7 +853,7 @@ jobs:
 
   native-windows-tests-3:
     needs: generate-windows-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: "windows-2025"
     steps:
     - uses: actions/checkout@v5
@@ -894,7 +894,7 @@ jobs:
 
   native-windows-tests-4:
     needs: generate-windows-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: "windows-2025"
     steps:
       - uses: actions/checkout@v5
@@ -935,7 +935,7 @@ jobs:
 
   native-windows-tests-5:
     needs: generate-windows-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: "windows-2025"
     steps:
       - uses: actions/checkout@v5
@@ -999,7 +999,7 @@ jobs:
 
   native-mostly-static-tests-1:
     needs: generate-mostly-static-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
@@ -1046,7 +1046,7 @@ jobs:
 
   native-mostly-static-tests-2:
     needs: generate-mostly-static-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
@@ -1079,7 +1079,7 @@ jobs:
 
   native-mostly-static-tests-3:
     needs: generate-mostly-static-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
@@ -1112,7 +1112,7 @@ jobs:
 
   native-mostly-static-tests-4:
     needs: generate-mostly-static-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -1145,7 +1145,7 @@ jobs:
 
   native-mostly-static-tests-5:
     needs: generate-mostly-static-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -1202,7 +1202,7 @@ jobs:
 
   native-static-tests-1:
     needs: generate-static-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
@@ -1249,7 +1249,7 @@ jobs:
 
   native-static-tests-2:
     needs: generate-static-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
@@ -1284,7 +1284,7 @@ jobs:
 
   native-static-tests-3:
     needs: generate-static-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5
@@ -1319,7 +1319,7 @@ jobs:
 
   native-static-tests-4:
     needs: generate-static-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
@@ -1354,7 +1354,7 @@ jobs:
 
   native-static-tests-5:
     needs: generate-static-launcher
-    timeout-minutes: 120
+    timeout-minutes: 150
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
In particular, MacOS jobs seem to have crazy variable times, going between 40 and close to 120 minutes for actually successful builds.
As we download a lot of stuff in the integration tests, it's likely connection issues are a part of it.
Other than that, a lot of IO operations likely doesn't help on a GitHub runner.
Relevant to:
- https://github.com/VirtusLab/scala-cli/issues/2937 