### PR TITLE
Run tests with JDK 26

### DIFF
--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -105,7 +105,7 @@ object Java {
     defaultJava,
     minimumJavaLauncherJava
   ).distinct
-  def mainJavaVersions: Seq[Int] = Seq(8, 11, 17, 21, 23, 24, 25)
+  def mainJavaVersions: Seq[Int] = Seq(8, 11, 17, 21, 23, 24, 25, 26)
   def allJavaVersions: Seq[Int]  = (mainJavaVersions ++ cliKeyJavaVersions).distinct
 }
 


### PR DESCRIPTION
We should run the basic JDK compat tests with Java 26, since it's out and about now.

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
not at all

## How was the solution tested?
existing test suites
