### PR TITLE
Allow to `--watch` extra paths with `--watching`

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -17,6 +17,7 @@ import scala.build.errors.*
 import scala.build.input.*
 import scala.build.internal.resource.ResourceMapper
 import scala.build.internal.{Constants, MainClass, Name, Util}
+import scala.build.internals.ConsoleUtils.ScalaCliConsole.warnPrefix
 import scala.build.options.*
 import scala.build.options.validation.ValidationException
 import scala.build.postprocessing.*
@@ -791,6 +792,7 @@ object Build {
     def doWatch(): Unit = either {
       val (crossSources: CrossSources, inputs0: Inputs) =
         value(allInputs(inputs, options, logger))
+      val mergedOptions          = crossSources.sharedOptions(options)
       val elements: Seq[Element] =
         if res == null then inputs0.elements
         else
@@ -851,6 +853,17 @@ object Build {
         watcher0.register(artifact.toNIO, depth)
         watcher0.addObserver(onChangeBufferedObserver(_ => watcher.schedule()))
       }
+
+      val extraWatchPaths = mergedOptions.watchOptions.extraWatchPaths.distinct
+      for (extraPath <- extraWatchPaths)
+        if os.exists(extraPath) then {
+          val depth    = if os.isFile(extraPath) then -1 else Int.MaxValue
+          val watcher0 = watcher.newWatcher()
+          watcher0.register(extraPath.toNIO, depth)
+          watcher0.addObserver(onChangeBufferedObserver(_ => watcher.schedule()))
+        }
+        else
+          logger.message(s"$warnPrefix provided watched path doesn't exist: $extraPath")
     }
 
     try doWatch()

--- a/modules/build/src/main/scala/scala/build/preprocessing/directives/DirectivesPreprocessingUtils.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/directives/DirectivesPreprocessingUtils.scala
@@ -31,6 +31,7 @@ object DirectivesPreprocessingUtils {
       directives.ScalaNative.handler,
       directives.ScalaVersion.handler,
       directives.Sources.handler,
+      directives.Watching.handler,
       directives.Tests.handler
     ).map(_.mapE(_.buildOptions))
 

--- a/modules/cli/src/main/scala/scala/cli/commands/compile/Compile.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/compile/Compile.scala
@@ -23,6 +23,9 @@ object Compile extends ScalaCommand[CompileOptions] with BuildCommandHelpers {
 
   override def sharedOptions(options: CompileOptions): Option[SharedOptions] = Some(options.shared)
 
+  override def buildOptions(options: CompileOptions): Some[scala.build.options.BuildOptions] =
+    Some(options.buildOptions().orExit(options.shared.logger))
+
   override def scalaSpecificationLevel: SpecificationLevel = SpecificationLevel.MUST
   val primaryHelpGroups: Seq[HelpGroup]                    =
     Seq(

--- a/modules/cli/src/main/scala/scala/cli/commands/compile/CompileOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/compile/CompileOptions.scala
@@ -23,7 +23,7 @@ final case class CompileOptions(
   @Tag(tags.should)
   @Tag(tags.inShortHelp)
     printClassPath: Boolean = false
-) extends HasSharedOptions
+) extends HasSharedOptions with HasSharedWatchOptions
   // format: on
 
 object CompileOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/PackageOptions.scala
@@ -141,7 +141,7 @@ final case class PackageOptions(
   @Tag(tags.restricted)
   @Tag(tags.inShortHelp)
     nativeImage: Boolean = false
-) extends HasSharedOptions {
+) extends HasSharedOptions with HasSharedWatchOptions {
   // format: on
 
   def packageTypeOpt: Option[PackageType] =
@@ -177,7 +177,7 @@ final case class PackageOptions(
       .left.map(CompositeBuildException(_))
 
   def baseBuildOptions(logger: Logger): Either[BuildException, BuildOptions] = either {
-    val baseOptions = value(shared.buildOptions())
+    val baseOptions = value(buildOptions())
     baseOptions.copy(
       mainClass = mainClass.mainClass.filter(_.nonEmpty),
       notForBloopOptions = baseOptions.notForBloopOptions.copy(

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -84,6 +84,9 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
   override def sharedOptions(options: PublishOptions): Option[SharedOptions] =
     Some(options.shared)
 
+  override def buildOptions(options: PublishOptions): Some[BuildOptions] =
+    Some(options.buildOptions().orExit(options.shared.logger))
+
   def mkBuildOptions(
     baseOptions: BuildOptions,
     sharedVersionOptions: SharedVersionOptions,

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
@@ -20,6 +20,9 @@ object PublishLocal extends ScalaCommand[PublishLocalOptions] {
   override def sharedOptions(options: PublishLocalOptions): Option[SharedOptions] =
     Some(options.shared)
 
+  override def buildOptions(options: PublishLocalOptions): Some[scala.build.options.BuildOptions] =
+    Some(options.buildOptions().orExit(options.shared.logger))
+
   override def names: List[List[String]] = List(
     List("publish", "local")
   )

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocalOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocalOptions.scala
@@ -22,7 +22,7 @@ final case class PublishLocalOptions(
     sharedPublish: SharedPublishOptions = SharedPublishOptions(),
   @Recurse
     scalaSigning: PgpScalaSigningOptions = PgpScalaSigningOptions(),
-) extends HasSharedOptions
+) extends HasSharedOptions with HasSharedWatchOptions
 // format: on
 
 object PublishLocalOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishOptions.scala
@@ -38,7 +38,7 @@ final case class PublishOptions(
   @Tag(tags.restricted)
   @Hidden
     parallelUpload: Option[Boolean] = None
-) extends HasSharedOptions
+) extends HasSharedOptions with HasSharedWatchOptions
 // format: on
 
 object PublishOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/Repl.scala
@@ -62,7 +62,7 @@ object Repl extends ScalaCommand[ReplOptions] with BuildCommandHelpers {
     val logger = ops.shared.logger
 
     val ammoniteVersionOpt = ammoniteVersion.map(_.trim).filter(_.nonEmpty)
-    val baseOptions        = shared.buildOptions().orExit(logger)
+    val baseOptions        = shared.buildOptions(watchOptions = watch).orExit(logger)
 
     val maybeDowngradedScalaVersion = {
       val isDefaultAmmonite = ammonite.contains(true) && ammoniteVersionOpt.isEmpty

--- a/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
@@ -71,7 +71,7 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
     import options.*
     import options.sharedRun.*
     val logger      = options.shared.logger
-    val baseOptions = shared.buildOptions().orExit(logger)
+    val baseOptions = options.buildOptions().orExit(logger)
     baseOptions.copy(
       mainClass = mainClass.mainClass,
       javaOptions = baseOptions.javaOptions.copy(

--- a/modules/cli/src/main/scala/scala/cli/commands/run/RunOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/RunOptions.scala
@@ -4,7 +4,9 @@ import caseapp.*
 import caseapp.core.help.Help
 
 import scala.cli.ScalaCli
-import scala.cli.commands.shared.{HasSharedOptions, HelpMessages, SharedOptions}
+import scala.cli.commands.shared.{
+  HasSharedOptions, HasSharedWatchOptions, HelpMessages, SharedOptions, SharedWatchOptions
+}
 
 @HelpMessage(RunOptions.helpMessage, "", RunOptions.detailedHelpMessage)
 // format: off
@@ -13,8 +15,10 @@ final case class RunOptions(
     shared: SharedOptions = SharedOptions(),
   @Recurse
     sharedRun: SharedRunOptions = SharedRunOptions()
-) extends HasSharedOptions
-// format: on
+) extends HasSharedOptions with HasSharedWatchOptions {
+  // format: on
+  override def watch: SharedWatchOptions = sharedRun.watch
+}
 
 object RunOptions {
   implicit lazy val parser: Parser[RunOptions] = Parser.derive

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/HasSharedWatchOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/HasSharedWatchOptions.scala
@@ -1,0 +1,11 @@
+package scala.cli.commands.shared
+
+import scala.build.errors.BuildException
+
+trait HasSharedWatchOptions { this: HasSharedOptions =>
+  def watch: SharedWatchOptions
+
+  def buildOptions(ignoreErrors: Boolean =
+    false): Either[BuildException, scala.build.options.BuildOptions] =
+    shared.buildOptions(ignoreErrors = ignoreErrors, watchOptions = watch)
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -290,7 +290,10 @@ final case class SharedOptions(
 
   def scalacOptions: List[String] = scalac.scalacOption ++ scalacOptionsFromFiles
 
-  def buildOptions(ignoreErrors: Boolean = false)
+  def buildOptions(
+    ignoreErrors: Boolean = false,
+    watchOptions: SharedWatchOptions = SharedWatchOptions()
+  )
     : Either[BuildException, scala.build.options.BuildOptions] =
     either {
       val releaseOpt = scalacOptions.getScalacOption("-release")
@@ -441,7 +444,7 @@ final case class SharedOptions(
           scalaPyVersion = sharedPython.scalaPyVersion
         ),
         useBuildServer = compilationServer.server
-      )
+      ).orElse(watchOptions.buildOptions())
     }
 
   private def resolvedDependencies(

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedWatchOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedWatchOptions.scala
@@ -2,6 +2,7 @@ package scala.cli.commands.shared
 
 import caseapp.*
 
+import scala.build.options.{BuildOptions, WatchOptions}
 import scala.cli.commands.tags
 
 // format: off
@@ -18,10 +19,22 @@ final case class SharedWatchOptions(
   @Tag(tags.should)
   @Tag(tags.inShortHelp)
   @Name("revolver")
-    restart: Boolean = false
+    restart: Boolean = false,
+  @Group(HelpGroup.Watch.toString)
+  @HelpMessage("Watch additional paths for changes (used together with --watch or --restart)")
+  @Tag(tags.experimental)
+  @Name("watchingPath")
+    watching: List[String] = Nil
 ) { // format: on
 
   lazy val watchMode: Boolean = watch || restart
+
+  def buildOptions(cwd: os.Path = os.pwd): BuildOptions =
+    BuildOptions(
+      watchOptions = WatchOptions(
+        extraWatchPaths = watching.map(os.Path(_, cwd))
+      )
+    )
 }
 
 object SharedWatchOptions {

--- a/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
@@ -37,7 +37,7 @@ object Test extends ScalaCommand[TestOptions] {
 
   override def buildOptions(opts: TestOptions): Option[BuildOptions] = Some {
     import opts.*
-    val baseOptions = shared.buildOptions().orExit(opts.shared.logger)
+    val baseOptions = shared.buildOptions(watchOptions = watch).orExit(opts.shared.logger)
     baseOptions.copy(
       javaOptions = baseOptions.javaOptions.copy(
         javaOpts =

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Watching.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Watching.scala
@@ -1,0 +1,48 @@
+package scala.build.preprocessing.directives
+
+import scala.build.Positioned
+import scala.build.directives.*
+import scala.build.errors.BuildException
+import scala.build.options.{BuildOptions, WatchOptions}
+import scala.cli.commands.SpecificationLevel
+
+@DirectiveGroupName("Watch additional inputs")
+@DirectiveExamples("//> using watching ./data")
+@DirectiveUsage(
+  """//> using watching _path_
+    |
+    |//> using watching _path1_ _path2_ …""".stripMargin,
+  """`//> using watching` _path_
+    |
+    |`//> using watching` _path1_ _path2_ …
+    |
+    |""".stripMargin
+)
+@DirectiveDescription("Watch additional files or directories when using watch mode")
+@DirectiveLevel(SpecificationLevel.EXPERIMENTAL)
+final case class Watching(
+  watching: DirectiveValueParser.WithScopePath[List[Positioned[String]]] =
+    DirectiveValueParser.WithScopePath.empty(Nil)
+) extends HasBuildOptions {
+  def buildOptions: Either[BuildException, BuildOptions] =
+    Watching.buildOptions(watching)
+}
+
+object Watching {
+  val handler: DirectiveHandler[Watching] = DirectiveHandler.derive
+
+  def buildOptions(
+    watching: DirectiveValueParser.WithScopePath[List[Positioned[String]]]
+  ): Either[BuildException, BuildOptions] = Right {
+    val paths         = watching.value.map(_.value)
+    val (_, rootOpt)  = Directive.osRootResource(watching.scopePath)
+    val resolvedPaths = rootOpt.toList.flatMap { root =>
+      paths.map(os.Path(_, root))
+    }
+    BuildOptions(
+      watchOptions = WatchOptions(
+        extraWatchPaths = resolvedPaths
+      )
+    )
+  }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -4,7 +4,9 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import java.io.File
 
+import scala.cli.integration.TestUtil.ProcOps
 import scala.cli.integration.util.BloopUtil
+import scala.concurrent.duration.DurationInt
 import scala.util.Properties
 
 abstract class CompileTestDefinitions
@@ -907,4 +909,43 @@ abstract class CompileTestDefinitions
       )
     }
   }
+
+  if (!Properties.isMac || !TestUtil.isCI)
+    test("--watching with --watch re-compiles on external file change") {
+      val sourceFile   = os.rel / "Main.scala"
+      val externalFile = os.rel / "data" / "input.txt"
+      TestInputs(
+        sourceFile ->
+          """object Main {
+            |  def value = 1
+            |}
+            |""".stripMargin,
+        externalFile -> "Hello"
+      ).fromRoot { root =>
+        TestUtil.withProcessWatching(
+          proc = os.proc(
+            TestUtil.cli,
+            "--power",
+            "compile",
+            ".",
+            "--watch",
+            "--watching",
+            "data",
+            extraOptions
+          )
+            .spawn(cwd = root, stderr = os.Pipe),
+          timeout = 120.seconds
+        ) { (proc, timeout, ec) =>
+          implicit val ec0  = ec
+          val initialOutput = proc.readStderrUntilWatchingMessage(timeout)
+          expect(initialOutput.exists(_.contains("Compiled")))
+
+          Thread.sleep(2000L)
+          os.write.over(root / externalFile, "World")
+
+          val rerunOutput = proc.readStderrUntilWatchingMessage(timeout)
+          expect(rerunOutput.nonEmpty)
+        }
+      }
+    }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -9,6 +9,7 @@ import java.util
 import java.util.zip.ZipFile
 
 import scala.cli.integration.TestUtil.*
+import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters.*
 import scala.util.{Properties, Using}
 
@@ -1561,6 +1562,47 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
           os.proc(TestUtil.cli, "package", ".", "--js", "--power", extraOptions)
             .call(cwd = root, mergeErrIntoOut = true, stderr = os.Pipe)
         expect(res.out.trim().contains(s"$moduleName.js"))
+      }
+    }
+
+  if (!Properties.isMac || !TestUtil.isCI)
+    test("--watching with --watch re-packages on external file change") {
+      val sourceFile   = os.rel / "Main.scala"
+      val externalFile = os.rel / "data" / "input.txt"
+      TestInputs(
+        sourceFile ->
+          """object Main extends App {
+            |  println("Hello")
+            |}
+            |""".stripMargin,
+        externalFile -> "Hello"
+      ).fromRoot { root =>
+        TestUtil.withProcessWatching(
+          proc = os.proc(
+            TestUtil.cli,
+            "--power",
+            "package",
+            ".",
+            "--watch",
+            "--watching",
+            "data",
+            "-o",
+            "app",
+            extraOptions
+          )
+            .spawn(cwd = root, mergeErrIntoOut = true),
+          timeout = 120.seconds
+        ) { (proc, timeout, ec) =>
+          implicit val ec0  = ec
+          val initialOutput = proc.readOutputUntilWatchingMessage(timeout)
+          expect(initialOutput.exists(_.contains("Wrote")))
+
+          Thread.sleep(2000L)
+          os.write.over(root / externalFile, "World")
+
+          val rerunOutput = proc.readOutputUntilWatchingMessage(timeout)
+          expect(rerunOutput.nonEmpty)
+        }
       }
     }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunWithWatchTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunWithWatchTestDefinitions.scala
@@ -77,6 +77,135 @@ trait RunWithWatchTestDefinitions { this: RunTestDefinitions =>
       }
   }
 
+  if (!Properties.isMac || !TestUtil.isCI) {
+    test("--watching with CLI option triggers re-run on external file change") {
+      val sourceFile   = os.rel / "app.scala"
+      val externalFile = os.rel / "data" / "input.txt"
+      val code         =
+        """object App {
+          |  def main(args: Array[String]): Unit = {
+          |    val content = scala.io.Source.fromFile("data/input.txt").mkString.trim
+          |    println(content)
+          |  }
+          |}
+          |""".stripMargin
+
+      TestInputs(
+        sourceFile   -> code,
+        externalFile -> "Hello"
+      ).fromRoot { root =>
+        TestUtil.withProcessWatching(
+          proc = os.proc(
+            TestUtil.cli,
+            "--power",
+            "run",
+            ".",
+            "--watch",
+            "--watching",
+            "data",
+            extraOptions
+          )
+            .spawn(cwd = root, stderr = os.Pipe),
+          timeout = 120.seconds
+        ) { (proc, timeout, ec) =>
+          val output1 = TestUtil.readLine(proc.stdout, ec, timeout)
+          expect(output1 == "Hello")
+          proc.printStderrUntilRerun(timeout)(ec)
+          Thread.sleep(2000L)
+          os.write.over(root / externalFile, "World")
+          val output2 = TestUtil.readLine(proc.stdout, ec, timeout)
+          expect(output2 == "World")
+        }
+      }
+    }
+
+    test("//> using watching directive triggers re-run on external file change") {
+      val sourceFile   = os.rel / "app.scala"
+      val externalFile = os.rel / "data" / "input.txt"
+      val code         =
+        """//> using watching ./data
+          |object App {
+          |  def main(args: Array[String]): Unit = {
+          |    val content = scala.io.Source.fromFile("data/input.txt").mkString.trim
+          |    println(content)
+          |  }
+          |}
+          |""".stripMargin
+
+      TestInputs(
+        sourceFile   -> code,
+        externalFile -> "Hello"
+      ).fromRoot { root =>
+        TestUtil.withProcessWatching(
+          proc = os.proc(TestUtil.cli, "--power", "run", ".", "--watch", extraOptions)
+            .spawn(cwd = root, stderr = os.Pipe),
+          timeout = 120.seconds
+        ) { (proc, timeout, ec) =>
+          val output1 = TestUtil.readLine(proc.stdout, ec, timeout)
+          expect(output1 == "Hello")
+          proc.printStderrUntilRerun(timeout)(ec)
+          Thread.sleep(2000L)
+          os.write.over(root / externalFile, "World")
+          val output2 = TestUtil.readLine(proc.stdout, ec, timeout)
+          expect(output2 == "World")
+        }
+      }
+    }
+
+    test("--watching CLI + //> using watching directive union") {
+      val sourceFile         = os.rel / "app.scala"
+      val directiveWatchFile = os.rel / "data1" / "input1.txt"
+      val cliWatchFile       = os.rel / "data2" / "input2.txt"
+      val code               =
+        """//> using watching ./data1
+          |object App {
+          |  def main(args: Array[String]): Unit = {
+          |    val fromDirective = scala.io.Source.fromFile("data1/input1.txt").mkString.trim
+          |    val fromCli = scala.io.Source.fromFile("data2/input2.txt").mkString.trim
+          |    println(s"$fromDirective|$fromCli")
+          |  }
+          |}
+          |""".stripMargin
+
+      TestInputs(
+        sourceFile         -> code,
+        directiveWatchFile -> "Hello",
+        cliWatchFile       -> "World"
+      ).fromRoot { root =>
+        TestUtil.withProcessWatching(
+          proc =
+            os.proc(
+              TestUtil.cli,
+              "--power",
+              "run",
+              ".",
+              "--watch",
+              "--watching",
+              "data2",
+              extraOptions
+            )
+              .spawn(cwd = root, stderr = os.Pipe),
+          timeout = 120.seconds
+        ) { (proc, timeout, ec) =>
+          val output1 = TestUtil.readLine(proc.stdout, ec, timeout)
+          expect(output1 == "Hello|World")
+
+          proc.printStderrUntilRerun(timeout)(ec)
+          Thread.sleep(2000L)
+          os.write.over(root / directiveWatchFile, "Bonjour")
+          val output2 = TestUtil.readLine(proc.stdout, ec, timeout)
+          expect(output2 == "Bonjour|World")
+
+          proc.printStderrUntilRerun(timeout)(ec)
+          Thread.sleep(2000L)
+          os.write.over(root / cliWatchFile, "Universe")
+          val output3 = TestUtil.readLine(proc.stdout, ec, timeout)
+          expect(output3 == "Bonjour|Universe")
+        }
+      }
+    }
+  }
+
   for {
     (platformDescription, platformOpts) <- Seq(
       "JVM"    -> Nil,

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -4,7 +4,9 @@ import com.eed3si9n.expecty.Expecty.expect
 
 import scala.annotation.tailrec
 import scala.cli.integration.Constants.munitVersion
-import scala.cli.integration.TestUtil.StringOps
+import scala.cli.integration.TestUtil.{ProcOps, StringOps}
+import scala.concurrent.duration.DurationInt
+import scala.util.Properties
 
 abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
   this: TestScalaVersion =>
@@ -231,6 +233,51 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
       expect(output.contains("Hello from tests"))
     }
   }
+
+  if (!Properties.isMac || !TestUtil.isCI)
+    test("--watching with --watch re-runs tests on external file change") {
+      val sourceFile   = os.rel / "MyTests.test.scala"
+      val externalFile = os.rel / "data" / "input.txt"
+      TestInputs(
+        sourceFile ->
+          s"""//> using dep org.scalameta::munit::$munitVersion
+             |
+             |class MyTests extends munit.FunSuite {
+             |  test("watched input") {
+             |    val content = scala.io.Source.fromFile("data/input.txt").mkString.trim
+             |    println(content)
+             |    assert(content.nonEmpty)
+             |  }
+             |}
+             |""".stripMargin,
+        externalFile -> "Hello"
+      ).fromRoot { root =>
+        TestUtil.withProcessWatching(
+          proc = os.proc(
+            TestUtil.cli,
+            "--power",
+            "test",
+            ".",
+            "--watch",
+            "--watching",
+            "data",
+            extraOptions
+          )
+            .spawn(cwd = root, mergeErrIntoOut = true),
+          timeout = 120.seconds
+        ) { (proc, timeout, ec) =>
+          implicit val ec0  = ec
+          val initialOutput = proc.readOutputUntilWatchingMessage(timeout)
+          expect(initialOutput.exists(_.contains("Hello")))
+
+          Thread.sleep(2000L)
+          os.write.over(root / externalFile, "World")
+
+          val rerunOutput = proc.readOutputUntilWatchingMessage(timeout)
+          expect(rerunOutput.exists(_.contains("World")))
+        }
+      }
+    }
 
   if (actualScalaVersion.startsWith("2"))
     test("successful test JVM 8") {

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -408,6 +408,26 @@ object TestUtil {
     while (!revertTriggered()) Thread.sleep(100L)
   }
 
+  def readLinesUntil(
+    stream: os.SubProcess.OutputStream,
+    ec: ExecutionContext,
+    timeout: Duration
+  )(condition: String => Boolean): Seq[String] = {
+    val lines = scala.collection.mutable.ListBuffer.empty[String]
+    var done  = false
+    while (!done) {
+      val line = TestUtil.readLine(stream, ec, timeout)
+      if (line == null) done = true
+      else {
+        lines += line
+        done = condition(line)
+      }
+    }
+    lines.toSeq
+  }
+
+  private val watchingSourcesCondition: String => Boolean = _.contains("Watching sources")
+
   implicit class ProcOps(proc: os.SubProcess) {
     def printStderrUntilJlineRevertsToDumbTerminal(proc: os.SubProcess)(
       f: String => Unit
@@ -416,6 +436,16 @@ object TestUtil {
 
     def printStderrUntilRerun(timeout: Duration)(implicit ec: ExecutionContext): Unit =
       TestUtil.printStderrUntilCondition(proc, timeout)(_.contains("re-run"))()
+
+    def readStderrUntilWatchingMessage(timeout: Duration)(implicit
+      ec: ExecutionContext
+    ): Seq[String] =
+      TestUtil.readLinesUntil(proc.stderr, ec, timeout)(watchingSourcesCondition)
+
+    def readOutputUntilWatchingMessage(timeout: Duration)(implicit
+      ec: ExecutionContext
+    ): Seq[String] =
+      TestUtil.readLinesUntil(proc.stdout, ec, timeout)(watchingSourcesCondition)
   }
 
   // based on the implementation from bloop-rifle:

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -46,6 +46,7 @@ final case class BuildOptions(
   mainClass: Option[String] = None,
   testOptions: TestOptions = TestOptions(),
   notForBloopOptions: PostBuildOptions = PostBuildOptions(),
+  watchOptions: WatchOptions = WatchOptions(),
   sourceGeneratorOptions: SourceGeneratorOptions = SourceGeneratorOptions(),
   useBuildServer: Option[Boolean] = None
 ) {

--- a/modules/options/src/main/scala/scala/build/options/WatchOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/WatchOptions.scala
@@ -1,0 +1,10 @@
+package scala.build.options
+
+final case class WatchOptions(
+  extraWatchPaths: Seq[os.Path] = Nil
+)
+
+object WatchOptions {
+  implicit val hasHashData: HasHashData[WatchOptions] = HasHashData.nop
+  implicit val monoid: ConfigMonoid[WatchOptions]     = ConfigMonoid.derive
+}

--- a/website/docs/commands/compile.md
+++ b/website/docs/commands/compile.md
@@ -64,6 +64,22 @@ Watching sources, press Ctrl+C to exit.
 
 </ChainedSnippets>
 
+### Watching additional paths
+
+Use `--watching` to re-trigger compilation when files outside your Scala sources change:
+
+```bash ignore
+scala-cli compile --watch --watching ./data Hello.scala
+```
+
+You can also configure this from sources with:
+
+```scala
+//> using watching ./data
+```
+
+If you use both, Scala CLI watches every path from both the command line and the directive.
+
 ## Scala version
 
 Scala CLI uses the latest stable version of Scala which was tested in Scala CLI (see our list

--- a/website/docs/commands/package.md
+++ b/website/docs/commands/package.md
@@ -56,6 +56,28 @@ Hello
 Hello
 -->
 
+## Watch mode
+
+Use `--watch` to rebuild the package whenever sources change:
+
+```bash ignore
+scala-cli --power package --watch Hello.scala -o hello
+```
+
+You can watch additional inputs too:
+
+```bash ignore
+scala-cli --power package --watch --watching ./data Hello.scala -o hello
+```
+
+This also works from sources:
+
+```scala
+//> using watching ./data
+```
+
+When both are present, Scala CLI watches all of the configured paths.
+
 ## Library JARs
 
 *Library JARs* are suitable if you plan to put the resulting JAR in a class path, rather than running it as is.

--- a/website/docs/commands/repl.md
+++ b/website/docs/commands/repl.md
@@ -80,6 +80,26 @@ scala> :quit
 
 </ChainedSnippets>
 
+## Watch mode
+
+Use `--watch` to recompile your inputs and restart the REPL session when sources change:
+
+```bash ignore
+scala-cli repl --watch Main.scala
+```
+
+`--watching` lets you include additional files or directories:
+
+```bash ignore
+scala-cli repl --watch --watching ./data Main.scala
+```
+
+You can also configure extra watched paths in sources:
+
+```scala
+//> using watching ./data
+```
+
 ## Passing REPL options
 It is also possible to manually pass REPL-specific options.
 It can be done in a couple ways:

--- a/website/docs/commands/run.md
+++ b/website/docs/commands/run.md
@@ -227,6 +227,22 @@ Watching sources while your program is running.
 
 </ChainedSnippets>
 
+### Watching additional paths
+
+`--watching` lets you specify additional files or directories to watch while using `--watch` or `--restart`:
+
+```bash ignore
+scala-cli run --watch --watching ./data --watching ./templates Hello.scala
+```
+
+You can also declare extra watched paths from your sources:
+
+```scala
+//> using watching ./data
+```
+
+When both `--watching` and `//> using watching` are used, Scala CLI watches all of the specified paths.
+
 ## Scala.js
 
 Scala.js applications can also be compiled and run with the `--js` option.

--- a/website/docs/commands/test.md
+++ b/website/docs/commands/test.md
@@ -171,6 +171,28 @@ tests.only.BarTests:
 + bar
 -->
 
+## Watch mode
+
+Use `--watch` to re-run your tests whenever sources change:
+
+```bash ignore
+scala-cli test --watch MyTests.test.scala
+```
+
+`--watching` can extend that to files or directories outside your Scala sources:
+
+```bash ignore
+scala-cli test --watch --watching ./data MyTests.test.scala
+```
+
+You can declare the same extra watched paths from sources:
+
+```scala
+//> using watching ./data
+```
+
+If both are used, Scala CLI watches all of the configured paths.
+
 ## Filter test case
 
 ### Munit

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1957,6 +1957,12 @@ Aliases: `--revolver`
 
 Run the application in the background, automatically kill the process and restart if sources have been changed
 
+### `--watching`
+
+Aliases: `--watching-path`
+
+Watch additional paths for changes (used together with --watch or --restart)
+
 ## Internal options 
 ### Add path options
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -695,6 +695,19 @@ Use a toolkit as dependency (not supported in Scala 2.12), 'default' version for
 
 `//> using test.toolkit default`
 
+### Watch additional inputs
+
+Watch additional files or directories when using watch mode
+
+`//> using watching` _path_
+
+`//> using watching` _path1_ _path2_ …
+
+
+
+#### Examples
+`//> using watching ./data`
+
 
 ## target directives
 


### PR DESCRIPTION
Fixes #2059 

Adds the `--watching` option / `//> using watching <file-path>` directive for adding non-source paths which should be watched when in `--watch` mode.

```bash
scala-cli run . --watch --watching <external-path>
```

```scala
//> using watching <external-path>
```