### PR TITLE
Add `signed-by` support to Debian APT repository

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1849,6 +1849,33 @@ object ci extends Module {
     )
       .call(cwd = debianDir, stdin = pgpPassphrase, stdout = inReleasePath)
 
+    // Export the public key as a binary (non-armored) keyring at the repo root so that
+    // users can reference it via `signed-by` in their APT sources.
+    // Binary format is required per https://wiki.debian.org/DebianRepository/UseThirdParty
+    val keyringPath = packagesDir / "scala-cli-archive-keyring.gpg"
+    os.proc("gpg", "--batch", "--yes", "--export", keyName)
+      .call(stdout = keyringPath)
+
+    // Update the .list file to include the signed-by option pointing at the keyring.
+    // This scopes the key to this repository only, preventing the globally-trusted key
+    // security issue described in the Debian wiki.
+    os.write.over(
+      debianDir / "scala_cli_packages.list",
+      "deb [signed-by=/etc/apt/keyrings/scala-cli-archive-keyring.gpg] https://virtuslab.github.io/scala-cli-packages/debian ./\n"
+    )
+
+    // Also provide a DEB822 .sources file for users on modern Debian (apt modernize-sources).
+    // No Components field: this is a flat repository (Suites: ./).
+    // No Architectures field: avoids breaking when aarch64 packages are added later.
+    os.write.over(
+      debianDir / "scala_cli_packages.sources",
+      """Types: deb
+        |URIs: https://virtuslab.github.io/scala-cli-packages/debian
+        |Suites: ./
+        |Signed-By: /etc/apt/keyrings/scala-cli-archive-keyring.gpg
+        |""".stripMargin
+    )
+
     commitChanges(s"Update Debian packages for $version", branch, packagesDir)
   }
   def updateChocolateyPackage(): Command[os.CommandResult] = Task.Command {

--- a/website/docs/_advanced_install.mdx
+++ b/website/docs/_advanced_install.mdx
@@ -83,7 +83,8 @@ scala-cli version
 Scala CLI can be installed via [apt](https://wiki.debian.org/Apt) packager tool.
 
 ```bash
-curl -sS "https://virtuslab.github.io/scala-cli-packages/KEY.gpg" | sudo gpg --dearmor  -o /etc/apt/trusted.gpg.d/scala-cli.gpg 2>/dev/null
+sudo mkdir -p /etc/apt/keyrings
+curl -sS "https://virtuslab.github.io/scala-cli-packages/scala-cli-archive-keyring.gpg" | sudo tee /etc/apt/keyrings/scala-cli-archive-keyring.gpg > /dev/null
 sudo curl -s --compressed -o /etc/apt/sources.list.d/scala_cli_packages.list "https://virtuslab.github.io/scala-cli-packages/debian/scala_cli_packages.list"
 sudo apt update
 sudo apt install scala-cli


### PR DESCRIPTION
Fixes #3501 

## Checklist
- [x] ~tested the solution locally and it works~ (no way to do that)
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Cursor + Claude

## How was the solution tested?
Can't really test it other than do a new release and re-check APT.

## Additional notes
This is somewhat adjacent (but separate) to #4127, which requires regenerating the key with SHA-256+
