### PR TITLE
Add `rc` & `*.rc` Scala version aliases

### DIFF
--- a/modules/core/src/main/scala/scala/build/internals/Regexes.scala
+++ b/modules/core/src/main/scala/scala/build/internals/Regexes.scala
@@ -3,5 +3,7 @@ package scala.build.internal
 object Regexes {
   val scala2NightlyRegex         = raw"""2\.(\d+)\.(\d+)-bin-[a-f0-9]*""".r
   val scala3NightlyNicknameRegex = raw"""3\.([0-9]*)\.nightly""".r
+  val scala3RcRegex              = raw"""3\.([0-9]*\.[0-9]*-[rR][cC][0-9]+)""".r
+  val scala3RcNicknameRegex      = raw"""3\.([0-9]*)\.?[rR][cC]""".r
   val scala3LtsRegex             = raw"""3\.3\.[0-9]+""".r
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTests3NextRc.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTests3NextRc.scala
@@ -3,26 +3,63 @@ package scala.cli.integration
 import com.eed3si9n.expecty.Expecty.expect
 
 class RunTests3NextRc extends RunTestDefinitions with Test3NextRc {
+
+  def getScalaVersion(
+    scalaVersionIndex: String,
+    root: os.Path,
+    check: Boolean = true,
+    mergeErrIntoOut: Boolean = false
+  ): String =
+    os.proc(
+      TestUtil.cli,
+      "run",
+      "-e",
+      "println(dotty.tools.dotc.config.Properties.simpleVersionString)",
+      "-S",
+      scalaVersionIndex,
+      "--with-compiler",
+      TestUtil.extraOptions
+    )
+      .call(cwd = root, check = check, mergeErrIntoOut = mergeErrIntoOut)
+      .out
+      .trim()
+
   test("Scala 3.nightly & 3.<latest-minor>.nightly point to the same version") {
     TestInputs.empty.fromRoot { root =>
-      def getScalaVersion(scalaVersionIndex: String) =
-        os.proc(
-          TestUtil.cli,
-          "run",
-          "-e",
-          s"""println($retrieveScalaVersionCode)""",
-          "-S",
-          scalaVersionIndex,
-          TestUtil.extraOptions
-        )
-          .call(cwd = root)
-          .out
-          .trim()
-
-      val version1     = getScalaVersion("3.nightly")
+      val version1     = getScalaVersion("3.nightly", root)
       val nightlyMinor = version1.split('.').take(2).last
-      val version2     = getScalaVersion(s"3.$nightlyMinor.nightly")
+      val version2     = getScalaVersion(s"3.$nightlyMinor.nightly", root)
       expect(version1 == version2)
     }
   }
+
+  for {
+    label <- List("rc", "3.rc", "3.lts.rc", "lts.rc", s"${Constants.scala3LtsPrefix}.rc", "3.7.rc")
+  }
+    test(s"$label is valid and works as expected") {
+      TestInputs.empty.fromRoot { root =>
+        val latestRcVersion = getScalaVersion(label, root)
+        if latestRcVersion == actualScalaVersion then {
+          expect(
+            label == "rc" || label == "3.rc"
+          ) // this should only be the case for *latest* labels
+          System.err.println(s"RC version $latestRcVersion is the same as the hardcoded latest RC")
+        }
+        expect(latestRcVersion.startsWith("3."))
+        expect(latestRcVersion.contains("-RC"))
+        expect(!latestRcVersion.contains("SNAPSHOT"))
+        expect(!latestRcVersion.contains("NIGHTLY"))
+      }
+    }
+
+  for { label <- List("2.rc", "2.12.rc", "2.13.rc") }
+    test(s"$label produces a reasonable error") {
+      TestInputs.empty.fromRoot { root =>
+        val result = getScalaVersion(label, root, check = false, mergeErrIntoOut = true)
+        expect(result.contains("Invalid Scala version"))
+        expect(result.contains(
+          "In the case of Scala 2, a particular nightly version serves as a release candidate."
+        ))
+      }
+    }
 }

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -17,7 +17,11 @@ import scala.build.errors.*
 import scala.build.interactive.Interactive
 import scala.build.interactive.Interactive.*
 import scala.build.internal.Constants.*
-import scala.build.internal.Regexes.scala3NightlyNicknameRegex
+import scala.build.internal.Regexes.{
+  scala3NightlyNicknameRegex,
+  scala3RcNicknameRegex,
+  scala3RcRegex
+}
 import scala.build.internal.{Constants, OsLibc, Util}
 import scala.build.internals.EnvVar
 import scala.build.options.validation.BuildOptionsRule
@@ -345,14 +349,22 @@ final case class BuildOptions(
           val sv = value {
             svInput match {
               case sv if ScalaVersionUtil.scala3Lts.contains(sv) =>
-                ScalaVersionUtil.validateStable(
-                  Constants.scala3LtsPrefix,
-                  cache,
-                  repositories
-                )
+                ScalaVersionUtil.validateStable(Constants.scala3LtsPrefix, cache, repositories)
+              case sv if ScalaVersionUtil.scala3LatestRc.contains(sv.toLowerCase) =>
+                ScalaVersionUtil.validateRc("3", cache, repositories)
+              case sv if ScalaVersionUtil.scala3LtsLatestRc.contains(sv.toLowerCase) =>
+                ScalaVersionUtil.validateRc(Constants.scala3LtsPrefix, cache, repositories)
+              case scala3RcRegex(threeSubBinarySuffix) =>
+                ScalaVersionUtil.validateRc(s"3.$threeSubBinarySuffix", cache, repositories)
+              case scala3RcNicknameRegex(threeSubBinarySuffix) =>
+                ScalaVersionUtil.validateRc(s"3.$threeSubBinarySuffix", cache, repositories)
               case sv if ScalaVersionUtil.scala2Lts.contains(sv) =>
                 Left(new ScalaVersionError(
                   s"Invalid Scala version: $sv. There is no official LTS version for Scala 2."
+                ))
+              case sv if ScalaVersionUtil.scala2LatestRc.contains(sv) =>
+                Left(new ScalaVersionError(
+                  s"Invalid Scala version: $sv. In the case of Scala 2, a particular nightly version serves as a release candidate."
                 ))
               case sv if sv == ScalaVersionUtil.scala3Nightly =>
                 ScalaVersionUtil.GetNightly.scala3(cache)
@@ -376,7 +388,7 @@ final case class BuildOptions(
                 )
                   .map(_ => versionString)
               case versionString if versionString.exists(_.isLetter) =>
-                ScalaVersionUtil.validateNonStable(
+                ScalaVersionUtil.validateExactVersion(
                   versionString,
                   cache,
                   repositories

--- a/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
@@ -27,12 +27,16 @@ import scala.util.control.NonFatal
 
 object ScalaVersionUtil {
 
-  private def scala2Library = cmod"org.scala-lang:scala-library"
-  private def scala3Library = cmod"org.scala-lang:scala3-library_3"
-  def scala212Nightly       = "2.12.nightly"
-  def scala213Nightly       = List("2.13.nightly", "2.nightly")
-  def scala3Nightly         = "3.nightly"
-  def scala3Lts             = List("3.lts", "lts")
+  private def scala2Library           = cmod"org.scala-lang:scala-library"
+  private def scala3Library           = cmod"org.scala-lang:scala3-library_3"
+  def scala212Nightly                 = "2.12.nightly"
+  def scala213Nightly                 = List("2.13.nightly", "2.nightly")
+  def scala3Nightly                   = "3.nightly"
+  private def rcAlias(prefix: String) = s"$prefix.rc"
+  def scala2LatestRc                  = List(rcAlias("2"), rcAlias("2.12"), rcAlias("2.13"))
+  def scala3LatestRc                  = List("rc", rcAlias("3"))
+  def scala3LtsLatestRc = List(rcAlias("lts"), rcAlias("3.lts"), rcAlias(Constants.scala3LtsPrefix))
+  def scala3Lts         = List("3.lts", "lts")
   // not valid versions, defined only for informative error messages
   def scala2Lts = List("2.13.lts", "2.12.lts", "2.lts")
   extension (cache: FileCache[Task]) {
@@ -182,53 +186,55 @@ object ScalaVersionUtil {
       cache.versionsWithTtl0(scala3Library, repositories).verify(versionString)
   }
 
-  def validateNonStable(
+  def validate(
+    scalaVersionStringArg: String,
+    cache: FileCache[Task],
+    repositories: Seq[Repository],
+    isExactVersion: Boolean
+  )(validationFunction: String => Boolean): Either[ScalaVersionError, String] = {
+    val versionPool =
+      ScalaVersionUtil.allMatchingVersions(Some(scalaVersionStringArg), cache, repositories)
+        .filter(validationFunction)
+
+    val prefix =
+      if Util.isFullScalaVersion(scalaVersionStringArg) then scalaVersionStringArg
+      else if scalaVersionStringArg.endsWith(".") then scalaVersionStringArg
+      else scalaVersionStringArg + "."
+    val matchingVersions = versionPool.filter(_.startsWith(prefix)).map(Version(_))
+    if matchingVersions.isEmpty ||
+      (isExactVersion && !matchingVersions.contains(scalaVersionStringArg))
+    then Left(new InvalidBinaryScalaVersionError(scalaVersionStringArg))
+    else {
+      val supportedMatchingVersions = matchingVersions.filter(v => isSupportedVersion(v.repr))
+      supportedMatchingVersions.find(_.repr == scalaVersionStringArg) match {
+        case Some(v)                                                       => Right(v.repr)
+        case None if supportedMatchingVersions.nonEmpty && !isExactVersion =>
+          Right(supportedMatchingVersions.max.repr)
+        case _ => Left(new UnsupportedScalaVersionError(scalaVersionStringArg))
+      }
+    }
+  }
+
+  def validateExactVersion(
     scalaVersionStringArg: String,
     cache: FileCache[Task],
     repositories: Seq[Repository]
-  ): Either[ScalaVersionError, String] = {
-    val versionPool =
-      ScalaVersionUtil.allMatchingVersions(Some(scalaVersionStringArg), cache, repositories)
-
-    if (versionPool.contains(scalaVersionStringArg))
-      if (isSupportedVersion(scalaVersionStringArg))
-        Right(scalaVersionStringArg)
-      else
-        Left(new UnsupportedScalaVersionError(scalaVersionStringArg))
-    else
-      Left(new InvalidBinaryScalaVersionError(scalaVersionStringArg))
-  }
+  ): Either[ScalaVersionError, String] =
+    validate(scalaVersionStringArg, cache, repositories, isExactVersion = true)(_ => true)
 
   def validateStable(
     scalaVersionStringArg: String,
     cache: FileCache[Task],
     repositories: Seq[Repository]
-  ): Either[ScalaVersionError, String] = {
-    val versionPool =
-      ScalaVersionUtil.allMatchingVersions(Some(scalaVersionStringArg), cache, repositories)
-        .filter(ScalaVersionUtil.isStable)
+  ): Either[ScalaVersionError, String] =
+    validate(scalaVersionStringArg, cache, repositories, isExactVersion = false)(isStable)
 
-    val prefix =
-      if (Util.isFullScalaVersion(scalaVersionStringArg)) scalaVersionStringArg
-      else if (scalaVersionStringArg.endsWith(".")) scalaVersionStringArg
-      else scalaVersionStringArg + "."
-    val matchingStableVersions = versionPool.filter(_.startsWith(prefix)).map(Version(_))
-    if (matchingStableVersions.isEmpty)
-      Left(new InvalidBinaryScalaVersionError(scalaVersionStringArg))
-    else {
-      val supportedMatchingStableVersions =
-        matchingStableVersions.filter(v => isSupportedVersion(v.repr))
-
-      supportedMatchingStableVersions.find(_.repr == scalaVersionStringArg) match {
-        case Some(v)                                          => Right(v.repr)
-        case None if supportedMatchingStableVersions.nonEmpty =>
-          Right(supportedMatchingStableVersions.max.repr)
-        case _ => Left(
-            new UnsupportedScalaVersionError(scalaVersionStringArg)
-          )
-      }
-    }
-  }
+  def validateRc(
+    scalaVersionStringArg: String,
+    cache: FileCache[Task],
+    repositories: Seq[Repository]
+  ): Either[ScalaVersionError, String] =
+    validate(scalaVersionStringArg, cache, repositories, isExactVersion = false)(isRc)
 
   private def isSupportedVersion(version: String): Boolean =
     version.startsWith("2.12.") || version.startsWith("2.13.") || version.startsWith("3.")
@@ -241,6 +247,12 @@ object ScalaVersionUtil {
     (version.startsWith("3") && version.endsWith("-NIGHTLY")) || version == scala3Nightly
   def isStable(version: String): Boolean =
     !version.exists(_.isLetter)
+  def isRc(version: String): Boolean = {
+    val lowerCasedVersion = version.toLowerCase
+    lowerCasedVersion.contains("rc") &&
+    !lowerCasedVersion.contains("-nightly") &&
+    !lowerCasedVersion.contains("-snapshot")
+  }
 
   def allMatchingVersions(
     maybeScalaVersionArg: Option[String],


### PR DESCRIPTION
This provides convenient syntax for getting the latest release candidate versions for a particular Scala minor (or latest in general).
The labels are not case sensitive, by the way, I just use camel case for readability.
Note that the latest RC may be pretty much the same thing as the latest stable at times.

```bash
scala-cli -e 'println(scala.util.Properties.versionNumberString)' -S rc
# 3.8.0-RC3
scala-cli -e 'println(scala.util.Properties.versionNumberString)' -S 3.rc
# 3.8.0-RC3
scala-cli -e 'println(scala.util.Properties.versionNumberString)' -S 3.8.rc
# 3.8.0-RC3
scala-cli -e 'println(dotty.tools.dotc.config.Properties.simpleVersionString)' -S 3.lts.rc --with-compiler
# 3.3.7-RC2
scala-cli -e 'println(dotty.tools.dotc.config.Properties.simpleVersionString)' -S lts.rc --with-compiler
# 3.3.7-RC2
```

Also note that there is no easy way to identify an RC for Scala 2 / 2.12 / 2.13 (as a particular nightly serves as the RC for those Scala distributions).
A reasonable error is also provided when it is requested.

```bash
scala-cli -e 'println(scala.util.Properties.versionNumberString)' -S 2.rc
# Invalid Scala version: 2.rc. In the case of Scala 2, a particular nightly version serves as a release candidate.
scala-cli -e 'println(scala.util.Properties.versionNumberString)' -S 2.12.rc
# Invalid Scala version: 2.12.rc. In the case of Scala 2, a particular nightly version serves as a release candidate.
scala-cli -e 'println(scala.util.Properties.versionNumberString)' -S 2.13.rc
# Invalid Scala version: 2.13.rc. In the case of Scala 2, a particular nightly version serves as a release candidate.
```
