### PR TITLE
Bump Ammonite to 3.0.6 (was 3.0.5)

### DIFF
--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -79,7 +79,7 @@ object Scala {
       .distinct
       .filter(minorVer(_) < minorVer(scala3Lts))
 
-  def maxAmmoniteScala212Version                    = "2.12.20"
+  def maxAmmoniteScala212Version                    = "2.12.21"
   def maxAmmoniteScala213Version                    = "2.13.18"
   def maxAmmoniteScala3Version                      = "3.7.4"
   def maxAmmoniteScala3LtsVersion                   = "3.3.7"
@@ -122,7 +122,7 @@ object InternalDeps {
 
 object Deps {
   object Versions {
-    def ammonite             = "3.0.5"
+    def ammonite             = "3.0.6"
     def ammoniteForScala3Lts = ammonite
     def argonautShapeless    = "1.3.1"
     // jni-utils version may need to be sync-ed when bumping the coursier version

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1250,7 +1250,7 @@ Use Ammonite (instead of the default Scala REPL)
 
 Aliases: `--ammonite-ver`
 
-Set the Ammonite version (3.0.5 by default)
+Set the Ammonite version (3.0.6 by default)
 
 ### `--ammonite-arg`
 


### PR DESCRIPTION
https://github.com/com-lihaoyi/Ammonite/releases/tag/3.0.6
This includes 2.12.21 support added in https://github.com/com-lihaoyi/Ammonite/pull/1701