### PR TITLE
Bump announced Scala 3 Next RC version to 3.8.4-RC1

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/CoursierScalaInstallationTestHelper.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CoursierScalaInstallationTestHelper.scala
@@ -41,11 +41,23 @@ trait CoursierScalaInstallationTestHelper {
           setCommandLine match { case scriptPathRegex(extractedPath) => extractedPath }
         val batchScriptPath = os.Path(batchScript)
         val oldContent      = os.read(batchScriptPath)
-        val newContent      = oldContent.replace(
-          "call %SCALA_CLI_CMD_WIN%",
-          s"""set "SCALA_CLI_CMD_WIN=${TestUtil.cliPath}"
-             |call %SCALA_CLI_CMD_WIN%""".stripMargin
-        )
+        val cliPathWin      = TestUtil.cliPath
+        val legacyInvoke    = "call %SCALA_CLI_CMD_WIN%"
+        val newContent      =
+          if oldContent.contains(legacyInvoke) then
+            oldContent.replace(
+              legacyInvoke,
+              s"""set "SCALA_CLI_CMD_WIN=$cliPathWin"
+                 |call %SCALA_CLI_CMD_WIN%""".stripMargin
+            )
+          else
+            // Scala 3.8.4+ Windows launcher uses delayed expansion (!SCALA_CLI_CMD_WIN!) instead of
+            // `call %SCALA_CLI_CMD_WIN%`. Override the variable after cli-common-platform.bat runs.
+            val anchor =
+              """call "%_PROG_HOME%\libexec\cli-common-platform.bat""""
+            val injection =
+              s"$anchor${System.lineSeparator()}${System.lineSeparator()}set \"SCALA_CLI_CMD_WIN=$cliPathWin\""
+            oldContent.replace(anchor, injection)
         expect(newContent != oldContent)
         os.write.over(batchScriptPath, newContent)
         batchWrapperScript -> batchScriptPath

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -22,7 +22,7 @@ object Scala {
   def scala3Next       = s"$scala3NextPrefix.3" // the newest/next version of Scala
   def scala3NextAnnounced   = s"$scala3NextPrefix.2"  // the newest/next version of Scala that's been announced
   def scala3NextRc          = "3.8.4-RC1" // the latest RC version of Scala Next
-  def scala3NextRcAnnounced = "3.8.3-RC3" // the latest announced RC version of Scala Next
+  def scala3NextRcAnnounced = "3.8.4-RC1" // the latest announced RC version of Scala Next
 
   // The Scala version used to build the CLI itself.
   def defaultInternal = sys.props.get("scala.version.internal").getOrElse(scala3Lts)


### PR DESCRIPTION
https://github.com/scala/scala3/releases/tag/3.8.4-RC1