### PR TITLE
[doc] publish.md: add info about `publish.scm` directive

### DIFF
--- a/website/docs/commands/publishing/publish.md
+++ b/website/docs/commands/publishing/publish.md
@@ -127,6 +127,7 @@ provided as a convenience.
 | License | `publish.license` | `--license` | `Apache-2.0`, `MIT`, `Foo:https://foo.com/license.txt`, … | Run `scala-cli publish --license list` to list pre-defined licenses |
 | URL | `publish.url` | `--url` | | |
 | VCS | `publish.vcs` | `--vcs` | `github:VirtusLab/scala-cli`, `https://github.com/VirtusLab/scala-cli.git` |scm:git:github.com/VirtusLab/scala-cli.git|scm:git:git@github.com:VirtusLab/scala-cli.git` | |
+| SCM | `publish.scm` |         |`github:VirtusLab/scala-cli`                                              | Use to set the SCM information of the release |
 | Developers | `publish.developer` | `--developer` | <code>alexme&vert;Alex Me&vert;https://alex.me</code> | Can be specified multiple times, using directives and CLI values add up |
 | Docs       | `publish.doc`       | `--doc`             | `--doc=false`, `//> using doc false`                                       | Use to disable publishing docs jar.                                     |
 


### PR DESCRIPTION
There is no `--scm` command line option as far as I can tell.