### PR TITLE
Make test framework discovery on Native more resilient & with better errors

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/Runner.scala
+++ b/modules/build/src/main/scala/scala/build/internal/Runner.scala
@@ -539,7 +539,7 @@ object Runner {
                |""".stripMargin
           )
 
-        if finalTestFrameworks.isEmpty then Left(new NoFrameworkFoundByBridgeError)
+        if finalTestFrameworks.isEmpty then Left(new NoFrameworkFoundByNativeBridgeError)
         else runTests(classPath, finalTestFrameworks, requireTests, args, parentInspector)
       }
       finally if adapter != null then adapter.close()

--- a/modules/build/src/test/scala/scala/build/tests/FrameworkDiscoveryTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/FrameworkDiscoveryTests.scala
@@ -1,0 +1,49 @@
+package scala.build.tests
+
+import java.nio.file.Files
+
+import scala.build.errors.NoFrameworkFoundByNativeBridgeError
+import scala.build.testrunner.AsmTestRunner
+
+class FrameworkDiscoveryTests extends TestUtil.ScalaCliBuildSuite {
+
+  test(
+    "findFrameworkServices parses Java ServiceLoader format (trim, skip comments and empty lines)"
+  ) {
+    val dir = Files.createTempDirectory("scala-cli-framework-services-")
+    try {
+      val servicesDir = dir.resolve("META-INF").resolve("services")
+      Files.createDirectories(servicesDir)
+      val serviceFile = servicesDir.resolve("sbt.testing.Framework")
+      // Content with newlines, comments, and surrounding whitespace
+      val content =
+        """munit.Framework
+          |# comment line
+          |
+          |  munit.native.Framework  
+          |
+          |""".stripMargin
+      Files.writeString(serviceFile, content)
+
+      val found = AsmTestRunner.findFrameworkServices(Seq(dir))
+      assertEquals(
+        found.sorted,
+        Seq("munit.Framework", "munit.native.Framework"),
+        clue = "Service file lines should be trimmed; comments and empty lines skipped"
+      )
+    }
+    finally {
+      def deleteRecursively(p: java.nio.file.Path): Unit = {
+        if Files.isDirectory(p) then Files.list(p).forEach(deleteRecursively)
+        Files.deleteIfExists(p)
+      }
+      deleteRecursively(dir)
+    }
+  }
+
+  test("NoFrameworkFoundByNativeBridgeError has Native-specific message (not Scala.js)") {
+    val err = new NoFrameworkFoundByNativeBridgeError
+    assert(err.getMessage.contains("Scala Native"), clue = "Message should mention Scala Native")
+    assert(!err.getMessage.contains("Scala.js"), clue = "Message should not mention Scala.js")
+  }
+}

--- a/modules/core/src/main/scala/scala/build/errors/NoFrameworkFoundByNativeBridgeError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/NoFrameworkFoundByNativeBridgeError.scala
@@ -1,0 +1,4 @@
+package scala.build.errors
+
+final class NoFrameworkFoundByNativeBridgeError
+    extends TestError("No framework found by Scala Native test bridge")

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
@@ -195,9 +195,19 @@ object AsmTestRunner {
       .iterator
       .flatMap(findInClassPath(_, name).iterator)
 
+  /** Parse Java ServiceLoader format: one class name per line; # comments and empty lines ignored.
+    */
+  private def parseServiceFileContent(content: String): Seq[String] =
+    content
+      .split("[\r\n]+")
+      .iterator
+      .map(_.trim)
+      .filter(line => line.nonEmpty && !line.startsWith("#"))
+      .toSeq
+
   def findFrameworkServices(classPath: Seq[Path]): Seq[String] =
     findInClassPath(classPath, "META-INF/services/sbt.testing.Framework")
-      .map(b => new String(b, StandardCharsets.UTF_8))
+      .flatMap(b => parseServiceFileContent(new String(b, StandardCharsets.UTF_8)))
       .toSeq
 
   def findFrameworks(


### PR DESCRIPTION
Fixes #4017 

Well, maybe it does, since we don't really have a real-life reproduction. But this just might have been it.
And if it isn't, at least the user will get a relevant error (rather than a Scala.js one with Scala Native 🤡)

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
extensively, the guess on what could have been the cause is entirely (Cursor+Claude)'s idea

## How was the solution tested?
unit tests included; we don't really have a reproducible example from the user, so it's hard to tell 100% if it was this.