### PR TITLE
Bump `coursier` to 2.1.25-M20 (was 2.1.25-M19)

### DIFF
--- a/.github/scripts/build-linux-aarch64.sh
+++ b/.github/scripts/build-linux-aarch64.sh
@@ -6,7 +6,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
 mkdir -p artifacts
 mkdir -p utils
-cp "$(cs get https://github.com/coursier/coursier/releases/download/v2.1.25-M19/cs-aarch64-pc-linux.gz --archive)" utils/cs
+cp "$(cs get https://github.com/coursier/coursier/releases/download/v2.1.25-M20/cs-aarch64-pc-linux.gz --archive)" utils/cs
 chmod +x utils/cs
 
 cp "$DIR/build-linux-aarch64-from-docker.sh" utils/

--- a/.github/scripts/get-latest-cs.sh
+++ b/.github/scripts/get-latest-cs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-CS_VERSION="2.1.25-M19"
+CS_VERSION="2.1.25-M20"
 
 DIR="$(cs get --archive "https://github.com/coursier/coursier/releases/download/v$CS_VERSION/cs-x86_64-pc-win32.zip")"
 

--- a/build.mill.scala
+++ b/build.mill.scala
@@ -2,7 +2,7 @@ package build
 
 import $packages._
 import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`
-import $ivy.`io.get-coursier::coursier-launcher:2.1.25-M19`
+import $ivy.`io.get-coursier::coursier-launcher:2.1.25-M20`
 import $ivy.`io.github.alexarchambault.mill::mill-native-image-upload:0.1.31-1`
 import build.ci.publishVersion
 import build.project.deps

--- a/mill
+++ b/mill
@@ -2,7 +2,7 @@
 
 # Adapted from
 
-coursier_version="2.1.25-M19"
+coursier_version="2.1.25-M20"
 COMMAND=$@
 
 # necessary for Windows various shell environments

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -120,7 +120,7 @@ object Deps {
     def ammoniteForScala3Lts = ammonite
     def argonautShapeless    = "1.3.1"
     // jni-utils version may need to be sync-ed when bumping the coursier version
-    def coursierDefault                   = "2.1.25-M19"
+    def coursierDefault                   = "2.1.25-M20"
     def coursier                          = coursierDefault
     def coursierCli                       = coursierDefault
     def coursierPublish                   = "0.4.3"


### PR DESCRIPTION
https://github.com/coursier/coursier/releases/tag/v2.1.25-M20