### PR TITLE
Improve Scala nightly version handling & add `lts.nightly`, `3.lts.nightly` and `nightly` Scala version tags

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
@@ -438,12 +438,12 @@ object Repl extends ScalaCommand[ReplOptions] with BuildCommandHelpers {
     def defaultArtifacts(): Either[BuildException, ReplArtifacts] = either {
       value {
         ReplArtifacts.default(
-          scalaParams,
-          allArtifacts.flatMap(_.userDependencies).distinct,
-          allArtifacts.flatMap(_.extraClassPath).distinct,
-          logger,
-          cache,
-          value(options.finalRepositories),
+          scalaParams = scalaParams,
+          dependencies = allArtifacts.flatMap(_.userDependencies).distinct,
+          extraClassPath = allArtifacts.flatMap(_.extraClassPath).distinct,
+          logger = logger,
+          cache = cache,
+          repositories = value(options.finalRepositories),
           addScalapy =
             if setupPython then
               Some(options.notForBloopOptions.scalaPyVersion.getOrElse(Constants.scalaPyVersion))

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
@@ -24,6 +24,7 @@ abstract class ReplTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
     cliOptions: Seq[String] = Seq.empty,
     shouldPipeStdErr: Boolean = false,
     check: Boolean = true,
+    skipScalaVersionArgs: Boolean = false,
     env: Map[String, String] = Map.empty
   )(
     runAfterRepl: os.CommandResult => Unit,
@@ -39,7 +40,7 @@ abstract class ReplTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
           "--repl-quit-after-init",
           "--repl-init-script",
           codeToRunInRepl,
-          extraOptions,
+          if skipScalaVersionArgs then TestUtil.extraOptions else extraOptions,
           cliOptions,
           potentiallyExtraCliOpts
         )

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTests3Lts.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTests3Lts.scala
@@ -1,5 +1,38 @@
 package scala.cli.integration
 
+import com.eed3si9n.expecty.Expecty.expect
+
 class ReplTests3Lts extends ReplTestDefinitions with Test3Lts
     with ReplAmmoniteTestDefinitions
-    with ReplAmmoniteTests3StableDefinitions
+    with ReplAmmoniteTests3StableDefinitions {
+  import Constants.scala3LtsPrefix
+  if canRunInRepl then
+    for { ltsNightlyTag <- List("3.lts.nightly", "lts.nightly") }
+      test(
+        s"$runInReplPrefix $ltsNightlyTag returns the same Scala version as $scala3LtsPrefix.nightly"
+      ) {
+        val code = s"""println($retrieveScalaVersionCode)"""
+        runInRepl(
+          code,
+          cliOptions = Seq("-S", ltsNightlyTag, "--with-compiler"),
+          skipScalaVersionArgs = true
+        ) { r1 =>
+          val version1 = r1.out.trim()
+          System.err.println(s"$ltsNightlyTag returns the following nightly: $version1")
+          runInRepl(
+            code,
+            cliOptions = Seq("-S", s"$scala3LtsPrefix.nightly", "--with-compiler"),
+            skipScalaVersionArgs = true
+          ) { r2 =>
+            val version2 = r2.out.trim()
+            expect(version1 == version2)
+            val major = version1.split('.').take(1).head.toInt
+            expect(major == 3)
+            val minor = version1.split('.').take(2).last.toInt
+            expect(minor >= scala3LtsPrefix.split('.').last.toInt)
+            val patch = version1.split('.').take(3).last.takeWhile(_.isDigit).toInt
+            if minor == 3 then expect(patch >= 8) // new nightly repo
+          }
+        }
+      }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestsDefault.scala
@@ -7,23 +7,24 @@ class ReplTestsDefault extends ReplTestDefinitions
     with ReplAmmoniteTests3StableDefinitions
     with TestDefault {
   if canRunInRepl then
-    test(
-      s"$runInReplPrefix 3.nightly returns the same Scala version as <latest-minor>.nightly"
-    ) {
-      val code = """println(scala.util.Properties.versionNumberString)"""
-      runInRepl(code, cliOptions = Seq("-S", "3.nightly")) { r1 =>
-        val version1 = r1.out.trim()
-        System.err.println(s"3.nightly returns the following nightly: $version1")
-        val nightlyPrefix = version1.split('.').take(2).mkString(".")
-        runInRepl(code, cliOptions = Seq("-S", s"$nightlyPrefix.nightly")) { r2 =>
-          val version2 = r2.out.trim()
-          System.err.println(s"$nightlyPrefix.nightly returns the following nightly: $version2")
-          expect(version1 == version2)
-          val major = version1.split('.').take(1).head.toInt
-          expect(major == 3)
-          val minor = version1.split('.').take(2).last.toInt
-          expect(minor >= Constants.scala3NextPrefix.split('.').last.toInt)
+    for { nightlyTag <- List("3.nightly", "nightly") }
+      test(
+        s"$runInReplPrefix $nightlyTag returns the same Scala version as <latest-minor>.nightly"
+      ) {
+        val code = """println(scala.util.Properties.versionNumberString)"""
+        runInRepl(code, cliOptions = Seq("-S", nightlyTag)) { r1 =>
+          val version1 = r1.out.trim()
+          System.err.println(s"$nightlyTag returns the following nightly: $version1")
+          val nightlyPrefix = version1.split('.').take(2).mkString(".")
+          runInRepl(code, cliOptions = Seq("-S", s"$nightlyPrefix.nightly")) { r2 =>
+            val version2 = r2.out.trim()
+            System.err.println(s"$nightlyPrefix.nightly returns the following nightly: $version2")
+            expect(version1 == version2)
+            val major = version1.split('.').take(1).head.toInt
+            expect(major == 3)
+            val minor = version1.split('.').take(2).last.toInt
+            expect(minor >= Constants.scala3NextPrefix.split('.').last.toInt)
+          }
         }
       }
-    }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestsDefault.scala
@@ -1,6 +1,29 @@
 package scala.cli.integration
 
+import com.eed3si9n.expecty.Expecty.expect
+
 class ReplTestsDefault extends ReplTestDefinitions
     with ReplAmmoniteTestDefinitions
     with ReplAmmoniteTests3StableDefinitions
-    with TestDefault
+    with TestDefault {
+  if canRunInRepl then
+    test(
+      s"$runInReplPrefix 3.nightly returns the same Scala version as <latest-minor>.nightly"
+    ) {
+      val code = """println(scala.util.Properties.versionNumberString)"""
+      runInRepl(code, cliOptions = Seq("-S", "3.nightly")) { r1 =>
+        val version1 = r1.out.trim()
+        System.err.println(s"3.nightly returns the following nightly: $version1")
+        val nightlyPrefix = version1.split('.').take(2).mkString(".")
+        runInRepl(code, cliOptions = Seq("-S", s"$nightlyPrefix.nightly")) { r2 =>
+          val version2 = r2.out.trim()
+          System.err.println(s"$nightlyPrefix.nightly returns the following nightly: $version2")
+          expect(version1 == version2)
+          val major = version1.split('.').take(1).head.toInt
+          expect(major == 3)
+          val minor = version1.split('.').take(2).last.toInt
+          expect(minor >= Constants.scala3NextPrefix.split('.').last.toInt)
+        }
+      }
+    }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -32,6 +32,26 @@ abstract class RunTestDefinitions
   protected val ciOpt: Seq[String] =
     Option(System.getenv("CI")).map(v => Seq("-e", s"CI=$v")).getOrElse(Nil)
 
+  protected def getScalaVersion(
+    scalaVersionIndex: String,
+    root: os.Path,
+    check: Boolean = true,
+    mergeErrIntoOut: Boolean = false
+  ): String =
+    os.proc(
+      TestUtil.cli,
+      "run",
+      "-e",
+      "println(dotty.tools.dotc.config.Properties.simpleVersionString)",
+      "-S",
+      scalaVersionIndex,
+      "--with-compiler",
+      TestUtil.extraOptions
+    )
+      .call(cwd = root, check = check, mergeErrIntoOut = mergeErrIntoOut)
+      .out
+      .trim()
+
   test("print command") {
     val fileName = "simple.sc"
     val message  = "Hello"

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTests3Lts.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTests3Lts.scala
@@ -1,3 +1,19 @@
 package scala.cli.integration
 
-class RunTests3Lts extends RunTestDefinitions with Test3Lts
+import com.eed3si9n.expecty.Expecty.expect
+
+class RunTests3Lts extends RunTestDefinitions with Test3Lts {
+  import Constants.scala3LtsPrefix
+  for (ltsNightlyAlias <- List("lts.nightly", "3.lts.nightly"))
+    test(s"Scala $ltsNightlyAlias & $scala3LtsPrefix.nightly point to the same version") {
+      TestInputs.empty.fromRoot { root =>
+        val version1      = getScalaVersion(ltsNightlyAlias, root)
+        val nightlyPrefix = version1.split('.').take(2).mkString(".")
+        expect(nightlyPrefix == Constants.scala3LtsPrefix)
+        val nightlyPatch = version1.split('.').take(3).last.takeWhile(_.isDigit).toInt
+        if nightlyPrefix == "3.3" then expect(nightlyPatch >= 8) // new nightly repo
+        val version2 = getScalaVersion(s"${Constants.scala3LtsPrefix}.nightly", root)
+        expect(version1 == version2)
+      }
+    }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTests3NextRc.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTests3NextRc.scala
@@ -3,14 +3,15 @@ package scala.cli.integration
 import com.eed3si9n.expecty.Expecty.expect
 
 class RunTests3NextRc extends RunTestDefinitions with Test3NextRc {
-  test("Scala 3.nightly & 3.<latest-minor>.nightly point to the same version") {
-    TestInputs.empty.fromRoot { root =>
-      val version1     = getScalaVersion("3.nightly", root)
-      val nightlyMinor = version1.split('.').take(2).last
-      val version2     = getScalaVersion(s"3.$nightlyMinor.nightly", root)
-      expect(version1 == version2)
+  for { nightlyTag <- List("3.nightly", "nightly") }
+    test(s"Scala $nightlyTag & 3.<latest-minor>.nightly point to the same version") {
+      TestInputs.empty.fromRoot { root =>
+        val version1     = getScalaVersion(nightlyTag, root)
+        val nightlyMinor = version1.split('.').take(2).last
+        val version2     = getScalaVersion(s"3.$nightlyMinor.nightly", root)
+        expect(version1 == version2)
+      }
     }
-  }
 
   for {
     label <- List("rc", "3.rc", "3.lts.rc", "lts.rc", s"${Constants.scala3LtsPrefix}.rc", "3.7.rc")

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTests3NextRc.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTests3NextRc.scala
@@ -3,27 +3,6 @@ package scala.cli.integration
 import com.eed3si9n.expecty.Expecty.expect
 
 class RunTests3NextRc extends RunTestDefinitions with Test3NextRc {
-
-  def getScalaVersion(
-    scalaVersionIndex: String,
-    root: os.Path,
-    check: Boolean = true,
-    mergeErrIntoOut: Boolean = false
-  ): String =
-    os.proc(
-      TestUtil.cli,
-      "run",
-      "-e",
-      "println(dotty.tools.dotc.config.Properties.simpleVersionString)",
-      "-S",
-      scalaVersionIndex,
-      "--with-compiler",
-      TestUtil.extraOptions
-    )
-      .call(cwd = root, check = check, mergeErrIntoOut = mergeErrIntoOut)
-      .out
-      .trim()
-
   test("Scala 3.nightly & 3.<latest-minor>.nightly point to the same version") {
     TestInputs.empty.fromRoot { root =>
       val version1     = getScalaVersion("3.nightly", root)

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -368,6 +368,11 @@ final case class BuildOptions(
                 ))
               case sv if sv == ScalaVersionUtil.scala3Nightly =>
                 ScalaVersionUtil.GetNightly.scala3(cache)
+              case sv if ScalaVersionUtil.scala3LtsNightly.contains(sv) =>
+                ScalaVersionUtil.GetNightly.scala3X(
+                  Constants.scala3LtsPrefix.split('.').last,
+                  cache
+                )
               case scala3NightlyNicknameRegex(threeSubBinaryNum) =>
                 ScalaVersionUtil.GetNightly.scala3X(threeSubBinaryNum, cache)
               case vs if ScalaVersionUtil.scala213Nightly.contains(vs) =>

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -366,9 +366,9 @@ final case class BuildOptions(
                 Left(new ScalaVersionError(
                   s"Invalid Scala version: $sv. In the case of Scala 2, a particular nightly version serves as a release candidate."
                 ))
-              case sv if sv == ScalaVersionUtil.scala3Nightly =>
+              case sv if ScalaVersionUtil.scala3Nightly.contains(sv.toLowerCase) =>
                 ScalaVersionUtil.GetNightly.scala3(cache)
-              case sv if ScalaVersionUtil.scala3LtsNightly.contains(sv) =>
+              case sv if ScalaVersionUtil.scala3LtsNightly.contains(sv.toLowerCase) =>
                 ScalaVersionUtil.GetNightly.scala3X(
                   Constants.scala3LtsPrefix.split('.').last,
                   cache

--- a/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
@@ -31,7 +31,7 @@ object ScalaVersionUtil {
   private def scala3Library           = cmod"org.scala-lang:scala3-library_3"
   def scala212Nightly                 = "2.12.nightly"
   def scala213Nightly                 = List("2.13.nightly", "2.nightly")
-  def scala3Nightly                   = "3.nightly"
+  def scala3Nightly                   = List("nightly", "3.nightly")
   def scala3LtsNightly                = List("lts.nightly", "3.lts.nightly")
   private def rcAlias(prefix: String) = s"$prefix.rc"
   def scala2LatestRc                  = List(rcAlias("2"), rcAlias("2.12"), rcAlias("2.13"))
@@ -246,7 +246,7 @@ object ScalaVersionUtil {
 
   def isScala3Nightly(version: String): Boolean =
     (version.startsWith("3") && version.toLowerCase.endsWith("nightly")) ||
-    version == scala3Nightly || scala3LtsNightly.contains(version)
+    scala3Nightly.contains(version.toLowerCase) || scala3LtsNightly.contains(version)
   def isStable(version: String): Boolean =
     !version.exists(_.isLetter)
   def isRc(version: String): Boolean = {

--- a/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
@@ -32,6 +32,7 @@ object ScalaVersionUtil {
   def scala212Nightly                 = "2.12.nightly"
   def scala213Nightly                 = List("2.13.nightly", "2.nightly")
   def scala3Nightly                   = "3.nightly"
+  def scala3LtsNightly                = List("lts.nightly", "3.lts.nightly")
   private def rcAlias(prefix: String) = s"$prefix.rc"
   def scala2LatestRc                  = List(rcAlias("2"), rcAlias("2.12"), rcAlias("2.13"))
   def scala3LatestRc                  = List("rc", rcAlias("3"))
@@ -244,7 +245,9 @@ object ScalaVersionUtil {
     || (scala212Nightly +: scala213Nightly).contains(version)
 
   def isScala3Nightly(version: String): Boolean =
-    (version.startsWith("3") && version.endsWith("-NIGHTLY")) || version == scala3Nightly
+    (version.startsWith("3") && version.endsWith(
+      "-NIGHTLY"
+    )) || version == scala3Nightly || scala3LtsNightly.contains(version)
   def isStable(version: String): Boolean =
     !version.exists(_.isLetter)
   def isRc(version: String): Boolean = {

--- a/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
@@ -245,9 +245,8 @@ object ScalaVersionUtil {
     || (scala212Nightly +: scala213Nightly).contains(version)
 
   def isScala3Nightly(version: String): Boolean =
-    (version.startsWith("3") && version.endsWith(
-      "-NIGHTLY"
-    )) || version == scala3Nightly || scala3LtsNightly.contains(version)
+    (version.startsWith("3") && version.toLowerCase.endsWith("nightly")) ||
+    version == scala3Nightly || scala3LtsNightly.contains(version)
   def isStable(version: String): Boolean =
     !version.exists(_.isLetter)
   def isRc(version: String): Boolean = {


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/4036

- fixes handling of nightly versions in the REPL
- adds the `lts.nightly` and `3.lts.nightly` tags for the nightly of the current LTS
- adds the `nightly` tag as a synonym to `3.nightly`
- adds a bunch of tests for all of the above