### PR TITLE
Restore Scala 2 nightlies

### DIFF
--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -206,7 +206,7 @@ class BuildOptionsTests extends TestUtil.ScalaCliBuildSuite {
     )
   }
 
-  test("-S 2.nightly option works".flaky) {
+  test("-S 2.nightly option works") {
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
         scalaVersion = Some(MaybeScalaVersion("2.nightly"))
@@ -219,7 +219,7 @@ class BuildOptionsTests extends TestUtil.ScalaCliBuildSuite {
     )
   }
 
-  test("-S 2.13.nightly option works".flaky) {
+  test("-S 2.13.nightly option works") {
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
         scalaVersion = Some(MaybeScalaVersion("2.13.nightly"))
@@ -245,7 +245,7 @@ class BuildOptionsTests extends TestUtil.ScalaCliBuildSuite {
     )
   }
 
-  test("-S 2.12.nightly option works".flaky) {
+  test("-S 2.12.nightly option works") {
     val options = BuildOptions(
       scalaOptions = ScalaOptions(
         scalaVersion = Some(MaybeScalaVersion("2.12.nightly"))

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTests213.scala
@@ -15,7 +15,7 @@ class ReplTests213 extends ReplTestDefinitions with ReplAmmoniteTestDefinitions 
         Seq.empty
     repoString = if withExplicitScala2SnapshotRepo then " with Scala 2 snapshot repo" else ""
   }
-    test(s"$dryRunPrefix repl Scala 2 snapshots: $nightlyVersion$repoString".ignore) {
+    test(s"$dryRunPrefix repl Scala 2 snapshots: $nightlyVersion$repoString") {
       dryRun(
         cliOptions = scalaVersionOptions ++ repoOptions,
         useExtraOptions = false

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTests212.scala
@@ -26,7 +26,7 @@ class RunTests212 extends RunTestDefinitions with Test212 {
       )
     }
   }
-  test("2.12.nightly".flaky) {
+  test("2.12.nightly") {
     TestInputs(os.rel / "sample.sc" -> "println(util.Properties.versionNumberString)").fromRoot {
       root =>
         val res =

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTests213.scala
@@ -22,7 +22,7 @@ class RunTests213 extends RunTestDefinitions with Test213 {
         expect(res.out.trim() == "2.13.11-20221128-143922-89f3de5")
     }
   }
-  test("2.13.nightly".flaky) {
+  test("2.13.nightly") {
     TestInputs(os.rel / "sample.sc" -> "println(util.Properties.versionNumberString)").fromRoot {
       root =>
         val res =

--- a/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
@@ -1,7 +1,5 @@
 package scala.build.options
 
-import com.github.plokhotnyuk.jsoniter_scala.core.*
-import com.github.plokhotnyuk.jsoniter_scala.macros.*
 import coursier.Versions
 import coursier.cache.{ArtifactError, FileCache}
 import coursier.core.{Module, Repository, Versions as CoreVersions}
@@ -11,7 +9,7 @@ import coursier.version.Version
 import java.io.File
 
 import scala.build.CoursierUtils.*
-import scala.build.EitherCps.{either, value}
+import scala.build.EitherCps.either
 import scala.build.RepositoryUtils
 import scala.build.errors.{
   BuildException,
@@ -77,47 +75,21 @@ object ScalaVersionUtil {
 
   object GetNightly {
 
-    private object Scala2Repo {
-      final case class ScalaVersion(name: String, lastModified: Long)
-      final case class ScalaVersionsMetaData(repo: String, children: List[ScalaVersion])
-
-      val codec: JsonValueCodec[ScalaVersionsMetaData] = JsonCodecMaker.make
-    }
-
-    private def downloadScala2RepoPage(cache: FileCache[Task])
-      : Either[BuildException, Array[Byte]] =
-      either {
-        val scala2NightlyRepo =
-          "https://scala-ci.typesafe.com/ui/api/v1/ui/nativeBrowser/scala-integration/org/scala-lang/scala-compiler"
-        val artifact = Artifact(scala2NightlyRepo).withChanging(true)
-        val res      = cache.fileWithTtl0(artifact)
-          .left.map { err =>
-            val msg =
-              """|Unable to compute the latest Scala 2 nightly version.
-                 |Throws error during downloading web page repository for Scala 2.""".stripMargin
-            new ScalaVersionError(msg, cause = err)
-          }
-
-        val res0    = value(res)
-        val content = os.read.bytes(os.Path(res0, os.pwd))
-        content
-      }
-
     def scala2(
       versionPrefix: String,
       cache: FileCache[Task]
     ): Either[BuildException, String] = either {
-      val webPageScala2Repo = value(downloadScala2RepoPage(cache))
-      val scala2Repo        = readFromArray(webPageScala2Repo)(using Scala2Repo.codec)
-      val versions          = scala2Repo.children
-      val sortedVersion     =
-        versions
-          .filter(_.name.startsWith(versionPrefix))
-          .filterNot(_.name.contains("pre"))
-          .sortBy(_.lastModified)
+      val allVersions = cache
+        .versionsWithTtl0(scala2Library, Seq(coursier.Repositories.scalaIntegration))
+        .versions.available0
+        .map(_.asString)
+      val nightlyVersions = allVersions
+        .filter(_.startsWith(versionPrefix))
+        .filterNot(_.contains("pre"))
+        .map(Version(_))
+        .sorted
 
-      val latestNightly = sortedVersion.lastOption.map(_.name)
-      latestNightly.getOrElse {
+      nightlyVersions.lastOption.map(_.repr).getOrElse {
         val msg = s"""|Unable to compute the latest Scala $versionPrefix nightly version.
                       |Pass explicitly full Scala 2 nightly version.""".stripMargin
         throw new ScalaVersionError(msg)


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/4107

Scala 2.12/2.13 nightlies are genuinely broken with the past Scala CLI versions.
The number of versions grew so much, the fetched JSON with their list is now truncated and crashes at parsing.
```
Exception in thread "main" com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException: expected '}' or ',', offset: 0x0001f91f, buf:
996-11] +----------+-------------------------------------------------+------------------+
996-11] |          |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f | 0123456789abcdef |
996-11] +----------+-------------------------------------------------+------------------+
996-11] | 0001f8f0 | 20 3a 20 30 2c 0a 20 20 20 20 22 66 6f 6c 64 65 |  : 0,.    "folde |
996-11] | 0001f900 | 72 22 20 3a 20 74 72 75 65 2c 0a 20 20 20 20 22 | r" : true,.    " |
996-11] | 0001f910 | 72 65 6d 6f 74 65 22 20 3a 20 66 7b 0a 20 20 22 | remote" : f{.  " |
996-11] | 0001f920 | 72 65 70 6f 22 20 3a 20 22 73 63 61 6c 61 2d 69 | repo" : "scala-i |
996-11] | 0001f930 | 6e 74 65 67 72 61 74 69 6f 6e 22 2c 0a 20 20 22 | ntegration",.  " |
```
This should fix it + it restores the disabled tests as well.