### PR TITLE
Bump `jgit` to 7.5.0.202512021534-r (was 7.3.0.202506031305-r)

### DIFF
--- a/build.mill.scala
+++ b/build.mill.scala
@@ -4,7 +4,7 @@
 //| - com.goyeau::mill-scalafix::0.6.0
 //| - com.lumidion::sonatype-central-client-requests:0.6.0
 //| - io.get-coursier:coursier-launcher_2.13:2.1.25-M23
-//| - org.eclipse.jgit:org.eclipse.jgit:7.3.0.202506031305-r
+//| - org.eclipse.jgit:org.eclipse.jgit:7.5.0.202512021534-r
 package build
 
 import build.ci.publishVersion

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -201,7 +201,7 @@ object Deps {
         "org.jline" -> "jline-terminal",
         "org.jline" -> "jline-terminal-jna"
       )
-  def jgit                 = mvn"org.eclipse.jgit:org.eclipse.jgit:7.3.0.202506031305-r"
+  def jgit                 = mvn"org.eclipse.jgit:org.eclipse.jgit:7.5.0.202512021534-r"
   def jimfs                = mvn"com.google.jimfs:jimfs:1.3.1"
   def jmhGeneratorBytecode = mvn"org.openjdk.jmh:jmh-generator-bytecode:${Versions.jmh}"
   def jmhCore              = mvn"org.openjdk.jmh:jmh-core:${Versions.jmh}"


### PR DESCRIPTION
https://github.com/eclipse-jgit/jgit/releases/tag/v7.5.0.202512021534-r