### PR TITLE
Fix `scala-cli-archive-keyring.gpg` generation; auto generate `KEY.gpg` for `scala-cli-packages`

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1887,9 +1887,30 @@ object ci extends Module {
     // Export the public key as a binary (non-armored) keyring at the repo root so that
     // users can reference it via `signed-by` in their APT sources.
     // Binary format is required per https://wiki.debian.org/DebianRepository/UseThirdParty
+    // We export all public keys (without specifying a user ID) because `gpg-setup.sh`
+    // imports exactly one key, and `gpg --export <user-id>` silently produces empty
+    // output with exit code 0 when the user ID doesn't match.
     val keyringPath = packagesDir / "scala-cli-archive-keyring.gpg"
-    os.proc("gpg", "--batch", "--yes", "--export", keyName)
+    os.proc("gpg", "--batch", "--yes", "--export")
       .call(stdout = keyringPath)
+    if (!os.exists(keyringPath) || os.size(keyringPath) == 0)
+      sys.error(
+        s"""gpg --export produced an empty keyring at $keyringPath; 
+           |check that PGP_SECRET was imported correctly by gpg-setup.sh""".stripMargin
+      )
+
+    // Also re-export the armored KEY.gpg used by Fedora/yum and referenced by the
+    // packages repo landing page. Regenerating it on every release keeps it in sync
+    // with the binary keyring above, so key rotations (e.g. to replace a SHA1
+    // self-signed key) automatically propagate to all consumers.
+    val armoredKeyPath = packagesDir / "KEY.gpg"
+    os.proc("gpg", "--batch", "--yes", "--armor", "--export")
+      .call(stdout = armoredKeyPath)
+    if (!os.exists(armoredKeyPath) || os.size(armoredKeyPath) == 0)
+      sys.error(
+        s"""gpg --armor --export produced an empty key at $armoredKeyPath; 
+           |check that PGP_SECRET was imported correctly by gpg-setup.sh""".stripMargin
+      )
 
     // Update the .list file to include the signed-by option pointing at the keyring.
     // This scopes the key to this repository only, preventing the globally-trusted key


### PR DESCRIPTION
- [scala-cli-archive-keyring.gpg
](https://github.com/VirtusLab/scala-cli-packages/blob/main/scala-cli-archive-keyring.gpg) was generated empty; as we fetched the key by ID, there may have been a mismatch. We only have one in the first place, so perhaps fetching by ID is unnecessary.
- auto-generation of [KEY.gpg](https://github.com/VirtusLab/scala-cli-packages/blob/main/KEY.gpg) should automate future key rotation

## Checklist
- ~tested the solution locally and it works~ rather tricky to check locally
- [x] ran the code formatter (`scala-cli fmt .`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Cursor + Claude

## How was the solution tested?
it hasn't. tricky to do so locally.