### PR TITLE
Bump `coursier` to 2.1.25-M23

### DIFF
--- a/.github/scripts/build-linux-aarch64.sh
+++ b/.github/scripts/build-linux-aarch64.sh
@@ -6,7 +6,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 
 mkdir -p artifacts
 mkdir -p utils
-cp "$(cs get https://github.com/coursier/coursier/releases/download/v2.1.25-M21/cs-aarch64-pc-linux.gz --archive)" utils/cs
+cp "$(cs get https://github.com/coursier/coursier/releases/download/v2.1.25-M23/cs-aarch64-pc-linux.gz --archive)" utils/cs
 chmod +x utils/cs
 
 cp "$DIR/build-linux-aarch64-from-docker.sh" utils/

--- a/.github/scripts/get-latest-cs.sh
+++ b/.github/scripts/get-latest-cs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-CS_VERSION="2.1.25-M21"
+CS_VERSION="2.1.25-M23"
 
 DIR="$(cs get --archive "https://github.com/coursier/coursier/releases/download/v$CS_VERSION/cs-x86_64-pc-win32.zip")"
 

--- a/build.mill.scala
+++ b/build.mill.scala
@@ -3,7 +3,7 @@
 //| - io.github.alexarchambault.mill::mill-native-image-upload:0.2.4
 //| - com.goyeau::mill-scalafix::0.6.0
 //| - com.lumidion::sonatype-central-client-requests:0.6.0
-//| - io.get-coursier:coursier-launcher_2.13:2.1.25-M21
+//| - io.get-coursier:coursier-launcher_2.13:2.1.25-M23
 //| - org.eclipse.jgit:org.eclipse.jgit:7.3.0.202506031305-r
 package build
 

--- a/mill
+++ b/mill
@@ -2,7 +2,7 @@
 
 # Adapted from
 
-coursier_version="2.1.25-M21"
+coursier_version="2.1.25-M23"
 COMMAND=$@
 
 # necessary for Windows various shell environments

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -121,7 +121,7 @@ object Deps {
     def ammoniteForScala3Lts = ammonite
     def argonautShapeless    = "1.3.1"
     // jni-utils version may need to be sync-ed when bumping the coursier version
-    def coursierDefault                   = "2.1.25-M21"
+    def coursierDefault                   = "2.1.25-M23"
     def coursier                          = coursierDefault
     def coursierCli                       = coursierDefault
     def coursierPublish                   = "0.4.4"


### PR DESCRIPTION
https://github.com/coursier/coursier/releases/tag/v2.1.25-M23