### PR TITLE
Bump Scala.js to 1.20.2

### DIFF
--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -43,8 +43,8 @@ object Scala {
   val scala3MainVersions  = (defaults ++ allScala3).distinct
   val runnerScalaVersions = (Seq(runnerScala3) ++ scala3MainVersions).distinct
 
-  def scalaJs    = "1.20.1"
-  def scalaJsCli = "1.20.1.1" // this must be compatible with the Scala.js version
+  def scalaJs    = "1.20.2"
+  def scalaJsCli = scalaJs // this must be compatible with the Scala.js version
 
   private def patchVer(sv: String): Int =
     sv.split('.').drop(2).head.takeWhile(_.isDigit).toInt

--- a/website/docs/guides/advanced/scala-js.md
+++ b/website/docs/guides/advanced/scala-js.md
@@ -197,5 +197,6 @@ The table below lists the last supported version of Scala.js in Scala CLI. If yo
 | 1.6.0 - 1.6.1      |  1.18.1  |
 | 1.6.2 - 1.7.1      |  1.18.2  |
 | 1.8.0 - 1.9.0      |  1.19.0  |
-| 1.9.1 - current    |  1.20.1  |
+| 1.9.1 - 1.11.0     |  1.20.1  |
+| 1.11.1 - current   |  1.20.2  |
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1329,7 +1329,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 ### `--js-version`
 
-The Scala.js version (1.20.1 by default).
+The Scala.js version (1.20.2 by default).
 
 ### `--js-mode`
 
@@ -1402,7 +1402,7 @@ Path to the Scala.js linker
 ### `--js-cli-version`
 
 [Internal]
-Scala.js CLI version to use for linking (1.20.1.1 by default).
+Scala.js CLI version to use for linking (1.20.2 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -635,7 +635,7 @@ Add Scala.js options
 
 
 #### Examples
-`//> using jsVersion 1.20.1`
+`//> using jsVersion 1.20.2`
 
 `//> using jsMode mode`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -772,7 +772,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 `SHOULD have` per Scala Runner specification
 
-The Scala.js version (1.20.1 by default).
+The Scala.js version (1.20.2 by default).
 
 ### `--js-mode`
 
@@ -872,7 +872,7 @@ Path to the Scala.js linker
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Scala.js CLI version to use for linking (1.20.1.1 by default).
+Scala.js CLI version to use for linking (1.20.2 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -429,7 +429,7 @@ Add Scala.js options
 
 
 #### Examples
-`//> using jsVersion 1.20.1`
+`//> using jsVersion 1.20.2`
 
 `//> using jsMode mode`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -134,7 +134,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.1 by default).
+The Scala.js version (1.20.2 by default).
 
 **--js-mode**
 
@@ -432,7 +432,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1.1 by default).
+Scala.js CLI version to use for linking (1.20.2 by default).
 
 **--js-cli-java-arg**
 
@@ -936,7 +936,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.1 by default).
+The Scala.js version (1.20.2 by default).
 
 **--js-mode**
 
@@ -1222,7 +1222,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1.1 by default).
+Scala.js CLI version to use for linking (1.20.2 by default).
 
 **--js-cli-java-arg**
 
@@ -1539,7 +1539,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.1 by default).
+The Scala.js version (1.20.2 by default).
 
 **--js-mode**
 
@@ -1831,7 +1831,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1.1 by default).
+Scala.js CLI version to use for linking (1.20.2 by default).
 
 **--js-cli-java-arg**
 
@@ -2168,7 +2168,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.1 by default).
+The Scala.js version (1.20.2 by default).
 
 **--js-mode**
 
@@ -2470,7 +2470,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1.1 by default).
+Scala.js CLI version to use for linking (1.20.2 by default).
 
 **--js-cli-java-arg**
 
@@ -2816,7 +2816,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.1 by default).
+The Scala.js version (1.20.2 by default).
 
 **--js-mode**
 
@@ -3118,7 +3118,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1.1 by default).
+Scala.js CLI version to use for linking (1.20.2 by default).
 
 **--js-cli-java-arg**
 
@@ -3440,7 +3440,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.1 by default).
+The Scala.js version (1.20.2 by default).
 
 **--js-mode**
 
@@ -3724,7 +3724,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1.1 by default).
+Scala.js CLI version to use for linking (1.20.2 by default).
 
 **--js-cli-java-arg**
 
@@ -4101,7 +4101,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.1 by default).
+The Scala.js version (1.20.2 by default).
 
 **--js-mode**
 
@@ -4408,7 +4408,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1.1 by default).
+Scala.js CLI version to use for linking (1.20.2 by default).
 
 **--js-cli-java-arg**
 
@@ -4822,7 +4822,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.1 by default).
+The Scala.js version (1.20.2 by default).
 
 **--js-mode**
 
@@ -5102,7 +5102,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1.1 by default).
+Scala.js CLI version to use for linking (1.20.2 by default).
 
 **--js-cli-java-arg**
 
@@ -5799,7 +5799,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.1 by default).
+The Scala.js version (1.20.2 by default).
 
 **--js-mode**
 
@@ -6079,7 +6079,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.1.1 by default).
+Scala.js CLI version to use for linking (1.20.2 by default).
 
 **--js-cli-java-arg**
 


### PR DESCRIPTION
https://github.com/scala-js/scala-js/releases/tag/v1.20.2
https://github.com/VirtusLab/scala-js-cli/releases/tag/v1.20.2