### PR TITLE
Fall back to legacy `runner` / `test-runner` for JVM < 17

### DIFF
--- a/build.mill.scala
+++ b/build.mill.scala
@@ -524,6 +524,12 @@ trait Core extends ScalaCliCrossSbtModule
          |  def scala3NextPrefix = "${Scala.scala3NextPrefix}"
          |  def scala3LtsPrefix = "${Scala.scala3LtsPrefix}"
          |  def scala3Lts       = "${Scala.scala3Lts}"
+         |  
+         |  def scala38Versions = Seq(${Scala.scala38Versions
+          .sorted
+          .map(s => s"\"$s\"")
+          .mkString(", ")})
+         |  def scala38MinJavaVersion = ${Java.minimumScala38Java}
          |
          |  def workspaceDirName = "$workspaceDirName"
          |  def projectFileName = "$projectFileName"
@@ -1032,6 +1038,7 @@ trait CliIntegration extends SbtModule with ScalaCliPublishModule with HasTests
             .sorted
             .map(s => s"\"$s\"")
             .mkString(", ")})
+           |  def scala38MinJavaVersion        = ${Java.minimumScala38Java}
            |  def defaultScalafmtVersion       = "${Deps.scalafmtCli.dep.versionConstraint.asString}"
            |  def maxAmmoniteScala212Version   = "${Scala.maxAmmoniteScala212Version}"
            |  def maxAmmoniteScala213Version   = "${Scala.maxAmmoniteScala213Version}"

--- a/modules/core/src/main/scala/scala/build/CsUtils.scala
+++ b/modules/core/src/main/scala/scala/build/CsUtils.scala
@@ -2,4 +2,12 @@ package scala.build
 
 import coursier.version.Version
 
+import scala.build.internal.Constants
+
 extension (s: String) def coursierVersion: Version = Version(s)
+
+extension (csv: Version)
+  def isScala38OrNewer: Boolean =
+    Constants.scala38Versions
+      .map(_.coursierVersion)
+      .exists(_ <= csv)

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -464,7 +464,7 @@ final case class BuildOptions(
     }
     val extraRepositories: Seq[Repository] = value(finalRepositories)
     val maybeArtifacts                     = Artifacts(
-      scalaArtifactsParamsOpt,
+      scalaArtifactsParamsOpt = scalaArtifactsParamsOpt,
       javacPluginDependencies = value(javacPluginDependencies),
       extraJavacPlugins = javaOptions.javacPlugins.map(_.value),
       defaultDependencies = value(defaultDependencies),
@@ -474,6 +474,7 @@ final case class BuildOptions(
       extraCompileOnlyJars = allExtraCompileOnlyJars,
       extraSourceJars = allExtraSourceJars,
       fetchSources = classPathOptions.fetchSources.getOrElse(false),
+      jvmVersion = javaHome().value.version,
       addJvmRunner = addRunnerDependency0,
       addJvmTestRunner = isTests && addJvmTestRunner,
       addJmhDependencies = jmhOptions.finalJmhVersion,

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -90,6 +90,7 @@ object Scala {
 object Java {
   def minimumJavaLauncherJava  = 11
   def minimumBloopJava: Int    = 17
+  def minimumScala38Java: Int  = 17
   def minimumInternalJava: Int = 16
   def defaultJava: Int         = minimumBloopJava
   def cliKeyJavaVersions       = Seq(


### PR DESCRIPTION
Following up to the Scala 3.8.0-RC1 bump.
Requires:
- https://github.com/VirtusLab/scala-cli/pull/3957