### PR TITLE
Bump Scala Native to 0.5.10

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
@@ -470,7 +470,9 @@ trait RunScalaNativeTestDefinitions { this: RunTestDefinitions =>
             expect(r.exitCode == 0)
             expect(r.out.trim() == expectedOutput)
           }
-          expect(r.err.trim().contains(s"multithreadingEnabled=$expectedMultithreadingState"))
+          val outputMultithreadingState =
+            if setExplicitly then expectedMultithreadingState.toString else "detect"
+          expect(r.err.trim().contains(s"multithreadingEnabled=$outputMultithreadingState"))
         }
       }
     }

--- a/project/deps/package.mill.scala
+++ b/project/deps/package.mill.scala
@@ -134,7 +134,7 @@ object Deps {
     def scalaMeta                         = "4.14.1"
     def scalafmt                          = "3.10.4"
     def scalaNative04                     = "0.4.17"
-    def scalaNative05                     = "0.5.9"
+    def scalaNative05                     = "0.5.10"
     def scalaNative                       = scalaNative05
     def maxScalaNativeForToolkit          = scalaNative05
     def maxScalaNativeForTypelevelToolkit = scalaNative04

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1428,7 +1428,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 ### `--native-version`
 
-Set the Scala Native version (0.5.9 by default).
+Set the Scala Native version (0.5.10 by default).
 
 ### `--native-mode`
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -541,7 +541,7 @@ Add Scala Native options
 
 `//> using nativeLto full`
 
-`//> using nativeVersion 0.5.9`
+`//> using nativeVersion 0.5.10`
 
 `//> using nativeCompile -flto=thin`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -904,7 +904,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 `SHOULD have` per Scala Runner specification
 
-Set the Scala Native version (0.5.9 by default).
+Set the Scala Native version (0.5.10 by default).
 
 ### `--native-mode`
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -350,7 +350,7 @@ Add Scala Native options
 
 `//> using nativeLto full`
 
-`//> using nativeVersion 0.5.9`
+`//> using nativeVersion 0.5.10`
 
 `//> using nativeCompile -flto=thin`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -178,7 +178,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.9 by default).
+Set the Scala Native version (0.5.10 by default).
 
 **--native-mode**
 
@@ -980,7 +980,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.9 by default).
+Set the Scala Native version (0.5.10 by default).
 
 **--native-mode**
 
@@ -1583,7 +1583,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.9 by default).
+Set the Scala Native version (0.5.10 by default).
 
 **--native-mode**
 
@@ -2212,7 +2212,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.9 by default).
+Set the Scala Native version (0.5.10 by default).
 
 **--native-mode**
 
@@ -2860,7 +2860,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.9 by default).
+Set the Scala Native version (0.5.10 by default).
 
 **--native-mode**
 
@@ -3484,7 +3484,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.9 by default).
+Set the Scala Native version (0.5.10 by default).
 
 **--native-mode**
 
@@ -4145,7 +4145,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.9 by default).
+Set the Scala Native version (0.5.10 by default).
 
 **--native-mode**
 
@@ -4866,7 +4866,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.9 by default).
+Set the Scala Native version (0.5.10 by default).
 
 **--native-mode**
 
@@ -5843,7 +5843,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.9 by default).
+Set the Scala Native version (0.5.10 by default).
 
 **--native-mode**
 

--- a/website/docs/release_notes.md
+++ b/website/docs/release_notes.md
@@ -21,6 +21,34 @@ scala-cli version
 
 Added by [@Gedochao](https://github.com/Gedochao) in [#4065](https://github.com/VirtusLab/scala-cli/pull/4065)
 
+### Change default Scala Native version to 0.5.10
+This Scala CLI version switches the default Scala Native version to 0.5.10.
+
+```bash
+scala-cli -e 'println("Hello from Scala Native 0.5.10!")' --native
+# Compiling project (Scala 3.8.1, Scala Native 0.5.10)
+# Compiled project (Scala 3.8.1, Scala Native 0.5.10)
+# [info] Linking (multithreadingEnabled=detect) (725 ms)
+# [info] Discovered 903 classes and 5554 methods after classloading
+# [info] Checking intermediate code (quick) (31 ms)
+# [info] Multithreading was not explicitly enabled - initial class loading has not detected any usage of system threads. Multithreading support will be disabled to improve performance.
+# [info] Linking (multithreadingEnabled=false) (273 ms)
+# [info] Discovered 512 classes and 2629 methods after classloading
+# [info] Checking intermediate code (quick) (7 ms)
+# [info] Discovered 493 classes and 2002 methods after optimization
+# [info] Optimizing (debug mode) (447 ms)
+# [info] Produced 12 LLVM IR files
+# [info] Generating intermediate code (826 ms)
+# [info] Compiling to native code (5461 ms)
+# [info] Linking with [pthread, dl, m]
+# [info] Linking native code (immix gc, none lto) (257 ms)
+# [info] Postprocessing (0 ms)
+# [info] Total (7688 ms)
+# Hello from Scala Native 0.5.10!
+```
+
+Added by [@Gedochao](https://github.com/Gedochao) in [#4078](https://github.com/VirtusLab/scala-cli/pull/4078)
+
 ### Fixes
 * fix: openjdk:17-slim is not available. using 17.0.2-slim instead by [@kaplan-shaked](https://github.com/kaplan-shaked) in [#4057](https://github.com/VirtusLab/scala-cli/pull/4057)
 
@@ -39,6 +67,7 @@ Added by [@Gedochao](https://github.com/Gedochao) in [#4065](https://github.com/
 * Switch from `graalvm-java17` to `graalvm-community` by [@Gedochao](https://github.com/Gedochao) in [#3459](https://github.com/VirtusLab/scala-cli/pull/3459)
 * Bump Ammonite to 3.0.7 (was 3.0.6) by [@Gedochao](https://github.com/Gedochao) in [#4070](https://github.com/VirtusLab/scala-cli/pull/4070)
 * Bump Scala 3 Next RC to 3.8.2-RC1 by [@Gedochao](https://github.com/Gedochao) in [#4071](https://github.com/VirtusLab/scala-cli/pull/4071)
+* Bump Scala Native to 0.5.10 (was 0.5.9) by [@Gedochao](https://github.com/Gedochao) in [#4078](https://github.com/VirtusLab/scala-cli/pull/4078)
 
 ## New Contributors
 * [@kaplan-shaked](https://github.com/kaplan-shaked) made their first contribution in [#4057](https://github.com/VirtusLab/scala-cli/pull/4057)


### PR DESCRIPTION
https://github.com/scala-native/scala-native/releases/tag/v0.5.10
The PR also adds the mention to Scala CLI v1.12.1 release notes.