### PR TITLE
Support `-opt-inline:help`

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -192,7 +192,7 @@ abstract class ScalaCommand[T <: HasGlobalOptions](implicit myParser: Parser[T],
       shared <- sharedOptions(options)
       scalacOptions        = shared.scalacOptions
       updatedScalacOptions = scalacOptions.withScalacExtraOptions(shared.scalacExtra)
-      if updatedScalacOptions.map(_.noDashPrefixes).exists(ScalacOptions.ScalacPrintOptions)
+      if updatedScalacOptions.map(_.noDashPrefixes).exists(ScalacOptions.isScalacPrintOption)
       logger            = shared.logger
       fixedBuildOptions = buildOptions.copy(scalaOptions =
         buildOptions.scalaOptions.copy(defaultScalaVersion = Some(ScalaCli.getDefaultScalaVersion))

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
@@ -108,21 +108,28 @@ object ScalacOptions {
       "unique-id"
     ) ++ replNoArgAliasedOptions
 
-  /** This includes all the scalac options which disregard inputs and print a help and/or context
-    * message instead.
+  /** True when the token ends with a `:help` suffix, with any number of colon-separated segments
+    * before it (e.g. `Xlint:help`, `opt:a:b:c:help`). Used together with `ScalacPrintOptions` so
+    * new compiler `…:help` flags work without listing each one.
     */
+  def isColonHelpPrintOption(noDashPrefixes: String): Boolean =
+    noDashPrefixes.endsWith(":help")
+
+  /** `scalac` options that print help or context and exit without requiring source inputs. */
   val ScalacPrintOptions: Set[String] =
     scalacOptionsPurePrefixes ++ Set(
       "help",
-      "opt:help",
-      "opt-inline:help",
       "Xshow-phases",
-      "Xsource:help",
       "Xplugin-list",
-      "Xmixin-force-forwarders:help",
-      "Xlint:help",
       "Vphases"
     )
+
+  /** Whether `ScalaCommand.maybePrintSimpleScalacOutput` should run for this token (after
+    * `ScalacOpt.noDashPrefixes`).
+    */
+  def isScalacPrintOption(noDashPrefixes: String): Boolean =
+    ScalacPrintOptions.contains(noDashPrefixes) ||
+    isColonHelpPrintOption(noDashPrefixes)
 
   /** This includes all the scalac options which are redirected to native Scala CLI options. */
   val ScalaCliRedirectedOptions: Set[String] = Set(

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/ScalacOptions.scala
@@ -70,6 +70,7 @@ object ScalacOptions {
       "g",
       "language",
       "opt",
+      "opt-inline",
       "pagewidth",
       "page-width",
       "target",
@@ -114,6 +115,7 @@ object ScalacOptions {
     scalacOptionsPurePrefixes ++ Set(
       "help",
       "opt:help",
+      "opt-inline:help",
       "Xshow-phases",
       "Xsource:help",
       "Xplugin-list",

--- a/modules/cli/src/test/scala/scala/cli/tests/ScalacOptionsPrintTest.scala
+++ b/modules/cli/src/test/scala/scala/cli/tests/ScalacOptionsPrintTest.scala
@@ -1,0 +1,35 @@
+package scala.cli.tests
+
+import munit.FunSuite
+
+import scala.cli.commands.shared.ScalacOptions
+
+final class ScalacOptionsPrintTest extends FunSuite {
+
+  test("isColonHelpPrintOption: :help suffix (single segment)") {
+    assert(ScalacOptions.isColonHelpPrintOption("opt-inline:help"))
+    assert(ScalacOptions.isColonHelpPrintOption("Xlint:help"))
+    assert(ScalacOptions.isColonHelpPrintOption("opt:help"))
+  }
+
+  test("isColonHelpPrintOption: :help suffix (multi-level colons)") {
+    assert(ScalacOptions.isColonHelpPrintOption("opt:l:inline:help"))
+    assert(ScalacOptions.isColonHelpPrintOption("a:b:help"))
+    assert(ScalacOptions.isColonHelpPrintOption("foo:bar:baz:help"))
+  }
+
+  test("isColonHelpPrintOption: reject non-suffix") {
+    assert(!ScalacOptions.isColonHelpPrintOption("help"))
+    assert(!ScalacOptions.isColonHelpPrintOption("Xlint:infer-any"))
+    assert(!ScalacOptions.isColonHelpPrintOption("help:foo"))
+    assert(!ScalacOptions.isColonHelpPrintOption("something:helpme"))
+  }
+
+  test("isScalacPrintOption: combines explicit set and :help rule") {
+    assert(ScalacOptions.isScalacPrintOption("Xshow-phases"))
+    assert(ScalacOptions.isScalacPrintOption("help"))
+    assert(ScalacOptions.isScalacPrintOption("Xsource:help"))
+    assert(ScalacOptions.isScalacPrintOption("opt:l:inline:help"))
+    assert(!ScalacOptions.isScalacPrintOption("random-flag"))
+  }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
@@ -72,6 +72,21 @@ class HelpTests extends ScalaCliSuite {
       "-cp, --jar, --jars, --class, --classes, -classpath, --extra-jar, --classpath, --extra-jars, --class-path, --extra-class, --extra-classes, --extra-class-path paths"
     ))
   }
+  for {
+    (subcommandLabel, leadArgs) <-
+      Seq(("compile subcommand", Seq("compile")), ("default subcommand", Seq.empty))
+  } test(s"-opt-inline:help works without inputs ($subcommandLabel) (Scala 3.8.3+)") {
+    TestInputs.empty.fromRoot { root =>
+      val cmd: Seq = Seq(TestUtil.cli) ++ leadArgs ++
+        Seq("-S", Constants.scala3Next, "-opt-inline:help")
+      val res = os.proc(cmd*).call(cwd = root, mergeErrIntoOut = true, check = false)
+      expect(res.exitCode == 0)
+      val out = res.out.text()
+      expect(out.nonEmpty)
+      expect(out.contains("Inlining requires"))
+    }
+  }
+
   for (withPower <- Seq(true, false))
     test("envs help" + (if (withPower) " with power" else "")) {
       val powerOptions = if (withPower) Seq("--power") else Nil

--- a/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
@@ -73,13 +73,15 @@ class HelpTests extends ScalaCliSuite {
     ))
   }
   for {
-    (subcommandLabel, leadArgs) <-
-      Seq(("compile subcommand", Seq("compile")), ("default subcommand", Seq.empty))
+    (subcommandLabel, leadArgs) <- Seq(
+      ("compile subcommand", Seq("compile")),
+      ("default subcommand", Seq.empty)
+    )
   } test(s"-opt-inline:help works without inputs ($subcommandLabel) (Scala 3.8.3+)") {
     TestInputs.empty.fromRoot { root =>
-      val cmd: Seq = Seq(TestUtil.cli) ++ leadArgs ++
-        Seq("-S", Constants.scala3Next, "-opt-inline:help")
-      val res = os.proc(cmd*).call(cwd = root, mergeErrIntoOut = true, check = false)
+      val res =
+        os.proc(TestUtil.cli, leadArgs, "-S", Constants.scala3Next, "-opt-inline:help")
+          .call(cwd = root, mergeErrIntoOut = true, check = false)
       expect(res.exitCode == 0)
       val out = res.out.text()
       expect(out.nonEmpty)

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalacCompatTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalacCompatTestDefinitions.scala
@@ -154,9 +154,14 @@ trait RunScalacCompatTestDefinitions {
     printOption <- {
       val printOptionsForAllVersions   = Seq("-X", "-Xshow-phases", "-Xplugin-list", "-Y")
       val printOptionsScala213OrHigher = Seq("-V", "-Vphases", "-W", "-Xsource:help")
+      val printOptionsScala38Help      = Seq("-opt-inline:help")
       val printOptionsScala2 = Seq("-Xlint:help", "-opt:help", "-Xmixin-force-forwarders:help")
       actualScalaVersion match {
-        case v if v.startsWith("3")    => printOptionsForAllVersions ++ printOptionsScala213OrHigher
+        case v if v.startsWith("3") =>
+          val scala38Help =
+            if v.coursierVersion >= "3.8.3".coursierVersion then printOptionsScala38Help
+            else Nil
+          printOptionsForAllVersions ++ printOptionsScala213OrHigher ++ scala38Help
         case v if v.startsWith("2.13") =>
           printOptionsForAllVersions ++ printOptionsScala213OrHigher ++ printOptionsScala2
         case v if v.startsWith("2.12") => printOptionsForAllVersions ++ printOptionsScala2


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/25668

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Cursor + Claude

## How was the solution tested?
added unit tests for automatic `<known-prefix>*:help` detection
added integration tests for optimizer help

## Additional notes

Long term, the proper fix would be to solve https://github.com/VirtusLab/scala-cli/issues/2867