### PR TITLE
Split `release_notes.md` into a separate test per-release-tag in `docs-tests`

### DIFF
--- a/modules/docs-tests/src/test/scala/sclicheck/DocTests.scala
+++ b/modules/docs-tests/src/test/scala/sclicheck/DocTests.scala
@@ -3,6 +3,7 @@ package sclicheck
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration.FiniteDuration
+import scala.util.matching.Regex
 
 class DocTests extends munit.FunSuite {
   override def munitTimeout = new FiniteDuration(600, TimeUnit.SECONDS)
@@ -19,6 +20,14 @@ class DocTests extends munit.FunSuite {
 
   val options: Options = Options(scalaCliCommand = Seq(TestUtil.scalaCliPath.toString))
 
+  private val ReleaseNotesMd = os.rel / "release_notes.md"
+
+  /** `## [v1.12.0](https://…)` style headings that delimit per-version release note sections. */
+  private val ReleaseVersionHeading: Regex = """^##\s+\[(v[\w.\-]+)\]""".r
+
+  private def isReleaseVersionHeadingLine(line: String): Boolean =
+    ReleaseVersionHeading.findFirstMatchIn(line).nonEmpty
+
   private def lineContainsAnyChecks(l: String): Boolean =
     l.startsWith("```md") || l.startsWith("```bash") ||
     l.startsWith("```scala compile") || l.startsWith("```scala fail") ||
@@ -26,6 +35,27 @@ class DocTests extends munit.FunSuite {
     l.startsWith("```java compile") || l.startsWith("````java fail")
   private def fileContainsAnyChecks(f: os.Path): Boolean =
     os.read.lines(f).exists(lineContainsAnyChecks)
+
+  /** One sclicheck run per `## [v…]` section so each gets its own timeout and workspace (Option C).
+    */
+  private def releaseNotesSections(file: os.Path): Seq[(String, IndexedSeq[String])] =
+    val lines  = os.read.lines(file).toIndexedSeq
+    val starts = lines.zipWithIndex.collect {
+      case (line, i) if isReleaseVersionHeadingLine(line) => i
+    }
+    if starts.isEmpty && fileContainsAnyChecks(file) then Seq(("release_notes", lines))
+    else if starts.isEmpty then Nil
+    else
+      starts.zipWithIndex.map { case (startIdx, chunkIdx) =>
+        val endIdx =
+          if chunkIdx + 1 < starts.size then starts(chunkIdx + 1)
+          else lines.size
+        val slice =
+          if chunkIdx == 0 then lines.slice(0, endIdx)
+          else lines.slice(startIdx, endIdx)
+        val ver = ReleaseVersionHeading.findFirstMatchIn(lines(startIdx)).get.group(1)
+        (ver, slice)
+      }.filter { case (_, slice) => slice.exists(lineContainsAnyChecks) }
 
   for {
     DocTestEntry(tpe, dir, depth) <- entries
@@ -36,9 +66,24 @@ class DocTests extends munit.FunSuite {
       .map(_.relativeTo(dir))
       .sortBy(_.toString)
     md <- inputs
+    if !(tpe == "root" && md == ReleaseNotesMd)
   }
     test(s"$tpe ${md.toString.stripSuffix(".md")}") {
       TestUtil.retryOnCi()(checkFile(dir / md, options))
     }
+
+  private val releaseNotesFile = docsRootPath / "release_notes.md"
+  if os.isFile(releaseNotesFile) && fileContainsAnyChecks(releaseNotesFile) then
+    for (ver, slice) <- releaseNotesSections(releaseNotesFile) do
+      val safeStem = ver.replaceAll("[^a-zA-Z0-9._\\-]", "_")
+      test(s"root release_notes $ver") {
+        TestUtil.retryOnCi() {
+          TestUtil.withTmpDir("sclicheck-release-notes") { tmp =>
+            val chunkFile = tmp / s"release_notes-$safeStem.md"
+            os.write.over(chunkFile, slice.mkString("", "\n", "\n"))
+            checkFile(chunkFile, options)
+          }
+        }
+      }
 
 }


### PR DESCRIPTION
This splits the `release_notes.md` test in `docs-tests` down into separate tests per release tag header.
As the doc grows with each release, the test grows as well and breaks timeout limits.
This change allows to keep the doc unchanged.

This should address `docs-tests` being flaky with timeouts on the CI.

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Cursor + Claude

## How was the solution tested?
ran the split down tests locally, everything passes