### PR TITLE
Bump Scala Native to 0.5.11 (was 0.5.10)

### DIFF
--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -134,7 +134,7 @@ object Deps {
     def scalaMeta                         = "4.15.2"
     def scalafmt                          = "3.11.0"
     def scalaNative04                     = "0.4.17"
-    def scalaNative05                     = "0.5.10"
+    def scalaNative05                     = "0.5.11"
     def scalaNative                       = scalaNative05
     def maxScalaNativeForToolkit          = scalaNative05
     def maxScalaNativeForTypelevelToolkit = scalaNative04

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1452,7 +1452,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 ### `--native-version`
 
-Set the Scala Native version (0.5.10 by default).
+Set the Scala Native version (0.5.11 by default).
 
 ### `--native-mode`
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -553,7 +553,7 @@ Add Scala Native options
 
 `//> using nativeLto full`
 
-`//> using nativeVersion 0.5.10`
+`//> using nativeVersion 0.5.11`
 
 `//> using nativeCompile -flto=thin`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -904,7 +904,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 `SHOULD have` per Scala Runner specification
 
-Set the Scala Native version (0.5.10 by default).
+Set the Scala Native version (0.5.11 by default).
 
 ### `--native-mode`
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -350,7 +350,7 @@ Add Scala Native options
 
 `//> using nativeLto full`
 
-`//> using nativeVersion 0.5.10`
+`//> using nativeVersion 0.5.11`
 
 `//> using nativeCompile -flto=thin`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -178,7 +178,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.10 by default).
+Set the Scala Native version (0.5.11 by default).
 
 **--native-mode**
 
@@ -992,7 +992,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.10 by default).
+Set the Scala Native version (0.5.11 by default).
 
 **--native-mode**
 
@@ -1605,7 +1605,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.10 by default).
+Set the Scala Native version (0.5.11 by default).
 
 **--native-mode**
 
@@ -2244,7 +2244,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.10 by default).
+Set the Scala Native version (0.5.11 by default).
 
 **--native-mode**
 
@@ -2902,7 +2902,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.10 by default).
+Set the Scala Native version (0.5.11 by default).
 
 **--native-mode**
 
@@ -3536,7 +3536,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.10 by default).
+Set the Scala Native version (0.5.11 by default).
 
 **--native-mode**
 
@@ -4207,7 +4207,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.10 by default).
+Set the Scala Native version (0.5.11 by default).
 
 **--native-mode**
 
@@ -4938,7 +4938,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.10 by default).
+Set the Scala Native version (0.5.11 by default).
 
 **--native-mode**
 
@@ -5925,7 +5925,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.10 by default).
+Set the Scala Native version (0.5.11 by default).
 
 **--native-mode**
 


### PR DESCRIPTION
Closes #4199 

The CI is acting up, so I'm doing things step by step as a sanity check (extracted the bump out of https://github.com/VirtusLab/scala-cli/pull/4243)

https://github.com/scala-native/scala-native/releases/tag/v0.5.11