### PR TITLE
Add LLM policy & a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+<!-- Fixes #XYZ (where XYZ is the issue number from the issue tracker) -->
+
+<!-- TODO description of the change -->
+
+<!-- if the PR is still a WIP, create it as a draft PR (or convert it into one) -->
+
+## Checklist
+- [ ] tested the solution locally and it works 
+- [ ] ran the code formatter (`scala-cli fmt .`)
+- [ ] ran `scalafix` (`./mill -i __.fix`)
+- [ ] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)
+
+## How much have your relied on LLM-based tools in this contribution?
+
+<!-- 
+  State clearly in the pull request description, 
+  whether LLM-based tools were used and to what extent 
+
+  (extensively/moderately/minimally/not at all)
+-->
+
+<!--
+  Refer to our [LLM usage policy](https://github.com/scala/scala3/blob/main/LLM_POLICY.md) for rules and guidelines
+  regarding usage of LLM-based tools in contributions.
+-->
+
+## How was the solution tested?
+
+<!-- 
+  If automated tests are included, mention it.
+  If they are not, explain why and how the solution was tested.
+-->
+
+## Additional notes
+
+<!-- Placeholder for any extra context regarding this contribution. -->
+
+<!-- When in doubt, check[our contribution guide](https://github.com/VirtusLab/scala-cli/blob/main/CONTRIBUTING.md) -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,9 @@ A subsequent PR from `stable` back to `main` is created automatically.
 Whenever reasonable, we try to follow the following set of rules when merging code to the repository. Following those
 will save you from getting a load of comments and speed up the code review.
 
+- If you are using LLM-based tools to assist you in your contribution, state that clearly in the PR description 
+  and refer to our [LLM usage policy](LLM_POLICY.md) for rules and guidelines regarding usage of LLM-based tools 
+  in contributions.
 - If the PR is meant to be merged as a single commit (`squash & merge`), please make sure that you modify only one
   thing.
     - This means such a PR shouldn't include code clean-up, a secondary feature or bug fix, just the single thing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ will save you from getting a load of comments and speed up the code review.
 
 Other notes:
 
-- give a short explanation on what the PR is meant to achieve in the description, unless covered by the PR title;
+- fill the pull request template;
 - make sure to add tests wherever possible;
     - favor unit tests over integration tests where applicable;
 - try to add scaladocs for key classes and functions;

--- a/LLM_POLICY.md
+++ b/LLM_POLICY.md
@@ -1,0 +1,7 @@
+# Policy regarding LLM-generated code in contributions to Scala CLI
+
+Scala CLI accepts contributions containing code produced with AI assistance. This means that using LLM-based
+tooling aiding software development (like Cursor, Claude Code, Copilot or whatever else) is allowed.
+
+All such contributions are regulated by the policy defined in the Scala 3 compiler repository, which can be found at:
+https://github.com/scala/scala3/blob/main/LLM_POLICY.md


### PR DESCRIPTION
This refers the `LLM_POLICY.md` file from the Scala 3 compiler repo & adds a PR template similar to the one in the compiler.

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
not at all

## How was the solution tested?
These are just dev docs.

## Additional notes
- https://github.com/scala/scala3/pull/25326
- https://github.com/scala/scala3/pull/25348
