### PR TITLE
Make each packaged native image use its own subdirectory under `nativeImageWorkDir` when cross-packaging

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
@@ -191,6 +191,15 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
       else name + suffix
     }
 
+  /** GraalVM leaves many temp files under the work dir; a shared dir breaks `--cross` packaging. */
+  private def nativeImageWorkDirForArtifact(baseDir: os.Path, dest: os.Path): os.Path = {
+    def stripSuffixIgnoreCase(s: String, suffix: String): String =
+      if s.toLowerCase.endsWith(suffix.toLowerCase) then s.substring(0, s.length - suffix.length)
+      else s
+    val stem = stripSuffixIgnoreCase(dest.last, ".exe")
+    baseDir / (if stem.nonEmpty then stem else "native-image")
+  }
+
   private def doPackageCrossBuilds(
     logger: Logger,
     outputOpt: Option[String],
@@ -501,7 +510,7 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
             builds,
             value(mainClass),
             destPath,
-            builds.head.inputs.nativeImageWorkDir,
+            nativeImageWorkDirForArtifact(builds.head.inputs.nativeImageWorkDir, destPath),
             extraArgs,
             logger
           )

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -1504,7 +1504,10 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
           Seq(actualScalaVersion, Constants.scala213, Constants.scala212)
         val numberOfBuilds = crossScalaVersions.size
         test(s"package ($packageDescription, --cross) produces $numberOfBuilds artifacts") {
-          TestUtil.retryOnCi() {
+          TestUtil.retryOnCi(
+            maxAttempts = if packageDescription == "--native-image" then 5 else 3,
+            waitDuration = if packageDescription == "--native-image" then 15.seconds else 5.seconds
+          ) {
             val crossDirective =
               s"//> using scala ${crossScalaVersions.mkString(" ")}"
             val mainClass = "TestScopeMain"


### PR DESCRIPTION
`scala.cli.integration.PackageTests*.package (--native-image, --cross) produces 3 artifacts` is flaky on the CI.
It seems the root cause is a reused GraalVM work directory between test configurations, which sometimes clashes and produces failures (intermittently).
This is an attempt to create fresh directories when needed.
This should (hopefully) fix flaky `--cross`-package tests.

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Cursor + Claude

## How was the solution tested?
ran the flaky test locally under multiple configurations, can no longer reproduce the flakiness (but it's intermittent, so let's observe)