### PR TITLE
Bump Typelevel Toolkit to 0.2.0 and enable it for Scala Native 0.5.*

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
@@ -1,6 +1,7 @@
 package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
+import coursier.version.Version
 
 import scala.cli.integration.TestUtil.removeAnsiColors
 import scala.util.Properties
@@ -313,9 +314,8 @@ trait RunScalaNativeTestDefinitions { this: RunTestDefinitions =>
       titleStr = if (useDirectives) "with directives" else "with command line args"
       explicitNativeVersion <-
         Seq(Some(Constants.scalaNativeVersion04), Some(Constants.scalaNativeVersion05), None)
-      actualNativeVersion = explicitNativeVersion.getOrElse(Constants.scalaNativeVersion)
-      nativeVersionStr    = explicitNativeVersion.map(v => s"explicit: $v").getOrElse("default")
-      nativeVersionOpts   = explicitNativeVersion.toSeq.flatMap(v => Seq("--native-version", v))
+      nativeVersionStr  = explicitNativeVersion.map(v => s"explicit: $v").getOrElse("default")
+      nativeVersionOpts = explicitNativeVersion.toSeq.flatMap(v => Seq("--native-version", v))
       nativeVersionDirectiveStr =
         explicitNativeVersion
           .map(v => s"""//> using nativeVersion $v
@@ -327,8 +327,8 @@ trait RunScalaNativeTestDefinitions { this: RunTestDefinitions =>
         else "default"
       typelevelToolkitVersion = "default"
     } {
-      // for the time being, typelevel toolkit does nto support Scala Native 0.5.x
-      if (!explicitNativeVersion.contains(Constants.scalaNativeVersion05))
+      // Typelevel toolkit 0.2.x is published for Scala Native 0.5+ only (no native0.4 artifacts).
+      if (!explicitNativeVersion.contains(Constants.scalaNativeVersion04))
         test(
           s"native ($nativeVersionStr) & typelevel toolkit ($typelevelToolkitVersion) $titleStr"
         ) {
@@ -361,7 +361,11 @@ trait RunScalaNativeTestDefinitions { this: RunTestDefinitions =>
               val result = os.proc(TestUtil.cli, "run", "toolkit.scala", cmdLineOpts, extraOptions)
                 .call(cwd = root, stderr = os.Pipe)
               expect(result.out.trim() == expectedMessage)
-              if (actualNativeVersion != Constants.typelevelToolkitMaxScalaNative) {
+              if (
+                explicitNativeVersion.isEmpty &&
+                Version(Constants.scalaNativeVersion) >
+                  Version(Constants.typelevelToolkitMaxScalaNative)
+              ) {
                 val err = result.err.trim()
                 expect(
                   err.contains(

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -1334,13 +1334,14 @@ abstract class RunTestDefinitions
 
   test("should add typelevel toolkit-test to classpath") {
     val inputs = TestInputs(
-      os.rel / "Hello.test.scala" ->
+      os.rel / "HelloSuite.test.scala" ->
         s"""|import cats.effect.*
-            |import munit.CatsEffectSuite
-            |class HelloSuite extends CatsEffectSuite {
-            |  // IO should be added to classpath by typelevel toolkit-test
+            |import weaver._
+            |
+            |object HelloSuite extends SimpleIOSuite {
             |  test("warm hello from the sun is coming") {
-            |    (IO("i love to live in the") *> IO("sun")).assertEquals("sun")
+            |    IO.println("typelevel-toolkit-test-ok") *>
+            |      (IO("i love to live in the") *> IO("sun")).map(expect.eql(_, "sun"))
             |  }
             |}""".stripMargin
     )
@@ -1354,7 +1355,7 @@ abstract class RunTestDefinitions
       )
         .call(cwd = root).out.text()
 
-      expect(output.contains("+")) // test succeeded
+      expect(output.contains("typelevel-toolkit-test-ok"))
     }
   }
 

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -137,7 +137,7 @@ object Deps {
     def scalaNative05                     = "0.5.11"
     def scalaNative                       = scalaNative05
     def maxScalaNativeForToolkit          = scalaNative05
-    def maxScalaNativeForTypelevelToolkit = scalaNative04
+    def maxScalaNativeForTypelevelToolkit = scalaNative05
     def maxScalaNativeForScalaPy          = scalaNative04
     def maxScalaNativeForMillExport       = scalaNative05
     def scalaPackager                     = "0.2.1"
@@ -279,7 +279,7 @@ object Deps {
   val toolkitVersionForNative05 = toolkitVersion
   def toolkit                   = mvn"org.scala-lang:toolkit:$toolkitVersion"
   def toolkitTest               = mvn"org.scala-lang:toolkit-test:$toolkitVersion"
-  val typelevelToolkitVersion   = "0.1.29"
+  val typelevelToolkitVersion   = "0.2.0"
   def typelevelToolkit          = mvn"org.typelevel:toolkit:$typelevelToolkitVersion"
   // Lives at https://github.com/VirtusLab/no-crc32-zip-input-stream, see #865
   // This provides a ZipInputStream that doesn't verify CRC32 checksums, that users

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1703,7 +1703,7 @@ Copy compilation results to output directory using either relative or absolute p
 
 Aliases: `--toolkit`
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.1.29
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.2.0
 
 ### `--exclude`
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -693,7 +693,7 @@ Set the test framework
 
 ### Toolkit
 
-Use a toolkit as dependency (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.1.29
+Use a toolkit as dependency (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.2.0
 
 `//> using toolkit` _version_
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -1156,7 +1156,7 @@ Aliases: `--toolkit`
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.1.29
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.2.0
 
 ### `--exclude`
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -475,7 +475,7 @@ Set the test framework
 
 ### Toolkit
 
-Use a toolkit as dependency (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.1.29
+Use a toolkit as dependency (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.2.0
 
 `//> using toolkit` _version_
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -642,7 +642,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.1.29
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.2.0
 
 Aliases: `--toolkit`
 
@@ -1444,7 +1444,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.1.29
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.2.0
 
 Aliases: `--toolkit`
 
@@ -2063,7 +2063,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.1.29
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.2.0
 
 Aliases: `--toolkit`
 
@@ -2712,7 +2712,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.1.29
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.2.0
 
 Aliases: `--toolkit`
 
@@ -3370,7 +3370,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.1.29
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.2.0
 
 Aliases: `--toolkit`
 
@@ -3986,7 +3986,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.1.29
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.2.0
 
 Aliases: `--toolkit`
 
@@ -4680,7 +4680,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.1.29
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.2.0
 
 Aliases: `--toolkit`
 
@@ -5384,7 +5384,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.1.29
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.2.0
 
 Aliases: `--toolkit`
 
@@ -6371,7 +6371,7 @@ Aliases: `--help-fmt` ,`--scalafmt-help` ,`--fmt-help`
 
 **--with-toolkit**
 
-Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.1.29
+Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Scala toolkit: 0.8.0, 'default' version for typelevel toolkit: 0.2.0
 
 Aliases: `--toolkit`
 


### PR DESCRIPTION
https://github.com/typelevel/toolkit/releases/tag/v0.2.0
- https://github.com/typelevel/toolkit/issues/171

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
moderate, Cursor + Claude

## How was the solution tested?
existing tests for the toolkit (adjusted for 0.2.0)
