### PR TITLE
Add `AGENTS.md`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,165 @@
+# AGENTS.md — Guidance for AI agents contributing to Scala CLI
+
+Short reference for AI agents. For task-specific guidance (directives, integration tests), load skills from *
+*[agentskills/](agentskills/)** when relevant.
+
+> **LLM Policy**: All AI-assisted contributions must comply with the
+> [LLM usage policy](https://github.com/scala/scala3/blob/HEAD/LLM_POLICY.md). The contributor (human) is responsible
+> for every line. State LLM usage in the PR description. See [LLM_POLICY.md](LLM_POLICY.md).
+
+## Human-facing docs
+
+- **[DEV.md](DEV.md)**                   — Setup, run from source, tests, launchers, GraalVM.
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — PR workflow, formatting, reference doc generation.
+- **[INTERNALS.md](INTERNALS.md)**       — Modules, `Inputs → Sources → Build`, preprocessing.
+
+## Build system
+
+The project uses [Mill](https://mill-build.org/). Mill launchers ship with the repo (`./mill`). JVM 17 required.
+Cross-compilation: default `Scala.defaultInternal`; `[]` = default version, `[_]` = all.
+
+### Key build files
+
+| File                            | Purpose                                                                                  |
+|---------------------------------|------------------------------------------------------------------------------------------|
+| `build.mill`                    | Root build definition: all module declarations, CI helper tasks, integration test wiring |
+| `project/deps/package.mill`     | Dependency versions and definitions (`Deps`, `Scala`, `Java` objects)                    |
+| `project/settings/package.mill` | Shared traits, utils (`HasTests`, `CliLaunchers`, `FormatNativeImageConf`, etc.)         |
+| `project/publish/package.mill`  | Publishing settings                                                                      |
+| `project/website/package.mill`  | Website-related build tasks                                                              |
+
+### Essential commands
+
+```bash
+./mill -i clean                                                           # Clean Mill context
+./mill -i scala …args…                                                    # Run Scala CLI from source
+./mill -i __.compile                                                      # Compile everything
+./mill -i unitTests                                                       # All unit tests
+./mill -i 'build-module[].test'                                           # Unit tests for a specific module
+./mill -i 'build-module[].test' 'scala.build.tests.BuildTestsScalac.*'    # Filter by suite
+./mill -i 'build-module[].test' 'scala.build.tests.BuildTests.simple'     # Single test by name
+./mill -i integration.test.jvm                                            # Integration tests (JVM launcher)
+./mill -i integration.test.jvm 'scala.cli.integration.RunTestsDefault.*'  # Integration: filter by suite
+./mill -i 'generate-reference-doc[]'.run                                  # Regenerate reference docs
+./mill -i __.fix                                                          # Fix import ordering (scalafix)
+scala-cli fmt .                                                           # Format all code (scalafmt)
+```
+
+## Project modules
+
+Modules live under `modules/`. The dependency graph flows roughly as:
+
+```
+specification-level → config → core → options → directives → build-module → cli
+```
+
+### Module overview
+
+The list below may not be exhaustive — check `modules/` and `build.mill` for the current set.
+
+| Module                                        | Purpose                                                                                                          |
+|-----------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| `specification-level`                         | Defines `SpecificationLevel` (MUST / SHOULD / IMPLEMENTATION / RESTRICTED / EXPERIMENTAL) for SIP-46 compliance. |
+| `config`                                      | Scala CLI configuration keys and persistence.                                                                    |
+| `build-macros`                                | Compile-time macros (e.g. `EitherCps`).                                                                          |
+| `core`                                        | Core types: `Inputs`, `Sources`, build constants, Bloop integration, JVM/JS/Native tooling.                      |
+| `options`                                     | `BuildOptions`, `SharedOptions`, and all option types.                                                           |
+| `directives`                                  | Using directive handlers — the bridge between `//> using` directives and `BuildOptions`.                         |
+| `build-module` (aliased from `build` in mill) | The main build pipeline: preprocessing, compilation, post-processing. Most business logic lives here.            |
+| `cli`                                         | Command definitions, argument parsing (CaseApp), the `ScalaCli` entry point. Packaged as the native image.       |
+| `runner`                                      | Lightweight app that runs a main class and pretty-prints exceptions. Fetched at runtime.                         |
+| `test-runner`                                 | Discovers and runs test frameworks/suites. Fetched at runtime.                                                   |
+| `tasty-lib`                                   | Edits file names in `.tasty` files for source mapping.                                                           |
+| `scala-cli-bsp`                               | BSP protocol types.                                                                                              |
+| `integration`                                 | Integration tests (see dedicated section below).                                                                 |
+| `docs-tests`                                  | Tests that validate documentation (`Sclicheck`).                                                                 |
+| `generate-reference-doc`                      | Generates reference documentation from CLI option/directive metadata.                                            |
+
+## Specification levels
+
+Every command, CLI option, and using directive has a `SpecificationLevel`. This is central to how features are exposed.
+
+| Level            | In the Scala Runner spec? | Available without `--power`? | Stability                       |
+|------------------|---------------------------|------------------------------|---------------------------------|
+| `MUST`           | Yes                       | Yes                          | Stable                          |
+| `SHOULD`         | Yes                       | Yes                          | Stable                          |
+| `IMPLEMENTATION` | No                        | Yes                          | Stable                          |
+| `RESTRICTED`     | No                        | No (requires `--power`)      | Stable                          |
+| `EXPERIMENTAL`   | No                        | No (requires `--power`)      | Unstable — may change/disappear |
+
+**New features contributed by agents should generally be marked `EXPERIMENTAL`** unless the maintainers explicitly
+request otherwise. This applies to new sub-commands, options, and directives alike.
+
+The specification level is set via:
+
+- **Directives**: `@DirectiveLevel(SpecificationLevel.EXPERIMENTAL)` annotation on the directive case class.
+- **CLI options**: `@Tag(tags.experimental)` annotation on option fields.
+- **Commands**: Override `scalaSpecificationLevel` in the command class.
+
+## Using directives
+
+Using directives are in-source configuration comments:
+
+```scala
+//> using scala 3
+//> using dep com.lihaoyi::os-lib:0.11.4
+//> using test.dep org.scalameta::munit::1.1.1
+```
+
+Directives are parsed by `using_directives`, then `ExtractedDirectives` → `DirectivesPreprocessor` → `BuildOptions`/
+`BuildRequirements`. **CLI options override directive values.** To add a new directive,
+see [agentskills/adding-directives/](agentskills/adding-directives/SKILL.md).
+
+## Testing
+
+> **Every contribution that changes logic must include automated tests.** A PR without tests for
+> new or changed behavior will not be accepted. If testing is truly infeasible, explain why in the
+> PR description — but this should be exceptional.
+
+> **Unit tests are always preferred over integration tests.** Unit tests are faster, more reliable,
+> easier to debug, and cheaper to run on CI. Only add integration tests when the behavior cannot be
+> adequately verified at the unit level (e.g. end-to-end CLI invocation, launcher-specific behavior,
+> cross-process interactions).
+
+> **Always re-run and verify tests locally before submitting.** After any logic change, run the
+> relevant test suites on your machine and confirm they pass. Do not rely on CI to catch failures —
+> CI resources are shared, and broken PRs waste maintainer time.
+
+**Unit tests**: munit, in each module’s `test` submodule. Run commands above; add tests in `modules/build/.../tests/` or
+`modules/cli/src/test/scala/`. Prefer unit over integration.
+
+**Integration tests**: `modules/integration/`; they run the CLI as a subprocess.
+See [agentskills/integration-tests/](agentskills/integration-tests/SKILL.md) for structure and how to add tests.
+
+## Pre-PR checklist
+
+1. Code compiles: `./mill -i __.compile`
+2. Tests added and passing locally (unit tests first, integration if needed)
+3. Code formatted: `scala-cli fmt .`
+4. Imports ordered: `./mill -i __.fix`
+5. Reference docs regenerated (if options/directives changed): `./mill -i 'generate-reference-doc[]'.run`
+6. PR template filled, LLM usage stated
+
+## Code style
+
+Code style is enforced.
+
+**Scala 3**: Prefer `if … then … else`, `for … do`/`yield`, `enum`, `extension`, `given`/`using`, braceless blocks,
+top-level defs. Use union/intersection types when they simplify signatures. Always favor Scala 3 idiomatic syntax.
+
+**Functional**: Prefer `val`, immutable collections, `case class`.copy(). Prefer expressions over statements; prefer
+`map`/`flatMap`/`fold`/`for`-comprehensions over loops. Use `@tailrec` for tail recursion. Avoid `null`; use `Option`/
+`Either`/`EitherCps` (build-macros). Keep functions small; extract helpers.
+
+**No duplication**: Extract repeated logic into shared traits or utils (`*Options` traits, companion helpers,
+`CommandHelpers`, `TestUtil`). Check for existing abstractions before copying.
+
+**Logging**: Use the project `Logger` only — never `System.err` or `System.out`. Logger respects verbosity (`-v`, `-q`).
+Use `logger.message(msg)` (default), `logger.log(msg)` (verbose), `logger.debug(msg)` (debug), `logger.error(msg)` (
+always). In commands: `options.shared.logging.logger`; in build code it is passed in; in tests use `TestLogger`.
+
+**Mutability**: OK in hot paths or when a Java API requires it; keep scope minimal.
+
+## Further reference
+
+[DEV.md](DEV.md), [CONTRIBUTING.md](CONTRIBUTING.md), [INTERNALS.md](INTERNALS.md).

--- a/agentskills/README.md
+++ b/agentskills/README.md
@@ -1,0 +1,5 @@
+# Agent skills (Scala CLI)
+
+This directory holds **agent skills** — task-specific guidance loaded on demand by AI coding agents. The layout is tool-agnostic; Cursor, Claude Code, Codex, and other tools that support a standard skill directory can use this (e.g. by configuring or symlinking to `.agents/skills/` if required).
+
+Each subdirectory contains a `SKILL.md` with frontmatter and instructions. See [agentskills/agentskills](https://github.com/agentskills/agentskills) for the open standard.

--- a/agentskills/adding-directives/SKILL.md
+++ b/agentskills/adding-directives/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: scala-cli-adding-directives
+description: Add or change using directives in Scala CLI. Use when adding a new //> using directive, registering a directive handler, or editing directive preprocessing.
+---
+
+# Adding a new directive (Scala CLI)
+
+1. **Create a case class** in `modules/directives/src/main/scala/scala/build/preprocessing/directives/` extending one of:
+   - `HasBuildOptions` — produces `BuildOptions` directly
+   - `HasBuildOptionsWithRequirements` — produces `BuildOptions` with scoped requirements (e.g. `test.dep`)
+   - `HasBuildRequirements` — produces `BuildRequirements` (for `//> require`)
+
+2. **Annotate**: `@DirectiveLevel(SpecificationLevel.EXPERIMENTAL)`, `@DirectiveDescription("…")`, `@DirectiveUsage("…")`, `@DirectiveExamples("…")`, `@DirectiveName("key")` on fields.
+
+3. **Companion**: `val handler: DirectiveHandler[YourDirective] = DirectiveHandler.derive`
+
+4. **Register** in `modules/build/.../DirectivesPreprocessingUtils.scala` in the right list: `usingDirectiveHandlers`, `usingDirectiveWithReqsHandlers`, or `requireDirectiveHandlers`.
+
+5. **Regenerate reference docs**: `./mill -i 'generate-reference-doc[]'.run`
+
+CLI options always override directive values when both set the same thing.

--- a/agentskills/integration-tests/SKILL.md
+++ b/agentskills/integration-tests/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: scala-cli-integration-tests
+description: Add or run Scala CLI integration tests. Use when adding integration tests, debugging RunTests/CompileTests/etc., or working in modules/integration.
+---
+
+# Integration tests (Scala CLI)
+
+**Location**: `modules/integration/`. Tests invoke the CLI as an external process.
+
+**Run**: `./mill -i integration.test.jvm` (all). Filter: `./mill -i integration.test.jvm 'scala.cli.integration.RunTestsDefault.*'` or by test name. Native: `./mill -i integration.test.native`.
+
+**Structure**: `*TestDefinitions.scala` (abstract, holds test logic) → `*TestsDefault`, `*Tests213`, etc. (concrete, Scala version trait). Traits: `TestDefault`, `Test212`, `Test213`, `Test3Lts`, `Test3NextRc`.
+
+**Adding a test**:
+1. Open the right `*TestDefinitions` (e.g. `RunTestDefinitions` for `run`).
+2. Add `test("description") { … }` using `TestInputs(os.rel / "Main.scala" -> "…").fromRoot { root => … }` and `os.proc(TestUtil.cli, "run", …).call(cwd = root)`.
+3. Assert on stdout/stderr.
+
+**Helpers**: `TestInputs(...).fromRoot`, `TestUtil.cli`. Test groups (CI): `SCALA_CLI_IT_GROUP=1..5`; see `modules/integration/` for group mapping.


### PR DESCRIPTION
Some context for speeding up agents, encouraging certain behaviours and such.

Requires/includes:
- https://github.com/VirtusLab/scala-cli/pull/4177

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
extensively, this is made by agents for agents, purely vibe coded metaprompting ™️ 
used Cursor with Claude

## How was the solution tested?
I use this as context for agents when working with this repo and it works reasonably well

## Additional notes
A similar file in the Scala 3 repo (without the detailed one)
https://github.com/scala/scala3/blob/main/AGENTS.md
