### PR TITLE
Adjust libsodium 1.0.18 download address to the new (legacy) address

### DIFF
--- a/project/settings/package.mill.scala
+++ b/project/settings/package.mill.scala
@@ -243,7 +243,7 @@ trait CliLaunchers extends SbtModule { self =>
         cs,
         "get",
         "--archive",
-        s"https://download.libsodium.org/libsodium/releases/libsodium-$libsodiumVersion-stable-msvc.zip"
+        s"https://download.libsodium.org/libsodium/releases/old/libsodium-$libsodiumVersion-stable-msvc.zip"
       ).call()
       val dir = os.Path(dirRes.out.trim(), workspace)
       os.copy.over(


### PR DESCRIPTION
- a potential, temporary alternative to https://github.com/VirtusLab/scala-cli/pull/4041
- we likely need to migrate to a newer version somehow, as 1.0.18 is explicitly treated as an "old" version now