### PR TITLE
Add support for exporting to Mill 1.1.x series (tests on Mill 1.1.0-RC4)

### DIFF
--- a/build.mill.scala
+++ b/build.mill.scala
@@ -865,6 +865,7 @@ trait Cli extends CrossSbtModule with ProtoBuildModule with CliLaunchers
          |  def defaultMillVersion = "${BuildInfo.millVersion}"
          |  def mill012Version = "${Deps.Versions.mill012Version}"
          |  def mill10Version = "${Deps.Versions.mill10Version}"
+         |  def mill11Version = "${Deps.Versions.mill11Version}"
          |  def defaultSbtVersion = "${Deps.Versions.sbtVersion}"
          |  def defaultMavenVersion = "${Deps.Versions.mavenVersion}"
          |  def defaultMavenScalaCompilerPluginVersion = "${Deps.Versions.mavenScalaCompilerPluginVersion}"
@@ -1122,6 +1123,7 @@ trait CliIntegration extends SbtModule
            |  def defaultMillVersion = "${BuildInfo.millVersion}"
            |  def mill012Version = "${Deps.Versions.mill012Version}"
            |  def mill10Version = "${Deps.Versions.mill10Version}"
+           |  def mill11Version = "${Deps.Versions.mill11Version}"
            |}
            |""".stripMargin
       if (!os.isFile(dest) || os.read(dest) != code)

--- a/modules/cli/src/main/scala/scala/cli/commands/export0/Export.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/export0/Export.scala
@@ -99,11 +99,13 @@ object Export extends ScalaCommand[ExportOptions] {
     cache: FileCache[Task],
     projectName: Option[String],
     millVersion: String,
+    useLatestLaunchers: Boolean = true,
     logger: Logger
   ): MillProjectDescriptor = {
+    val launcherTag       = if useLatestLaunchers then "main" else millVersion
     val launcherArtifacts = Seq(
-      os.rel / "mill"     -> s"https://github.com/com-lihaoyi/mill/raw/$millVersion/mill",
-      os.rel / "mill.bat" -> s"https://github.com/com-lihaoyi/mill/raw/$millVersion/mill.bat"
+      os.rel / "mill"     -> s"https://github.com/com-lihaoyi/mill/raw/$launcherTag/mill",
+      os.rel / "mill.bat" -> s"https://github.com/com-lihaoyi/mill/raw/$launcherTag/mill.bat"
     )
     val launcherTasks = launcherArtifacts.map {
       case (path, url) =>
@@ -274,6 +276,7 @@ object Export extends ScalaCommand[ExportOptions] {
             cache = options.shared.coursierCache,
             projectName = options.project,
             millVersion = options.millVersion.getOrElse(Constants.millVersion),
+            useLatestLaunchers = options.useLatestMillLaunchers.getOrElse(true),
             logger = logger
           )
         else if shouldExportToMaven then

--- a/modules/cli/src/main/scala/scala/cli/commands/export0/ExportOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/export0/ExportOptions.scala
@@ -62,6 +62,12 @@ final case class ExportOptions(
   )
   millVersion: Option[String] = None,
   @Group(HelpGroup.BuildToolExport.toString)
+  @Tag(tags.restricted)
+  @HelpMessage(
+    s"If set, latest Mill launchers from the main branch will be used, rather than the ones for the used version tag (true by default)"
+  )
+  useLatestMillLaunchers: Option[Boolean] = None,
+  @Group(HelpGroup.BuildToolExport.toString)
   @Tag(tags.experimental)
   @HelpMessage(
     s"Version of Maven Compiler Plugin to be used for the export (${Constants.defaultMavenVersion} by default)"

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/MillProject.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/MillProject.scala
@@ -177,7 +177,7 @@ final case class MillProject(
       os.write(path0, content, createFolders = true)
     }
 
-    val outputBuildFile = if isMill1OrNewer then dir / "build.mill.scala" else dir / "build.sc"
+    val outputBuildFile = if isMill1OrNewer then dir / "build.mill" else dir / "build.sc"
     os.write(outputBuildFile, buildFileContent.getBytes(charSet))
   }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMill11Tests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMill11Tests212.scala
@@ -1,0 +1,3 @@
+package scala.cli.integration
+
+class ExportMill11Tests212 extends ExportMillTestDefinitions with Test212 with TestMill11

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMill11Tests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMill11Tests213.scala
@@ -1,0 +1,27 @@
+package scala.cli.integration
+
+class ExportMill11Tests213 extends ExportMillTestDefinitions with Test213 with TestMill11 {
+  if runExportTests then {
+    test(s"scalac options$commonTestDescriptionSuffix") {
+      simpleTest(
+        inputs = ExportTestProjects.scalacOptionsScala2Test(actualScalaVersion),
+        mainClass = None,
+        extraExportArgs = defaultExportCommandArgs
+      )
+    }
+    test(s"pure java$commonTestDescriptionSuffix") {
+      simpleTest(
+        inputs = ExportTestProjects.pureJavaTest("ScalaCliJavaTest"),
+        mainClass = None,
+        extraExportArgs = defaultExportCommandArgs
+      )
+    }
+    test(s"custom JAR$commonTestDescriptionSuffix") {
+      simpleTest(
+        inputs = ExportTestProjects.customJarTest(actualScalaVersion),
+        mainClass = None,
+        extraExportArgs = defaultExportCommandArgs
+      )
+    }
+  }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMill11Tests3Lts.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMill11Tests3Lts.scala
@@ -1,0 +1,3 @@
+package scala.cli.integration
+
+class ExportMill11Tests3Lts extends ExportMillTestDefinitions with Test3Lts with TestMill11

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMill11TestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMill11TestsDefault.scala
@@ -1,0 +1,3 @@
+package scala.cli.integration
+
+class ExportMill11TestsDefault extends ExportMillTestDefinitions with TestDefault with TestMill11

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
@@ -5,6 +5,8 @@ import os.RelPath
 
 import java.nio.charset.Charset
 
+import scala.util.Properties
+
 abstract class ExportMillTestDefinitions extends ScalaCliSuite
     with TestScalaVersionArgs
     with ExportCommonTestDefinitions
@@ -104,6 +106,16 @@ abstract class ExportMillTestDefinitions extends ScalaCliSuite
         jvmTestScalacOptions(className = "Hello", exportArgs = defaultExportCommandArgs)
       }
     }
+    if (!Properties.isMac || TestUtil.isM1) && !Properties.isWin then
+      // TODO enable this for intel Macs when Mill is bumped to 1.1.0 stable or newer: https://github.com/com-lihaoyi/mill/issues/6632
+      test(s"JVM scalac options with disabled latest launchers$commonTestDescriptionSuffix") {
+        TestUtil.retryOnCi() {
+          jvmTestScalacOptions(
+            className = "Hello",
+            exportArgs = defaultExportCommandArgs ++ Seq("--use-latest-mill-launchers=false")
+          )
+        }
+      }
     if !actualScalaVersion.startsWith("2.12") then
       test(s"JVM with a compiler plugin$commonTestDescriptionSuffix") {
         TestUtil.retryOnCi() {

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
@@ -121,3 +121,6 @@ trait TestMill012 extends TestMillVersion:
 trait TestMill10 extends TestMillVersion:
   self: ExportMillTestDefinitions =>
   override def millVersion: String = Constants.mill10Version
+trait TestMill11 extends TestMillVersion:
+  self: ExportMillTestDefinitions =>
+  override def millVersion: String = Constants.mill11Version

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -148,6 +148,8 @@ object Deps {
     def mill012Version                    = "0.12.17"
     def mill10Version                     =
       if (BuildInfo.millVersion.startsWith("1.0.")) BuildInfo.millVersion else "1.0.6"
+    def mill11Version =
+      if (BuildInfo.millVersion.startsWith("1.1.")) BuildInfo.millVersion else "1.1.0-RC4"
     def mavenVersion                    = "3.8.1"
     def mavenScalaCompilerPluginVersion = "4.9.1"
     def mavenExecPluginVersion          = "3.3.0"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -390,6 +390,10 @@ Version of SBT to be used for the export (1.11.7 by default)
 
 Version of Mill to be used for the export (1.0.6 by default)
 
+### `--use-latest-mill-launchers`
+
+If set, latest Mill launchers from the main branch will be used, rather than the ones for the used version tag (true by default)
+
 ### `--mvn-version`
 
 Version of Maven Compiler Plugin to be used for the export (3.8.1 by default)


### PR DESCRIPTION
https://github.com/com-lihaoyi/mill/releases/tag/1.1.0-RC4
As the `.mill.scala` format was dropped in 1.1.0-RC1, I changed the default build file output to `.mill` for Mill 1.0 exports as well.
We've yet to change it in the Scala CLI repo itself.