### PR TITLE
Fix Scala 3.nightly and 3.<latest-minor>.nightly to consistently point to the same version

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/RunTests3NextRc.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTests3NextRc.scala
@@ -1,3 +1,28 @@
 package scala.cli.integration
 
-class RunTests3NextRc extends RunTestDefinitions with Test3NextRc
+import com.eed3si9n.expecty.Expecty.expect
+
+class RunTests3NextRc extends RunTestDefinitions with Test3NextRc {
+  test("Scala 3.nightly & 3.<latest-minor>.nightly point to the same version") {
+    TestInputs.empty.fromRoot { root =>
+      def getScalaVersion(scalaVersionIndex: String) =
+        os.proc(
+          TestUtil.cli,
+          "run",
+          "-e",
+          s"""println($retrieveScalaVersionCode)""",
+          "-S",
+          scalaVersionIndex,
+          TestUtil.extraOptions
+        )
+          .call(cwd = root)
+          .out
+          .trim()
+
+      val version1     = getScalaVersion("3.nightly")
+      val nightlyMinor = version1.split('.').take(2).last
+      val version2     = getScalaVersion(s"3.$nightlyMinor.nightly")
+      expect(version1 == version2)
+    }
+  }
+}

--- a/modules/options/src/main/scala/scala/build/Artifacts.scala
+++ b/modules/options/src/main/scala/scala/build/Artifacts.scala
@@ -195,7 +195,11 @@ object Artifacts {
     val maybeSnapshotRepo = {
       val hasSnapshots = jvmTestRunnerDependencies.exists(_.version.endsWith("SNAPSHOT")) ||
         scalaArtifactsParamsOpt.flatMap(_.scalaNativeCliVersion).exists(_.endsWith("SNAPSHOT"))
-      if hasSnapshots then
+      val hasNightlies = scalaArtifactsParamsOpt.exists(a =>
+        a.params.scalaVersion.endsWith("-NIGHTLY") ||
+        a.params.scalaBinaryVersion.endsWith("-NIGHTLY")
+      )
+      if hasSnapshots || hasNightlies then
         Seq(
           coursier.Repositories.sonatype("snapshots"),
           coursier.Repositories.sonatypeS01("snapshots"),

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -357,10 +357,7 @@ final case class BuildOptions(
               case sv if sv == ScalaVersionUtil.scala3Nightly =>
                 ScalaVersionUtil.GetNightly.scala3(cache)
               case scala3NightlyNicknameRegex(threeSubBinaryNum) =>
-                ScalaVersionUtil.GetNightly.scala3X(
-                  threeSubBinaryNum,
-                  cache
-                )
+                ScalaVersionUtil.GetNightly.scala3X(threeSubBinaryNum, cache)
               case vs if ScalaVersionUtil.scala213Nightly.contains(vs) =>
                 ScalaVersionUtil.GetNightly.scala2("2.13", cache)
               case sv if sv == ScalaVersionUtil.scala212Nightly =>

--- a/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
@@ -6,7 +6,7 @@ import coursier.Versions
 import coursier.cache.{ArtifactError, FileCache}
 import coursier.core.{Module, Repository, Versions as CoreVersions}
 import coursier.util.{Artifact, Task}
-import coursier.version.{Latest, Version}
+import coursier.version.Version
 
 import java.io.File
 
@@ -126,7 +126,8 @@ object ScalaVersionUtil {
       threeSubBinaryNum: String,
       cache: FileCache[Task]
     ): Either[BuildException, String] = {
-      val res = cache.versionsWithTtl0(scala3Library)
+      val repositories = Seq(RepositoryUtils.scala3NightlyRepository)
+      val res          = cache.versionsWithTtl0(scala3Library, repositories)
         .versions.available0.filter(_.asString.endsWith("-NIGHTLY"))
 
       val threeXNightlies = res.filter(_.asString.startsWith(s"3.$threeSubBinaryNum."))
@@ -152,7 +153,7 @@ object ScalaVersionUtil {
       versions: CoreVersions,
       desc: String
     ): Either[scala.build.errors.ScalaVersionError, String] =
-      versions.latest(Latest.Release) match {
+      versions.latest(coursier.version.Latest.Release) match {
         case Some(versionString) => Right(versionString.asString)
         case None                =>
           val availableVersionsString = versions.available0.map(_.asString).mkString(", ")


### PR DESCRIPTION
Before this change, passing `3.8.nightly` as the Scala version would not consider https://repo.scala-lang.org