### PR TITLE
Bump libsodium to 1.0.21 (partially, except for static launchers locked at 1.0.18)

### DIFF
--- a/build.mill.scala
+++ b/build.mill.scala
@@ -559,6 +559,8 @@ trait Core extends ScalaCliCrossSbtModule
          |
          |  def libsodiumVersion = "${deps.libsodiumVersion}"
          |  def libsodiumjniVersion = "${Deps.libsodiumjni.dep.versionConstraint.asString}"
+         |  def alpineLibsodiumVersion = "${deps.alpineLibsodiumVersion}"
+         |  def condaLibsodiumVersion = "${deps.condaLibsodiumVersion}"
          |
          |  def scalaPyVersion = "${Deps.scalaPy.dep.versionConstraint.asString}"
          |  def scalaPyMaxScalaNative = "${Deps.Versions.maxScalaNativeForScalaPy}"
@@ -1097,6 +1099,8 @@ trait CliIntegration extends SbtModule
            |  def cs                           = "${settings.cs().replace("\\", "\\\\")}"
            |  def workspaceDirName             = "$workspaceDirName"
            |  def libsodiumVersion             = "${deps.libsodiumVersion}"
+           |  def alpineLibsodiumVersion       = "${deps.alpineLibsodiumVersion}"
+           |  def condaLibsodiumVersion        = "${deps.condaLibsodiumVersion}"
            |  def dockerArchLinuxImage         = "${TestDeps.archLinuxImage}"
            |  
            |  def toolkitVersion                 = "${Deps.toolkitVersion}"

--- a/modules/cli/src/main/scala/scala/cli/commands/github/LibSodiumJni.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/github/LibSodiumJni.scala
@@ -38,16 +38,17 @@ object LibSodiumJni {
     }
   }
 
-  private def libsodiumVersion    = Constants.libsodiumVersion
-  private def libsodiumjniVersion = Constants.libsodiumjniVersion
-  private def alpineVersion       = Constants.alpineVersion
+  private def condaLibsodiumVersion  = Constants.condaLibsodiumVersion
+  private def alpineLibsodiumVersion = Constants.alpineLibsodiumVersion
+  private def libsodiumjniVersion    = Constants.libsodiumjniVersion
+  private def alpineVersion          = Constants.alpineVersion
 
   private def archiveUrlAndPath() =
     if (Properties.isLinux && launcherKindOpt.contains("static"))
       // Should actually be unused, as we statically link libsodium from the static launcher
       // Keeping it just-in-case. This could be useful from a musl-based JVM.
       (
-        s"https://dl-cdn.alpinelinux.org/alpine/v$alpineVersion/main/x86_64/libsodium-$libsodiumVersion-r0.apk",
+        s"https://dl-cdn.alpinelinux.org/alpine/v$alpineVersion/main/x86_64/libsodium-$alpineLibsodiumVersion-r0.apk",
         os.rel / "usr" / "lib" / "libsodium.so.23.3.0" // FIXME Could this change?
       )
     else {
@@ -71,7 +72,7 @@ object LibSodiumJni {
         case other           => sys.error(s"Unrecognized conda platform $other")
       }
       (
-        s"https://anaconda.org/conda-forge/libsodium/$libsodiumVersion/download/$condaPlatform/libsodium-$libsodiumVersion$suffix.tar.bz2",
+        s"https://anaconda.org/conda-forge/libsodium/$condaLibsodiumVersion/download/$condaPlatform/libsodium-$condaLibsodiumVersion$suffix.tar.bz2",
         relPath
       )
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/GitHubTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/GitHubTests.scala
@@ -93,7 +93,7 @@ object GitHubTests {
   implicit val encryptedSecretCodec: JsonValueCodec[EncryptedSecret] =
     JsonCodecMaker.make
 
-  private def libsodiumVersion = Constants.libsodiumVersion
+  private def condaLibsodiumVersion = Constants.condaLibsodiumVersion
 
   // Warning: somehow also in settings.sc in the build, and in FetchExternalBinary
   lazy val condaPlatform: String = {
@@ -131,7 +131,7 @@ object GitHubTests {
       case other           => sys.error(s"Unrecognized conda platform $other")
     }
     (
-      s"https://anaconda.org/conda-forge/libsodium/$libsodiumVersion/download/$condaPlatform/libsodium-$libsodiumVersion$suffix.tar.bz2",
+      s"https://anaconda.org/conda-forge/libsodium/$condaLibsodiumVersion/download/$condaPlatform/libsodium-$condaLibsodiumVersion$suffix.tar.bz2",
       relPath
     )
   }

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -296,7 +296,9 @@ def csDockerVersion = Deps.Versions.coursierCli
 def buildCsVersion = Deps.Versions.coursierCli
 
 // Native library used to encrypt GitHub secrets
-def libsodiumVersion = "1.0.18"
+def libsodiumVersion       = "1.0.21"
+def alpineLibsodiumVersion = "1.0.18"
+def condaLibsodiumVersion  = alpineLibsodiumVersion // used in integration tests
 // Using the libsodium static library from this Alpine version (in the static launcher)
 def alpineVersion = "3.16"
 def ubuntuVersion = "24.04"

--- a/project/settings/package.mill.scala
+++ b/project/settings/package.mill.scala
@@ -5,6 +5,7 @@ import deps.{
   Deps,
   Docker,
   alpineVersion,
+  alpineLibsodiumVersion,
   buildCsVersion,
   libsodiumVersion,
   ubuntuVersion
@@ -255,7 +256,7 @@ trait CliLaunchers extends SbtModule { self =>
       val arcPath = os.proc(
         cs,
         "get",
-        s"https://dl-cdn.alpinelinux.org/alpine/v$alpineVersion/main/x86_64/libsodium-static-$libsodiumVersion-r0.apk"
+        s"https://dl-cdn.alpinelinux.org/alpine/v$alpineVersion/main/x86_64/libsodium-static-$alpineLibsodiumVersion-r0.apk"
       ).call().out.trim()
       val tmpDir = os.temp.dir(prefix = "libsodium-static")
       try {


### PR DESCRIPTION
- As every once and then, old `libsodium` links are once again unresponsive, effectively killing our CI.
https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip seems dead, as of the time of me writing this, returning a 404.
- However, the freshly released 1.0.21 seems to work, so let's try that: https://github.com/jedisct1/libsodium/releases/tag/1.0.21-RELEASE
- I'm freezing the alpine & conda libsodium versions at 1.0.18 for now, as bumping that would be a considerable effort and should be done separately (there's a different packaging format there, which `coursier` does not support).
- This supersedes https://github.com/VirtusLab/scala-cli/pull/3494