### PR TITLE
Fix BSP `buildTarget/wrappedSources` for GraalVM native image

### DIFF
--- a/modules/cli/src/main/resources/META-INF/native-image/org.virtuslab/scala-cli-core/reflect-config.json
+++ b/modules/cli/src/main/resources/META-INF/native-image/org.virtuslab/scala-cli-core/reflect-config.json
@@ -1243,6 +1243,42 @@
     "allDeclaredFields": true
   },
   {
+    "name": "scala.build.bsp.ScalaScriptBuildServer",
+    "queryAllDeclaredMethods": true,
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "scala.build.bsp.WrappedSourceItem",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "scala.build.bsp.WrappedSourcesItem",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "scala.build.bsp.WrappedSourcesParams",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "scala.build.bsp.WrappedSourcesResult",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
     "name": "scala.build.bsp.protocol.TextEdit",
     "allDeclaredConstructors": true,
     "allPublicConstructors": true,

--- a/modules/integration/src/test/java/scala/cli/integration/bsp/WrappedSourceItem.java
+++ b/modules/integration/src/test/java/scala/cli/integration/bsp/WrappedSourceItem.java
@@ -1,0 +1,8 @@
+package scala.cli.integration.bsp;
+
+public class WrappedSourceItem {
+  public String uri;
+  public String generatedUri;
+  public String topWrapper;
+  public String bottomWrapper;
+}

--- a/modules/integration/src/test/java/scala/cli/integration/bsp/WrappedSourcesItem.java
+++ b/modules/integration/src/test/java/scala/cli/integration/bsp/WrappedSourcesItem.java
@@ -1,0 +1,9 @@
+package scala.cli.integration.bsp;
+
+import ch.epfl.scala.bsp4j.BuildTargetIdentifier;
+import java.util.List;
+
+public class WrappedSourcesItem {
+  public BuildTargetIdentifier target;
+  public List<WrappedSourceItem> sources;
+}

--- a/modules/integration/src/test/java/scala/cli/integration/bsp/WrappedSourcesResult.java
+++ b/modules/integration/src/test/java/scala/cli/integration/bsp/WrappedSourcesResult.java
@@ -1,0 +1,7 @@
+package scala.cli.integration.bsp;
+
+import java.util.List;
+
+public class WrappedSourcesResult {
+  public List<WrappedSourcesItem> items;
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/BspSuite.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspSuite.scala
@@ -79,7 +79,8 @@ trait BspSuite { this: ScalaCliSuite =>
     f: (
       os.Path,
       TestBspClient,
-      b.BuildServer & b.ScalaBuildServer & b.JavaBuildServer & b.JvmBuildServer
+      b.BuildServer & b.ScalaBuildServer & b.JavaBuildServer & b.JvmBuildServer &
+        TestBspClient.WrappedSourcesBuildServer
     ) => Future[T]
   ): T = withBspInitResults(
     inputs,
@@ -107,7 +108,8 @@ trait BspSuite { this: ScalaCliSuite =>
     f: (
       os.Path,
       TestBspClient,
-      b.BuildServer & b.ScalaBuildServer & b.JavaBuildServer & b.JvmBuildServer,
+      b.BuildServer & b.ScalaBuildServer & b.JavaBuildServer & b.JvmBuildServer &
+        TestBspClient.WrappedSourcesBuildServer,
       b.InitializeBuildResult
     ) => Future[T]
   ): T = {
@@ -120,8 +122,9 @@ trait BspSuite { this: ScalaCliSuite =>
 
       val proc = os.proc(TestUtil.cli, "bsp", bspOptions ++ extraOptionsOverride, args)
         .spawn(cwd = root, stderr = stderr, env = bspEnvs)
-      var remoteServer: b.BuildServer & b.ScalaBuildServer & b.JavaBuildServer & b.JvmBuildServer =
-        null
+      var remoteServer
+        : b.BuildServer & b.ScalaBuildServer & b.JavaBuildServer & b.JvmBuildServer &
+          TestBspClient.WrappedSourcesBuildServer = null
 
       val bspServerExited = Promise[Unit]()
       val t               = new Thread("bsp-server-watcher") {

--- a/modules/integration/src/test/scala/scala/cli/integration/TestBspClient.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestBspClient.scala
@@ -4,8 +4,9 @@ import ch.epfl.scala.bsp4j as b
 import org.eclipse.lsp4j.jsonrpc
 
 import java.io.{InputStream, OutputStream}
-import java.util.concurrent.ExecutorService
+import java.util.concurrent.{CompletableFuture, ExecutorService}
 
+import scala.cli.integration.bsp.WrappedSourcesResult
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
@@ -100,8 +101,14 @@ class TestBspClient extends b.BuildClient {
 
 object TestBspClient {
 
+  trait WrappedSourcesBuildServer {
+    @org.eclipse.lsp4j.jsonrpc.services.JsonRequest("buildTarget/wrappedSources")
+    def buildTargetWrappedSources(params: b.SourcesParams)
+      : CompletableFuture[WrappedSourcesResult]
+  }
+
   private trait BuildServer extends b.BuildServer with b.ScalaBuildServer with b.JavaBuildServer
-      with b.JvmBuildServer
+      with b.JvmBuildServer with WrappedSourcesBuildServer
 
   def connect(
     in: InputStream,
@@ -109,7 +116,8 @@ object TestBspClient {
     es: ExecutorService
   ): (
     TestBspClient,
-    b.BuildServer & b.ScalaBuildServer & b.JavaBuildServer & b.JvmBuildServer,
+    b.BuildServer & b.ScalaBuildServer & b.JavaBuildServer & b.JvmBuildServer &
+      WrappedSourcesBuildServer,
     Future[Unit]
   ) = {
 


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/4152