### PR TITLE
Fix Scala 2.13 nightly tests

### DIFF
--- a/build.mill.scala
+++ b/build.mill.scala
@@ -1053,7 +1053,6 @@ trait CliIntegration extends SbtModule
            |  def defaultJvmVersion            = ${Java.defaultJava}
            |  def scala212                     = "${Scala.scala212}"
            |  def scala213                     = "${Scala.scala213}"
-           |  def scalaSnapshot213             = "${TestDeps.scalaSnapshot213}"
            |  def scala3LtsPrefix              = "${Scala.scala3LtsPrefix}"
            |  def scala3Lts                    = "${Scala.scala3Lts}"
            |  def scala3NextPrefix             = "${Scala.scala3NextPrefix}"

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTests213.scala
@@ -3,8 +3,8 @@ package scala.cli.integration
 class ReplTests213 extends ReplTestDefinitions with ReplAmmoniteTestDefinitions with Test213 {
   for {
     withExplicitScala2SnapshotRepo <- Seq(true, false)
-    snapshotVersion     = Constants.scalaSnapshot213
-    scalaVersionOptions = Seq("--scala", snapshotVersion)
+    nightlyVersion      = "2.13.nightly"
+    scalaVersionOptions = Seq("--scala", nightlyVersion)
     repoOptions         =
       if withExplicitScala2SnapshotRepo then
         Seq(
@@ -15,7 +15,7 @@ class ReplTests213 extends ReplTestDefinitions with ReplAmmoniteTestDefinitions 
         Seq.empty
     repoString = if withExplicitScala2SnapshotRepo then " with Scala 2 snapshot repo" else ""
   }
-    test(s"$dryRunPrefix repl Scala 2 snapshots: $snapshotVersion$repoString") {
+    test(s"$dryRunPrefix repl Scala 2 snapshots: $nightlyVersion$repoString") {
       dryRun(
         cliOptions = scalaVersionOptions ++ repoOptions,
         useExtraOptions = false

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -109,9 +109,8 @@ object Java {
 
 // Dependencies used in integration test fixtures
 object TestDeps {
-  def pprint: Dep              = Deps.pprint
-  def munit: Dep               = Deps.munit
-  def scalaSnapshot213: String = "2.13.19-bin-efb7184"
+  def pprint: Dep = Deps.pprint
+  def munit: Dep  = Deps.munit
 
   def archLinuxImage: String =
     "archlinux@sha256:b15db21228c7cd5fd3ab364a97193ba38abfad0e8b9593c15b71850b74738153"


### PR DESCRIPTION
It seems 2.13.19-bin-efb7184 is no longer available. I'm not sure if there was a change in version retention (snapshots are now held for a limited time on Maven Central - but 2.13 snapshots aren't on Maven Central 🤔), but I think it makes little difference if we test for a particular snapshot or just the latest one.
This should fix the CI on `main`.