### PR TITLE
Fix Scala version validation to accept locally built compiler

### DIFF
--- a/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
@@ -175,7 +175,7 @@ object ScalaVersionUtil {
       else scalaVersionStringArg + "."
     val matchingVersions = versionPool.filter(_.startsWith(prefix)).map(Version(_))
     if matchingVersions.isEmpty ||
-      (isExactVersion && !matchingVersions.contains(scalaVersionStringArg))
+      (isExactVersion && !matchingVersions.exists(_.repr == scalaVersionStringArg))
     then Left(new InvalidBinaryScalaVersionError(scalaVersionStringArg))
     else {
       val supportedMatchingVersions = matchingVersions.filter(v => isSupportedVersion(v.repr))


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/4133

Well, now I feel silly.
Seems to have been introduced when I migrated to Coursier 2.1.25-M*

A proper test would require building the Scala 3 compiler on the CI, which feels overkill. Although I guess I could be convinced to do that.