### PR TITLE
Run the entire REPL test suite on both Ammonite and Scala 3 REPL

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/ReplAmmoniteTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplAmmoniteTestDefinitions.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 import scala.cli.integration.TestUtil.{normalizeArgsForWindows, removeAnsiColors}
 
 trait ReplAmmoniteTestDefinitions { this: ReplTestDefinitions =>
-  protected val ammonitePrefix: String        = "Ammonite REPL:"
+  protected val ammonitePrefix: String        = "Running in Ammonite REPL:"
   def expectedScalaVersionForAmmonite: String =
     actualScalaVersion match {
       case s

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplAmmoniteTests3StableDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplAmmoniteTests3StableDefinitions.scala
@@ -2,54 +2,29 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-import scala.util.Properties
+import scala.cli.integration.TestUtil.normalizeArgsForWindows
 
 trait ReplAmmoniteTests3StableDefinitions {
   this: ReplTestDefinitions & ReplAmmoniteTestDefinitions =>
-  if (!actualScalaVersion.equals(actualMaxAmmoniteScalaVersion)) {
-    lazy val defaultScalaVersionString =
-      s" with Scala $actualScalaVersion (the default version, may downgrade)"
-    test(s"ammonite$defaultScalaVersionString") {
-      ammoniteTest(useMaxAmmoniteScalaVersion = false)
-    }
-
-    test(s"ammonite scalapy$defaultScalaVersionString") {
-      ammoniteScalapyTest(useMaxAmmoniteScalaVersion = false)
-    }
-
-    test(s"ammonite with test scope sources$defaultScalaVersionString") {
-      ammoniteTestScope(useMaxAmmoniteScalaVersion = false)
-    }
+  test(s"$ammonitePrefix https://github.com/scala/scala3/issues/21229$ammoniteMaxVersionString") {
+    // FIXME: test this on standard Scala 3 REPL, rather than just Ammonite
+    runInAmmoniteRepl(
+      codeToRunInRepl = "println(stuff.baz)",
+      testInputs = TestInputs(
+        os.rel / "Pprint.scala" ->
+          """//> using dep com.lihaoyi::pprint::0.9.0
+            |package stuff
+            |import scala.quoted.*
+            |def foo = pprint(1)
+            |inline def bar = pprint(1)
+            |inline def baz = ${ bazImpl }
+            |def bazImpl(using Quotes) = '{ pprint(1) }
+            |""".stripMargin
+      )
+    )(res => expect(res.out.trim().nonEmpty))
   }
 
-  test("https://github.com/scala/scala3/issues/21229") {
-    TestInputs(
-      os.rel / "Pprint.scala" ->
-        """//> using dep com.lihaoyi::pprint::0.9.0
-          |package stuff
-          |import scala.quoted.*
-          |def foo = pprint(1)
-          |inline def bar = pprint(1)
-          |inline def baz = ${ bazImpl }
-          |def bazImpl(using Quotes) = '{ pprint(1) }
-          |""".stripMargin
-    ).fromRoot { root =>
-      val ammArgs = Seq("-c", "println(stuff.baz)")
-        .map {
-          if (Properties.isWin)
-            a => if (a.contains(" ")) "\"" + a.replace("\"", "\\\"") + "\"" else a
-          else
-            identity
-        }
-        .flatMap(arg => Seq("--ammonite-arg", arg))
-      // FIXME: test this on standard Scala 3 REPL, rather than just Ammonite
-      val res = os.proc(TestUtil.cli, "repl", ".", "--power", "--amm", ammArgs, extraOptions)
-        .call(cwd = root)
-      expect(res.out.trim().nonEmpty)
-    }
-  }
-
-  test("as jar") {
+  test(s"$ammonitePrefix as jar$ammoniteMaxVersionString") {
     val inputs = TestInputs(
       os.rel / "CheckCp.scala" ->
         """//> using dep com.lihaoyi::os-lib:0.9.1
@@ -64,39 +39,12 @@ trait ReplAmmoniteTests3StableDefinitions {
           |}
           |""".stripMargin
     )
-
-    inputs.fromRoot { root =>
-      val ammArgs = Seq(
-        "-c",
-        """println("hasDir=" + checkcp.CheckCp.hasDir)"""
-      )
-        .map {
-          if (Properties.isWin)
-            a => if (a.contains(" ")) "\"" + a.replace("\"", "\\\"") + "\"" else a
-          else
-            identity
-        }
-        .flatMap(arg => Seq("--ammonite-arg", arg))
-
-      val output =
-        os.proc(TestUtil.cli, "--power", "repl", ".", TestUtil.extraOptions, "--ammonite", ammArgs)
-          .call(cwd = root)
-          .out.trim()
-      expect(output == "hasDir=true")
-
-      val asJarOutput = os.proc(
-        TestUtil.cli,
-        "--power",
-        "repl",
-        ".",
-        TestUtil.extraOptions,
-        "--ammonite",
-        ammArgs,
-        "--as-jar"
-      )
-        .call(cwd = root)
-        .out.trim()
-      expect(asJarOutput == "hasDir=false")
+    val code = """println("hasDir=" + checkcp.CheckCp.hasDir)"""
+    runInAmmoniteRepl(codeToRunInRepl = code, testInputs = inputs) {
+      res => expect(res.out.trim() == "hasDir=true")
+    }
+    runInAmmoniteRepl(codeToRunInRepl = code, testInputs = inputs, cliOptions = Seq("--as-jar")) {
+      res => expect(res.out.trim() == "hasDir=false")
     }
   }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplAmmoniteTests3StableDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplAmmoniteTests3StableDefinitions.scala
@@ -2,8 +2,6 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-import scala.cli.integration.TestUtil.normalizeArgsForWindows
-
 trait ReplAmmoniteTests3StableDefinitions {
   this: ReplTestDefinitions & ReplAmmoniteTestDefinitions =>
   test(s"$ammonitePrefix https://github.com/scala/scala3/issues/21229$ammoniteMaxVersionString") {

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
@@ -3,6 +3,7 @@ package scala.cli.integration
 import com.eed3si9n.expecty.Expecty.expect
 
 import scala.cli.integration.TestUtil.removeAnsiColors
+import scala.util.Properties
 
 abstract class ReplTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
   this: TestScalaVersion =>
@@ -15,23 +16,39 @@ abstract class ReplTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
     actualScalaVersion.coursierVersion >= "3.7.0-RC1".coursierVersion
 
   protected val dryRunPrefix: String    = "Dry run:"
-  protected val runInReplPrefix: String = "Running in REPL:"
+  protected val runInReplPrefix: String = "Running in Scala REPL:"
 
   def runInRepl(
     codeToRunInRepl: String,
-    testInputs: TestInputs = TestInputs.empty
-  )(f: os.CommandResult => Unit): Unit = {
+    testInputs: TestInputs = TestInputs.empty,
+    cliOptions: Seq[String] = Seq.empty,
+    shouldPipeStdErr: Boolean = false,
+    check: Boolean = true,
+    env: Map[String, String] = Map.empty
+  )(
+    runAfterRepl: os.CommandResult => Unit,
+    runBeforeReplAndGetExtraCliOpts: () => Seq[os.Shellable] = () => Seq.empty
+  ): Unit = {
     testInputs.fromRoot { root =>
-      f(
+      val potentiallyExtraCliOpts = runBeforeReplAndGetExtraCliOpts()
+      runAfterRepl(
         os.proc(
           TestUtil.cli,
           "repl",
+          ".",
           "--repl-quit-after-init",
           "--repl-init-script",
           codeToRunInRepl,
-          extraOptions
+          extraOptions,
+          cliOptions,
+          potentiallyExtraCliOpts
         )
-          .call(cwd = root)
+          .call(
+            cwd = root,
+            stderr = if shouldPipeStdErr then os.Pipe else os.Inherit,
+            env = env,
+            check = check
+          )
       )
     }
   }
@@ -114,11 +131,160 @@ abstract class ReplTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
     expect(output.contains("typer"))
   }
 
-  if canRunInRepl then
+  if canRunInRepl then {
     test(s"$runInReplPrefix simple") {
       val expectedMessage = "1337"
       runInRepl(s"""println($expectedMessage)""")(r =>
         expect(r.out.trim() == expectedMessage)
       )
     }
+
+    test(s"$runInReplPrefix verify Scala version from the REPL") {
+      val opts = if actualScalaVersion.startsWith("3") && !isScala38OrNewer then
+        Seq("--with-compiler")
+      else Seq.empty
+      runInRepl(
+        codeToRunInRepl = s"""println($retrieveScalaVersionCode)""",
+        cliOptions = opts
+      )(r => expect(r.out.trim() == actualScalaVersion))
+    }
+
+    test(s"$runInReplPrefix test scope") {
+      val message = "something something something REPL"
+      runInRepl(
+        codeToRunInRepl = "println(example.TestScopeExample.message)",
+        testInputs = TestInputs(
+          os.rel / "example" / "TestScopeExample.test.scala" ->
+            s"""package example
+               |
+               |object TestScopeExample {
+               |  def message: String = "$message"
+               |}
+               |""".stripMargin
+        ),
+        cliOptions = Seq("--test")
+      )(r => expect(r.out.trim() == message))
+    }
+
+    test(s"$runInReplPrefix https://github.com/scala/scala3/issues/21229") {
+      runInRepl(
+        codeToRunInRepl = "println(stuff.baz)",
+        testInputs = TestInputs(
+          os.rel / "Pprint.scala" ->
+            """//> using dep com.lihaoyi::pprint::0.9.0
+              |package stuff
+              |import scala.quoted.*
+              |def foo = pprint(1)
+              |inline def bar = pprint(1)
+              |inline def baz = ${ bazImpl }
+              |def bazImpl(using Quotes) = '{ pprint(1) }
+              |""".stripMargin
+        )
+      )(res => expect(res.out.trim().nonEmpty))
+    }
+
+    if !Properties.isWin then {
+      test(s"$runInReplPrefix ScalaPy") {
+        val opts =
+          if actualScalaVersion.startsWith("3") && !isScala38OrNewer then Seq("--with-compiler")
+          else Seq.empty
+        runInRepl(
+          codeToRunInRepl =
+            s"""import me.shadaj.scalapy.py
+               |println("Hello" + " from Scala " + $retrieveScalaVersionCode)
+               |val sth = py.module("foo.something")
+               |py.Dynamic.global.applyDynamicNamed("print")("" -> sth.messageStart, "" -> sth.messageEnd, "flush" -> py.Any.from(true))
+               |""".stripMargin,
+          testInputs = TestInputs(
+            os.rel / "foo" / "something.py" ->
+              """messageStart = 'Hello from'
+                |messageEnd = 'ScalaPy'
+                |""".stripMargin
+          ),
+          cliOptions = Seq("--python", "--power") ++ opts,
+          shouldPipeStdErr = true
+        ) { res =>
+          val output = res.out.trim().linesIterator.toVector.take(2).mkString("\n")
+          expect(output ==
+            s"""Hello from Scala $actualScalaVersion
+               |Hello from ScalaPy""".stripMargin)
+        }
+      }
+
+      test(s"$runInReplPrefix ScalaPy with PYTHONSAFEPATH") {
+        val opts =
+          if actualScalaVersion.startsWith("3") && !isScala38OrNewer then Seq("--with-compiler")
+          else Seq.empty
+        runInRepl(
+          codeToRunInRepl =
+            s"""import me.shadaj.scalapy.py
+               |println("Hello" + " from Scala " + $retrieveScalaVersionCode)
+               |val sth = py.module("foo.something")
+               |py.Dynamic.global.applyDynamicNamed("print")("" -> sth.messageStart, "" -> sth.messageEnd, "flush" -> py.Any.from(true))
+               |""".stripMargin,
+          testInputs = TestInputs(
+            os.rel / "foo" / "something.py" ->
+              """messageStart = 'Hello from'
+                |messageEnd = 'ScalaPy'
+                |""".stripMargin
+          ),
+          cliOptions = Seq("--python", "--power") ++ opts,
+          shouldPipeStdErr = true,
+          // check = false, // technically should be an error, but the REPL itself doesn't return it as such.
+          env = Map("PYTHONSAFEPATH" -> "foo")
+        ) { errorRes =>
+          // expect(errorRes.exitCode != 0) // technically should be an error, but the REPL itself doesn't return it as such.
+          val errorOutput = TestUtil.removeAnsiColors(errorRes.err.trim() + errorRes.out.trim())
+          expect(errorOutput.contains("No module named 'foo'"))
+        }
+      }
+
+      test(s"$runInReplPrefix with extra JAR") {
+        runInRepl(codeToRunInRepl =
+          """import shapeless._; println("Here's an HList: " + (2 :: true :: "a" :: HNil))"""
+        )(
+          runBeforeReplAndGetExtraCliOpts = () =>
+            val shapelessJar =
+              os.proc(TestUtil.cs, "fetch", "--intransitive", "com.chuusai:shapeless_2.13:2.3.7")
+                .call()
+                .out
+                .text()
+                .trim
+            Seq("--jar", shapelessJar)
+          ,
+          runAfterRepl = res => expect(res.out.trim() == "Here's an HList: 2 :: true :: a :: HNil")
+        )
+      }
+
+      if !isScala38OrNewer then
+        // TODO rewrite this test to work with Scala 3.8+ once 3.8.0 stable is out
+        test(s"$runInReplPrefix as jar") {
+          val inputs = TestInputs(
+            os.rel / "CheckCp.scala" ->
+              """//> using dep com.lihaoyi::os-lib:0.9.1
+                |package checkcp
+                |class CheckCp
+                |object CheckCp {
+                |  def hasDir: Boolean = {
+                |    val uri: java.net.URI = classOf[checkcp.CheckCp].getProtectionDomain.getCodeSource.getLocation.toURI
+                |    os.isDir(os.Path(java.nio.file.Paths.get(uri)))
+                |  }
+                |}
+                |""".stripMargin
+          )
+          val code = """println("hasDir=" + checkcp.CheckCp.hasDir)"""
+          runInRepl(codeToRunInRepl = code, testInputs = inputs) {
+            res => expect(res.out.trim().contains("hasDir=true"))
+          }
+          runInRepl(
+            codeToRunInRepl = code,
+            testInputs = inputs,
+            cliOptions = Seq("--as-jar", "--power")
+          ) {
+            res => expect(res.out.trim().contains("hasDir=false"))
+          }
+
+        }
+    }
+  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTests213.scala
@@ -2,16 +2,15 @@ package scala.cli.integration
 
 class ReplTests213 extends ReplTestDefinitions with ReplAmmoniteTestDefinitions with Test213 {
   test("repl custom repositories work".flaky) {
-    TestInputs.empty.fromRoot { root =>
-      os.proc(
-        TestUtil.cli,
-        "repl",
-        "--repl-dry-run",
-        "--scala",
-        Constants.scalaSnapshot213,
-        "--repository",
-        "https://scala-ci.typesafe.com/artifactory/scala-integration"
-      ).call(cwd = root)
-    }
+    dryRun(
+      cliOptions =
+        Seq(
+          "--scala",
+          Constants.scalaSnapshot213,
+          "--repository",
+          "https://scala-ci.typesafe.com/artifactory/scala-integration"
+        ),
+      useExtraOptions = false
+    )
   }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTests213.scala
@@ -1,16 +1,24 @@
 package scala.cli.integration
 
 class ReplTests213 extends ReplTestDefinitions with ReplAmmoniteTestDefinitions with Test213 {
-  test("repl custom repositories work".flaky) {
-    dryRun(
-      cliOptions =
+  for {
+    withExplicitScala2SnapshotRepo <- Seq(true, false)
+    snapshotVersion     = Constants.scalaSnapshot213
+    scalaVersionOptions = Seq("--scala", snapshotVersion)
+    repoOptions         =
+      if withExplicitScala2SnapshotRepo then
         Seq(
-          "--scala",
-          Constants.scalaSnapshot213,
           "--repository",
-          "https://scala-ci.typesafe.com/artifactory/scala-integration"
-        ),
-      useExtraOptions = false
-    )
+          "https://scala-ci.typesafe.com/artifactory/scala-2.13-snapshots"
+        )
+      else
+        Seq.empty
+    repoString = if withExplicitScala2SnapshotRepo then " with Scala 2 snapshot repo" else ""
   }
+    test(s"$dryRunPrefix repl Scala 2 snapshots: $snapshotVersion$repoString") {
+      dryRun(
+        cliOptions = scalaVersionOptions ++ repoOptions,
+        useExtraOptions = false
+      )
+    }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTests3NextRc.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTests3NextRc.scala
@@ -1,25 +1,3 @@
 package scala.cli.integration
 
-import com.eed3si9n.expecty.Expecty.expect
-
-class ReplTests3NextRc extends ReplTestDefinitions with Test3NextRc {
-  test("run hello world from the 3.8 REPL") {
-    TestInputs.empty.fromRoot { root =>
-      val expectedMessage = "1337"
-      val code            = s"""println($expectedMessage)"""
-      val r               = os.proc(
-        TestUtil.cli,
-        "repl",
-        "--repl-quit-after-init",
-        "--repl-init-script",
-        code,
-        "-S",
-        // TODO: switch this test to 3.8.0-RC1 once it's out
-        "3.8.0-RC1-bin-20251104-b83b3d9-NIGHTLY",
-        TestUtil.extraOptions
-      )
-        .call(cwd = root)
-      expect(r.out.trim() == expectedMessage)
-    }
-  }
-}
+class ReplTests3NextRc extends ReplTestDefinitions with Test3NextRc

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestsDefault.scala
@@ -1,39 +1,6 @@
 package scala.cli.integration
 
-import com.eed3si9n.expecty.Expecty.expect
-
-import java.io.File
-
 class ReplTestsDefault extends ReplTestDefinitions
     with ReplAmmoniteTestDefinitions
     with ReplAmmoniteTests3StableDefinitions
-    with TestDefault {
-  if (TestUtil.isNativeCli)
-    test("not download java 17 when run repl without sources") {
-      TestUtil.retryOnCi() {
-        TestInputs.empty.fromRoot { root =>
-          val java8Home =
-            os.Path(os.proc(TestUtil.cs, "java-home", "--jvm", "zulu:8").call().out.trim(), os.pwd)
-
-          val res =
-            os.proc(TestUtil.cli, "--power", "repl", TestUtil.extraOptions, "--", "-version").call(
-              cwd = root,
-              mergeErrIntoOut = true,
-              env = Map(
-                "JAVA_HOME"              -> java8Home.toString,
-                "COURSIER_ARCHIVE_CACHE" -> (root / "archive-cache").toString(),
-                "COURSIER_CACHE"         -> (root / "cache").toString(),
-                "PATH" -> ((java8Home / "bin").toString + File.pathSeparator + System.getenv(
-                  "PATH"
-                ))
-              )
-            )
-
-          val output = res.out.trim().toLowerCase()
-
-          expect(!output.contains("jdk17"))
-          expect(!output.contains("jvm-index"))
-        }
-      }
-    }
-}
+    with TestDefault

--- a/modules/integration/src/test/scala/scala/cli/integration/TestScalaVersionArgs.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestScalaVersionArgs.scala
@@ -23,6 +23,11 @@ trait TestScalaVersionArgs extends ScalaCliSuite { this: TestScalaVersion =>
     Constants.scala38Versions
       .map(_.coursierVersion)
       .exists(_ <= actualScalaVersion.coursierVersion)
+
+  def retrieveScalaVersionCode: String =
+    if actualScalaVersion.startsWith("2.") || isScala38OrNewer then
+      "scala.util.Properties.versionNumberString"
+    else "dotty.tools.dotc.config.Properties.simpleVersionString"
 }
 
 sealed trait TestScalaVersion { this: TestScalaVersionArgs =>

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -436,4 +436,11 @@ object TestUtil {
     def await: T                         = Await.result(f, Duration.Inf)
     def awaitWithTimeout(d: Duration): T = Await.result(f, d)
   }
+
+  extension (args: Seq[String]) {
+    def normalizeArgsForWindows: Seq[String] =
+      if Properties.isWin then
+        args.map(a => if a.contains(" ") then "\"" + a.replace("\"", "\\\"") + "\"" else a)
+      else args
+  }
 }

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -107,7 +107,7 @@ object Java {
 object TestDeps {
   def pprint: Dep              = Deps.pprint
   def munit: Dep               = Deps.munit
-  def scalaSnapshot213: String = "2.13.8-bin-e814d78"
+  def scalaSnapshot213: String = "2.13.19-bin-efb7184"
 
   def archLinuxImage: String =
     "archlinux@sha256:b15db21228c7cd5fd3ab364a97193ba38abfad0e8b9593c15b71850b74738153"


### PR DESCRIPTION
- refactors existing REPL tests
- removes some redundant tests which no longer test anything
- rewrites tests which used to rely on Ammonite to be tested to now run on Scala 3 REPL with `--repl-quit-after-init` and`--repl-init-script`
- this sets up the ground for Ammonite being deprecated