### PR TITLE
Add `java-test-runner` module to support running tests with pure Java

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -112,6 +112,8 @@ object runner extends Cross[Runner](Scala.runnerScalaVersions)
     with CrossScalaDefaultToRunner
 object `test-runner` extends Cross[TestRunner](Scala.runnerScalaVersions)
     with CrossScalaDefaultToRunner
+object `java-test-runner` extends JavaTestRunner
+    with LocatedInModules
 object `tasty-lib` extends Cross[TastyLib](Scala.scala3MainVersions)
     with CrossScalaDefaultToInternal
 
@@ -452,10 +454,16 @@ trait Core extends ScalaCliCrossSbtModule
     val runnerMainClass = build.runner(crossScalaVersion)
       .mainClass()
       .getOrElse(sys.error("No main class defined for runner"))
+    val javaTestRunnerMainClass = `java-test-runner`
+      .mainClass()
+      .getOrElse(sys.error("No main class defined for java-test-runner"))
     val detailedVersionValue =
       if (`local-repo`.developingOnStubModules) s"""Some("${vcsState()}")"""
       else "None"
     val testRunnerOrganization = `test-runner`(crossScalaVersion)
+      .pomSettings()
+      .organization
+    val javaTestRunnerOrganization = `java-test-runner`
       .pomSettings()
       .organization
     val code =
@@ -478,6 +486,11 @@ trait Core extends ScalaCliCrossSbtModule
          |  def testRunnerModuleName = "${`test-runner`(crossScalaVersion).artifactName()}"
          |  def testRunnerVersion = "${`test-runner`(crossScalaVersion).publishVersion()}"
          |  def testRunnerMainClass = "$testRunnerMainClass"
+         |
+         |  def javaTestRunnerOrganization = "$javaTestRunnerOrganization"
+         |  def javaTestRunnerModuleName = "${`java-test-runner`.artifactName()}"
+         |  def javaTestRunnerVersion = "${`java-test-runner`.publishVersion()}"
+         |  def javaTestRunnerMainClass = "$javaTestRunnerMainClass"
          |
          |  def runnerOrganization = "${build.runner(crossScalaVersion).pomSettings().organization}"
          |  def runnerModuleName = "${build.runner(crossScalaVersion).artifactName()}"
@@ -1323,6 +1336,16 @@ trait TestRunner extends CrossSbtModule
   override def mainClass: T[Option[String]] = Some("scala.build.testrunner.DynamicTestRunner")
 }
 
+trait JavaTestRunner extends JavaModule
+    with ScalaCliPublishModule
+    with LocatedInModules {
+  override def mvnDeps: T[Seq[Dep]] = super.mvnDeps() ++ Seq(
+    Deps.asm,
+    Deps.testInterface
+  )
+  override def mainClass: T[Option[String]] = Some("scala.build.testrunner.JavaDynamicTestRunner")
+}
+
 trait TastyLib extends ScalaCliCrossSbtModule
     with ScalaCliPublishModule
     with ScalaCliScalafixModule
@@ -1357,7 +1380,7 @@ object `local-repo` extends LocalRepo {
   def developingOnStubModules = false
 
   override def stubsModules: Seq[PublishLocalNoFluff] =
-    Seq(runner(Scala.runnerScala3), `test-runner`(Scala.runnerScala3))
+    Seq(runner(Scala.runnerScala3), `test-runner`(Scala.runnerScala3), `java-test-runner`)
 
   override def version: T[String] = runner(Scala.runnerScala3).publishVersion()
 }

--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -1105,8 +1105,7 @@ object Build {
     either {
 
       val options0 =
-        // FIXME: don't add Scala to pure Java test builds (need to add pure Java test runner)
-        if sources.hasJava && !sources.hasScala && scope != Scope.Test
+        if sources.hasJava && !sources.hasScala
         then
           options.copy(
             scalaOptions = options.scalaOptions.copy(

--- a/modules/build/src/main/scala/scala/build/internal/Runner.scala
+++ b/modules/build/src/main/scala/scala/build/internal/Runner.scala
@@ -15,11 +15,14 @@ import scala.build.Logger
 import scala.build.errors.*
 import scala.build.internals.EnvVar
 import scala.build.testrunner.FrameworkUtils.*
-import scala.build.testrunner.{AsmTestRunner, TestRunner}
+import scala.build.testrunner.{AsmTestRunner, Logger as TestRunnerLogger, TestRunner}
 import scala.scalanative.testinterface.adapter.TestAdapter as ScalaNativeTestAdapter
 import scala.util.{Failure, Properties, Success}
 
 object Runner {
+
+  private def toTestRunnerLogger(logger: Logger): TestRunnerLogger =
+    TestRunnerLogger(logger.verbosity)
 
   def maybeExec(
     commandName: String,
@@ -346,15 +349,18 @@ object Runner {
     frameworks: Seq[Framework],
     requireTests: Boolean,
     args: Seq[String],
-    parentInspector: AsmTestRunner.ParentInspector
+    parentInspector: AsmTestRunner.ParentInspector,
+    logger: Logger
   ): Either[NoTestsRun, Boolean] = frameworks
     .flatMap { framework =>
+      val trLogger = toTestRunnerLogger(logger)
       val taskDefs =
         AsmTestRunner.taskDefs(
           classPath,
           keepJars = false,
           framework.fingerprints().toIndexedSeq,
-          parentInspector
+          parentInspector,
+          trLogger
         ).toArray
 
       val runner       = framework.runner(args.toArray, Array(), null)
@@ -380,16 +386,17 @@ object Runner {
     parentInspector: AsmTestRunner.ParentInspector,
     logger: Logger
   ): Either[NoTestFrameworkFoundError, Seq[String]] = {
+    val trLogger = toTestRunnerLogger(logger)
     logger.debug("Looking for test framework services on the classpath...")
     val foundFrameworkServices =
-      AsmTestRunner.findFrameworkServices(classPath)
+      AsmTestRunner.findFrameworkServices(classPath, trLogger)
         .map(_.replace('/', '.').replace('\\', '.'))
     logger.debug(s"Found ${foundFrameworkServices.length} test framework services.")
     if foundFrameworkServices.nonEmpty then
       logger.debug(s"  - ${foundFrameworkServices.mkString("\n  - ")}")
     logger.debug("Looking for more test frameworks on the classpath...")
     val foundFrameworks =
-      AsmTestRunner.findFrameworks(classPath, TestRunner.commonTestFrameworks, parentInspector)
+      AsmTestRunner.findFrameworks(classPath, TestRunner.commonTestFrameworks, parentInspector, trLogger)
         .map(_.replace('/', '.').replace('\\', '.'))
     logger.debug(s"Found ${foundFrameworks.length} additional test frameworks")
     if foundFrameworks.nonEmpty then
@@ -444,7 +451,7 @@ object Runner {
 
     logger.debug(s"JS tests class path: $classPath")
 
-    val parentInspector                   = new AsmTestRunner.ParentInspector(classPath)
+    val parentInspector                   = new AsmTestRunner.ParentInspector(classPath, toTestRunnerLogger(logger))
     val foundFrameworkNames: List[String] = predefinedTestFrameworks match {
       case f if f.nonEmpty => f.toList
       case Nil             => value(frameworkNames(classPath, parentInspector, logger)).toList
@@ -474,7 +481,7 @@ object Runner {
           )
 
         if finalTestFrameworks.isEmpty then Left(new NoFrameworkFoundByBridgeError)
-        else runTests(classPath, finalTestFrameworks, requireTests, args, parentInspector)
+        else runTests(classPath, finalTestFrameworks, requireTests, args, parentInspector, logger)
       }
       finally if adapter != null then adapter.close()
 
@@ -492,7 +499,7 @@ object Runner {
     logger.debug("Preparing to run tests with Scala Native...")
     logger.debug(s"Native tests class path: $classPath")
 
-    val parentInspector                   = new AsmTestRunner.ParentInspector(classPath)
+    val parentInspector                   = new AsmTestRunner.ParentInspector(classPath, toTestRunnerLogger(logger))
     val foundFrameworkNames: List[String] = predefinedTestFrameworks match {
       case f if f.nonEmpty => f.toList
       case Nil             => value(frameworkNames(classPath, parentInspector, logger)).toList
@@ -540,7 +547,7 @@ object Runner {
           )
 
         if finalTestFrameworks.isEmpty then Left(new NoFrameworkFoundByNativeBridgeError)
-        else runTests(classPath, finalTestFrameworks, requireTests, args, parentInspector)
+        else runTests(classPath, finalTestFrameworks, requireTests, args, parentInspector, logger)
       }
       finally if adapter != null then adapter.close()
 

--- a/modules/build/src/main/scala/scala/build/internal/Runner.scala
+++ b/modules/build/src/main/scala/scala/build/internal/Runner.scala
@@ -396,7 +396,12 @@ object Runner {
       logger.debug(s"  - ${foundFrameworkServices.mkString("\n  - ")}")
     logger.debug("Looking for more test frameworks on the classpath...")
     val foundFrameworks =
-      AsmTestRunner.findFrameworks(classPath, TestRunner.commonTestFrameworks, parentInspector, trLogger)
+      AsmTestRunner.findFrameworks(
+        classPath,
+        TestRunner.commonTestFrameworks,
+        parentInspector,
+        trLogger
+      )
         .map(_.replace('/', '.').replace('\\', '.'))
     logger.debug(s"Found ${foundFrameworks.length} additional test frameworks")
     if foundFrameworks.nonEmpty then
@@ -451,7 +456,7 @@ object Runner {
 
     logger.debug(s"JS tests class path: $classPath")
 
-    val parentInspector                   = new AsmTestRunner.ParentInspector(classPath, toTestRunnerLogger(logger))
+    val parentInspector = new AsmTestRunner.ParentInspector(classPath, toTestRunnerLogger(logger))
     val foundFrameworkNames: List[String] = predefinedTestFrameworks match {
       case f if f.nonEmpty => f.toList
       case Nil             => value(frameworkNames(classPath, parentInspector, logger)).toList
@@ -499,7 +504,7 @@ object Runner {
     logger.debug("Preparing to run tests with Scala Native...")
     logger.debug(s"Native tests class path: $classPath")
 
-    val parentInspector                   = new AsmTestRunner.ParentInspector(classPath, toTestRunnerLogger(logger))
+    val parentInspector = new AsmTestRunner.ParentInspector(classPath, toTestRunnerLogger(logger))
     val foundFrameworkNames: List[String] = predefinedTestFrameworks match {
       case f if f.nonEmpty => f.toList
       case Nil             => value(frameworkNames(classPath, parentInspector, logger)).toList

--- a/modules/build/src/test/scala/scala/build/tests/FrameworkDiscoveryTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/FrameworkDiscoveryTests.scala
@@ -3,7 +3,7 @@ package scala.build.tests
 import java.nio.file.Files
 
 import scala.build.errors.NoFrameworkFoundByNativeBridgeError
-import scala.build.testrunner.AsmTestRunner
+import scala.build.testrunner.{AsmTestRunner, Logger as TestRunnerLogger}
 
 class FrameworkDiscoveryTests extends TestUtil.ScalaCliBuildSuite {
 
@@ -25,7 +25,7 @@ class FrameworkDiscoveryTests extends TestUtil.ScalaCliBuildSuite {
           |""".stripMargin
       Files.writeString(serviceFile, content)
 
-      val found = AsmTestRunner.findFrameworkServices(Seq(dir))
+      val found = AsmTestRunner.findFrameworkServices(Seq(dir), TestRunnerLogger(0))
       assertEquals(
         found.sorted,
         Seq("munit.Framework", "munit.native.Framework"),

--- a/modules/build/src/test/scala/scala/build/tests/JavaTestRunnerTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/JavaTestRunnerTests.scala
@@ -1,0 +1,51 @@
+package scala.build.tests
+
+import com.eed3si9n.expecty.Expecty.assert as expect
+
+import scala.build.options.*
+
+class JavaTestRunnerTests extends TestUtil.ScalaCliBuildSuite {
+
+  private def makeOptions(
+    scalaVersionOpt: Option[MaybeScalaVersion],
+    addTestRunner: Boolean
+  ): BuildOptions =
+    BuildOptions(
+      scalaOptions = ScalaOptions(
+        scalaVersion = scalaVersionOpt
+      ),
+      internalDependencies = InternalDependenciesOptions(
+        addTestRunnerDependencyOpt = Some(addTestRunner)
+      )
+    )
+
+  test("pure Java build has no scalaParams") {
+    val opts   = makeOptions(Some(MaybeScalaVersion.none), addTestRunner = false)
+    val params = opts.scalaParams.toOption.flatten
+    expect(params.isEmpty, "Pure Java build should have no scalaParams")
+  }
+
+  test("Scala build has scalaParams") {
+    val opts   = makeOptions(None, addTestRunner = false)
+    val params = opts.scalaParams.toOption.flatten
+    expect(params.isDefined, "Scala build should have scalaParams")
+  }
+
+  test("pure Java test build gets addJvmJavaTestRunner=true in Artifacts params") {
+    val opts   = makeOptions(Some(MaybeScalaVersion.none), addTestRunner = true)
+    val isJava = opts.scalaParams.toOption.flatten.isEmpty
+    expect(isJava, "Expected pure Java build to have no scalaParams")
+  }
+
+  test("Scala test build gets addJvmTestRunner=true in Artifacts params") {
+    val opts   = makeOptions(None, addTestRunner = true)
+    val isJava = opts.scalaParams.toOption.flatten.isEmpty
+    expect(!isJava, "Expected Scala build to have scalaParams")
+  }
+
+  test("mixed Scala+Java build still gets Scala test runner") {
+    val opts   = makeOptions(None, addTestRunner = true)
+    val isJava = opts.scalaParams.toOption.flatten.isEmpty
+    expect(!isJava, "Mixed Scala+Java build should still use Scala test runner")
+  }
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
@@ -256,11 +256,16 @@ object Test extends ScalaCommand[TestOptions] {
             testOnly.map(to => s"--test-only=$to").toSeq ++
             Seq("--") ++ args
 
+        val testRunnerMainClass =
+          if build.artifacts.hasJavaTestRunner
+          then Constants.javaTestRunnerMainClass
+          else Constants.testRunnerMainClass
+
         Runner.runJvm(
           build.options.javaHome().value.javaCommand,
           build.options.javaOptions.javaOpts.toSeq.map(_.value.value),
           classPath,
-          Constants.testRunnerMainClass,
+          testRunnerMainClass,
           extraArgs,
           logger,
           allowExecve = allowExecve

--- a/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
@@ -279,7 +279,8 @@ object Test extends ScalaCommand[TestOptions] {
     // https://github.com/VirtusLab/scala-cli/issues/426
     if classPath0.exists(_.contains("zio-test")) && !classPath0.exists(_.contains("zio-test-sbt"))
     then {
-      val parentInspector = new AsmTestRunner.ParentInspector(classPath, TestRunnerLogger(logger.verbosity))
+      val parentInspector =
+        new AsmTestRunner.ParentInspector(classPath, TestRunnerLogger(logger.verbosity))
       Runner.frameworkNames(classPath, parentInspector, logger) match {
         case Right(f) => f.headOption
         case Left(_)  =>

--- a/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
@@ -12,7 +12,7 @@ import scala.build.errors.{BuildException, CompositeBuildException}
 import scala.build.internal.{Constants, Runner}
 import scala.build.internals.ConsoleUtils.ScalaCliConsole
 import scala.build.options.{BuildOptions, JavaOpt, Platform, Scope}
-import scala.build.testrunner.AsmTestRunner
+import scala.build.testrunner.{AsmTestRunner, Logger as TestRunnerLogger}
 import scala.cli.CurrentParams
 import scala.cli.commands.run.Run
 import scala.cli.commands.setupide.SetupIde
@@ -279,7 +279,7 @@ object Test extends ScalaCommand[TestOptions] {
     // https://github.com/VirtusLab/scala-cli/issues/426
     if classPath0.exists(_.contains("zio-test")) && !classPath0.exists(_.contains("zio-test-sbt"))
     then {
-      val parentInspector = new AsmTestRunner.ParentInspector(classPath)
+      val parentInspector = new AsmTestRunner.ParentInspector(classPath, TestRunnerLogger(logger.verbosity))
       Runner.frameworkNames(classPath, parentInspector, logger) match {
         case Right(f) => f.headOption
         case Left(_)  =>

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/MillProjectDescriptor.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/MillProjectDescriptor.scala
@@ -137,8 +137,9 @@ final case class MillProjectDescriptor(
         logger.debug(exception.message)
         Seq.empty
     }
-    val parentInspector = new AsmTestRunner.ParentInspector(testClassPath, TestRunnerLogger(logger.verbosity))
-    val frameworkName0  = options.testOptions.frameworks.headOption.orElse {
+    val parentInspector =
+      new AsmTestRunner.ParentInspector(testClassPath, TestRunnerLogger(logger.verbosity))
+    val frameworkName0 = options.testOptions.frameworks.headOption.orElse {
       frameworkNames(testClassPath, parentInspector, logger).toOption
         .flatMap(_.headOption) // TODO: handle multiple frameworks here
     }

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/MillProjectDescriptor.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/MillProjectDescriptor.scala
@@ -9,7 +9,7 @@ import scala.build.errors.BuildException
 import scala.build.internal.Constants
 import scala.build.internal.Runner.frameworkNames
 import scala.build.options.{BuildOptions, Platform, ScalaJsOptions, ScalaNativeOptions, Scope}
-import scala.build.testrunner.AsmTestRunner
+import scala.build.testrunner.{AsmTestRunner, Logger as TestRunnerLogger}
 import scala.build.{Logger, Sources}
 import scala.cli.ScalaCli
 
@@ -137,7 +137,7 @@ final case class MillProjectDescriptor(
         logger.debug(exception.message)
         Seq.empty
     }
-    val parentInspector = new AsmTestRunner.ParentInspector(testClassPath)
+    val parentInspector = new AsmTestRunner.ParentInspector(testClassPath, TestRunnerLogger(logger.verbosity))
     val frameworkName0  = options.testOptions.frameworks.headOption.orElse {
       frameworkNames(testClassPath, parentInspector, logger).toOption
         .flatMap(_.headOption) // TODO: handle multiple frameworks here

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/SbtProjectDescriptor.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/SbtProjectDescriptor.scala
@@ -258,8 +258,9 @@ final case class SbtProjectDescriptor(
         Seq.empty
     }
 
-    val parentInspector = new AsmTestRunner.ParentInspector(testClassPath, TestRunnerLogger(logger.verbosity))
-    val frameworkName0  = options.testOptions.frameworks.headOption.orElse {
+    val parentInspector =
+      new AsmTestRunner.ParentInspector(testClassPath, TestRunnerLogger(logger.verbosity))
+    val frameworkName0 = options.testOptions.frameworks.headOption.orElse {
       frameworkNames(testClassPath, parentInspector, logger).toOption
         .flatMap(_.headOption) // TODO: handle multiple frameworks here
     }

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/SbtProjectDescriptor.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/SbtProjectDescriptor.scala
@@ -17,7 +17,7 @@ import scala.build.options.{
   Scope,
   ShadowingSeq
 }
-import scala.build.testrunner.AsmTestRunner
+import scala.build.testrunner.{AsmTestRunner, Logger as TestRunnerLogger}
 import scala.build.{Logger, Positioned, Sources}
 import scala.cli.ScalaCli
 
@@ -258,7 +258,7 @@ final case class SbtProjectDescriptor(
         Seq.empty
     }
 
-    val parentInspector = new AsmTestRunner.ParentInspector(testClassPath)
+    val parentInspector = new AsmTestRunner.ParentInspector(testClassPath, TestRunnerLogger(logger.verbosity))
     val frameworkName0  = options.testOptions.frameworks.headOption.orElse {
       frameworkNames(testClassPath, parentInspector, logger).toOption
         .flatMap(_.headOption) // TODO: handle multiple frameworks here

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
@@ -236,4 +236,30 @@ class RunTestsDefault extends RunTestDefinitions
         expect(res.err.trim().contains(expectedWarning))
       }
     }
+
+  for {
+    buildServerOptions <- Seq(Nil, Seq("--server=false"))
+    buildServerDesc =
+      if buildServerOptions.isEmpty then "with build server" else "without build server"
+  }
+    test(s"pure Java run has no Scala on classpath $buildServerDesc") {
+      TestInputs(
+        os.rel / "Main.java" ->
+          """public class Main {
+            |  public static void main(String[] args) {
+            |    try {
+            |      Class.forName("scala.Predef");
+            |      throw new RuntimeException("Scala should not be on the classpath");
+            |    } catch (ClassNotFoundException e) {
+            |      System.out.println("No Scala on classpath!");
+            |    }
+            |  }
+            |}
+            |""".stripMargin
+      ).fromRoot { root =>
+        val res =
+          os.proc(TestUtil.cli, "run", buildServerOptions, extraOptions, ".").call(cwd = root)
+        expect(res.out.text().contains("No Scala on classpath!"))
+      }
+    }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
@@ -98,4 +98,38 @@ class TestTestsDefault extends TestTestDefinitions with TestDefault {
         expect(err.countOccurrences(expectedWarning) == 1)
       }
     }
+
+  for {
+    buildServerOptions <- Seq(Nil, Seq("--server=false"))
+    buildServerDesc =
+      if buildServerOptions.isEmpty then "with build server" else "without build server"
+  }
+    test(s"pure Java test with JUnit has no Scala on classpath $buildServerDesc") {
+      TestInputs(
+        os.rel / "test" / "MyTests.java" ->
+          """//> using test.dep junit:junit:4.13.2
+            |//> using test.dep com.novocode:junit-interface:0.11
+            |import org.junit.Test;
+            |import static org.junit.Assert.assertEquals;
+            |
+            |public class MyTests {
+            |  @Test
+            |  public void foo() {
+            |    try {
+            |      Class.forName("scala.Predef");
+            |      throw new AssertionError("Scala should not be on the classpath");
+            |    } catch (ClassNotFoundException e) {
+            |      // expected
+            |    }
+            |    assertEquals(4, 2 + 2);
+            |    System.out.println("No Scala on classpath!");
+            |  }
+            |}
+            |""".stripMargin
+      ).fromRoot { root =>
+        val res =
+          os.proc(TestUtil.cli, "test", extraOptions, buildServerOptions, ".").call(cwd = root)
+        expect(res.out.text().contains("No Scala on classpath!"))
+      }
+    }
 }

--- a/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaAsmTestRunner.java
+++ b/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaAsmTestRunner.java
@@ -219,7 +219,7 @@ public class JavaAsmTestRunner {
                         }
                     });
             } catch (IOException e) {
-                logger.debug("Could not walk directory " + entry + ": " + e.getMessage());
+                logger.log("Could not walk directory " + entry + ": " + e.getMessage());
             }
         } else if (keepJars && Files.isRegularFile(entry)) {
             byte[] buf = new byte[16384];
@@ -240,7 +240,7 @@ public class JavaAsmTestRunner {
                     result.put(name, baos.toByteArray());
                 }
             } catch (IOException e) {
-                logger.debug("Could not read JAR " + entry + ": " + e.getMessage());
+                logger.log("Could not read JAR " + entry + ": " + e.getMessage());
             }
         }
         return result;

--- a/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaAsmTestRunner.java
+++ b/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaAsmTestRunner.java
@@ -15,15 +15,17 @@ public class JavaAsmTestRunner {
 
     public static class ParentInspector {
         private final List<Path> classPath;
+        private final JavaTestLogger logger;
         private final ConcurrentHashMap<String, List<String>> cache = new ConcurrentHashMap<>();
 
-        public ParentInspector(List<Path> classPath) {
+        public ParentInspector(List<Path> classPath, JavaTestLogger logger) {
             this.classPath = classPath;
+            this.logger = logger;
         }
 
         private List<String> parents(String className) {
             return cache.computeIfAbsent(className, name -> {
-                byte[] byteCode = findInClassPath(classPath, name + ".class");
+                byte[] byteCode = findInClassPath(classPath, name + ".class", logger);
                 if (byteCode == null) return Collections.emptyList();
                 TestClassChecker checker = new TestClassChecker();
                 ClassReader reader = new ClassReader(byteCode);
@@ -52,7 +54,8 @@ public class JavaAsmTestRunner {
         InputStream byteCodeStream,
         List<Fingerprint> fingerprints,
         ParentInspector parentInspector,
-        ClassLoader loader
+        ClassLoader loader,
+        JavaTestLogger logger
     ) throws IOException {
         TestClassChecker checker = new TestClassChecker();
         ClassReader reader = new ClassReader(byteCodeStream);
@@ -85,11 +88,13 @@ public class JavaAsmTestRunner {
                         String clsNameForLoad = rawName.endsWith("$") ? rawName.substring(0, rawName.length() - 1) : rawName;
                         Class<?> cls = loader.loadClass(clsNameForLoad);
                         Optional<Fingerprint> result =
-                            JavaFrameworkUtils.matchFingerprints(loader, cls, new Fingerprint[]{fp});
+                            JavaFrameworkUtils.matchFingerprints(loader, cls, new Fingerprint[]{fp}, logger);
                         if (result.isPresent()) return Optional.of(fp);
                     } catch (ClassNotFoundException | NoClassDefFoundError |
                              UnsupportedClassVersionError | IncompatibleClassChangeError e) {
-                        // fall through
+                        // Expected: class may not be loadable during scanning
+                        logger.debug(
+                            "Could not load class for annotation matching: " + className + " (" + e + ")");
                     }
                 }
             }
@@ -97,9 +102,9 @@ public class JavaAsmTestRunner {
         return Optional.empty();
     }
 
-    public static List<String> findFrameworkServices(List<Path> classPath) {
+    public static List<String> findFrameworkServices(List<Path> classPath, JavaTestLogger logger) {
         List<String> result = new ArrayList<>();
-        byte[] content = findInClassPath(classPath, "META-INF/services/sbt.testing.Framework");
+        byte[] content = findInClassPath(classPath, "META-INF/services/sbt.testing.Framework", logger);
         if (content != null) {
             parseServiceFileContent(new String(content, StandardCharsets.UTF_8), result);
         }
@@ -118,13 +123,14 @@ public class JavaAsmTestRunner {
     public static List<String> findFrameworks(
         List<Path> classPath,
         List<String> preferredClasses,
-        ParentInspector parentInspector
+        ParentInspector parentInspector,
+        JavaTestLogger logger
     ) {
         List<String> result = new ArrayList<>();
         // first check preferred classes
         for (String preferred : preferredClasses) {
             String resourceName = preferred.replace('.', '/') + ".class";
-            byte[] bytes = findInClassPath(classPath, resourceName);
+            byte[] bytes = findInClassPath(classPath, resourceName, logger);
             if (bytes != null) {
                 TestClassChecker checker = new TestClassChecker();
                 new ClassReader(bytes).accept(checker, 0);
@@ -139,7 +145,7 @@ public class JavaAsmTestRunner {
         if (!result.isEmpty()) return result;
 
         // scan all classes in classpath
-        for (Map.Entry<String, byte[]> entry : listClassesByteCode(classPath, true).entrySet()) {
+        for (Map.Entry<String, byte[]> entry : listClassesByteCode(classPath, true, logger).entrySet()) {
             String name = entry.getKey();
             if (name.contains("module-info")) continue;
             TestClassChecker checker = new TestClassChecker();
@@ -158,10 +164,11 @@ public class JavaAsmTestRunner {
         boolean keepJars,
         List<Fingerprint> fingerprints,
         ParentInspector parentInspector,
-        ClassLoader loader
+        ClassLoader loader,
+        JavaTestLogger logger
     ) {
         List<TaskDef> result = new ArrayList<>();
-        for (Map.Entry<String, byte[]> entry : listClassesByteCode(classPath, keepJars).entrySet()) {
+        for (Map.Entry<String, byte[]> entry : listClassesByteCode(classPath, keepJars, logger).entrySet()) {
             String name = entry.getKey();
             if (name.contains("module-info")) continue;
             try {
@@ -170,7 +177,8 @@ public class JavaAsmTestRunner {
                     new ByteArrayInputStream(entry.getValue()),
                     fingerprints,
                     parentInspector,
-                    loader
+                    loader,
+                    logger
                 );
                 if (fp.isPresent()) {
                     String stripped = name.endsWith("$") ? name.substring(0, name.length() - 1) : name;
@@ -178,21 +186,25 @@ public class JavaAsmTestRunner {
                     result.add(new TaskDef(clsName, fp.get(), false, new Selector[]{new SuiteSelector()}));
                 }
             } catch (IOException e) {
-                // skip
+                logger.debug("Could not read bytecode for " + name + ": " + e.getMessage());
             }
         }
         return result;
     }
 
-    private static Map<String, byte[]> listClassesByteCode(List<Path> classPath, boolean keepJars) {
+    private static Map<String, byte[]> listClassesByteCode(
+        List<Path> classPath, boolean keepJars, JavaTestLogger logger
+    ) {
         Map<String, byte[]> result = new LinkedHashMap<>();
         for (Path entry : classPath) {
-            result.putAll(listClassesByteCode(entry, keepJars));
+            result.putAll(listClassesByteCode(entry, keepJars, logger));
         }
         return result;
     }
 
-    private static Map<String, byte[]> listClassesByteCode(Path entry, boolean keepJars) {
+    private static Map<String, byte[]> listClassesByteCode(
+        Path entry, boolean keepJars, JavaTestLogger logger
+    ) {
         Map<String, byte[]> result = new LinkedHashMap<>();
         if (Files.isDirectory(entry)) {
             try (Stream<Path> stream = Files.walk(entry, Integer.MAX_VALUE)) {
@@ -203,11 +215,11 @@ public class JavaAsmTestRunner {
                         try {
                             result.put(name, Files.readAllBytes(p));
                         } catch (IOException e) {
-                            // skip
+                            logger.debug("Could not read class file " + p + ": " + e.getMessage());
                         }
                     });
             } catch (IOException e) {
-                // skip
+                logger.debug("Could not walk directory " + entry + ": " + e.getMessage());
             }
         } else if (keepJars && Files.isRegularFile(entry)) {
             byte[] buf = new byte[16384];
@@ -228,27 +240,28 @@ public class JavaAsmTestRunner {
                     result.put(name, baos.toByteArray());
                 }
             } catch (IOException e) {
-                // skip
+                logger.debug("Could not read JAR " + entry + ": " + e.getMessage());
             }
         }
         return result;
     }
 
-    private static byte[] findInClassPath(List<Path> classPath, String name) {
+    static byte[] findInClassPath(List<Path> classPath, String name, JavaTestLogger logger) {
         for (Path entry : classPath) {
-            byte[] found = findInClassPathEntry(entry, name);
+            byte[] found = findInClassPathEntry(entry, name, logger);
             if (found != null) return found;
         }
         return null;
     }
 
-    private static byte[] findInClassPathEntry(Path entry, String name) {
+    private static byte[] findInClassPathEntry(Path entry, String name, JavaTestLogger logger) {
         if (Files.isDirectory(entry)) {
             Path p = entry.resolve(name);
             if (Files.isRegularFile(p)) {
                 try {
                     return Files.readAllBytes(p);
                 } catch (IOException e) {
+                    logger.debug("Could not read " + p + ": " + e.getMessage());
                     return null;
                 }
             }
@@ -266,6 +279,7 @@ public class JavaAsmTestRunner {
                 }
                 return baos.toByteArray();
             } catch (IOException e) {
+                logger.debug("Could not read " + name + " from " + entry + ": " + e.getMessage());
                 return null;
             }
         }

--- a/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaAsmTestRunner.java
+++ b/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaAsmTestRunner.java
@@ -1,0 +1,315 @@
+package scala.build.testrunner;
+
+import org.objectweb.asm.*;
+import sbt.testing.*;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+import java.util.zip.*;
+
+public class JavaAsmTestRunner {
+
+    public static class ParentInspector {
+        private final List<Path> classPath;
+        private final ConcurrentHashMap<String, List<String>> cache = new ConcurrentHashMap<>();
+
+        public ParentInspector(List<Path> classPath) {
+            this.classPath = classPath;
+        }
+
+        private List<String> parents(String className) {
+            return cache.computeIfAbsent(className, name -> {
+                byte[] byteCode = findInClassPath(classPath, name + ".class");
+                if (byteCode == null) return Collections.emptyList();
+                TestClassChecker checker = new TestClassChecker();
+                ClassReader reader = new ClassReader(byteCode);
+                reader.accept(checker, 0);
+                return checker.getImplements();
+            });
+        }
+
+        public List<String> allParents(String className) {
+            List<String> result = new ArrayList<>();
+            Set<String> done = new HashSet<>();
+            Deque<String> todo = new ArrayDeque<>();
+            todo.add(className);
+            while (!todo.isEmpty()) {
+                String current = todo.poll();
+                if (!done.add(current)) continue;
+                result.add(current);
+                todo.addAll(parents(current));
+            }
+            return result;
+        }
+    }
+
+    public static Optional<Fingerprint> matchFingerprints(
+        String className,
+        InputStream byteCodeStream,
+        List<Fingerprint> fingerprints,
+        ParentInspector parentInspector,
+        ClassLoader loader
+    ) throws IOException {
+        TestClassChecker checker = new TestClassChecker();
+        ClassReader reader = new ClassReader(byteCodeStream);
+        reader.accept(checker, 0);
+
+        boolean isModule = className.endsWith("$");
+        boolean hasPublicConstructors = checker.getPublicConstructorCount() > 0;
+        boolean definitelyNoTests = checker.isAbstract() ||
+            checker.isInterface() ||
+            checker.getPublicConstructorCount() > 1 ||
+            isModule == hasPublicConstructors;
+
+        if (definitelyNoTests) return Optional.empty();
+
+        for (Fingerprint fp : fingerprints) {
+            if (fp instanceof SubclassFingerprint) {
+                SubclassFingerprint sf = (SubclassFingerprint) fp;
+                if (sf.isModule() != isModule) continue;
+                String superName = sf.superclassName().replace('.', '/');
+                if (parentInspector.allParents(checker.getName()).contains(superName)) {
+                    return Optional.of(fp);
+                }
+            } else if (fp instanceof AnnotatedFingerprint) {
+                AnnotatedFingerprint af = (AnnotatedFingerprint) fp;
+                if (af.isModule() != isModule) continue;
+                // Use classloader-based reflection for annotation matching (proven approach)
+                if (loader != null) {
+                    try {
+                        String rawName = className.replace('/', '.').replace('\\', '.');
+                        String clsNameForLoad = rawName.endsWith("$") ? rawName.substring(0, rawName.length() - 1) : rawName;
+                        Class<?> cls = loader.loadClass(clsNameForLoad);
+                        Optional<Fingerprint> result =
+                            JavaFrameworkUtils.matchFingerprints(loader, cls, new Fingerprint[]{fp});
+                        if (result.isPresent()) return Optional.of(fp);
+                    } catch (ClassNotFoundException | NoClassDefFoundError |
+                             UnsupportedClassVersionError | IncompatibleClassChangeError e) {
+                        // fall through
+                    }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static List<String> findFrameworkServices(List<Path> classPath) {
+        List<String> result = new ArrayList<>();
+        byte[] content = findInClassPath(classPath, "META-INF/services/sbt.testing.Framework");
+        if (content != null) {
+            parseServiceFileContent(new String(content, StandardCharsets.UTF_8), result);
+        }
+        return result;
+    }
+
+    private static void parseServiceFileContent(String content, List<String> result) {
+        for (String line : content.split("[\r\n]+")) {
+            String trimmed = line.trim();
+            if (!trimmed.isEmpty() && !trimmed.startsWith("#")) {
+                result.add(trimmed);
+            }
+        }
+    }
+
+    public static List<String> findFrameworks(
+        List<Path> classPath,
+        List<String> preferredClasses,
+        ParentInspector parentInspector
+    ) {
+        List<String> result = new ArrayList<>();
+        // first check preferred classes
+        for (String preferred : preferredClasses) {
+            String resourceName = preferred.replace('.', '/') + ".class";
+            byte[] bytes = findInClassPath(classPath, resourceName);
+            if (bytes != null) {
+                TestClassChecker checker = new TestClassChecker();
+                new ClassReader(bytes).accept(checker, 0);
+                if (!checker.isAbstract() && checker.getPublicConstructorCount() == 1) {
+                    String internalName = preferred.replace('.', '/');
+                    if (parentInspector.allParents(internalName).contains("sbt/testing/Framework")) {
+                        result.add(internalName);
+                    }
+                }
+            }
+        }
+        if (!result.isEmpty()) return result;
+
+        // scan all classes in classpath
+        for (Map.Entry<String, byte[]> entry : listClassesByteCode(classPath, true).entrySet()) {
+            String name = entry.getKey();
+            if (name.contains("module-info")) continue;
+            TestClassChecker checker = new TestClassChecker();
+            new ClassReader(entry.getValue()).accept(checker, 0);
+            if (!checker.isAbstract() && checker.getPublicConstructorCount() == 1) {
+                if (parentInspector.allParents(name).contains("sbt/testing/Framework")) {
+                    result.add(name);
+                }
+            }
+        }
+        return result;
+    }
+
+    public static List<TaskDef> taskDefs(
+        List<Path> classPath,
+        boolean keepJars,
+        List<Fingerprint> fingerprints,
+        ParentInspector parentInspector,
+        ClassLoader loader
+    ) {
+        List<TaskDef> result = new ArrayList<>();
+        for (Map.Entry<String, byte[]> entry : listClassesByteCode(classPath, keepJars).entrySet()) {
+            String name = entry.getKey();
+            if (name.contains("module-info")) continue;
+            try {
+                Optional<Fingerprint> fp = matchFingerprints(
+                    name,
+                    new ByteArrayInputStream(entry.getValue()),
+                    fingerprints,
+                    parentInspector,
+                    loader
+                );
+                if (fp.isPresent()) {
+                    String stripped = name.endsWith("$") ? name.substring(0, name.length() - 1) : name;
+                    String clsName = stripped.replace('/', '.').replace('\\', '.');
+                    result.add(new TaskDef(clsName, fp.get(), false, new Selector[]{new SuiteSelector()}));
+                }
+            } catch (IOException e) {
+                // skip
+            }
+        }
+        return result;
+    }
+
+    private static Map<String, byte[]> listClassesByteCode(List<Path> classPath, boolean keepJars) {
+        Map<String, byte[]> result = new LinkedHashMap<>();
+        for (Path entry : classPath) {
+            result.putAll(listClassesByteCode(entry, keepJars));
+        }
+        return result;
+    }
+
+    private static Map<String, byte[]> listClassesByteCode(Path entry, boolean keepJars) {
+        Map<String, byte[]> result = new LinkedHashMap<>();
+        if (Files.isDirectory(entry)) {
+            try (Stream<Path> stream = Files.walk(entry, Integer.MAX_VALUE)) {
+                stream.filter(p -> p.getFileName().toString().endsWith(".class"))
+                    .forEach(p -> {
+                        String rel = entry.relativize(p).toString().replace('\\', '/');
+                        String name = rel.endsWith(".class") ? rel.substring(0, rel.length() - 6) : rel;
+                        try {
+                            result.put(name, Files.readAllBytes(p));
+                        } catch (IOException e) {
+                            // skip
+                        }
+                    });
+            } catch (IOException e) {
+                // skip
+            }
+        } else if (keepJars && Files.isRegularFile(entry)) {
+            byte[] buf = new byte[16384];
+            try (ZipFile zf = new ZipFile(entry.toFile())) {
+                Enumeration<? extends ZipEntry> entries = zf.entries();
+                while (entries.hasMoreElements()) {
+                    ZipEntry ze = entries.nextElement();
+                    if (!ze.getName().endsWith(".class")) continue;
+                    String name = ze.getName();
+                    name = name.substring(0, name.length() - 6);
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                    try (InputStream is = zf.getInputStream(ze)) {
+                        int read;
+                        while ((read = is.read(buf)) >= 0) {
+                            baos.write(buf, 0, read);
+                        }
+                    }
+                    result.put(name, baos.toByteArray());
+                }
+            } catch (IOException e) {
+                // skip
+            }
+        }
+        return result;
+    }
+
+    private static byte[] findInClassPath(List<Path> classPath, String name) {
+        for (Path entry : classPath) {
+            byte[] found = findInClassPathEntry(entry, name);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    private static byte[] findInClassPathEntry(Path entry, String name) {
+        if (Files.isDirectory(entry)) {
+            Path p = entry.resolve(name);
+            if (Files.isRegularFile(p)) {
+                try {
+                    return Files.readAllBytes(p);
+                } catch (IOException e) {
+                    return null;
+                }
+            }
+        } else if (Files.isRegularFile(entry)) {
+            byte[] buf = new byte[16384];
+            try (ZipFile zf = new ZipFile(entry.toFile())) {
+                ZipEntry ze = zf.getEntry(name);
+                if (ze == null) return null;
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                try (InputStream is = zf.getInputStream(ze)) {
+                    int read;
+                    while ((read = is.read(buf)) >= 0) {
+                        baos.write(buf, 0, read);
+                    }
+                }
+                return baos.toByteArray();
+            } catch (IOException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    public static class TestClassChecker extends ClassVisitor {
+        private String name;
+        private int publicConstructorCount = 0;
+        private boolean isInterface = false;
+        private boolean isAbstract = false;
+        private List<String> implementsList = new ArrayList<>();
+
+        public TestClassChecker() {
+            super(Opcodes.ASM9);
+        }
+
+        @Override
+        public void visit(int version, int access, String name, String signature,
+                          String superName, String[] interfaces) {
+            this.name = name;
+            this.isInterface = (access & Opcodes.ACC_INTERFACE) != 0;
+            this.isAbstract = (access & Opcodes.ACC_ABSTRACT) != 0;
+            if (superName != null) implementsList.add(superName);
+            if (interfaces != null) {
+                for (String iface : interfaces) {
+                    implementsList.add(iface);
+                }
+            }
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                         String signature, String[] exceptions) {
+            if ("<init>".equals(name) && (access & Opcodes.ACC_PUBLIC) != 0) {
+                publicConstructorCount++;
+            }
+            return null;
+        }
+
+        public String getName() { return name; }
+        public int getPublicConstructorCount() { return publicConstructorCount; }
+        public boolean isInterface() { return isInterface; }
+        public boolean isAbstract() { return isAbstract; }
+        public List<String> getImplements() { return implementsList; }
+    }
+}

--- a/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaDynamicTestRunner.java
+++ b/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaDynamicTestRunner.java
@@ -47,7 +47,7 @@ public class JavaDynamicTestRunner {
                 try {
                     verbosity = Integer.parseInt(arg.substring("--verbosity=".length()));
                 } catch (NumberFormatException e) {
-                    // ignore malformed
+                    System.err.println("Warning: malformed --verbosity value: " + arg);
                 }
             } else if ("--require-tests".equals(arg)) {
                 requireTests = true;
@@ -64,7 +64,7 @@ public class JavaDynamicTestRunner {
         }
 
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        java.util.List<java.nio.file.Path> classPath0 = JavaTestRunner.classPath(classLoader);
+        java.util.List<java.nio.file.Path> classPath0 = JavaTestRunner.classPath(classLoader, logger);
 
         List<Framework> frameworks;
         if (!testFrameworks.isEmpty()) {
@@ -73,15 +73,15 @@ public class JavaDynamicTestRunner {
                 try {
                     frameworks.add(JavaFrameworkUtils.loadFramework(classLoader, fw));
                 } catch (Exception e) {
-                    System.err.println("Could not load test framework: " + fw);
-                    System.err.println(e.getMessage());
+                    logger.error("Could not load test framework: " + fw);
+                    logger.error(e.toString());
                     System.exit(1);
                 }
             }
         } else {
             List<Framework> frameworkServices = JavaFrameworkUtils.findFrameworkServices(classLoader);
             List<Framework> scannedFrameworks = JavaFrameworkUtils.findFrameworks(
-                classPath0, classLoader, JavaTestRunner.commonTestFrameworks()
+                classPath0, classLoader, JavaTestRunner.commonTestFrameworks(), logger
             );
             List<Framework> toRun = JavaFrameworkUtils.getFrameworksToRun(
                 frameworkServices, scannedFrameworks, logger
@@ -108,19 +108,20 @@ public class JavaDynamicTestRunner {
             Runner runner = framework.runner(runnerArgs, new String[0], classLoader);
 
             List<Class<?>> classes = new ArrayList<>();
-            for (String name : JavaFrameworkUtils.listClasses(classPath0, false)) {
+            for (String name : JavaFrameworkUtils.listClasses(classPath0, false, logger)) {
                 try {
                     classes.add(classLoader.loadClass(name));
                 } catch (ClassNotFoundException | NoClassDefFoundError |
                          UnsupportedClassVersionError | IncompatibleClassChangeError e) {
-                    // skip
+                    // Expected: not every .class file on the classpath is loadable
+                    logger.debug("Could not load class " + name + ": " + e);
                 }
             }
 
             List<TaskDef> taskDefs = new ArrayList<>();
             for (Class<?> cls : classes) {
                 Optional<Fingerprint> fp = JavaFrameworkUtils.matchFingerprints(
-                    classLoader, cls, fingerprints
+                    classLoader, cls, fingerprints, logger
                 );
                 if (!fp.isPresent()) continue;
                 String clsName = cls.getName().endsWith("$")

--- a/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaDynamicTestRunner.java
+++ b/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaDynamicTestRunner.java
@@ -1,0 +1,161 @@
+package scala.build.testrunner;
+
+import sbt.testing.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+public class JavaDynamicTestRunner {
+
+    /**
+     * Based on junit-interface GlobFilter.compileGlobPattern:
+     * https://github.com/sbt/junit-interface/blob/f8c6372ed01ce86f15393b890323d96afbe6d594/src/main/java/com/novocode/junit/GlobFilter.java#L37
+     *
+     * Converts a glob expression (only * supported) into a regex Pattern.
+     */
+    private static Pattern globPattern(String expr) {
+        String[] parts = expr.split("\\*", -1);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < parts.length; i++) {
+            if (i != 0) sb.append(".*");
+            if (!parts[i].isEmpty()) sb.append(Pattern.quote(parts[i].replace("\n", "\\n")));
+        }
+        return Pattern.compile(sb.toString());
+    }
+
+    public static void main(String[] args) {
+        List<String> testFrameworks = new ArrayList<>();
+        List<String> remainingArgs = new ArrayList<>();
+        boolean requireTests = false;
+        int verbosity = 0;
+        Optional<String> testOnly = Optional.empty();
+
+        boolean pastDashDash = false;
+        for (String arg : args) {
+            if (pastDashDash) {
+                remainingArgs.add(arg);
+            } else if ("--".equals(arg)) {
+                pastDashDash = true;
+            } else if (arg.startsWith("--test-framework=")) {
+                testFrameworks.add(arg.substring("--test-framework=".length()));
+            } else if (arg.startsWith("--test-only=")) {
+                testOnly = Optional.of(arg.substring("--test-only=".length()));
+            } else if (arg.startsWith("--verbosity=")) {
+                try {
+                    verbosity = Integer.parseInt(arg.substring("--verbosity=".length()));
+                } catch (NumberFormatException e) {
+                    // ignore malformed
+                }
+            } else if ("--require-tests".equals(arg)) {
+                requireTests = true;
+            } else {
+                remainingArgs.add(arg);
+            }
+        }
+
+        JavaTestLogger logger = new JavaTestLogger(verbosity, System.err);
+
+        if (!testFrameworks.isEmpty()) {
+            logger.debug("Directly passed " + testFrameworks.size() + " test frameworks:\n  - " +
+                String.join("\n  - ", testFrameworks));
+        }
+
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        java.util.List<java.nio.file.Path> classPath0 = JavaTestRunner.classPath(classLoader);
+
+        List<Framework> frameworks;
+        if (!testFrameworks.isEmpty()) {
+            frameworks = new ArrayList<>();
+            for (String fw : testFrameworks) {
+                try {
+                    frameworks.add(JavaFrameworkUtils.loadFramework(classLoader, fw));
+                } catch (Exception e) {
+                    System.err.println("Could not load test framework: " + fw);
+                    System.err.println(e.getMessage());
+                    System.exit(1);
+                }
+            }
+        } else {
+            List<Framework> frameworkServices = JavaFrameworkUtils.findFrameworkServices(classLoader);
+            List<Framework> scannedFrameworks = JavaFrameworkUtils.findFrameworks(
+                classPath0, classLoader, JavaTestRunner.commonTestFrameworks()
+            );
+            List<Framework> toRun = JavaFrameworkUtils.getFrameworksToRun(
+                frameworkServices, scannedFrameworks, logger
+            );
+            if (toRun.isEmpty()) {
+                if (verbosity >= 2) {
+                    throw new RuntimeException("No test framework found");
+                } else {
+                    System.err.println("No test framework found");
+                    System.exit(1);
+                }
+            }
+            frameworks = toRun;
+        }
+
+        String[] runnerArgs = remainingArgs.toArray(new String[0]);
+        final Optional<String> testOnlyFinal = testOnly;
+        final boolean requireTestsFinal = requireTests;
+
+        boolean anyFailed = false;
+        for (Framework framework : frameworks) {
+            logger.log("Running test framework: " + framework.name());
+            Fingerprint[] fingerprints = framework.fingerprints();
+            Runner runner = framework.runner(runnerArgs, new String[0], classLoader);
+
+            List<Class<?>> classes = new ArrayList<>();
+            for (String name : JavaFrameworkUtils.listClasses(classPath0, false)) {
+                try {
+                    classes.add(classLoader.loadClass(name));
+                } catch (ClassNotFoundException | NoClassDefFoundError |
+                         UnsupportedClassVersionError | IncompatibleClassChangeError e) {
+                    // skip
+                }
+            }
+
+            List<TaskDef> taskDefs = new ArrayList<>();
+            for (Class<?> cls : classes) {
+                Optional<Fingerprint> fp = JavaFrameworkUtils.matchFingerprints(
+                    classLoader, cls, fingerprints
+                );
+                if (!fp.isPresent()) continue;
+                String clsName = cls.getName().endsWith("$")
+                    ? cls.getName().substring(0, cls.getName().length() - 1)
+                    : cls.getName();
+                if (testOnlyFinal.isPresent()) {
+                    Pattern pat = globPattern(testOnlyFinal.get());
+                    if (!pat.matcher(clsName).matches()) continue;
+                }
+                taskDefs.add(new TaskDef(clsName, fp.get(), false, new Selector[]{new SuiteSelector()}));
+            }
+
+            Task[] initialTasks = runner.tasks(taskDefs.toArray(new TaskDef[0]));
+            List<Event> events = JavaTestRunner.runTasks(Arrays.asList(initialTasks), System.out);
+
+            boolean failed = events.stream().anyMatch(ev ->
+                ev.status() == Status.Error ||
+                ev.status() == Status.Failure ||
+                ev.status() == Status.Canceled
+            );
+
+            String doneMsg = runner.done();
+            if (doneMsg != null && !doneMsg.isEmpty()) System.out.println(doneMsg);
+
+            if (requireTestsFinal && events.isEmpty()) {
+                logger.error("Error: no tests were run for " + framework.name() + ".");
+                anyFailed = true;
+            } else if (failed) {
+                logger.error("Error: " + framework.name() + " tests failed.");
+                anyFailed = true;
+            } else {
+                logger.log(framework.name() + " tests ran successfully.");
+            }
+        }
+
+        System.exit(anyFailed ? 1 : 0);
+    }
+}

--- a/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaFrameworkUtils.java
+++ b/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaFrameworkUtils.java
@@ -30,7 +30,8 @@ public class JavaFrameworkUtils {
     public static List<Framework> findFrameworks(
         List<Path> classPath,
         ClassLoader loader,
-        List<String> preferredClasses
+        List<String> preferredClasses,
+        JavaTestLogger logger
     ) {
         Class<?> frameworkCls = Framework.class;
         List<Framework> result = new ArrayList<>();
@@ -38,7 +39,7 @@ public class JavaFrameworkUtils {
 
         // first try preferred classes, then scan classpath
         List<String> candidates = new ArrayList<>(preferredClasses);
-        for (String name : listClasses(classPath, true)) {
+        for (String name : listClasses(classPath, true, logger)) {
             if (!seen.contains(name)) {
                 candidates.add(name);
             }
@@ -51,6 +52,7 @@ public class JavaFrameworkUtils {
                 cls = loader.loadClass(name);
             } catch (ClassNotFoundException | UnsupportedClassVersionError |
                      NoClassDefFoundError | IncompatibleClassChangeError e) {
+                // Expected: most classpath entries aren't test frameworks
                 continue;
             }
             if (!frameworkCls.isAssignableFrom(cls)) continue;
@@ -63,7 +65,7 @@ public class JavaFrameworkUtils {
                 Framework instance = (Framework) cls.getConstructor().newInstance();
                 result.add(instance);
             } catch (Exception e) {
-                // skip
+                logger.debug("Could not instantiate framework " + name + ": " + e);
             }
         }
         return result;
@@ -72,7 +74,8 @@ public class JavaFrameworkUtils {
     public static Optional<Fingerprint> matchFingerprints(
         ClassLoader loader,
         Class<?> cls,
-        Fingerprint[] fingerprints
+        Fingerprint[] fingerprints,
+        JavaTestLogger logger
     ) {
         boolean isModule = cls.getName().endsWith("$");
         long publicCtorCount = Arrays.stream(cls.getConstructors())
@@ -93,7 +96,8 @@ public class JavaFrameworkUtils {
                     Class<?> superCls = loader.loadClass(sf.superclassName());
                     if (superCls.isAssignableFrom(cls)) return Optional.of(fp);
                 } catch (ClassNotFoundException e) {
-                    // skip
+                    logger.debug(
+                        "Superclass not found for fingerprint matching: " + sf.superclassName());
                 }
             } else if (fp instanceof AnnotatedFingerprint) {
                 AnnotatedFingerprint af = (AnnotatedFingerprint) fp;
@@ -111,7 +115,8 @@ public class JavaFrameworkUtils {
                                           Modifier.isPublic(m.getModifiers()));
                     if (matches) return Optional.of(fp);
                 } catch (ClassNotFoundException e) {
-                    // skip
+                    logger.debug(
+                        "Annotation class not found for fingerprint matching: " + af.annotationName());
                 }
             }
         }
@@ -150,15 +155,15 @@ public class JavaFrameworkUtils {
         return finalFrameworks;
     }
 
-    public static List<String> listClasses(List<Path> classPath, boolean keepJars) {
+    public static List<String> listClasses(List<Path> classPath, boolean keepJars, JavaTestLogger logger) {
         List<String> result = new ArrayList<>();
         for (Path entry : classPath) {
-            result.addAll(listClasses(entry, keepJars));
+            result.addAll(listClasses(entry, keepJars, logger));
         }
         return result;
     }
 
-    public static List<String> listClasses(Path entry, boolean keepJars) {
+    public static List<String> listClasses(Path entry, boolean keepJars, JavaTestLogger logger) {
         List<String> result = new ArrayList<>();
         if (Files.isDirectory(entry)) {
             try (Stream<Path> stream = Files.walk(entry, Integer.MAX_VALUE)) {
@@ -175,7 +180,7 @@ public class JavaFrameworkUtils {
                     })
                     .forEach(result::add);
             } catch (Exception e) {
-                // skip
+                logger.debug("Could not walk directory " + entry + ": " + e.getMessage());
             }
         } else if (keepJars && Files.isRegularFile(entry)) {
             try (ZipFile zf = new ZipFile(entry.toFile())) {
@@ -188,7 +193,7 @@ public class JavaFrameworkUtils {
                     }
                 }
             } catch (Exception e) {
-                // skip
+                logger.debug("Could not read JAR " + entry + ": " + e.getMessage());
             }
         }
         return result;

--- a/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaFrameworkUtils.java
+++ b/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaFrameworkUtils.java
@@ -65,7 +65,7 @@ public class JavaFrameworkUtils {
                 Framework instance = (Framework) cls.getConstructor().newInstance();
                 result.add(instance);
             } catch (Exception e) {
-                logger.debug("Could not instantiate framework " + name + ": " + e);
+                logger.log("Could not instantiate framework " + name + ": " + e);
             }
         }
         return result;
@@ -180,7 +180,7 @@ public class JavaFrameworkUtils {
                     })
                     .forEach(result::add);
             } catch (Exception e) {
-                logger.debug("Could not walk directory " + entry + ": " + e.getMessage());
+                logger.log("Could not walk directory " + entry + ": " + e.getMessage());
             }
         } else if (keepJars && Files.isRegularFile(entry)) {
             try (ZipFile zf = new ZipFile(entry.toFile())) {
@@ -193,7 +193,7 @@ public class JavaFrameworkUtils {
                     }
                 }
             } catch (Exception e) {
-                logger.debug("Could not read JAR " + entry + ": " + e.getMessage());
+                logger.log("Could not read JAR " + entry + ": " + e.getMessage());
             }
         }
         return result;

--- a/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaFrameworkUtils.java
+++ b/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaFrameworkUtils.java
@@ -1,0 +1,196 @@
+package scala.build.testrunner;
+
+import sbt.testing.*;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.stream.Stream;
+
+public class JavaFrameworkUtils {
+
+    public static List<Framework> findFrameworkServices(ClassLoader loader) {
+        List<Framework> result = new ArrayList<>();
+        ServiceLoader<Framework> serviceLoader = ServiceLoader.load(Framework.class, loader);
+        for (Framework f : serviceLoader) {
+            result.add(f);
+        }
+        return result;
+    }
+
+    public static Framework loadFramework(ClassLoader loader, String className) throws Exception {
+        Class<?> cls = loader.loadClass(className);
+        return (Framework) cls.getConstructor().newInstance();
+    }
+
+    public static List<Framework> findFrameworks(
+        List<Path> classPath,
+        ClassLoader loader,
+        List<String> preferredClasses
+    ) {
+        Class<?> frameworkCls = Framework.class;
+        List<Framework> result = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+
+        // first try preferred classes, then scan classpath
+        List<String> candidates = new ArrayList<>(preferredClasses);
+        for (String name : listClasses(classPath, true)) {
+            if (!seen.contains(name)) {
+                candidates.add(name);
+            }
+        }
+
+        for (String name : candidates) {
+            if (!seen.add(name)) continue;
+            Class<?> cls;
+            try {
+                cls = loader.loadClass(name);
+            } catch (ClassNotFoundException | UnsupportedClassVersionError |
+                     NoClassDefFoundError | IncompatibleClassChangeError e) {
+                continue;
+            }
+            if (!frameworkCls.isAssignableFrom(cls)) continue;
+            if (Modifier.isAbstract(cls.getModifiers())) continue;
+            long publicNoArgCtors = Arrays.stream(cls.getConstructors())
+                .filter(c -> Modifier.isPublic(c.getModifiers()) && c.getParameterCount() == 0)
+                .count();
+            if (publicNoArgCtors != 1) continue;
+            try {
+                Framework instance = (Framework) cls.getConstructor().newInstance();
+                result.add(instance);
+            } catch (Exception e) {
+                // skip
+            }
+        }
+        return result;
+    }
+
+    public static Optional<Fingerprint> matchFingerprints(
+        ClassLoader loader,
+        Class<?> cls,
+        Fingerprint[] fingerprints
+    ) {
+        boolean isModule = cls.getName().endsWith("$");
+        long publicCtorCount = Arrays.stream(cls.getConstructors())
+            .filter(c -> Modifier.isPublic(c.getModifiers()))
+            .count();
+        boolean noPublicConstructors = publicCtorCount == 0;
+        boolean definitelyNoTests = Modifier.isAbstract(cls.getModifiers()) ||
+            cls.isInterface() ||
+            publicCtorCount > 1 ||
+            isModule != noPublicConstructors;
+        if (definitelyNoTests) return Optional.empty();
+
+        for (Fingerprint fp : fingerprints) {
+            if (fp instanceof SubclassFingerprint) {
+                SubclassFingerprint sf = (SubclassFingerprint) fp;
+                if (sf.isModule() != isModule) continue;
+                try {
+                    Class<?> superCls = loader.loadClass(sf.superclassName());
+                    if (superCls.isAssignableFrom(cls)) return Optional.of(fp);
+                } catch (ClassNotFoundException e) {
+                    // skip
+                }
+            } else if (fp instanceof AnnotatedFingerprint) {
+                AnnotatedFingerprint af = (AnnotatedFingerprint) fp;
+                if (af.isModule() != isModule) continue;
+                try {
+                    @SuppressWarnings("unchecked")
+                    Class<? extends Annotation> annotationCls =
+                        (Class<? extends Annotation>) loader.loadClass(af.annotationName());
+                    boolean matches =
+                        cls.isAnnotationPresent(annotationCls) ||
+                        Arrays.stream(cls.getDeclaredMethods())
+                            .anyMatch(m -> m.isAnnotationPresent(annotationCls)) ||
+                        Arrays.stream(cls.getMethods())
+                            .anyMatch(m -> m.isAnnotationPresent(annotationCls) &&
+                                          Modifier.isPublic(m.getModifiers()));
+                    if (matches) return Optional.of(fp);
+                } catch (ClassNotFoundException e) {
+                    // skip
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static List<Framework> getFrameworksToRun(
+        List<Framework> frameworkServices,
+        List<Framework> frameworks,
+        JavaTestLogger logger
+    ) {
+        List<Framework> all = new ArrayList<>(frameworkServices);
+        all.addAll(frameworks);
+        return getFrameworksToRun(all, logger);
+    }
+
+    public static List<Framework> getFrameworksToRun(
+        List<Framework> allFrameworks,
+        JavaTestLogger logger
+    ) {
+        // dedup by name
+        Map<String, Framework> byName = new LinkedHashMap<>();
+        for (Framework f : allFrameworks) {
+            byName.putIfAbsent(f.name(), f);
+        }
+        List<Framework> distinct = new ArrayList<>(byName.values());
+
+        // filter out frameworks that are superclasses of another framework in the list
+        List<Framework> finalFrameworks = new ArrayList<>();
+        for (Framework f1 : distinct) {
+            boolean isInherited = distinct.stream()
+                .filter(f2 -> f2 != f1)
+                .anyMatch(f2 -> f1.getClass().isAssignableFrom(f2.getClass()));
+            if (!isInherited) finalFrameworks.add(f1);
+        }
+        return finalFrameworks;
+    }
+
+    public static List<String> listClasses(List<Path> classPath, boolean keepJars) {
+        List<String> result = new ArrayList<>();
+        for (Path entry : classPath) {
+            result.addAll(listClasses(entry, keepJars));
+        }
+        return result;
+    }
+
+    public static List<String> listClasses(Path entry, boolean keepJars) {
+        List<String> result = new ArrayList<>();
+        if (Files.isDirectory(entry)) {
+            try (Stream<Path> stream = Files.walk(entry, Integer.MAX_VALUE)) {
+                stream.filter(p -> p.getFileName().toString().endsWith(".class"))
+                    .map(entry::relativize)
+                    .map(p -> {
+                        StringBuilder sb = new StringBuilder();
+                        for (int i = 0; i < p.getNameCount(); i++) {
+                            if (i > 0) sb.append(".");
+                            sb.append(p.getName(i).toString());
+                        }
+                        String name = sb.toString();
+                        return name.endsWith(".class") ? name.substring(0, name.length() - 6) : name;
+                    })
+                    .forEach(result::add);
+            } catch (Exception e) {
+                // skip
+            }
+        } else if (keepJars && Files.isRegularFile(entry)) {
+            try (ZipFile zf = new ZipFile(entry.toFile())) {
+                Enumeration<? extends ZipEntry> entries = zf.entries();
+                while (entries.hasMoreElements()) {
+                    ZipEntry ze = entries.nextElement();
+                    String name = ze.getName();
+                    if (name.endsWith(".class")) {
+                        result.add(name.substring(0, name.length() - 6).replace("/", "."));
+                    }
+                }
+            } catch (Exception e) {
+                // skip
+            }
+        }
+        return result;
+    }
+}

--- a/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaTestLogger.java
+++ b/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaTestLogger.java
@@ -1,0 +1,29 @@
+package scala.build.testrunner;
+
+import java.io.PrintStream;
+
+public class JavaTestLogger {
+    private final int verbosity;
+    private final PrintStream out;
+
+    public JavaTestLogger(int verbosity, PrintStream out) {
+        this.verbosity = verbosity;
+        this.out = out;
+    }
+
+    public void error(String message) {
+        out.println(message);
+    }
+
+    public void message(String message) {
+        if (verbosity >= 0) out.println(message);
+    }
+
+    public void log(String message) {
+        if (verbosity >= 1) out.println(message);
+    }
+
+    public void debug(String message) {
+        if (verbosity >= 2) out.println(message);
+    }
+}

--- a/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaTestRunner.java
+++ b/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaTestRunner.java
@@ -16,16 +16,10 @@ import java.util.List;
 public class JavaTestRunner {
 
     public static List<String> commonTestFrameworks() {
-        return Arrays.asList(
-            "munit.Framework",
-            "utest.runner.Framework",
-            "org.scalacheck.ScalaCheckFramework",
-            "zio.test.sbt.ZTestFramework",
-            "org.scalatest.tools.Framework",
-            "com.novocode.junit.JUnitFramework",
-            "org.scalajs.junit.JUnitFramework",
-            "weaver.framework.CatsEffect"
-        );
+        // Only pure-Java-compatible frameworks belong here.
+        // Scala-only frameworks (munit, utest, ScalaCheck, ZIO Test, ScalaTest, weaver)
+        // live in the Scala test-runner's TestRunner.commonTestFrameworks instead.
+        return Arrays.asList("com.novocode.junit.JUnitFramework");
     }
 
     public static List<Path> classPath(ClassLoader loader, JavaTestLogger logger) {

--- a/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaTestRunner.java
+++ b/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaTestRunner.java
@@ -28,13 +28,13 @@ public class JavaTestRunner {
         );
     }
 
-    public static List<Path> classPath(ClassLoader loader) {
+    public static List<Path> classPath(ClassLoader loader, JavaTestLogger logger) {
         List<Path> result = new ArrayList<>();
-        collectClassPath(loader, result);
+        collectClassPath(loader, result, logger);
         return result;
     }
 
-    private static void collectClassPath(ClassLoader loader, List<Path> result) {
+    private static void collectClassPath(ClassLoader loader, List<Path> result, JavaTestLogger logger) {
         if (loader == null) return;
         if (loader instanceof URLClassLoader) {
             URLClassLoader urlLoader = (URLClassLoader) loader;
@@ -43,7 +43,8 @@ public class JavaTestRunner {
                     try {
                         result.add(Paths.get(url.toURI()).toAbsolutePath());
                     } catch (Exception e) {
-                        // skip
+                        logger.debug(
+                            "Could not convert URL to path: " + url + " (" + e.getMessage() + ")");
                     }
                 }
             }
@@ -55,7 +56,7 @@ public class JavaTestRunner {
                 }
             }
         }
-        collectClassPath(loader.getParent(), result);
+        collectClassPath(loader.getParent(), result, logger);
     }
 
     public static List<Event> runTasks(List<Task> initialTasks, PrintStream out) {

--- a/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaTestRunner.java
+++ b/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaTestRunner.java
@@ -1,0 +1,87 @@
+package scala.build.testrunner;
+
+import sbt.testing.*;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.List;
+
+public class JavaTestRunner {
+
+    public static List<String> commonTestFrameworks() {
+        return Arrays.asList(
+            "munit.Framework",
+            "utest.runner.Framework",
+            "org.scalacheck.ScalaCheckFramework",
+            "zio.test.sbt.ZTestFramework",
+            "org.scalatest.tools.Framework",
+            "com.novocode.junit.JUnitFramework",
+            "org.scalajs.junit.JUnitFramework",
+            "weaver.framework.CatsEffect"
+        );
+    }
+
+    public static List<Path> classPath(ClassLoader loader) {
+        List<Path> result = new ArrayList<>();
+        collectClassPath(loader, result);
+        return result;
+    }
+
+    private static void collectClassPath(ClassLoader loader, List<Path> result) {
+        if (loader == null) return;
+        if (loader instanceof URLClassLoader) {
+            URLClassLoader urlLoader = (URLClassLoader) loader;
+            for (java.net.URL url : urlLoader.getURLs()) {
+                if ("file".equals(url.getProtocol())) {
+                    try {
+                        result.add(Paths.get(url.toURI()).toAbsolutePath());
+                    } catch (Exception e) {
+                        // skip
+                    }
+                }
+            }
+        } else if (loader.getClass().getName().equals("jdk.internal.loader.ClassLoaders$AppClassLoader")) {
+            String cp = System.getProperty("java.class.path", "");
+            for (String entry : cp.split(File.pathSeparator)) {
+                if (!entry.isEmpty()) {
+                    result.add(Paths.get(entry));
+                }
+            }
+        }
+        collectClassPath(loader.getParent(), result);
+    }
+
+    public static List<Event> runTasks(List<Task> initialTasks, PrintStream out) {
+        Deque<Task> tasks = new ArrayDeque<>(initialTasks);
+        List<Event> events = new ArrayList<>();
+
+        sbt.testing.Logger logger = new sbt.testing.Logger() {
+            public boolean ansiCodesSupported() { return true; }
+            public void error(String msg) { out.println(msg); }
+            public void warn(String msg) { out.println(msg); }
+            public void info(String msg) { out.println(msg); }
+            public void debug(String msg) { out.println(msg); }
+            public void trace(Throwable t) { t.printStackTrace(out); }
+        };
+
+        EventHandler eventHandler = event -> events.add(event);
+        sbt.testing.Logger[] loggers = new sbt.testing.Logger[]{logger};
+
+        while (!tasks.isEmpty()) {
+            Task task = tasks.poll();
+            Task[] newTasks = task.execute(eventHandler, loggers);
+            for (Task t : newTasks) {
+                tasks.add(t);
+            }
+        }
+
+        return events;
+    }
+}

--- a/modules/options/src/main/scala/scala/build/Artifacts.scala
+++ b/modules/options/src/main/scala/scala/build/Artifacts.scala
@@ -49,6 +49,7 @@ final case class Artifacts(
   extraSourceJars: Seq[os.Path],
   scalaOpt: Option[ScalaArtifacts],
   hasJvmRunner: Boolean,
+  hasJavaTestRunner: Boolean,
   resolution: Option[Resolution]
 ) {
 
@@ -131,6 +132,7 @@ object Artifacts {
     jvmVersion: Int,
     addJvmRunner: Option[Boolean],
     addJvmTestRunner: Boolean,
+    addJvmJavaTestRunner: Boolean,
     addJmhDependencies: Option[String],
     extraRepositories: Seq[Repository],
     keepResolution: Boolean,
@@ -189,11 +191,19 @@ object Artifacts {
       }
       else Nil
 
+    val jvmJavaTestRunnerDependencies =
+      if addJvmJavaTestRunner then
+        Seq(
+          dep"${Constants.javaTestRunnerOrganization}:${Constants.javaTestRunnerModuleName}:${Constants.javaTestRunnerVersion}"
+        )
+      else Nil
+
     val jmhDependencies = addJmhDependencies.toSeq
       .map(version => dep"${Constants.jmhOrg}:${Constants.jmhGeneratorBytecodeModule}:$version")
 
     val maybeSnapshotRepo = {
       val hasSnapshots = jvmTestRunnerDependencies.exists(_.version.endsWith("SNAPSHOT")) ||
+        jvmJavaTestRunnerDependencies.exists(_.version.endsWith("SNAPSHOT")) ||
         scalaArtifactsParamsOpt.flatMap(_.scalaNativeCliVersion).exists(_.endsWith("SNAPSHOT"))
       val hasNightlies = scalaArtifactsParamsOpt.exists(a =>
         a.params.scalaVersion.endsWith("-NIGHTLY") ||
@@ -409,6 +419,7 @@ object Artifacts {
 
     val internalDependencies =
       jvmTestRunnerDependencies.map(Positioned.none) ++
+        jvmJavaTestRunnerDependencies.map(Positioned.none) ++
         scalaOpt.toSeq.flatMap(_.internalDependencies).map(Positioned.none) ++
         jmhDependencies.map(Positioned.none)
     val updatedDependencies = dependencies ++
@@ -582,6 +593,7 @@ object Artifacts {
       extraSourceJars,
       scalaOpt,
       hasRunner,
+      addJvmJavaTestRunner,
       if (keepResolution) Some(fetchRes.resolution) else None
     )
   }

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -222,6 +222,10 @@ final case class BuildOptions(
   private def addJvmTestRunner: Boolean =
     platform.value == Platform.JVM &&
     internalDependencies.addTestRunnerDependency
+
+  private def addJvmJavaTestRunner: Boolean =
+    platform.value == Platform.JVM &&
+    internalDependencies.addTestRunnerDependency
   private def addJsTestBridge: Option[String] =
     if (platform.value == Platform.JS && internalDependencies.addTestRunnerDependency)
       Some(scalaJsOptions.finalVersion)
@@ -476,6 +480,7 @@ final case class BuildOptions(
       if (scalaArtifactsParamsOpt.isDefined) None
       else Some(false) // no runner in pure Java mode
     }
+    val isJavaBuild                        = scalaArtifactsParamsOpt.isEmpty
     val extraRepositories: Seq[Repository] = value(finalRepositories)
     val maybeArtifacts                     = Artifacts(
       scalaArtifactsParamsOpt = scalaArtifactsParamsOpt,
@@ -490,7 +495,8 @@ final case class BuildOptions(
       fetchSources = classPathOptions.fetchSources.getOrElse(false),
       jvmVersion = javaHome().value.version,
       addJvmRunner = addRunnerDependency0,
-      addJvmTestRunner = isTests && addJvmTestRunner,
+      addJvmTestRunner = isTests && addJvmTestRunner && !isJavaBuild,
+      addJvmJavaTestRunner = isTests && addJvmJavaTestRunner && isJavaBuild,
       addJmhDependencies = jmhOptions.finalJmhVersion,
       extraRepositories = extraRepositories,
       keepResolution = internal.keepResolution,

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
@@ -1,7 +1,7 @@
 package scala.build.testrunner
 
 import org.objectweb.asm
-import sbt.testing.*
+import sbt.testing.{Logger as _, *}
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
 import java.nio.charset.StandardCharsets
@@ -12,7 +12,7 @@ import scala.jdk.CollectionConverters.*
 
 object AsmTestRunner {
 
-  class ParentInspector(classPath: Seq[Path]) {
+  class ParentInspector(classPath: Seq[Path], logger: Logger) {
 
     private val cache = new ConcurrentHashMap[String, Seq[String]]
 
@@ -21,7 +21,7 @@ object AsmTestRunner {
         case Some(value) => value
         case None        =>
           val byteCodeOpt =
-            findInClassPath(classPath, className + ".class")
+            findInClassPath(classPath, className + ".class", logger)
               .take(1)
               .toList
               .headOption
@@ -99,7 +99,8 @@ object AsmTestRunner {
 
   private def listClassesByteCode(
     classPathEntry: Path,
-    keepJars: Boolean
+    keepJars: Boolean,
+    logger: Logger
   ): Iterator[(String, () => InputStream)] =
     if (Files.isDirectory(classPathEntry)) {
       var stream: java.util.stream.Stream[Path] = null
@@ -117,6 +118,11 @@ object AsmTestRunner {
           }
           .toVector // fully consume stream before closing it
           .iterator
+      }
+      catch {
+        case e: Exception =>
+          logger.debug(s"Could not walk directory $classPathEntry: ${e.getMessage}")
+          Iterator.empty
       }
       finally if (stream != null) stream.close()
     }
@@ -149,20 +155,36 @@ object AsmTestRunner {
           .toVector // fully consume ZipFile before closing it
           .iterator
       }
+      catch {
+        case e: Exception =>
+          logger.debug(s"Could not read JAR $classPathEntry: ${e.getMessage}")
+          Iterator.empty
+      }
       finally if (zf != null) zf.close()
     }
     else Iterator.empty
 
   private def listClassesByteCode(
     classPath: Seq[Path],
-    keepJars: Boolean
+    keepJars: Boolean,
+    logger: Logger
   ): Iterator[(String, () => InputStream)] =
-    classPath.iterator.flatMap(listClassesByteCode(_, keepJars))
+    classPath.iterator.flatMap(listClassesByteCode(_, keepJars, logger))
 
-  private def findInClassPath(classPathEntry: Path, name: String): Option[Array[Byte]] =
+  private def findInClassPath(
+    classPathEntry: Path,
+    name: String,
+    logger: Logger
+  ): Option[Array[Byte]] =
     if (Files.isDirectory(classPathEntry)) {
       val p = classPathEntry.resolve(name)
-      if (Files.isRegularFile(p)) Some(Files.readAllBytes(p))
+      if (Files.isRegularFile(p))
+        try Some(Files.readAllBytes(p))
+        catch {
+          case e: java.io.IOException =>
+            logger.debug(s"Could not read $p: ${e.getMessage}")
+            None
+        }
       else None
     }
     else if (Files.isRegularFile(classPathEntry)) {
@@ -186,14 +208,23 @@ object AsmTestRunner {
           finally if (is != null) is.close()
         }
       }
+      catch {
+        case e: java.io.IOException =>
+          logger.debug(s"Could not read $name from $classPathEntry: ${e.getMessage}")
+          None
+      }
       finally if (zf != null) zf.close()
     }
     else None
 
-  private def findInClassPath(classPath: Seq[Path], name: String): Iterator[Array[Byte]] =
+  private def findInClassPath(
+    classPath: Seq[Path],
+    name: String,
+    logger: Logger
+  ): Iterator[Array[Byte]] =
     classPath
       .iterator
-      .flatMap(findInClassPath(_, name).iterator)
+      .flatMap(findInClassPath(_, name, logger).iterator)
 
   /** Parse Java ServiceLoader format: one class name per line; # comments and empty lines ignored.
     */
@@ -205,26 +236,29 @@ object AsmTestRunner {
       .filter(line => line.nonEmpty && !line.startsWith("#"))
       .toSeq
 
-  def findFrameworkServices(classPath: Seq[Path]): Seq[String] =
-    findInClassPath(classPath, "META-INF/services/sbt.testing.Framework")
+  def findFrameworkServices(classPath: Seq[Path], logger: Logger): Seq[String] =
+    findInClassPath(classPath, "META-INF/services/sbt.testing.Framework", logger)
       .flatMap(b => parseServiceFileContent(new String(b, StandardCharsets.UTF_8)))
       .toSeq
 
   def findFrameworks(
     classPath: Seq[Path],
     preferredClasses: Seq[String],
-    parentInspector: ParentInspector
+    parentInspector: ParentInspector,
+    logger: Logger
   ): List[String] = {
+    // first check preferred classes
     val preferredClassesByteCode = preferredClasses
       .map(_.replace('.', '/'))
       .flatMap { name =>
-        findInClassPath(classPath, name + ".class")
+        findInClassPath(classPath, name + ".class", logger)
           .map { b =>
             def openStream() = new ByteArrayInputStream(b)
             (name, () => openStream())
           }
       }
-    (preferredClassesByteCode.iterator ++ listClassesByteCode(classPath, true))
+    // scan all classes in classpath
+    (preferredClassesByteCode.iterator ++ listClassesByteCode(classPath, true, logger))
       .flatMap {
         case (moduleInfo, _) if moduleInfo.contains("module-info") => Iterator.empty
         case (name, is)                                            =>
@@ -290,14 +324,21 @@ object AsmTestRunner {
     classPath: Seq[Path],
     keepJars: Boolean,
     fingerprints: Seq[Fingerprint],
-    parentInspector: ParentInspector
+    parentInspector: ParentInspector,
+    logger: Logger
   ): Iterator[TaskDef] =
-    listClassesByteCode(classPath, keepJars = keepJars)
+    listClassesByteCode(classPath, keepJars = keepJars, logger)
       .flatMap {
         case (name, is) =>
-          matchFingerprints(name, is, fingerprints, parentInspector)
-            .map((name.stripSuffix("$"), _))
-            .iterator
+          try
+            matchFingerprints(name, is, fingerprints, parentInspector)
+              .map((name.stripSuffix("$"), _))
+              .iterator
+          catch {
+            case e: java.io.IOException =>
+              logger.debug(s"Could not read bytecode for $name: ${e.getMessage}")
+              Iterator.empty
+          }
       }
       .map {
         case (clsName, fp) =>
@@ -311,13 +352,15 @@ object AsmTestRunner {
 
   def main(args: Array[String]): Unit = {
 
+    val logger = Logger(0)
+
     val classLoader = Thread.currentThread().getContextClassLoader
-    val classPath   = TestRunner.classPath(classLoader)
+    val classPath   = TestRunner.classPath(classLoader, logger)
 
-    val parentCache = new ParentInspector(classPath)
+    val parentCache = new ParentInspector(classPath, logger)
 
-    val frameworkClassName = findFrameworkServices(classPath).headOption // TODO handle multiple
-      .orElse(findFrameworks(classPath, TestRunner.commonTestFrameworks, parentCache).headOption)
+    val frameworkClassName = findFrameworkServices(classPath, logger).headOption // TODO handle multiple
+      .orElse(findFrameworks(classPath, TestRunner.commonTestFrameworks, parentCache, logger).headOption)
       .getOrElse(sys.error("No test framework found"))
       .replace('/', '.')
       .replace('\\', '.')
@@ -335,7 +378,8 @@ object AsmTestRunner {
         classPath,
         keepJars = false,
         framework.fingerprints().toIndexedSeq,
-        parentCache
+        parentCache,
+        logger
       ).toArray
 
     val runner       = framework.runner(Array(), Array(), classLoader)

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
@@ -121,7 +121,7 @@ object AsmTestRunner {
       }
       catch {
         case e: Exception =>
-          logger.debug(s"Could not walk directory $classPathEntry: ${e.getMessage}")
+          logger.log(s"Could not walk directory $classPathEntry: ${e.getMessage}")
           Iterator.empty
       }
       finally if (stream != null) stream.close()
@@ -157,7 +157,7 @@ object AsmTestRunner {
       }
       catch {
         case e: Exception =>
-          logger.debug(s"Could not read JAR $classPathEntry: ${e.getMessage}")
+          logger.log(s"Could not read JAR $classPathEntry: ${e.getMessage}")
           Iterator.empty
       }
       finally if (zf != null) zf.close()
@@ -359,11 +359,17 @@ object AsmTestRunner {
 
     val parentCache = new ParentInspector(classPath, logger)
 
-    val frameworkClassName = findFrameworkServices(classPath, logger).headOption // TODO handle multiple
-      .orElse(findFrameworks(classPath, TestRunner.commonTestFrameworks, parentCache, logger).headOption)
-      .getOrElse(sys.error("No test framework found"))
-      .replace('/', '.')
-      .replace('\\', '.')
+    val frameworkClassName =
+      findFrameworkServices(classPath, logger).headOption // TODO handle multiple
+        .orElse(findFrameworks(
+          classPath,
+          TestRunner.commonTestFrameworks,
+          parentCache,
+          logger
+        ).headOption)
+        .getOrElse(sys.error("No test framework found"))
+        .replace('/', '.')
+        .replace('\\', '.')
 
     val framework = classLoader
       .loadClass(frameworkClassName)

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
@@ -101,7 +101,8 @@ object DynamicTestRunner {
         .getOrElse {
           getFrameworksToRun(
             frameworkServices = findFrameworkServices(classLoader),
-            frameworks = findFrameworks(classPath0, classLoader, TestRunner.commonTestFrameworks, logger)
+            frameworks =
+              findFrameworks(classPath0, classLoader, TestRunner.commonTestFrameworks, logger)
           )(logger) match {
             case f if f.nonEmpty     => f
             case _ if verbosity >= 2 => sys.error("No test framework found")

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
@@ -61,11 +61,18 @@ object DynamicTestRunner {
               t
             )
           case h :: t if h.startsWith("--verbosity=") =>
+            val v =
+              try h.stripPrefix("--verbosity=").toInt
+              catch {
+                case _: NumberFormatException =>
+                  System.err.println(s"Warning: malformed --verbosity value: $h")
+                  0
+              }
             parse(
               testFrameworks,
               reverseTestArgs,
               requireTests,
-              h.stripPrefix("--verbosity=").toInt,
+              v,
               testOnly,
               t
             )
@@ -86,7 +93,7 @@ object DynamicTestRunner {
     )
 
     val classLoader = Thread.currentThread().getContextClassLoader
-    val classPath0  = TestRunner.classPath(classLoader)
+    val classPath0  = TestRunner.classPath(classLoader, logger)
     val frameworks  =
       Option(testFrameworks)
         .filter(_.nonEmpty)
@@ -94,7 +101,7 @@ object DynamicTestRunner {
         .getOrElse {
           getFrameworksToRun(
             frameworkServices = findFrameworkServices(classLoader),
-            frameworks = findFrameworks(classPath0, classLoader, TestRunner.commonTestFrameworks)
+            frameworks = findFrameworks(classPath0, classLoader, TestRunner.commonTestFrameworks, logger)
           )(logger) match {
             case f if f.nonEmpty     => f
             case _ if verbosity >= 2 => sys.error("No test framework found")
@@ -105,7 +112,16 @@ object DynamicTestRunner {
         }
     def classes = {
       val keepJars = false // look into dependencies, much slower
-      listClasses(classPath0, keepJars).map(name => classLoader.loadClass(name))
+      listClasses(classPath0, keepJars, logger).flatMap { name =>
+        try Iterator(classLoader.loadClass(name))
+        catch {
+          case _: ClassNotFoundException | _: NoClassDefFoundError |
+              _: UnsupportedClassVersionError | _: IncompatibleClassChangeError =>
+            // Expected: not every .class file on the classpath is loadable
+            logger.debug(s"Could not load class $name")
+            Iterator.empty
+        }
+      }
     }
     val out = System.out
 
@@ -117,7 +133,7 @@ object DynamicTestRunner {
           val runner       = framework.runner(args0.toArray, Array(), classLoader)
 
           def clsFingerprints = classes.flatMap { cls =>
-            matchFingerprints(classLoader, cls, fingerprints)
+            matchFingerprints(classLoader, cls, fingerprints, logger)
               .map((cls, _))
               .iterator
           }

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/FrameworkUtils.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/FrameworkUtils.scala
@@ -87,46 +87,6 @@ object FrameworkUtils {
     getFrameworksToRun(allFrameworks = frameworkServices ++ frameworks)(logger)
   }
 
-  def listClasses(classPath: Seq[Path], keepJars: Boolean): Iterator[String] =
-    classPath.iterator.flatMap(listClasses(_, keepJars))
-
-  def listClasses(classPathEntry: Path, keepJars: Boolean): Iterator[String] =
-    if (Files.isDirectory(classPathEntry)) {
-      var stream: java.util.stream.Stream[Path] = null
-      try {
-        stream = Files.walk(classPathEntry, Int.MaxValue)
-        stream
-          .iterator
-          .asScala
-          .filter(_.getFileName.toString.endsWith(".class"))
-          .map(classPathEntry.relativize)
-          .map { p =>
-            val count = p.getNameCount
-            (0 until count).map(p.getName).mkString(".")
-          }
-          .map(_.stripSuffix(".class"))
-          .toVector // fully consume stream before closing it
-          .iterator
-      }
-      finally if (stream != null) stream.close()
-    }
-    else if (keepJars && Files.isRegularFile(classPathEntry)) {
-      import java.util.zip._
-      var zf: ZipFile = null
-      try {
-        zf = new ZipFile(classPathEntry.toFile)
-        zf.entries
-          .asScala
-          // FIXME Check if these are files too
-          .filter(_.getName.endsWith(".class"))
-          .map(ent => ent.getName.stripSuffix(".class").replace("/", "."))
-          .toVector // full consume ZipFile before closing it
-          .iterator
-      }
-      finally if (zf != null) zf.close()
-    }
-    else Iterator.empty
-
   def findFrameworkServices(loader: ClassLoader): Seq[Framework] =
     ServiceLoader.load(classOf[Framework], loader)
       .iterator()
@@ -145,15 +105,18 @@ object FrameworkUtils {
   def findFrameworks(
     classPath: Seq[Path],
     loader: ClassLoader,
-    preferredClasses: Seq[String]
+    preferredClasses: Seq[String],
+    logger: Logger
   ): Seq[Framework] = {
     val frameworkCls = classOf[Framework]
-    (preferredClasses.iterator ++ listClasses(classPath, true))
+    // first try preferred classes, then scan classpath
+    (preferredClasses.iterator ++ listClasses(classPath, true, logger))
       .flatMap { name =>
         val it: Iterator[Class[?]] =
           try Iterator(loader.loadClass(name))
           catch {
             case _: ClassNotFoundException | _: UnsupportedClassVersionError | _: NoClassDefFoundError | _: IncompatibleClassChangeError =>
+              // Expected: most classpath entries aren't test frameworks
               Iterator.empty
           }
         it
@@ -179,17 +142,70 @@ object FrameworkUtils {
           Iterator(constructor.newInstance().asInstanceOf[Framework])
         }
         catch {
-          case _: NoSuchMethodException => Iterator.empty
+          case e: Exception =>
+            logger.debug(s"Could not instantiate framework ${cls.getName}: $e")
+            Iterator.empty
         }
       }
       .toSeq
   }
 
+  def listClasses(classPath: Seq[Path], keepJars: Boolean, logger: Logger): Iterator[String] =
+    classPath.iterator.flatMap(listClasses(_, keepJars, logger))
+
+  def listClasses(classPathEntry: Path, keepJars: Boolean, logger: Logger): Iterator[String] =
+    if (Files.isDirectory(classPathEntry)) {
+      var stream: java.util.stream.Stream[Path] = null
+      try {
+        stream = Files.walk(classPathEntry, Int.MaxValue)
+        stream
+          .iterator
+          .asScala
+          .filter(_.getFileName.toString.endsWith(".class"))
+          .map(classPathEntry.relativize)
+          .map { p =>
+            val count = p.getNameCount
+            (0 until count).map(p.getName).mkString(".")
+          }
+          .map(_.stripSuffix(".class"))
+          .toVector // fully consume stream before closing it
+          .iterator
+      }
+      catch {
+        case e: Exception =>
+          logger.debug(s"Could not walk directory $classPathEntry: ${e.getMessage}")
+          Iterator.empty
+      }
+      finally if (stream != null) stream.close()
+    }
+    else if (keepJars && Files.isRegularFile(classPathEntry)) {
+      import java.util.zip._
+      var zf: ZipFile = null
+      try {
+        zf = new ZipFile(classPathEntry.toFile)
+        zf.entries
+          .asScala
+          // FIXME Check if these are files too
+          .filter(_.getName.endsWith(".class"))
+          .map(ent => ent.getName.stripSuffix(".class").replace("/", "."))
+          .toVector // full consume ZipFile before closing it
+          .iterator
+      }
+      catch {
+        case e: Exception =>
+          logger.debug(s"Could not read JAR $classPathEntry: ${e.getMessage}")
+          Iterator.empty
+      }
+      finally if (zf != null) zf.close()
+    }
+    else Iterator.empty
+
   // adapted from https://github.com/com-lihaoyi/mill/blob/ab4d61a50da24fb7fac97c4453dd8a770d8ac62b/scalalib/src/Lib.scala#L156-L172
   def matchFingerprints(
     loader: ClassLoader,
     cls: Class[?],
-    fingerprints: Array[Fingerprint]
+    fingerprints: Array[Fingerprint],
+    logger: Logger
   ): Option[Fingerprint] = {
     val isModule               = cls.getName.endsWith("$")
     val publicConstructorCount = cls.getConstructors.count(c => Modifier.isPublic(c.getModifiers))
@@ -203,21 +219,37 @@ object FrameworkUtils {
     else
       fingerprints.find {
         case f: SubclassFingerprint =>
-          f.isModule == isModule &&
-          loader.loadClass(f.superclassName())
-            .isAssignableFrom(cls)
+          f.isModule == isModule && {
+            try
+              loader.loadClass(f.superclassName())
+                .isAssignableFrom(cls)
+            catch {
+              case _: ClassNotFoundException =>
+                logger.debug(
+                  s"Superclass not found for fingerprint matching: ${f.superclassName()}")
+                false
+            }
+          }
 
         case f: AnnotatedFingerprint =>
-          val annotationCls = loader.loadClass(f.annotationName())
-            .asInstanceOf[Class[Annotation]]
-          f.isModule == isModule && (
-            cls.isAnnotationPresent(annotationCls) ||
-            cls.getDeclaredMethods.exists(_.isAnnotationPresent(annotationCls)) ||
-            cls.getMethods.exists { m =>
-              m.isAnnotationPresent(annotationCls) &&
-              Modifier.isPublic(m.getModifiers)
+          f.isModule == isModule && {
+            try {
+              val annotationCls = loader.loadClass(f.annotationName())
+                .asInstanceOf[Class[Annotation]]
+              cls.isAnnotationPresent(annotationCls) ||
+              cls.getDeclaredMethods.exists(_.isAnnotationPresent(annotationCls)) ||
+              cls.getMethods.exists { m =>
+                m.isAnnotationPresent(annotationCls) &&
+                Modifier.isPublic(m.getModifiers)
+              }
             }
-          )
+            catch {
+              case _: ClassNotFoundException =>
+                logger.debug(
+                  s"Annotation class not found for fingerprint matching: ${f.annotationName()}")
+                false
+            }
+          }
       }
   }
 }

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/FrameworkUtils.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/FrameworkUtils.scala
@@ -143,7 +143,7 @@ object FrameworkUtils {
         }
         catch {
           case e: Exception =>
-            logger.debug(s"Could not instantiate framework ${cls.getName}: $e")
+            logger.log(s"Could not instantiate framework ${cls.getName}: $e")
             Iterator.empty
         }
       }
@@ -173,7 +173,7 @@ object FrameworkUtils {
       }
       catch {
         case e: Exception =>
-          logger.debug(s"Could not walk directory $classPathEntry: ${e.getMessage}")
+          logger.log(s"Could not walk directory $classPathEntry: ${e.getMessage}")
           Iterator.empty
       }
       finally if (stream != null) stream.close()
@@ -193,7 +193,7 @@ object FrameworkUtils {
       }
       catch {
         case e: Exception =>
-          logger.debug(s"Could not read JAR $classPathEntry: ${e.getMessage}")
+          logger.log(s"Could not read JAR $classPathEntry: ${e.getMessage}")
           Iterator.empty
       }
       finally if (zf != null) zf.close()
@@ -226,7 +226,8 @@ object FrameworkUtils {
             catch {
               case _: ClassNotFoundException =>
                 logger.debug(
-                  s"Superclass not found for fingerprint matching: ${f.superclassName()}")
+                  s"Superclass not found for fingerprint matching: ${f.superclassName()}"
+                )
                 false
             }
           }
@@ -246,7 +247,8 @@ object FrameworkUtils {
             catch {
               case _: ClassNotFoundException =>
                 logger.debug(
-                  s"Annotation class not found for fingerprint matching: ${f.annotationName()}")
+                  s"Annotation class not found for fingerprint matching: ${f.annotationName()}"
+                )
                 false
             }
           }

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/TestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/TestRunner.scala
@@ -20,7 +20,7 @@ object TestRunner {
     "weaver.framework.CatsEffect"
   )
 
-  def classPath(loader: ClassLoader): Seq[Path] = {
+  def classPath(loader: ClassLoader, logger: Logger): Seq[Path] = {
     def helper(loader: ClassLoader): LazyList[Path] =
       if (loader == null) LazyList.empty
       else {
@@ -30,7 +30,9 @@ object TestRunner {
               .flatMap {
                 case url if url.getProtocol == "file" =>
                   Seq(Paths.get(url.toURI).toAbsolutePath)
-                case _ => Nil // FIXME Warn about this
+                case url =>
+                  logger.debug(s"Skipping non-file URL in classloader: $url")
+                  Nil
               }
               .to(LazyList)
           case cl if cl.getClass.getName == "jdk.internal.loader.ClassLoaders$AppClassLoader" =>
@@ -39,7 +41,9 @@ object TestRunner {
               .split(File.pathSeparator)
               .to(LazyList)
               .map(Paths.get(_))
-          case _ => LazyList.empty // FIXME Warn about this
+          case cl =>
+            logger.debug(s"Unknown classloader type: ${cl.getClass.getName}")
+            LazyList.empty
         }
         paths #::: helper(loader.getParent)
       }

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/TestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/TestRunner.scala
@@ -42,7 +42,7 @@ object TestRunner {
               .to(LazyList)
               .map(Paths.get(_))
           case cl =>
-            logger.debug(s"Unknown classloader type: ${cl.getClass.getName}")
+            logger.log(s"Unknown classloader type: ${cl.getClass.getName}")
             LazyList.empty
         }
         paths #::: helper(loader.getParent)


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/3010

This essentially adds a new (pure Java) `java-test-runner` module to Scala CLI, which is essentially a Java rewrite of the existing `test-runner`.
This in turn enables to not add Scala to test builds for Java projects.
I also added some extra logging to the old `test-runner` to get it on par with the new `java-test-runner`.

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Cursor + Claude

## How was the solution tested?
- unit tests for the new `java-test-runner` module included
- integration tests for running tests with pure Java included