### PR TITLE
Bump Scala.js to 1.21.0

### DIFF
--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -45,7 +45,7 @@ object Scala {
   val scala3MainVersions  = (defaults ++ allScala3).distinct
   val runnerScalaVersions = (Seq(runnerScala3) ++ scala3MainVersions).distinct
 
-  def scalaJs    = "1.20.2"
+  def scalaJs    = "1.21.0"
   def scalaJsCli = scalaJs // this must be compatible with the Scala.js version
 
   private def patchVer(sv: String): Int =

--- a/website/docs/guides/advanced/scala-js.md
+++ b/website/docs/guides/advanced/scala-js.md
@@ -198,5 +198,6 @@ The table below lists the last supported version of Scala.js in Scala CLI. If yo
 | 1.6.2 - 1.7.1      |  1.18.2  |
 | 1.8.0 - 1.9.0      |  1.19.0  |
 | 1.9.1 - 1.11.0     |  1.20.1  |
-| 1.12.0 - current   |  1.20.2  |
+| 1.12.0 - 1.12.5    |  1.20.2  |
+| 1.13.0 - current   |  1.21.0  |
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1353,7 +1353,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 ### `--js-version`
 
-The Scala.js version (1.20.2 by default).
+The Scala.js version (1.21.0 by default).
 
 ### `--js-mode`
 
@@ -1426,7 +1426,7 @@ Path to the Scala.js linker
 ### `--js-cli-version`
 
 [Internal]
-Scala.js CLI version to use for linking (1.20.2 by default).
+Scala.js CLI version to use for linking (1.21.0 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -639,7 +639,7 @@ Add Scala.js options
 
 
 #### Examples
-`//> using jsVersion 1.20.2`
+`//> using jsVersion 1.21.0`
 
 `//> using jsMode mode`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -772,7 +772,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 `SHOULD have` per Scala Runner specification
 
-The Scala.js version (1.20.2 by default).
+The Scala.js version (1.21.0 by default).
 
 ### `--js-mode`
 
@@ -872,7 +872,7 @@ Path to the Scala.js linker
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Scala.js CLI version to use for linking (1.20.2 by default).
+Scala.js CLI version to use for linking (1.21.0 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -429,7 +429,7 @@ Add Scala.js options
 
 
 #### Examples
-`//> using jsVersion 1.20.2`
+`//> using jsVersion 1.21.0`
 
 `//> using jsMode mode`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -134,7 +134,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.2 by default).
+The Scala.js version (1.21.0 by default).
 
 **--js-mode**
 
@@ -432,7 +432,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.2 by default).
+Scala.js CLI version to use for linking (1.21.0 by default).
 
 **--js-cli-java-arg**
 
@@ -948,7 +948,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.2 by default).
+The Scala.js version (1.21.0 by default).
 
 **--js-mode**
 
@@ -1234,7 +1234,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.2 by default).
+Scala.js CLI version to use for linking (1.21.0 by default).
 
 **--js-cli-java-arg**
 
@@ -1561,7 +1561,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.2 by default).
+The Scala.js version (1.21.0 by default).
 
 **--js-mode**
 
@@ -1853,7 +1853,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.2 by default).
+Scala.js CLI version to use for linking (1.21.0 by default).
 
 **--js-cli-java-arg**
 
@@ -2200,7 +2200,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.2 by default).
+The Scala.js version (1.21.0 by default).
 
 **--js-mode**
 
@@ -2502,7 +2502,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.2 by default).
+Scala.js CLI version to use for linking (1.21.0 by default).
 
 **--js-cli-java-arg**
 
@@ -2858,7 +2858,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.2 by default).
+The Scala.js version (1.21.0 by default).
 
 **--js-mode**
 
@@ -3160,7 +3160,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.2 by default).
+Scala.js CLI version to use for linking (1.21.0 by default).
 
 **--js-cli-java-arg**
 
@@ -3492,7 +3492,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.2 by default).
+The Scala.js version (1.21.0 by default).
 
 **--js-mode**
 
@@ -3776,7 +3776,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.2 by default).
+Scala.js CLI version to use for linking (1.21.0 by default).
 
 **--js-cli-java-arg**
 
@@ -4163,7 +4163,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.2 by default).
+The Scala.js version (1.21.0 by default).
 
 **--js-mode**
 
@@ -4470,7 +4470,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.2 by default).
+Scala.js CLI version to use for linking (1.21.0 by default).
 
 **--js-cli-java-arg**
 
@@ -4894,7 +4894,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.2 by default).
+The Scala.js version (1.21.0 by default).
 
 **--js-mode**
 
@@ -5174,7 +5174,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.2 by default).
+Scala.js CLI version to use for linking (1.21.0 by default).
 
 **--js-cli-java-arg**
 
@@ -5881,7 +5881,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.20.2 by default).
+The Scala.js version (1.21.0 by default).
 
 **--js-mode**
 
@@ -6161,7 +6161,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.20.2 by default).
+Scala.js CLI version to use for linking (1.21.0 by default).
 
 **--js-cli-java-arg**
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-js-cli/releases/tag/v1.21.0
https://github.com/scala-js/scala-js/releases/tag/v1.21.0

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
not at all