### PR TITLE
Add proper deprecation logic for features & deprecate Ammonite for removal

### DIFF
--- a/agentskills/deprecating-features/SKILL.md
+++ b/agentskills/deprecating-features/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: scala-cli-deprecating-features
+description: Deprecate CLI options, option aliases, using directives, sub-commands, or config keys in Scala CLI. Use when marking a feature as deprecated with a warning.
+---
+
+# Deprecating features (Scala CLI)
+
+All deprecation mechanisms emit aggregated warnings (single consolidated message) via `Logger.deprecationWarning` / `Logger.flushDeprecationWarnings`, respecting suppression via `--suppress-deprecated-warnings` or `config suppress-warning.deprecated-features true`.
+
+## Warning format
+
+The formatter always prefixes with the exact name used and the feature type:
+
+- Single: `` [warn] `--foo` option is deprecated. Use --bar instead.\nDeprecated features may be removed in a future version. ``
+- Multiple: consolidated bullet-point list with each entry prefixed by name and type
+
+The `message`/`detail` passed by callers should NOT repeat the feature name — only provide the reason or migration hint. Pass `""` for no extra detail.
+
+## 1. Deprecate a CLI option (entire option)
+
+In the options case class, add `@Tag(tags.deprecatedOption("detail"))` or `@Tag(tags.deprecatedOption)` (no detail):
+
+```scala
+@Tag(tags.deprecatedOption("Use --bar instead."))
+  foo: Option[Boolean] = None,
+```
+
+- Fires for **any** name/alias of the option — the exact alias used is shown in the warning
+- Detected in `RestrictedCommandsParser` via `arg.isDeprecatedOption`
+
+## 2. Deprecate a CLI option alias
+
+Add `@Tag(tags.deprecated("aliasName"))` alongside the `@Name("aliasName")`:
+
+```scala
+@Name("oldAlias")
+@Tag(tags.deprecated("oldAlias"))
+  myOption: Option[Boolean] = None,
+```
+
+- Fires only when the specific alias is used
+
+## 3. Deprecate a using directive (key or value)
+
+Add an entry to `DeprecatedDirectives.deprecatedCombinationsAndReplacements` in `modules/build/.../preprocessing/DeprecatedDirectives.scala`:
+
+```scala
+// Key swap (e.g. lib → dep):
+DirectiveTemplate(Seq("oldKey"), None) -> keyReplacement("newKey")(
+  deprecatedWarning("oldKey", "newKey")
+)
+
+// Deprecated for removal (no replacement):
+DirectiveTemplate(Seq("removedKey"), None) -> noReplacement(
+  deprecatedWarningForRemoval("removedKey")
+)
+```
+
+- `keyReplacement` / `valueReplacement` — swap to a new key or value, emits a `TextEdit` for IDE quick-fix
+- `noReplacement` — deprecated for removal, no `TextEdit` offered
+- Emitted as a positioned `Diagnostic` (supports BSP with source locations)
+- Not aggregated (kept as individual diagnostics for IDE support)
+
+## 4. Deprecate a sub-command
+
+Override `deprecationMessage` in the command object (detail only, name is auto-prefixed):
+
+```scala
+object MyCommand extends ScalaCommand[MyOptions] {
+  override def deprecationMessage: Option[String] =
+    Some("Use other-command instead.")
+}
+```
+
+For deprecating only a specific command alias, override `deprecatedNames`:
+
+```scala
+override def deprecatedNames: Set[List[String]] = Set(List("old-alias"))
+```
+
+## 5. Deprecate a config key
+
+Pass `deprecationMessage` to the `Key` constructor (currently supported on `BooleanEntry`):
+
+```scala
+val myKey = new Key.BooleanEntry(
+  prefix = Seq("my"),
+  name = "key",
+  specificationLevel = SpecificationLevel.IMPLEMENTATION,
+  description = "...",
+  deprecationMessage = Some("Use my.new-key instead.")
+)
+```
+
+- Warning emitted in `Config.scala` when the key is accessed
+
+## Post-deprecation checklist
+
+1. Run `./mill -i __.compile`
+2. Run relevant tests
+3. Run `./mill -i 'generate-reference-doc[]'.run` (deprecated options/aliases are marked in reference docs)
+4. Update user-facing documentation if needed

--- a/modules/build/src/main/scala/scala/build/PersistentDiagnosticLogger.scala
+++ b/modules/build/src/main/scala/scala/build/PersistentDiagnosticLogger.scala
@@ -46,4 +46,9 @@ class PersistentDiagnosticLogger(parent: Logger) extends Logger {
     parent.experimentalWarning(featureName, featureType)
 
   def flushExperimentalWarnings: Unit = parent.flushExperimentalWarnings
+
+  def deprecationWarning(featureName: String, message: String, featureType: FeatureType): Unit =
+    parent.deprecationWarning(featureName, message, featureType)
+
+  def flushDeprecationWarnings: Unit = parent.flushDeprecationWarnings
 }

--- a/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
+++ b/modules/build/src/main/scala/scala/build/internal/util/WarningMessages.scala
@@ -130,8 +130,38 @@ object WarningMessages {
   val mainScriptNameClashesWithAppWrapper =
     "Script file named 'main.sc' detected, keep in mind that accessing it from other scripts is impossible due to a clash of `main` symbols"
 
+  private val deprecationNote =
+    "Deprecated features may be removed in a future version."
+
+  private def formatDeprecationEntry(
+    name: String,
+    detail: String,
+    featureType: FeatureType
+  ): String =
+    val suffix = if detail.nonEmpty then s" $detail" else ""
+    s"`$name` $featureType is deprecated.$suffix"
+
+  def deprecatedFeaturesUsed(namesMessagesAndTypes: Seq[(String, String, FeatureType)]): String = {
+    val message = namesMessagesAndTypes match {
+      case Seq((name, detail, featureType)) =>
+        formatDeprecationEntry(name, detail, featureType)
+      case entries =>
+        val nl           = System.lineSeparator()
+        val bulletPoints = entries.map((name, detail, ft) =>
+          s" - ${formatDeprecationEntry(name, detail, ft)}"
+        ).mkString(nl)
+        s"""Some utilized features are deprecated:
+           |$bulletPoints""".stripMargin
+    }
+    s"""[${Console.YELLOW}warn${Console.RESET}] $message
+       |$deprecationNote""".stripMargin
+  }
+
   def deprecatedWarning(old: String, `new`: String) =
     s"Using '$old' is deprecated, use '${`new`}' instead"
+
+  def deprecatedWarningForRemoval(name: String) =
+    s"Using '$name' is deprecated and will be removed in a future version"
 
   def deprecatedToolkitLatest(updatedValue: String = "") =
     if updatedValue.isEmpty then

--- a/modules/build/src/main/scala/scala/build/preprocessing/DeprecatedDirectives.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/DeprecatedDirectives.scala
@@ -3,7 +3,11 @@ package scala.build.preprocessing
 import scala.build.Logger
 import scala.build.errors.Diagnostic.TextEdit
 import scala.build.internal.Constants
-import scala.build.internal.util.WarningMessages.{deprecatedToolkitLatest, deprecatedWarning}
+import scala.build.internal.util.WarningMessages.{
+  deprecatedToolkitLatest,
+  deprecatedWarning,
+  deprecatedWarningForRemoval
+}
 import scala.build.options.SuppressWarningOptions
 import scala.build.preprocessing.directives.{DirectiveHandler, StrictDirective, Toolkit}
 import scala.build.warnings.DeprecatedWarning
@@ -23,13 +27,16 @@ object DeprecatedDirectives {
       (values.isEmpty || values.contains(foundValues))
   }
 
-  private type WarningAndReplacement = (String, DirectiveTemplate)
+  private type WarningAndReplacement = (String, Option[DirectiveTemplate])
 
   private def keyReplacement(replacement: String)(warning: String): WarningAndReplacement =
-    (warning, DirectiveTemplate(Seq(replacement), None))
+    (warning, Some(DirectiveTemplate(Seq(replacement), None)))
 
   private def valueReplacement(replacements: String*)(warning: String): WarningAndReplacement =
-    (warning, DirectiveTemplate(Nil, Some(replacements.toSeq)))
+    (warning, Some(DirectiveTemplate(Nil, Some(replacements.toSeq))))
+
+  private def noReplacement(warning: String): WarningAndReplacement =
+    (warning, None)
 
   private def allKeysFrom(handler: DirectiveHandler[?]): Seq[String] =
     handler.keys.flatMap(_.nameAliases)
@@ -61,6 +68,12 @@ object DeprecatedDirectives {
       Some(Seq(s"${Constants.typelevelOrganization}:latest"))
     ) -> valueReplacement(s"${Toolkit.typelevel}:default")(
       deprecatedToolkitLatest()
+    ),
+    DirectiveTemplate(Seq("deprecatedTestDirective"), None) -> keyReplacement("testDirective")(
+      deprecatedWarning("deprecatedTestDirective", "testDirective")
+    ),
+    DirectiveTemplate(Seq("deprecatedForRemovalTestDirective"), None) -> noReplacement(
+      deprecatedWarningForRemoval("deprecatedForRemovalTestDirective")
     )
   )
 
@@ -78,19 +91,15 @@ object DeprecatedDirectives {
     if !suppressWarningOptions.suppressDeprecatedFeatureWarning.getOrElse(false) then
       directives.map(d => d -> warningAndReplacement(d))
         .foreach {
-          case (directive, Some(warning, replacement)) =>
-            val newKey    = replacement.keys.headOption.getOrElse(directive.key)
-            val newValues = replacement.values.getOrElse(directive.toStringValues)
-            val newText   = s"$newKey ${newValues.mkString(" ")}"
-
-            // TODO use key and/or value positions instead of whole directive
-            val position = directive.position(path)
-
-            val diagnostic = DeprecatedWarning(
-              warning,
-              Seq(position),
-              Some(TextEdit(s"Change to: $newText", newText))
-            )
+          case (directive, Some(warning, replacementOpt)) =>
+            val position    = directive.position(path)
+            val textEditOpt = replacementOpt.map { replacement =>
+              val newKey    = replacement.keys.headOption.getOrElse(directive.key)
+              val newValues = replacement.values.getOrElse(directive.toStringValues)
+              val newText   = s"$newKey ${newValues.mkString(" ")}"
+              TextEdit(s"Change to: $newText", newText)
+            }
+            val diagnostic = DeprecatedWarning(warning, Seq(position), textEditOpt)
             logger.log(Seq(diagnostic))
           case _ => ()
         }

--- a/modules/build/src/test/scala/scala/build/tests/BuildProjectTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildProjectTests.scala
@@ -51,6 +51,13 @@ class BuildProjectTests extends TestUtil.ScalaCliBuildSuite {
     override def experimentalWarning(featureName: String, featureType: FeatureType): Unit =
       System.err.println(s"experimental: $featureName")
     override def flushExperimentalWarnings: Unit = ()
+    override def deprecationWarning(
+      featureName: String,
+      message: String,
+      featureType: FeatureType
+    ): Unit =
+      System.err.println(s"deprecated: $featureName: $message")
+    override def flushDeprecationWarnings: Unit = ()
   }
 
   test("workspace for bsp") {

--- a/modules/build/src/test/scala/scala/build/tests/DeprecationTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DeprecationTests.scala
@@ -1,0 +1,101 @@
+package scala.build.tests
+
+import com.eed3si9n.expecty.Expecty.expect
+
+import scala.build.errors.Diagnostic
+import scala.build.internal.util.WarningMessages
+import scala.build.internals.FeatureType
+import scala.build.options.SuppressWarningOptions
+import scala.build.preprocessing.DeprecatedDirectives
+import scala.build.preprocessing.directives.StrictDirective
+import scala.collection.mutable.ListBuffer
+
+class DeprecationTests extends TestUtil.ScalaCliBuildSuite {
+
+  test("deprecatedFeaturesUsed formats single feature with name prefix") {
+    val msg = WarningMessages.deprecatedFeaturesUsed(
+      Seq(("--some-option", "Use --other instead.", FeatureType.Option))
+    )
+    expect(msg.contains("`--some-option` option is deprecated."))
+    expect(msg.contains("Use --other instead."))
+    expect(msg.contains("Deprecated features may be removed"))
+  }
+
+  test("deprecatedFeaturesUsed formats single feature with no detail") {
+    val msg = WarningMessages.deprecatedFeaturesUsed(
+      Seq(("--old-alias", "", FeatureType.Option))
+    )
+    expect(msg.contains("`--old-alias` option is deprecated."))
+    expect(!msg.contains("is deprecated. "))
+    expect(msg.contains("Deprecated features may be removed"))
+  }
+
+  test("deprecatedFeaturesUsed formats multiple features with name prefix") {
+    val msg = WarningMessages.deprecatedFeaturesUsed(Seq(
+      ("--opt-a", "Use --opt-b.", FeatureType.Option),
+      ("my-command", "Use other-command.", FeatureType.Subcommand)
+    ))
+    expect(msg.contains("`--opt-a` option is deprecated. Use --opt-b."))
+    expect(msg.contains("`my-command` sub-command is deprecated. Use other-command."))
+    expect(msg.contains("Deprecated features may be removed"))
+  }
+
+  private class DiagnosticCapturingLogger extends TestLogger() {
+    val diagnostics: ListBuffer[Diagnostic]        = ListBuffer.empty
+    override def log(diags: Seq[Diagnostic]): Unit =
+      diagnostics ++= diags
+  }
+
+  test("DeprecatedDirectives detects deprecatedTestDirective") {
+    val directive = StrictDirective("deprecatedTestDirective", Seq.empty)
+    val logger    = new DiagnosticCapturingLogger()
+    DeprecatedDirectives.issueWarnings(
+      Left("test.scala"),
+      Seq(directive),
+      SuppressWarningOptions(),
+      logger
+    )
+    expect(logger.diagnostics.exists(_.message.contains("deprecatedTestDirective")))
+  }
+
+  test("DeprecatedDirectives suppresses warnings when configured") {
+    val directive = StrictDirective("deprecatedTestDirective", Seq.empty)
+    val logger    = new DiagnosticCapturingLogger()
+    DeprecatedDirectives.issueWarnings(
+      Left("test.scala"),
+      Seq(directive),
+      SuppressWarningOptions(suppressDeprecatedFeatureWarning = Some(true)),
+      logger
+    )
+    expect(logger.diagnostics.isEmpty)
+  }
+
+  test("DeprecatedDirectives deprecated for removal emits warning without TextEdit") {
+    val directive = StrictDirective("deprecatedForRemovalTestDirective", Seq.empty)
+    val logger    = new DiagnosticCapturingLogger()
+    DeprecatedDirectives.issueWarnings(
+      Left("test.scala"),
+      Seq(directive),
+      SuppressWarningOptions(),
+      logger
+    )
+    val diag = logger.diagnostics.find(_.message.contains("deprecatedForRemovalTestDirective"))
+    expect(diag.isDefined)
+    expect(diag.get.message.contains("removed in a future version"))
+    expect(diag.get.textEdit.isEmpty)
+  }
+
+  test("DeprecatedDirectives key replacement emits warning with TextEdit") {
+    val directive = StrictDirective("deprecatedTestDirective", Seq.empty)
+    val logger    = new DiagnosticCapturingLogger()
+    DeprecatedDirectives.issueWarnings(
+      Left("test.scala"),
+      Seq(directive),
+      SuppressWarningOptions(),
+      logger
+    )
+    val diag = logger.diagnostics.find(_.message.contains("deprecatedTestDirective"))
+    expect(diag.isDefined)
+    expect(diag.get.textEdit.isDefined)
+  }
+}

--- a/modules/build/src/test/scala/scala/build/tests/TestLogger.scala
+++ b/modules/build/src/test/scala/scala/build/tests/TestLogger.scala
@@ -45,6 +45,13 @@ final class RecordingLogger(delegate: Logger = TestLogger()) extends Logger {
   override def experimentalWarning(featureName: String, featureType: FeatureType): Unit =
     delegate.experimentalWarning(featureName, featureType)
   override def flushExperimentalWarnings: Unit = delegate.flushExperimentalWarnings
+  override def deprecationWarning(
+    featureName: String,
+    message: String,
+    featureType: FeatureType
+  ): Unit =
+    delegate.deprecationWarning(featureName, message, featureType)
+  override def flushDeprecationWarnings: Unit = delegate.flushDeprecationWarnings
 }
 
 case class TestLogger(info: Boolean = true, debug: Boolean = false) extends Logger {
@@ -123,4 +130,13 @@ case class TestLogger(info: Boolean = true, debug: Boolean = false) extends Logg
     System.err.println(s"Experimental $featureType `$featureName` used")
 
   override def flushExperimentalWarnings: Unit = ()
+
+  override def deprecationWarning(
+    featureName: String,
+    message: String,
+    featureType: FeatureType
+  ): Unit =
+    System.err.println(s"Deprecated $featureType `$featureName`: $message")
+
+  override def flushDeprecationWarnings: Unit = ()
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictableCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictableCommand.scala
@@ -27,6 +27,13 @@ trait RestrictableCommand[T](implicit myParser: Parser[T]) {
 
   /** Is that command a MUST / SHOULD / NICE TO have for the Scala runner specification? */
   def scalaSpecificationLevel: SpecificationLevel
+
+  /** Override to mark the entire sub-command as deprecated. */
+  def deprecationMessage: Option[String] = None
+
+  /** Override to mark specific command name aliases as deprecated. */
+  def deprecatedNames: Set[List[String]] = Set.empty
+
   // To reduce imports...
   protected def SpecificationLevel = scala.cli.commands.SpecificationLevel
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
@@ -57,13 +57,18 @@ object RestrictedCommandsParser {
             logger.experimentalWarning(passedOption, FeatureType.Option)
             r
           case (r @ Right(Some(_, arg: Arg, _)), passedOption :: _)
+              if arg.isDeprecatedOption && !shouldSuppressDeprecatedWarnings =>
+            logger.deprecationWarning(
+              passedOption,
+              arg.deprecationMessage.getOrElse(""),
+              FeatureType.Option
+            )
+            r
+          case (r @ Right(Some(_, arg: Arg, _)), passedOption :: _)
               if arg.isDeprecated && !shouldSuppressDeprecatedWarnings =>
-            // TODO implement proper deprecation logic: https://github.com/VirtusLab/scala-cli/issues/3258
             arg.deprecatedOptionAliases.find(_ == passedOption)
               .foreach { deprecatedAlias =>
-                logger.message(
-                  s"""[${Console.YELLOW}warn${Console.RESET}] The $deprecatedAlias option alias has been deprecated and may be removed in a future version."""
-                )
+                logger.deprecationWarning(deprecatedAlias, "", FeatureType.Option)
               }
             r
           case (other, _) =>

--- a/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/ScalaCommand.scala
@@ -390,6 +390,22 @@ abstract class ScalaCommand[T <: HasGlobalOptions](implicit myParser: Parser[T],
     else if isExperimental && !shouldSuppressExperimentalFeatureWarnings then
       logger.experimentalWarning(name, FeatureType.Subcommand)
 
+    if !shouldSuppressDeprecatedFeatureWarnings then
+      deprecationMessage match
+        case Some(msg) =>
+          logger.deprecationWarning(actualCommandName, msg, FeatureType.Subcommand)
+        case None =>
+          val usedNames = argvOpt.map { argv =>
+            val maxLen = names.map(_.length).max max 1
+            argv.slice(1, maxLen + 1).toList
+          }.getOrElse(List(name))
+          names.find(_ == usedNames)
+            .filter(deprecatedNames.contains)
+            .foreach { depName =>
+              val aliasStr = depName.mkString(" ")
+              logger.deprecationWarning(aliasStr, "", FeatureType.Subcommand)
+            }
+
     maybePrintWarnings(options)
     maybePrintGroupHelp(options)
     buildOptions(options).foreach { bo =>
@@ -398,6 +414,7 @@ abstract class ScalaCommand[T <: HasGlobalOptions](implicit myParser: Parser[T],
     }
     maybePrintEnvsHelp(options)
     logger.flushExperimentalWarnings
+    logger.flushDeprecationWarnings
     runCommand(options, remainingArgs, options.global.logging.logger)
   }
 }

--- a/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/config/Config.scala
@@ -112,6 +112,10 @@ object Config extends ScalaCommand[ConfigOptions] {
             case Some(entry) =>
               if entry.isExperimental && !shouldSuppressExperimentalFeatureWarnings then
                 logger.experimentalWarning(entry.fullName, FeatureType.ConfigKey)
+              if !shouldSuppressDeprecatedFeatureWarnings then
+                entry.deprecationMessage.foreach { msg =>
+                  logger.deprecationWarning(entry.fullName, msg, FeatureType.ConfigKey)
+                }
               if (values.isEmpty)
                 if (options.unset) {
                   db.remove(entry)
@@ -290,6 +294,7 @@ object Config extends ScalaCommand[ConfigOptions] {
     }
 
     logger.flushExperimentalWarnings
+    logger.flushDeprecationWarnings
   }
 
   /** Check whether to ask for an update depending on the provided key.

--- a/modules/cli/src/main/scala/scala/cli/commands/repl/SharedReplOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/repl/SharedReplOptions.scala
@@ -18,6 +18,7 @@ final case class SharedReplOptions(
   @Group(HelpGroup.Repl.toString)
   @Tag(tags.restricted)
   @Tag(tags.inShortHelp)
+  @Tag(tags.deprecatedOption("Ammonite integration is deprecated. Use the default Scala REPL instead."))
   @HelpMessage("Use Ammonite (instead of the default Scala REPL)")
   @Name("A")
   @Name("amm")
@@ -25,6 +26,7 @@ final case class SharedReplOptions(
 
   @Group(HelpGroup.Repl.toString)
   @Tag(tags.restricted)
+  @Tag(tags.deprecatedOption("Ammonite integration is deprecated. Use the default Scala REPL instead."))
   @HelpMessage(s"Set the Ammonite version (${Constants.ammoniteVersion} by default)")
   @Name("ammoniteVer")
   @Tag(tags.inShortHelp)
@@ -34,6 +36,7 @@ final case class SharedReplOptions(
   @Name("a")
   @Tag(tags.restricted)
   @Tag(tags.inShortHelp)
+  @Tag(tags.deprecatedOption("Ammonite integration is deprecated. Use the default Scala REPL instead."))
   @HelpMessage("Provide arguments for ammonite repl")
   @Hidden
     ammoniteArg: List[String] = Nil,

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -211,7 +211,20 @@ final case class SharedOptions(
   @Tag(tags.experimental)
     objectWrapper: Option[Boolean] = None,
   @Recurse
-    scope: ScopeOptions = ScopeOptions()
+    scope: ScopeOptions = ScopeOptions(),
+
+  @Hidden
+  @Tag(tags.implementation)
+  @Tag(tags.deprecatedOption("For testing purposes only."))
+  @HelpMessage("Deprecated test option (internal, do not use)")
+    deprecatedTestOption: Option[Boolean] = None,
+
+  @Hidden
+  @Tag(tags.implementation)
+  @Name("deprecatedTestAlias")
+  @Tag(tags.deprecated("deprecatedTestAlias"))
+  @HelpMessage("Option with deprecated alias (internal, do not use)")
+    deprecatedTestAliasOption: Option[Boolean] = None
 ) extends HasGlobalOptions {
   // format: on
 

--- a/modules/cli/src/main/scala/scala/cli/internal/CliLogger.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/CliLogger.scala
@@ -132,6 +132,7 @@ class CliLogger(
       printEx(ex, new mutable.HashMap)
   def exit(ex: BuildException): Nothing =
     flushExperimentalWarnings
+    flushDeprecationWarnings
     if (verbosity < 0)
       sys.exit(1)
     else if (verbosity == 0) {
@@ -232,6 +233,29 @@ class CliLogger(
     } yield featureType -> (names ++ reportedNames)
     experimentalWarnings = Map.empty
   }
+
+  private var deprecationWarnings: Map[FeatureType, Map[String, String]] = Map.empty
+  private var reportedDeprecations: Map[FeatureType, Set[String]]        = Map.empty
+  def deprecationWarning(featureName: String, msg: String, featureType: FeatureType): Unit =
+    if !reportedDeprecations.get(featureType).exists(_.contains(featureName)) then
+      deprecationWarnings = deprecationWarnings.updatedWith(featureType) {
+        case None          => Some(Map(featureName -> msg))
+        case Some(entries) => Some(entries + (featureName -> msg))
+      }
+  def flushDeprecationWarnings: Unit = if deprecationWarnings.nonEmpty then
+    val entries =
+      for
+        (featureType, nameMap) <- deprecationWarnings.toSeq.sortBy(_._1)
+        (name, msg)            <- nameMap
+      yield (name, msg, featureType)
+    val messageStr = WarningMessages.deprecatedFeaturesUsed(entries)
+    message(messageStr)
+    reportedDeprecations =
+      for
+        (featureType, nameMap) <- deprecationWarnings
+        alreadyReported = reportedDeprecations.getOrElse(featureType, Set.empty[String])
+      yield featureType -> (nameMap.keySet ++ alreadyReported)
+    deprecationWarnings = Map.empty
 
   override def cliFriendlyDiagnostic(
     message: String,

--- a/modules/cli/src/main/scala/scala/cli/util/ArgHelpers.scala
+++ b/modules/cli/src/main/scala/scala/cli/util/ArgHelpers.scala
@@ -15,12 +15,16 @@ object ArgHelpers {
     private def hasTag(tag: String): Boolean             = arg.tags.exists(_.name == tag)
     private def hasTagPrefix(tagPrefix: String): Boolean =
       arg.tags.exists(_.name.startsWith(tagPrefix))
-    def isExperimental: Boolean = arg.hasTag(tags.experimental)
-    def isRestricted: Boolean   = arg.hasTag(tags.restricted)
-    def isDeprecated: Boolean   = arg.hasTagPrefix(tags.deprecatedPrefix)
+    def isExperimental: Boolean     = arg.hasTag(tags.experimental)
+    def isRestricted: Boolean       = arg.hasTag(tags.restricted)
+    def isDeprecated: Boolean       = arg.hasTagPrefix(tags.deprecatedPrefix)
+    def isDeprecatedOption: Boolean = arg.hasTagPrefix(tags.deprecatedOptionPrefix)
 
     def deprecatedNames: List[String] = arg.tags
-      .filter(_.name.startsWith(tags.deprecatedPrefix))
+      .filter(t =>
+        t.name.startsWith(tags.deprecatedPrefix) &&
+        !t.name.startsWith(tags.deprecatedOptionPrefix)
+      )
       .map(_.name.stripPrefix(s"${tags.deprecatedPrefix}${tags.valueSeparator}"))
       .toList
 
@@ -31,6 +35,12 @@ object ArgHelpers {
           _.toLowerCase
         ).mkString("-")
     }
+
+    def deprecationMessage: Option[String] = arg.tags
+      .find(_.name.startsWith(tags.deprecatedOptionPrefix))
+      .map(_.name.stripPrefix(s"${tags.deprecatedOptionPrefix}${tags.valueSeparator}"))
+      .map(_.stripPrefix(tags.deprecatedOptionPrefix))
+      .filter(_.nonEmpty)
 
     def isExperimentalOrRestricted: Boolean = arg.isRestricted || arg.isExperimental
 

--- a/modules/config/src/main/scala/scala/cli/config/Key.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Key.scala
@@ -56,6 +56,9 @@ abstract class Key[T] {
 
   def isExperimental: Boolean = specificationLevel == SpecificationLevel.EXPERIMENTAL
   def isRestricted: Boolean   = specificationLevel == SpecificationLevel.RESTRICTED
+
+  def deprecationMessage: Option[String] = None
+  def isDeprecated: Boolean              = deprecationMessage.isDefined
 }
 
 object Key {
@@ -127,7 +130,8 @@ object Key {
     val name: String,
     override val specificationLevel: SpecificationLevel,
     val description: String = "",
-    override val hidden: Boolean = false
+    override val hidden: Boolean = false,
+    override val deprecationMessage: Option[String] = None
   ) extends KeyWithJsonCodec[Boolean] {
     def asString(value: Boolean): Seq[String] =
       Seq(value.toString)

--- a/modules/config/src/main/scala/scala/cli/config/Keys.scala
+++ b/modules/config/src/main/scala/scala/cli/config/Keys.scala
@@ -148,6 +148,15 @@ object Keys {
   // Kept for binary compatibility
   val repositoriesMirrors: Key.StringListEntry = repositoryMirrors
 
+  val deprecatedTestKey = new Key.BooleanEntry(
+    prefix = Seq("test"),
+    name = "deprecated-key",
+    specificationLevel = SpecificationLevel.IMPLEMENTATION,
+    description = "Deprecated test key (internal, do not use).",
+    hidden = true,
+    deprecationMessage = Some("For testing purposes only.")
+  )
+
   // setting indicating if the global interactive mode was suggested
   val globalInteractiveWasSuggested = new Key.BooleanEntry(
     prefix = Seq.empty,
@@ -176,6 +185,7 @@ object Keys {
   def all: Seq[Key[?]] = Seq[Key[?]](
     actions,
     defaultRepositories,
+    deprecatedTestKey,
     ghToken,
     globalInteractiveWasSuggested,
     interactive,

--- a/modules/core/src/main/scala/scala/build/Logger.scala
+++ b/modules/core/src/main/scala/scala/build/Logger.scala
@@ -48,6 +48,9 @@ trait Logger {
   def experimentalWarning(featureName: String, featureType: FeatureType): Unit
   def flushExperimentalWarnings: Unit
 
+  def deprecationWarning(featureName: String, message: String, featureType: FeatureType): Unit
+  def flushDeprecationWarnings: Unit
+
   def cliFriendlyDiagnostic(
     message: String,
     @unused cliFriendlyMessage: String,
@@ -93,6 +96,9 @@ object Logger {
 
     def experimentalWarning(featureUsed: String, featureType: FeatureType): Unit = ()
     def flushExperimentalWarnings: Unit                                          = ()
+    def deprecationWarning(featureName: String, message: String, featureType: FeatureType): Unit =
+      ()
+    def flushDeprecationWarnings: Unit = ()
   }
   def nop: Logger = new Nop
 }

--- a/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
+++ b/modules/generate-reference-doc/src/main/scala/scala/cli/doc/GenerateReferenceDoc.scala
@@ -203,8 +203,10 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
           for (arg <- distinctArgs) {
             import caseapp.core.util.NameOps._
             arg.name.option(nameFormatter)
-            val names = (arg.name +: arg.extraNames).map(_.option(nameFormatter))
-            b.append(s"### `${names.head}`\n\n")
+            val names           = (arg.name +: arg.extraNames).map(_.option(nameFormatter))
+            val deprecatedLabel =
+              if arg.isDeprecatedOption then "[deprecated] " else ""
+            b.append(s"### $deprecatedLabel`${names.head}`\n\n")
             if (names.tail.nonEmpty)
               b.append(
                 names
@@ -217,6 +219,9 @@ object GenerateReferenceDoc extends CaseApp[InternalDocOptions] {
                   }
                   .mkString("Aliases: ", ", ", "\n\n")
               )
+            arg.deprecationMessage.foreach { msg =>
+              b.append(s"**Deprecated**: $msg\n\n")
+            }
 
             if (onlyRestricted)
               b.section(s"`${arg.level.md}` per Scala Runner specification")

--- a/modules/integration/src/test/scala/scala/cli/integration/DeprecationTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DeprecationTests.scala
@@ -1,0 +1,127 @@
+package scala.cli.integration
+
+import com.eed3si9n.expecty.Expecty.expect
+
+class DeprecationTests extends ScalaCliSuite {
+  override def group: ScalaCliSuite.TestGroup = ScalaCliSuite.TestGroup.First
+
+  private val configFile = os.rel / "config" / "config.json"
+  private val configEnvs = Map("SCALA_CLI_CONFIG" -> configFile.toString())
+
+  test("deprecated CLI option warning includes exact option name and detail") {
+    val inputPath = os.rel / "example.sc"
+    TestInputs(inputPath -> """println("hello")""").fromRoot { root =>
+      val res = os.proc(
+        TestUtil.cli,
+        "run",
+        TestUtil.extraOptions,
+        inputPath,
+        "--deprecated-test-option"
+      ).call(cwd = root, stderr = os.Pipe)
+      val err = res.err.trim()
+      expect(err.contains("--deprecated-test-option"))
+      expect(err.contains("is deprecated."))
+      expect(err.contains("For testing purposes only."))
+    }
+  }
+
+  test("deprecated CLI option alias warning includes exact alias name") {
+    val inputPath = os.rel / "example.sc"
+    TestInputs(inputPath -> """println("hello")""").fromRoot { root =>
+      val res = os.proc(
+        TestUtil.cli,
+        "run",
+        TestUtil.extraOptions,
+        inputPath,
+        "--deprecated-test-alias"
+      ).call(cwd = root, stderr = os.Pipe)
+      val err = res.err.trim()
+      expect(err.contains("--deprecated-test-alias"))
+      expect(err.contains("is deprecated."))
+    }
+  }
+
+  test("deprecated using directive produces a warning") {
+    val inputPath = os.rel / "example.sc"
+    TestInputs(inputPath ->
+      """//> using lib "com.lihaoyi::os-lib:0.11.4"
+        |println("hello")
+        |""".stripMargin).fromRoot { root =>
+      val res = os.proc(TestUtil.cli, "run", TestUtil.extraOptions, inputPath)
+        .call(cwd = root, stderr = os.Pipe)
+      val err = res.err.trim()
+      expect(err.contains("deprecated"))
+      expect(err.contains("lib"))
+    }
+  }
+
+  test("--suppress-deprecated-warnings silences deprecation warnings") {
+    val inputPath = os.rel / "example.sc"
+    TestInputs(inputPath -> """println("hello")""").fromRoot { root =>
+      val res = os.proc(
+        TestUtil.cli,
+        "run",
+        TestUtil.extraOptions,
+        inputPath,
+        "--deprecated-test-option",
+        "--suppress-deprecated-warnings"
+      ).call(cwd = root, stderr = os.Pipe)
+      val err = res.err.trim()
+      expect(!err.contains("is deprecated"))
+    }
+  }
+
+  test("config suppress-warning.deprecated-features silences deprecation warnings") {
+    val inputPath = os.rel / "example.sc"
+    TestInputs(inputPath -> """println("hello")""").fromRoot { root =>
+      os.proc(TestUtil.cli, "config", "suppress-warning.deprecated-features", "true")
+        .call(cwd = root, env = configEnvs)
+      val res = os.proc(
+        TestUtil.cli,
+        "run",
+        TestUtil.extraOptions,
+        inputPath,
+        "--deprecated-test-option"
+      ).call(cwd = root, stderr = os.Pipe, env = configEnvs)
+      val err = res.err.trim()
+      expect(!err.contains("is deprecated"))
+    }
+  }
+
+  test("--ammonite deprecation warning includes the exact alias used") {
+    TestInputs.empty.fromRoot { root =>
+      val res = os.proc(
+        TestUtil.cli,
+        "--power",
+        "repl",
+        TestUtil.extraOptions,
+        "--amm",
+        "--repl-dry-run"
+      ).call(cwd = root, stderr = os.Pipe)
+      val err = res.err.trim()
+      expect(err.contains("--amm"))
+      expect(err.contains("is deprecated."))
+      expect(err.contains("Use the default Scala REPL instead."))
+    }
+  }
+
+  test("multiple deprecated features produce a single consolidated warning") {
+    val inputPath = os.rel / "example.sc"
+    TestInputs(inputPath -> """println("hello")""").fromRoot { root =>
+      val res = os.proc(
+        TestUtil.cli,
+        "run",
+        TestUtil.extraOptions,
+        inputPath,
+        "--deprecated-test-option",
+        "--deprecated-test-alias"
+      ).call(cwd = root, stderr = os.Pipe)
+      val err = res.err.trim()
+      expect(err.contains("--deprecated-test-option"))
+      expect(err.contains("--deprecated-test-alias"))
+      val deprecatedWarningLines = err.linesIterator
+        .count(_.contains("Deprecated features may be removed"))
+      expect(deprecatedWarningLines == 1)
+    }
+  }
+}

--- a/modules/options/src/main/scala/scala/build/options/SuppressWarningOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/SuppressWarningOptions.scala
@@ -14,6 +14,7 @@ object SuppressWarningOptions {
   val suppressAll = SuppressWarningOptions(
     suppressDirectivesInMultipleFilesWarning = Some(true),
     suppressOutdatedDependencyWarning = Some(true),
-    suppressExperimentalFeatureWarning = Some(true)
+    suppressExperimentalFeatureWarning = Some(true),
+    suppressDeprecatedFeatureWarning = Some(true)
   )
 }

--- a/modules/specification-level/src/main/scala/scala/cli/commands/SpecificationLevel.scala
+++ b/modules/specification-level/src/main/scala/scala/cli/commands/SpecificationLevel.scala
@@ -75,6 +75,11 @@ object tags {
   def deprecated(name: String): String =
     s"$deprecatedPrefix$valueSeparator$name" // produces a deprecated warning for the given name
 
+  val deprecatedOptionPrefix: String            = "deprecatedOption"
+  def deprecatedOption: String                  = deprecatedOptionPrefix
+  def deprecatedOption(message: String): String =
+    s"$deprecatedOptionPrefix$valueSeparator$message"
+
   def levelFor(name: String): Option[SpecificationLevel] = name match {
     case `experimental`   => Some(SpecificationLevel.EXPERIMENTAL)
     case `restricted`     => Some(SpecificationLevel.RESTRICTED)

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -120,7 +120,7 @@ object TestDeps {
 
 object Deps {
   object Versions {
-    def ammonite             = "3.0.8"
+    def ammonite             = "3.0.9"
     def ammoniteForScala3Lts = ammonite
     def argonautShapeless    = "1.3.1"
     // jni-utils version may need to be sync-ed when bumping the coursier version

--- a/website/docs/commands/repl.md
+++ b/website/docs/commands/repl.md
@@ -26,6 +26,10 @@ Scala CLI by default uses the normal Scala REPL.
 
 If you prefer to use the [Ammonite REPL](https://ammonite.io/#Ammonite-REPL), specify `--amm` to launch it rather than the default REPL:
 
+:::warning
+The Ammonite integration (`--ammonite` / `--amm` / `-A` and related options) is **deprecated** and will be removed in a future version. Use the default Scala REPL instead.
+:::
+
 :::caution
 Using the Ammonite REPL is restricted and requires setting the `--power` option to be used.
 You can pass it explicitly or set it globally by running:

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1707,6 +1707,20 @@ Exclude sources
 
 Force object wrapper for scripts
 
+### [deprecated] `--deprecated-test-option`
+
+**Deprecated**: For testing purposes only.
+
+[Internal]
+Deprecated test option (internal, do not use)
+
+### `--deprecated-test-alias-option`
+
+Aliases: [deprecated] `--deprecated-test-alias`
+
+[Internal]
+Option with deprecated alias (internal, do not use)
+
 ## Snippet options
 
 Available in commands:

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1272,7 +1272,7 @@ Use Ammonite (instead of the default Scala REPL)
 
 Aliases: `--ammonite-ver`
 
-Set the Ammonite version (3.0.8 by default)
+Set the Ammonite version (3.0.9 by default)
 
 ### `--ammonite-arg`
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1262,21 +1262,27 @@ Available in commands:
 
 <!-- Automatically generated, DO NOT EDIT MANUALLY -->
 
-### `--ammonite`
+### [deprecated] `--ammonite`
 
 Aliases: `-A`, `--amm`
 
+**Deprecated**: Ammonite integration is deprecated. Use the default Scala REPL instead.
+
 Use Ammonite (instead of the default Scala REPL)
 
-### `--ammonite-version`
+### [deprecated] `--ammonite-version`
 
 Aliases: `--ammonite-ver`
 
+**Deprecated**: Ammonite integration is deprecated. Use the default Scala REPL instead.
+
 Set the Ammonite version (3.0.9 by default)
 
-### `--ammonite-arg`
+### [deprecated] `--ammonite-arg`
 
 Aliases: `-a`
+
+**Deprecated**: Ammonite integration is deprecated. Use the default Scala REPL instead.
 
 [Internal]
 Provide arguments for ammonite repl

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -72,6 +72,7 @@ Available keys:
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
   - suppress-warning.experimental-features         Globally suppresses warnings about experimental features.
   - suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
+  - test.deprecated-key                            Deprecated test key (internal, do not use).
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/config
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -1164,6 +1164,22 @@ Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Sc
 
 Exclude sources
 
+### [deprecated] `--deprecated-test-option`
+
+**Deprecated**: For testing purposes only.
+
+`IMPLEMENTATION specific` per Scala Runner specification
+
+Deprecated test option (internal, do not use)
+
+### `--deprecated-test-alias-option`
+
+Aliases: [deprecated] `--deprecated-test-alias`
+
+`IMPLEMENTATION specific` per Scala Runner specification
+
+Option with deprecated alias (internal, do not use)
+
 ## Snippet options
 
 Available in commands:

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -71,6 +71,7 @@ Available keys:
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
   - suppress-warning.experimental-features         Globally suppresses warnings about experimental features.
   - suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
+  - test.deprecated-key                            Deprecated test key (internal, do not use).
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/config
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -650,6 +650,16 @@ Aliases: `--toolkit`
 
 Exclude sources
 
+**--deprecated-test-option**
+
+Deprecated test option (internal, do not use)
+
+**--deprecated-test-alias-option**
+
+Option with deprecated alias (internal, do not use)
+
+Aliases: `--deprecated-test-alias`
+
 </details>
 
 ---
@@ -693,6 +703,7 @@ Available keys:
   - suppress-warning.directives-in-multiple-files  Globally suppresses warnings about directives declared in multiple source files.
   - suppress-warning.experimental-features         Globally suppresses warnings about experimental features.
   - suppress-warning.outdated-dependencies-files   Globally suppresses warnings about outdated dependencies.
+  - test.deprecated-key                            Deprecated test key (internal, do not use).
 
 For detailed documentation refer to our website: https://scala-cli.virtuslab.org/docs/commands/config
 
@@ -1441,6 +1452,16 @@ Aliases: `--toolkit`
 
 Exclude sources
 
+**--deprecated-test-option**
+
+Deprecated test option (internal, do not use)
+
+**--deprecated-test-alias-option**
+
+Option with deprecated alias (internal, do not use)
+
+Aliases: `--deprecated-test-alias`
+
 </details>
 
 ---
@@ -2049,6 +2070,16 @@ Aliases: `--toolkit`
 **--exclude**
 
 Exclude sources
+
+**--deprecated-test-option**
+
+Deprecated test option (internal, do not use)
+
+**--deprecated-test-alias-option**
+
+Option with deprecated alias (internal, do not use)
+
+Aliases: `--deprecated-test-alias`
 
 **--java-prop-option**
 
@@ -2688,6 +2719,16 @@ Aliases: `--toolkit`
 **--exclude**
 
 Exclude sources
+
+**--deprecated-test-option**
+
+Deprecated test option (internal, do not use)
+
+**--deprecated-test-alias-option**
+
+Option with deprecated alias (internal, do not use)
+
+Aliases: `--deprecated-test-alias`
 
 **--java-prop-option**
 
@@ -3337,6 +3378,16 @@ Aliases: `--toolkit`
 
 Exclude sources
 
+**--deprecated-test-option**
+
+Deprecated test option (internal, do not use)
+
+**--deprecated-test-alias-option**
+
+Option with deprecated alias (internal, do not use)
+
+Aliases: `--deprecated-test-alias`
+
 **--java-prop-option**
 
 Add java properties. Note that options equal `-Dproperty=value` are assumed to be java properties and don't require to be passed after `--java-prop`.
@@ -3942,6 +3993,16 @@ Aliases: `--toolkit`
 **--exclude**
 
 Exclude sources
+
+**--deprecated-test-option**
+
+Deprecated test option (internal, do not use)
+
+**--deprecated-test-alias-option**
+
+Option with deprecated alias (internal, do not use)
+
+Aliases: `--deprecated-test-alias`
 
 **--respect-project-filters**
 
@@ -4626,6 +4687,16 @@ Aliases: `--toolkit`
 **--exclude**
 
 Exclude sources
+
+**--deprecated-test-option**
+
+Deprecated test option (internal, do not use)
+
+**--deprecated-test-alias-option**
+
+Option with deprecated alias (internal, do not use)
+
+Aliases: `--deprecated-test-alias`
 
 **--java-prop-option**
 
@@ -5320,6 +5391,16 @@ Aliases: `--toolkit`
 **--exclude**
 
 Exclude sources
+
+**--deprecated-test-option**
+
+Deprecated test option (internal, do not use)
+
+**--deprecated-test-alias-option**
+
+Option with deprecated alias (internal, do not use)
+
+Aliases: `--deprecated-test-alias`
 
 **--json-options**
 
@@ -6297,6 +6378,16 @@ Aliases: `--toolkit`
 **--exclude**
 
 Exclude sources
+
+**--deprecated-test-option**
+
+Deprecated test option (internal, do not use)
+
+**--deprecated-test-alias-option**
+
+Option with deprecated alias (internal, do not use)
+
+Aliases: `--deprecated-test-alias`
 
 **--bsp-directory**
 


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/3258
- bumps Ammonite to 3.0.9 (where it deprecates itself)
- adds logic for deprecating features (command line options, directive aliases, sub-commands, config keys)
- adds logic for suppression of deprecation warnings
- adds an agent skill for deprecating features
- deprecates all Ammonite flags (`--ammonite`, `--ammonite-version`, and `--ammonite-arg`)

## Examples
- Ammonite deprecation
```bash
scala-cli --amm --power --ammonite-arg -c --ammonite-arg 'println("Hello")'
# [warn] Some utilized features are deprecated:
#  - `--amm` option is deprecated. Ammonite integration is deprecated. Use the default Scala REPL instead.
#  - `--ammonite-arg` option is deprecated. Ammonite integration is deprecated. Use the default Scala REPL instead.
# Deprecated features may be removed in a future version.
# Scala 3.8.3 is not yet supported with this version of Ammonite
# Defaulting to Scala 3.8.1
# Downloading Ammonite 3.0.9 sources
# Compiling /Users/pchabelski/IdeaProjects/scala-cli/(console)
# Hello
```

- deprecation warning suppression via command line option
```bash
scala-cli run Hello.scala --deprecated-test-option --suppress-deprecated-warnings
```
- deprecation warning suppression via config
```bash
scala-cli config suppress-warning.deprecated-features true
```

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
a lot; Cursor + Claude

## How was the solution tested?
Added dummy features of each category and automated tests for how the CLI warns on each of them.

### 1. `--deprecated-test-option` (full option deprecation)
```bash
scala-cli run Hello.scala --deprecated-test-option
# [warn] --deprecated-test-option is deprecated: For testing purposes only.
```
### 2. `--deprecated-test-alias` (alias deprecation)
```bash
scala-cli run Hello.scala --deprecated-test-alias
# [warn] --deprecated-test-alias is deprecated
```
### 3. `//> using deprecatedTestDirective` (directive deprecated with replacement)
```scala
//> using deprecatedTestDirective
```
```
# [warn] 'deprecatedTestDirective' is deprecated: use 'testDirective' instead
# (IDE quick-fix offered: change to 'testDirective')
```
### 4. `//> using deprecatedForRemovalTestDirective` (directive deprecated for removal)
```scala
//> using deprecatedForRemovalTestDirective
```
```
# [warn] Using 'deprecatedForRemovalTestDirective' is deprecated and will be removed in a future version
# (no IDE quick-fix offered)
```
### 5. `test.deprecated-key` (config key deprecation)
```bash
scala-cli config test.deprecated-key true
# [warn] test.deprecated-key is deprecated: For testing purposes only.
```

Tests pass locally.

## Additional notes
- https://github.com/com-lihaoyi/Ammonite/releases/tag/3.0.9
- https://github.com/com-lihaoyi/Ammonite/commit/388d10819e9cb22c260be2fb1b053088d725ffb1