### PR TITLE
Bump Ammonite to 3.0.7 (was 3.0.6)

### DIFF
--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -85,7 +85,7 @@ object Scala {
 
   def maxAmmoniteScala212Version                    = "2.12.21"
   def maxAmmoniteScala213Version                    = "2.13.18"
-  def maxAmmoniteScala3Version                      = "3.7.4"
+  def maxAmmoniteScala3Version                      = "3.8.0"
   def maxAmmoniteScala3LtsVersion                   = "3.3.7"
   lazy val listMaxAmmoniteScalaVersion: Seq[String] =
     Seq(maxAmmoniteScala212Version, maxAmmoniteScala213Version, maxAmmoniteScala3Version)
@@ -118,7 +118,7 @@ object TestDeps {
 
 object Deps {
   object Versions {
-    def ammonite             = "3.0.6"
+    def ammonite             = "3.0.7"
     def ammoniteForScala3Lts = ammonite
     def argonautShapeless    = "1.3.1"
     // jni-utils version may need to be sync-ed when bumping the coursier version

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1254,7 +1254,7 @@ Use Ammonite (instead of the default Scala REPL)
 
 Aliases: `--ammonite-ver`
 
-Set the Ammonite version (3.0.6 by default)
+Set the Ammonite version (3.0.7 by default)
 
 ### `--ammonite-arg`
 


### PR DESCRIPTION
https://github.com/com-lihaoyi/Ammonite/releases/tag/3.0.7
This bumps the supported Scala version to 3.8.0.
For 3.8.1, we'll have to wait for https://github.com/com-lihaoyi/Ammonite/pull/1712 to get merged & released.