### PR TITLE
Bump `scala-cli-signing` to 0.2.13 & `coursier-publish` to 0.4.4

### DIFF
--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -129,7 +129,7 @@ object Deps {
     def coursierDefault                   = "2.1.25-M19"
     def coursier                          = coursierDefault
     def coursierCli                       = coursierDefault
-    def coursierPublish                   = "0.4.3"
+    def coursierPublish                   = "0.4.4"
     def jmh                               = "1.37"
     def jsoniterScala                     = "2.38.5"
     def jsoup                             = "1.21.2"

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -143,7 +143,7 @@ object Deps {
     def maxScalaNativeForScalaPy          = scalaNative04
     def maxScalaNativeForMillExport       = scalaNative05
     def scalaPackager                     = "0.2.1"
-    def signingCli                        = "0.2.11"
+    def signingCli                        = "0.2.13"
     def signingCliJvmVersion              = Java.defaultJava
     def javaSemanticdb                    = "0.10.0"
     def javaClassName                     = "0.1.9"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -2204,7 +2204,7 @@ Available in commands:
 ### `--signing-cli-version`
 
 [Internal]
-scala-cli-signing version when running externally (0.2.11 by default)
+scala-cli-signing version when running externally (0.2.13 by default)
 
 ### `--signing-cli-java-arg`
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-cli-signing/releases/tag/v0.2.12
https://github.com/coursier/publish/releases/tag/v0.4.4