### PR TITLE
Use Java 17 mapping when generating docs with Scala 3.8+ with `doc`

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -528,6 +528,7 @@ trait Core extends ScalaCliCrossSbtModule
          |  def minimumBloopJavaVersion = ${Java.minimumBloopJava}
          |  def minimumInternalJavaVersion = ${Java.minimumInternalJava}
          |  def defaultJavaVersion = ${Java.defaultJava}
+         |  def mainJavaVersions = Seq(${Java.mainJavaVersions.sorted.mkString(", ")})
          |
          |  def defaultScalaVersion = "${Scala.defaultUser}"
          |  def defaultScala212Version = "${Scala.scala212}"

--- a/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
@@ -125,16 +125,26 @@ object Doc extends ScalaCommand[DocOptions] {
     logger.message(s"Wrote Scaladoc to $printableOutput")
   }
 
+  private def javadocBaseUrl(javaVersion: Int): String =
+    if javaVersion >= 11 then
+      s"https://docs.oracle.com/en/java/javase/$javaVersion/docs/api/java.base/"
+    else
+      s"https://docs.oracle.com/javase/$javaVersion/docs/api/"
+
+  private def scaladocBaseUrl(scalaVersion: String): String =
+    s"https://scala-lang.org/api/$scalaVersion/"
+
   // from https://github.com/VirtusLab/scala-cli/pull/103/files#diff-1039b442cbd23f605a61fdb9c3620b600aa4af6cab757932a719c54235d8e402R60
-  private def defaultScaladocArgs = Seq(
-    "-snippet-compiler:compile",
-    "-Ygenerate-inkuire",
-    "-external-mappings:" +
-      ".*/scala/.*::scaladoc3::https://scala-lang.org/api/3.x/," +
-      ".*/java/.*::javadoc::https://docs.oracle.com/javase/8/docs/api/",
-    "-author",
-    "-groups"
-  )
+  private[commands] def defaultScaladocArgs(scalaVersion: String, javaVersion: Int): Seq[String] =
+    Seq(
+      "-snippet-compiler:compile",
+      "-Ygenerate-inkuire",
+      "-external-mappings:" +
+        s".*/scala/.*::scaladoc3::${scaladocBaseUrl(scalaVersion)}," +
+        s".*/java/.*::javadoc::${javadocBaseUrl(javaVersion)}",
+      "-author",
+      "-groups"
+    )
 
   def generateScaladocDirPath(
     builds: Seq[Build.Successful],
@@ -171,10 +181,11 @@ object Doc extends ScalaCommand[DocOptions] {
           "-d",
           destDir.toString
         )
+        val javaVersion = builds.head.options.javaHome().value.version
         val defaultArgs =
           if builds.head.options.notForBloopOptions.packageOptions.useDefaultScaladocOptions
               .getOrElse(true)
-          then defaultScaladocArgs
+          then defaultScaladocArgs(scalaParams.scalaVersion, javaVersion)
           else Nil
         val args = baseArgs ++
           builds.head.project.scalaCompiler.map(_.scalacOptions).getOrElse(Nil) ++

--- a/modules/cli/src/test/scala/cli/commands/tests/DocTests.scala
+++ b/modules/cli/src/test/scala/cli/commands/tests/DocTests.scala
@@ -1,0 +1,40 @@
+package scala.cli.commands.tests
+
+import com.eed3si9n.expecty.Expecty.assert as expect
+
+import scala.build.internal.Constants
+import scala.cli.commands.doc.Doc
+
+class DocTests extends munit.FunSuite {
+
+  for (javaVersion <- Constants.mainJavaVersions)
+    test(s"correct external mappings for JVM $javaVersion") {
+      val args        = Doc.defaultScaladocArgs(Constants.defaultScalaVersion, javaVersion)
+      val mappingsArg = args.find(_.startsWith("-external-mappings:")).get
+      if javaVersion >= 11 then
+        expect(mappingsArg.contains(s"javase/$javaVersion/docs/api/java.base/"))
+      else
+        expect(mappingsArg.contains(s"javase/$javaVersion/docs/api/"))
+        expect(!mappingsArg.contains("java.base/"))
+      expect(mappingsArg.contains(s"scala-lang.org/api/${Constants.defaultScalaVersion}/"))
+    }
+
+  test(s"correct external mappings for Scala 3 LTS (${Constants.scala3Lts})") {
+    val args        = Doc.defaultScaladocArgs(Constants.scala3Lts, Constants.defaultJavaVersion)
+    val mappingsArg = args.find(_.startsWith("-external-mappings:")).get
+    expect(mappingsArg.contains(s"scala-lang.org/api/${Constants.scala3Lts}/"))
+    expect(
+      mappingsArg.contains(s"javase/${Constants.defaultJavaVersion}/docs/api/java.base/")
+    )
+  }
+
+  test(s"correct external mappings for default Scala (${Constants.defaultScalaVersion})") {
+    val args =
+      Doc.defaultScaladocArgs(Constants.defaultScalaVersion, Constants.defaultJavaVersion)
+    val mappingsArg = args.find(_.startsWith("-external-mappings:")).get
+    expect(mappingsArg.contains(s"scala-lang.org/api/${Constants.defaultScalaVersion}/"))
+    expect(
+      mappingsArg.contains(s"javase/${Constants.defaultJavaVersion}/docs/api/java.base/")
+    )
+  }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
@@ -97,4 +97,61 @@ abstract class DocTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
              |""".stripMargin
       ).fromRoot(root => os.proc(TestUtil.cli, "doc", ".", extraOptions).call(cwd = root))
     }
+
+  if actualScalaVersion.startsWith("3") then
+    for {
+      javaVersion <-
+        if isScala38OrNewer then
+          Constants.allJavaVersions.filter(_ >= Constants.scala38MinJavaVersion)
+        else Constants.allJavaVersions
+    }
+      test(s"doc generates correct external mapping URLs for JVM $javaVersion") {
+        TestUtil.retryOnCi() {
+          val dest   = os.rel / "doc-out"
+          val inputs = TestInputs(
+            os.rel / "Lib.scala" ->
+              """package mylib
+                |
+                |/** A wrapper around [[java.util.HashMap]] and [[scala.Option]]. */
+                |class Lib:
+                |  /** Returns a [[java.util.HashMap]]. */
+                |  def getMap: java.util.HashMap[String, String] = new java.util.HashMap()
+                |  /** Returns a [[scala.Option]]. */
+                |  def getOpt: Option[String] = Some("hello")
+                |""".stripMargin
+          )
+          inputs.fromRoot { root =>
+            os.proc(
+              TestUtil.cli,
+              "doc",
+              extraOptions,
+              ".",
+              "-o",
+              dest,
+              "--jvm",
+              javaVersion.toString
+            ).call(cwd = root, stdin = os.Inherit, stdout = os.Inherit)
+
+            val docDir = root / dest
+            expect(os.isDir(docDir))
+
+            val htmlContent = os.walk(docDir)
+              .filter(_.last.endsWith(".html"))
+              .map(os.read(_))
+              .mkString
+
+            val expectedJavadocFragment =
+              if javaVersion >= 11 then
+                s"docs.oracle.com/en/java/javase/$javaVersion/docs/api/java.base/"
+              else
+                s"docs.oracle.com/javase/$javaVersion/docs/api/"
+            expect(htmlContent.contains(expectedJavadocFragment))
+
+            if javaVersion < 11 then
+              expect(!htmlContent.contains("java.base/"))
+
+            expect(htmlContent.contains(s"scala-lang.org/api/$actualScalaVersion/"))
+          }
+        }
+      }
 }


### PR DESCRIPTION
Scala 3.8 uses Java 17, adjusted the `doc` command passed external mappings.

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Cursor + Claude

## How was the solution tested?
Added a simple unit test.
Verified the mappings work, otherwise (an integration test feels overkill, but let me know if I should add smth anyway).

## Additional notes
Kudos to @hamzaremmal for spotting this