### PR TITLE
Bump `scala-js-cli` to 1.20.1.1 (was 1.20.1)

### DIFF
--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -42,7 +42,7 @@ object Scala {
   val runnerScalaVersions = (Seq(runnerScala3) ++ scala3MainVersions).distinct
 
   def scalaJs    = "1.20.1"
-  def scalaJsCli = scalaJs // this must be compatible with the Scala.js version
+  def scalaJsCli = "1.20.1.1" // this must be compatible with the Scala.js version
 
   private def patchVer(sv: String): Int =
     sv.split('.').drop(2).head.takeWhile(_.isDigit).toInt

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1398,7 +1398,7 @@ Path to the Scala.js linker
 ### `--js-cli-version`
 
 [Internal]
-Scala.js CLI version to use for linking (1.20.1 by default).
+Scala.js CLI version to use for linking (1.20.1.1 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -822,7 +822,7 @@ Path to the Scala.js linker
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Scala.js CLI version to use for linking (1.20.1 by default).
+Scala.js CLI version to use for linking (1.20.1.1 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -432,7 +432,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1 by default).
+Scala.js CLI version to use for linking (1.20.1.1 by default).
 
 **--js-cli-java-arg**
 
@@ -1222,7 +1222,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1 by default).
+Scala.js CLI version to use for linking (1.20.1.1 by default).
 
 **--js-cli-java-arg**
 
@@ -1831,7 +1831,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1 by default).
+Scala.js CLI version to use for linking (1.20.1.1 by default).
 
 **--js-cli-java-arg**
 
@@ -2470,7 +2470,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1 by default).
+Scala.js CLI version to use for linking (1.20.1.1 by default).
 
 **--js-cli-java-arg**
 
@@ -3118,7 +3118,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1 by default).
+Scala.js CLI version to use for linking (1.20.1.1 by default).
 
 **--js-cli-java-arg**
 
@@ -3724,7 +3724,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1 by default).
+Scala.js CLI version to use for linking (1.20.1.1 by default).
 
 **--js-cli-java-arg**
 
@@ -4408,7 +4408,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1 by default).
+Scala.js CLI version to use for linking (1.20.1.1 by default).
 
 **--js-cli-java-arg**
 
@@ -5102,7 +5102,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1 by default).
+Scala.js CLI version to use for linking (1.20.1.1 by default).
 
 **--js-cli-java-arg**
 
@@ -6079,7 +6079,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1 by default).
+Scala.js CLI version to use for linking (1.20.1.1 by default).
 
 **--js-cli-java-arg**
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-js-cli/releases/tag/v1.20.1.1