### PR TITLE
Bump misc dependencies

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.10.1"
+version = "3.10.2"
 
 align.preset = more
 maxColumn = 100

--- a/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
@@ -111,7 +111,7 @@ class ConfigTests extends ScalaCliSuite {
     TestInputs().fromRoot { root =>
       val confDir  = root / "config"
       val confFile = confDir / "test-config.json"
-      val content =
+      val content  =
         // non-formatted on purpose
         s"""{
            |  "httpProxy": {  "address" :      "$proxyAddr"     } }

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -134,7 +134,7 @@ object Deps {
     def jsoniterScala                     = "2.38.5"
     def jsoup                             = "1.21.2"
     def scalaMeta                         = "4.14.1"
-    def scalafmt                          = "3.10.1"
+    def scalafmt                          = "3.10.2"
     def scalaNative04                     = "0.4.17"
     def scalaNative05                     = "0.5.9"
     def scalaNative                       = scalaNative05

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -131,7 +131,7 @@ object Deps {
     def coursierCli                       = coursierDefault
     def coursierPublish                   = "0.4.3"
     def jmh                               = "1.37"
-    def jsoniterScala                     = "2.38.4"
+    def jsoniterScala                     = "2.38.5"
     def jsoup                             = "1.21.2"
     def scalaMeta                         = "4.14.1"
     def scalafmt                          = "3.10.1"

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -146,7 +146,7 @@ object Deps {
     def signingCli                        = "0.2.11"
     def signingCliJvmVersion              = Java.defaultJava
     def javaSemanticdb                    = "0.10.0"
-    def javaClassName                     = "0.1.8"
+    def javaClassName                     = "0.1.9"
     def bloop                             = "2.0.17"
     def sbtVersion                        = "1.11.7"
     def mavenVersion                      = "3.8.1"

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -214,7 +214,7 @@ object Deps {
   def metaconfigTypesafe =
     mvn"org.scalameta::metaconfig-typesafe-config:0.16.0"
       .exclude(("org.scala-lang", "scala-compiler"))
-  def munit              = mvn"org.scalameta::munit:1.2.0"
+  def munit              = mvn"org.scalameta::munit:1.2.1"
   def nativeTestRunner   = mvn"org.scala-native::test-runner:${Versions.scalaNative}"
   def nativeTools        = mvn"org.scala-native::tools:${Versions.scalaNative}"
   def osLib              = mvn"com.lihaoyi::os-lib:0.11.6"

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -191,7 +191,7 @@ object Deps {
   def dockerClient  = mvn"com.spotify:docker-client:8.16.0"
   def expecty       = mvn"com.eed3si9n.expecty::expecty:0.17.1"
   def fansi         = mvn"com.lihaoyi::fansi:0.5.1"
-  def giter8        = mvn"org.foundweekends.giter8:giter8:0.16.2"
+  def giter8        = mvn"org.foundweekends.giter8:giter8:0.18.0"
   def guava         = mvn"com.google.guava:guava:33.5.0-jre"
   def javaClassName =
     mvn"org.virtuslab.scala-cli.java-class-name:java-class-name_3:${Versions.javaClassName}"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -501,7 +501,7 @@ Pass a global dialect for scalafmt. This overrides whatever value is configured 
 
 Aliases: `--fmt-version`
 
-Pass scalafmt version before running it (3.10.1 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
+Pass scalafmt version before running it (3.10.2 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
 
 ## Global suppress warning options
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -370,7 +370,7 @@ Aliases: `--fmt-version`
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Pass scalafmt version before running it (3.10.1 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
+Pass scalafmt version before running it (3.10.2 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
 
 ## Global suppress warning options
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -3996,7 +3996,7 @@ Aliases: `--dialect`
 
 **--scalafmt-version**
 
-Pass scalafmt version before running it (3.10.1 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
+Pass scalafmt version before running it (3.10.2 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
 
 Aliases: `--fmt-version`
 


### PR DESCRIPTION
- java-class-name to 0.1.9 (was 0.1.8)
- jsoniter-scala to 2.38.5 (was 2.38.4)
- scalafmt to 3.10.2 (was 3.10.1)
- giter8 to 0.18.0 (was 0.16.2)
- munit to 1.2.1 (was 1.2.0)