### PR TITLE
Add additional packaging.graalvm* directives

### DIFF
--- a/modules/build/src/test/scala/scala/build/tests/PackagingUsingDirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/PackagingUsingDirectiveTests.scala
@@ -34,7 +34,7 @@ class PackagingUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
     }
   }
 
-  test("graalvm packaging") {
+  test("graalvm packaging jvmId") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->
         """//> using packaging.packageType graalvm
@@ -48,6 +48,22 @@ class PackagingUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
       val nativeImageOpt = maybeBuild.options.notForBloopOptions.packageOptions.nativeImageOptions
       expect(nativeImageOpt.jvmId == "graalvm-community:23.0.2")
       expect(nativeImageOpt.graalvmArgs.exists(_.value == "--no-fallback"))
+    }
+  }
+
+  test("graalvm packaging javaVersion") {
+    val inputs = TestInputs(
+      os.rel / "p.sc" ->
+        """//> using packaging.packageType graalvm
+          |//> using packaging.graalvmJavaVersion 23
+          |//> using packaging.graalvmVersion 23.0.2
+          |
+          |def foo() = println("hello foo")
+          |""".stripMargin
+    )
+    inputs.withLoadedBuild(buildOptions, buildThreads, bloopConfig) { (_, _, maybeBuild) =>
+      val nativeImageOpt = maybeBuild.options.notForBloopOptions.packageOptions.nativeImageOptions
+      expect(nativeImageOpt.jvmId == "graalvm-java23:23.0.2")
     }
   }
 

--- a/modules/build/src/test/scala/scala/build/tests/PackagingUsingDirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/PackagingUsingDirectiveTests.scala
@@ -51,7 +51,7 @@ class PackagingUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
     }
   }
 
-  test("graalvm packaging javaVersion") {
+  test("graalvm packaging valid javaVersion") {
     val inputs = TestInputs(
       os.rel / "p.sc" ->
         """//> using packaging.packageType graalvm
@@ -64,6 +64,27 @@ class PackagingUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
     inputs.withLoadedBuild(buildOptions, buildThreads, bloopConfig) { (_, _, maybeBuild) =>
       val nativeImageOpt = maybeBuild.options.notForBloopOptions.packageOptions.nativeImageOptions
       expect(nativeImageOpt.jvmId == "graalvm-java23:23.0.2")
+    }
+  }
+
+  test("graalvm packaging invalid javaVersion") {
+    val inputs = TestInputs(
+      os.rel / "p.sc" ->
+        """//> using packaging.packageType graalvm
+          |//> using packaging.graalvmJavaVersion 7
+          |
+          |def foo() = println("hello foo")
+          |""".stripMargin
+    )
+    inputs.withBuild(buildOptions, buildThreads, bloopConfig) { (_, _, maybeBuild) =>
+      maybeBuild match
+        case Left(e) =>
+          expect(
+            e.message.contains("graalvm-java-version") &&
+            e.message.contains("an integer greater than 7")
+          )
+        case Right(_) =>
+          fail("Expected build to fail with invalid graalvmJavaVersion")
     }
   }
 

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Packaging.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Packaging.scala
@@ -134,12 +134,12 @@ final case class Packaging(
     val maybeGraalVMJavaVersion = graalvmJavaVersion
       .map { version =>
         version.value.toIntOption
-          .filter(_ > 0)
+          .filter(_ > 7)
           .toRight {
             new MalformedInputError(
               "graalvm-java-version",
               version.value,
-              "a positive integer",
+              "an integer greater than 7",
               positions = version.positions
             )
           }

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Packaging.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Packaging.scala
@@ -24,7 +24,9 @@ import scala.util.Try
 @DirectiveExamples("//> using packaging.output foo")
 @DirectiveExamples("//> using packaging.provided org.apache.spark::spark-sql")
 @DirectiveExamples("//> using packaging.graalvmArgs --no-fallback")
-@DirectiveExamples("//> using packaging.graalvmJvmId graalvm-community:23.0.2")
+@DirectiveExamples("//> using packaging.graalvmVersion 17.0.9")
+@DirectiveExamples("//> using packaging.graalvmJavaVersion 17")
+@DirectiveExamples("//> using packaging.graalvmJvmId graalvm-java17:17.0.9")
 @DirectiveExamples("//> using packaging.dockerFrom openjdk:11")
 @DirectiveExamples("//> using packaging.dockerImageTag 1.0.0")
 @DirectiveExamples("//> using packaging.dockerImageRegistry virtuslab")
@@ -39,6 +41,9 @@ import scala.util.Try
   """using packaging.packageType [package type]
     |using packaging.output [destination path]
     |using packaging.provided [module]
+    |using packaging.graalvmVersion [graalvm version]
+    |using packaging.graalvmJavaVersion [graalvm java version]
+    |using packaging.graalvmJvmId [graalvm jvm id]
     |using packaging.graalvmArgs [args]
     |using packaging.dockerFrom [base docker image]
     |using packaging.dockerImageTag [image tag]
@@ -54,6 +59,10 @@ import scala.util.Try
     |`//> using packaging.provided` _module_
     |
     |`//> using packaging.graalvmArgs` _args_
+    |
+    |`//> using packaging.graalvmVersion` _graalvm-version_
+    |
+    |`//> using packaging.graalvmJavaVersion` _graalvm-java-version_
     |
     |`//> using packaging.graalvmJvmId` _graalvm-jvm-id_
     |
@@ -79,6 +88,8 @@ final case class Packaging(
   output: Option[String] = None,
   provided: List[Positioned[String]] = Nil,
   graalvmArgs: List[Positioned[String]] = Nil,
+  graalvmVersion: Option[String] = None,
+  graalvmJavaVersion: Option[Positioned[String]] = None,
   graalvmJvmId: Option[String] = None,
   dockerFrom: Option[String] = None,
   dockerImageTag: Option[String] = None,
@@ -120,9 +131,23 @@ final case class Packaging(
       }
       .sequence
       .left.map(CompositeBuildException(_))
+    val maybeGraalVMJavaVersion = graalvmJavaVersion
+      .map { version =>
+        version.value.toIntOption
+          .filter(_ > 0)
+          .toRight {
+            new MalformedInputError(
+              "graalvm-java-version",
+              version.value,
+              "a positive integer",
+              positions = version.positions
+            )
+          }
+      }
+      .sequence
 
-    val (packageTypeOpt, output0, provided0) = value {
-      (maybePackageTypeOpt, maybeOutput, maybeProvided)
+    val (packageTypeOpt, output0, provided0, graalVMJavaVersion0) = value {
+      (maybePackageTypeOpt, maybeOutput, maybeProvided, maybeGraalVMJavaVersion)
         .traverseN
         .left.map(CompositeBuildException(_))
     }
@@ -162,6 +187,8 @@ final case class Packaging(
             extraDirectories = extraDirectories
           ),
           nativeImageOptions = NativeImageOptions(
+            graalvmVersion = graalvmVersion,
+            graalvmJavaVersion = graalVMJavaVersion0,
             graalvmJvmId = graalvmJvmId,
             graalvmArgs = graalvmArgs
           )

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -290,6 +290,10 @@ Set parameters for packaging
 
 `//> using packaging.graalvmArgs` _args_
 
+`//> using packaging.graalvmVersion` _graalvm-version_
+
+`//> using packaging.graalvmJavaVersion` _graalvm-java-version_
+
 `//> using packaging.graalvmJvmId` _graalvm-jvm-id_
 
 `//> using packaging.dockerFrom` _base-docker-image_
@@ -316,7 +320,11 @@ Set parameters for packaging
 
 `//> using packaging.graalvmArgs --no-fallback`
 
-`//> using packaging.graalvmJvmId graalvm-community:23.0.2`
+`//> using packaging.graalvmVersion 17.0.9`
+
+`//> using packaging.graalvmJavaVersion 17`
+
+`//> using packaging.graalvmJvmId graalvm-java17:17.0.9`
 
 `//> using packaging.dockerFrom openjdk:11`
 


### PR DESCRIPTION
Fixes #4224.

- Add directive `packaging.graalvmVersion` (string)
- Add directive `packaging.graalvmJavaVersion` (int)
- Validate (valid int and >0) of `graalvmJavaVersion`
- Update docs to reflect the changes (as well as a previously missed doc for `graalvmJvmId`)
- Also updated the docs to reflect the "default" GraalVM versions and IDs -- I did not think it mattered too much, but I thought it was best for the sake of consistency.
- Add unit tests for the newly added directives.

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?

**Moderately.** In a previous PR #4223 I got familiarized with the `preprocessing.directives.Packaging` case class as well as relevant unit tests with the help of GitHub Copilot (using Claude Sonnet 4.6), so I did not need much AI assistance this time around. I did trip on the fact that `graalvmJvmVersion` arg of `NativeImageOptions` was supposed to be an `Option[Int]` while the arg I was getting from the `Packaging` args was an `Option[String]`. I tried using a simple `.flatMap(_.toIntOption)` but then realized if a bad (non-int) `graalvmJvmVersion` is passed, it would be replaced silently. So I used AI help to figure out how to weave-in validation into the `buildOptions` method. A hint was all it took; it was easy enough to follow existing patterns.

## How was the solution tested?

Unit tests included.

Additionally, I created a test project with the following lines:
```scala
//> using packaging.packageType graalvm
//> using packaging.graalvmVersion 25.0.2
//> using packaging.graalvmJavaVersion 25
//> using packaging.output "sctest02"
//> using packaging.graalvmArgs --no-fallback
```

And ran with
```cmd
../scala-cli/out/cli/3.3.7/standaloneLauncher.dest/launcher --power package .
```

I saw the version `GraalVM CE 25.0.2+10.1` in the build output, which verified that `graalvmVersion` and `graalvmJavaVersion` were being correctly compiled into a valid JVM ID by the just-compiled launcher.

I also tried with an invalid graalvmJavaVersion and saw the expected error output:
```cmd
[error] ./build.scala:10:40
[error] Malformed graalvm-java-version "notint", expected a positive integer
[error] //> using packaging.graalvmJavaVersion foo
[error]
```
verifying that integer validation of `graalvmJavaVersion` was working as intended.

## Additional notes

I think enhancements could be made to `NativeImageOptions`.

Currently, passing just a whole JVM ID (e.g. `graalvm-community:25.0.2`) works smoothly. If the _JVM ID is not passed,_ and instead a Java version (e.g. 25) _along with a_ JVM version (e.g. 25.0.2) is passed, then `NativeImageOptions` uses that to construct a JVM ID (in case of e.g. it would be `graalvm-java25:25.0.2`). If both a JVM ID _as well as_ the Java version + JVM version pair are passed, then the latter get ignored entirely. This is all expected behavior.

If user mistakenly passes an unmatched Java version and JVM version pair (e.g. `graalvm-version=24.0.2 graalvm-java-version=22`), `NativeImageOptions` naively compiles that to an invalid JVM ID (in case of e.g. `graalvm-java22:24.0.2`). This, too, may be considered expected behavior and an obvious user error.

However, something that IMO could be more common and not an obvious user error, would be that user passes a JVM version but neglects to pass a Java version or vice versa (e.g. user passes `graalvm-version=24.0.2`, resulting in `graalvm-jvm-id=graalvm-java17:24.0.2` or user passes `graalvm-java-version=24`, resulting in `graalvm-jvm-id=graalvm-java24:17.0.9`).

So for the user, passing a JVM ID directly may be the recommended action, rendering the separate Java version and JVM version parameters useless and superficial in practice. Alternatively, we can have `NativeImageOptions` resolve JVM version + Java version pair in a more intelligent, slightly better way. Perhaps, if a JVM version is provided without a Java version, the Java version can be determined from the first part of the JVM version (e.g. for JVM version 24.0.2 assume the Java version will always be 24). If Java version is provided without a JVM version, the latest JVM version for the given Java version could automatically be determined somehow. An error could be shown if the JVM version and Java version are both given but do not match. etc. etc.

This is just something I was considering when making the changes in this PR. For now I think the changes in the PR are fine and in-line with the currently expected behavior. I would welcome comments on the suggested improvements to NativeImageOptions and consider making the changes in the future if I can get folks onboard with my thinking.