### PR TITLE
Support for `.test.java`

### DIFF
--- a/modules/build/src/main/scala/scala/build/CrossSources.scala
+++ b/modules/build/src/main/scala/scala/build/CrossSources.scala
@@ -135,6 +135,10 @@ final case class CrossSources(
 }
 
 object CrossSources {
+  private val testScopeFileSuffixes: Set[String] = Set(".test.scala", ".test.java")
+
+  private def hasTestScopeSuffix(fileName: String): Boolean =
+    testScopeFileSuffixes.exists(fileName.endsWith)
 
   private def withinTestSubDirectory(p: ScopePath, inputs: Inputs): Boolean =
     p.root.exists { path =>
@@ -248,12 +252,14 @@ object CrossSources {
           .flatMap(_.valueFor(path).toSeq)
           .foldLeft(BuildRequirements())(_.orElse(_))
 
-      // Scala CLI treats all `.test.scala` files tests as well as
-      // files from within `test` subdirectory from provided input directories
-      // If file has `using target <scope>` directive this take precendeces.
+      // Scala CLI treats all source files whose names end with one of the
+      // testScopeFileSuffixes (e.g. `.test.scala`, `.test.java`) as tests, as well as
+      // files from within `test` subdirectory from provided input directories.
+      // If file has `using target <scope>` directive this takes precedence.
       if (
         fromDirectives.scope.isEmpty &&
-        (path.subPath.last.endsWith(".test.scala") || withinTestSubDirectory(path, allInputs))
+        (CrossSources.hasTestScopeSuffix(path.subPath.last) ||
+        withinTestSubDirectory(path, allInputs))
       )
         fromDirectives.copy(scope = Some(BuildRequirements.ScopeRequirement(Scope.Test)))
       else fromDirectives

--- a/modules/build/src/main/scala/scala/build/preprocessing/JavaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/JavaPreprocessor.scala
@@ -10,7 +10,7 @@ import scala.build.Logger
 import scala.build.errors.BuildException
 import scala.build.input.{JavaFile, ScalaCliInvokeData, SingleElement, VirtualJavaFile}
 import scala.build.internal.JavaParserProxyMaker
-import scala.build.options.{BuildRequirements, SuppressWarningOptions}
+import scala.build.options.SuppressWarningOptions
 import scala.build.preprocessing.directives.PreprocessedDirectives
 
 /** Java source preprocessor.
@@ -56,8 +56,8 @@ final case class JavaPreprocessor(
             path = j.path,
             options = Some(preprocessedDirectives.globalUsings),
             optionsWithTargetRequirements = preprocessedDirectives.usingsWithReqs,
-            requirements = Some(BuildRequirements()),
-            scopedRequirements = Nil,
+            requirements = Some(preprocessedDirectives.globalReqs),
+            scopedRequirements = preprocessedDirectives.scopedReqs,
             mainClassOpt = None,
             directivesPositions = preprocessedDirectives.directivesPositions
           ))
@@ -102,8 +102,8 @@ final case class JavaPreprocessor(
             wrapperParamsOpt = None,
             options = Some(preprocessedDirectives.globalUsings),
             optionsWithTargetRequirements = preprocessedDirectives.usingsWithReqs,
-            requirements = Some(BuildRequirements()),
-            scopedRequirements = Nil,
+            requirements = Some(preprocessedDirectives.globalReqs),
+            scopedRequirements = preprocessedDirectives.scopedReqs,
             mainClassOpt = None,
             scopePath = v.scopePath,
             directivesPositions = preprocessedDirectives.directivesPositions

--- a/modules/build/src/main/scala/scala/build/preprocessing/JavaPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/JavaPreprocessor.scala
@@ -52,15 +52,44 @@ final case class JavaPreprocessor(
             )
               .preprocess(content)
           }
-          Seq(PreprocessedSource.OnDisk(
-            path = j.path,
-            options = Some(preprocessedDirectives.globalUsings),
-            optionsWithTargetRequirements = preprocessedDirectives.usingsWithReqs,
-            requirements = Some(preprocessedDirectives.globalReqs),
-            scopedRequirements = preprocessedDirectives.scopedReqs,
-            mainClassOpt = None,
-            directivesPositions = preprocessedDirectives.directivesPositions
-          ))
+          // Java's source-file rule requires that a public class be declared in a file named
+          // exactly `<ClassName>.java`, so emit `*.test.java` as an in-memory source whose
+          // generated path strips the `.test` infix. This lets users follow the same naming
+          // convention as `.test.scala` for routing while still compiling under `javac`.
+          val testJavaSuffix          = ".test.java"
+          val preprocessedJavaSources =
+            if j.subPath.last.endsWith(testJavaSuffix) then {
+              val strippedFileName =
+                s"${j.subPath.last.stripSuffix(testJavaSuffix)}.java"
+              val strippedSubPath: os.SubPath =
+                if j.subPath.segments.sizeIs > 1 then
+                  os.sub / j.subPath.segments.init / strippedFileName
+                else os.sub / strippedFileName
+              Seq(PreprocessedSource.InMemory(
+                originalPath = Right((j.subPath, j.path)),
+                relPath = os.rel / strippedSubPath,
+                content = content.getBytes(StandardCharsets.UTF_8),
+                wrapperParamsOpt = None,
+                options = Some(preprocessedDirectives.globalUsings),
+                optionsWithTargetRequirements = preprocessedDirectives.usingsWithReqs,
+                requirements = Some(preprocessedDirectives.globalReqs),
+                scopedRequirements = preprocessedDirectives.scopedReqs,
+                mainClassOpt = None,
+                scopePath = scopePath,
+                directivesPositions = preprocessedDirectives.directivesPositions
+              ))
+            }
+            else
+              Seq(PreprocessedSource.OnDisk(
+                path = j.path,
+                options = Some(preprocessedDirectives.globalUsings),
+                optionsWithTargetRequirements = preprocessedDirectives.usingsWithReqs,
+                requirements = Some(preprocessedDirectives.globalReqs),
+                scopedRequirements = preprocessedDirectives.scopedReqs,
+                mainClassOpt = None,
+                directivesPositions = preprocessedDirectives.directivesPositions
+              ))
+          preprocessedJavaSources
         })
       case v: VirtualJavaFile =>
         val res = either {

--- a/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
@@ -334,12 +334,12 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
     }
   }
 
-  /** Asserts that the only Java source produced by `testInputs` is routed to the test scope and
-    * appears at `expectedPath`.
+  /** Asserts that the only Java source produced by `testInputs` is routed to the test scope and is
+    * reachable on disk at `expectedOnDiskPath`.
     */
   private def expectJavaFileRoutedToTestScope(
     testInputs: TestInputs,
-    expectedPath: os.RelPath
+    expectedOnDiskPath: os.RelPath
   ): Unit =
     testInputs.withInputs { (root, inputs) =>
       val (crossSources, _) =
@@ -367,36 +367,68 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
         ).orThrow
 
       expect(mainSources.paths.isEmpty)
-      expect(testSources.paths.map(_._2) == Seq(expectedPath))
+      expect(mainSources.inMemory.isEmpty)
+      val onDiskPaths           = testSources.paths.map(_._2)
+      val inMemoryOriginalPaths =
+        testSources.inMemory.flatMap(_.originalPath.toOption.map(_._1: os.SubPath))
+      expect((onDiskPaths ++ inMemoryOriginalPaths.map(os.rel / _)) == Seq(expectedOnDiskPath))
     }
 
-  private val javaTestSourceContent: String =
-    """public class Something {
-      |  public int a = 1;
-      |}
-      |""".stripMargin
+  private val javaTestPublicClassName: String = "Something"
+  private val javaTestSourceContent: String   =
+    s"""public class $javaTestPublicClassName {
+       |  public int a = 1;
+       |}
+       |""".stripMargin
 
   test("a .test.java file should be routed to the test scope") {
-    val expectedPath = os.rel / "Something.test.java"
-    val testInputs   = TestInputs(expectedPath -> javaTestSourceContent)
-    expectJavaFileRoutedToTestScope(testInputs, expectedPath)
+    val onDiskPath = os.rel / s"$javaTestPublicClassName.test.java"
+    val testInputs = TestInputs(onDiskPath -> javaTestSourceContent)
+    expectJavaFileRoutedToTestScope(testInputs, onDiskPath)
+  }
+
+  test("a .test.java file's generated path strips the .test infix for javac") {
+    val onDiskPath = os.rel / s"$javaTestPublicClassName.test.java"
+    TestInputs(onDiskPath -> javaTestSourceContent).withInputs { (root, inputs) =>
+      val (crossSources, _) =
+        CrossSources.forInputs(
+          inputs,
+          preprocessors,
+          TestLogger(),
+          SuppressWarningOptions()
+        ).orThrow
+
+      val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
+      val testSources   =
+        scopedSources.sources(
+          Scope.Test,
+          crossSources.sharedOptions(BuildOptions()),
+          root,
+          TestLogger()
+        ).orThrow
+
+      val expectedGeneratedRelPath = os.rel / s"$javaTestPublicClassName.java"
+      expect(testSources.paths.isEmpty)
+      expect(testSources.inMemory.length == 1)
+      expect(testSources.inMemory.head.generatedRelPath == expectedGeneratedRelPath)
+    }
   }
 
   test("a .java file under a test/ directory should be routed to the test scope") {
-    val expectedPath = os.rel / "test" / "Something.java"
-    val testInputs   = TestInputs(Seq(expectedPath -> javaTestSourceContent), Seq("."))
-    expectJavaFileRoutedToTestScope(testInputs, expectedPath)
+    val onDiskPath = os.rel / "test" / s"$javaTestPublicClassName.java"
+    val testInputs = TestInputs(Seq(onDiskPath -> javaTestSourceContent), Seq("."))
+    expectJavaFileRoutedToTestScope(testInputs, onDiskPath)
   }
 
   test("a .java file with //> using target.scope test should be routed to the test scope") {
-    val expectedPath = os.rel / "Something.java"
-    val testInputs   = TestInputs(
-      expectedPath ->
+    val onDiskPath = os.rel / s"$javaTestPublicClassName.java"
+    val testInputs = TestInputs(
+      onDiskPath ->
         s"""//> using target.scope test
            |
            |$javaTestSourceContent""".stripMargin
     )
-    expectJavaFileRoutedToTestScope(testInputs, expectedPath)
+    expectJavaFileRoutedToTestScope(testInputs, onDiskPath)
   }
 
   test("should skip SheBang in .sc and .scala") {

--- a/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/SourcesTests.scala
@@ -334,6 +334,71 @@ class SourcesTests extends TestUtil.ScalaCliBuildSuite {
     }
   }
 
+  /** Asserts that the only Java source produced by `testInputs` is routed to the test scope and
+    * appears at `expectedPath`.
+    */
+  private def expectJavaFileRoutedToTestScope(
+    testInputs: TestInputs,
+    expectedPath: os.RelPath
+  ): Unit =
+    testInputs.withInputs { (root, inputs) =>
+      val (crossSources, _) =
+        CrossSources.forInputs(
+          inputs,
+          preprocessors,
+          TestLogger(),
+          SuppressWarningOptions()
+        ).orThrow
+
+      val scopedSources = crossSources.scopedSources(BuildOptions()).orThrow
+      val mainSources   =
+        scopedSources.sources(
+          Scope.Main,
+          crossSources.sharedOptions(BuildOptions()),
+          root,
+          TestLogger()
+        ).orThrow
+      val testSources =
+        scopedSources.sources(
+          Scope.Test,
+          crossSources.sharedOptions(BuildOptions()),
+          root,
+          TestLogger()
+        ).orThrow
+
+      expect(mainSources.paths.isEmpty)
+      expect(testSources.paths.map(_._2) == Seq(expectedPath))
+    }
+
+  private val javaTestSourceContent: String =
+    """public class Something {
+      |  public int a = 1;
+      |}
+      |""".stripMargin
+
+  test("a .test.java file should be routed to the test scope") {
+    val expectedPath = os.rel / "Something.test.java"
+    val testInputs   = TestInputs(expectedPath -> javaTestSourceContent)
+    expectJavaFileRoutedToTestScope(testInputs, expectedPath)
+  }
+
+  test("a .java file under a test/ directory should be routed to the test scope") {
+    val expectedPath = os.rel / "test" / "Something.java"
+    val testInputs   = TestInputs(Seq(expectedPath -> javaTestSourceContent), Seq("."))
+    expectJavaFileRoutedToTestScope(testInputs, expectedPath)
+  }
+
+  test("a .java file with //> using target.scope test should be routed to the test scope") {
+    val expectedPath = os.rel / "Something.java"
+    val testInputs   = TestInputs(
+      expectedPath ->
+        s"""//> using target.scope test
+           |
+           |$javaTestSourceContent""".stripMargin
+    )
+    expectJavaFileRoutedToTestScope(testInputs, expectedPath)
+  }
+
   test("should skip SheBang in .sc and .scala") {
     val testInputs = TestInputs(
       os.rel / "something1.sc" ->

--- a/modules/cli/src/main/scala/scala/cli/commands/test/TestOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/TestOptions.scala
@@ -43,14 +43,14 @@ object TestOptions {
   implicit lazy val help: Help[TestOptions]     = Help.derive
 
   val cmdName                     = "test"
-  private val helpHeader          = "Compile and test Scala code."
+  private val helpHeader          = "Compile and test Scala (or Java) code."
   val helpMessage: String         = HelpMessages.shortHelpMessage(cmdName, helpHeader)
   val detailedHelpMessage: String =
     s"""$helpHeader
        |
        |Test sources are compiled separately (after the 'main' sources), and may use different dependencies, compiler options, and other configurations.
        |A source file is treated as a test source if:
-       |  - the file name ends with `.test.scala`
+       |  - the file name ends with `.test.scala` or `.test.java`
        |  - the file comes from a directory that is provided as input, and the relative path from that file to its original directory contains a `test` directory
        |  - it contains the `//> using target.scope test` directive (Experimental)
        |

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -834,28 +834,41 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
     }
   }
 
-  test("successful pure Java test with JUnit") {
-    val expectedMessage = "Hello from JUnit"
-    TestInputs(
-      os.rel / "test" / "MyTests.java" ->
-        s"""//> using test.dependencies junit:junit:4.13.2
-           |//> using test.dependencies com.novocode:junit-interface:0.11
-           |import org.junit.Test;
-           |import static org.junit.Assert.assertEquals;
-           |
-           |public class MyTests {
-           |  @Test
-           |  public void foo() {
-           |    assertEquals(4, 2 + 2);
-           |    System.out.println("$expectedMessage");
-           |  }
-           |}
-           |""".stripMargin
-    ).fromRoot { root =>
-      val res = os.proc(TestUtil.cli, "test", extraOptions, ".").call(cwd = root)
-      expect(res.out.text().contains(expectedMessage))
-    }
+  for {
+    (placementName, fileRelPath, extraDirectives, extraCliFlags) <- Seq(
+      (".test.java suffix", os.rel / "MyTests.test.java", "", Seq.empty[String]),
+      ("test/ subdirectory", os.rel / "test" / "MyTests.java", "", Seq.empty[String]),
+      (
+        "//> using target.scope test",
+        os.rel / "MyTests.java",
+        "//> using target.scope test\n",
+        Seq("--power")
+      )
+    )
+    expectedMessage = "Hello from JUnit"
   }
+    test(s"successful pure Java test with JUnit ($placementName)") {
+      TestInputs(
+        fileRelPath ->
+          s"""$extraDirectives//> using test.dep junit:junit:4.13.2
+             |//> using test.dep com.novocode:junit-interface:0.11
+             |import org.junit.Test;
+             |import static org.junit.Assert.assertEquals;
+             |
+             |public class MyTests {
+             |  @Test
+             |  public void foo() {
+             |    assertEquals(4, 2 + 2);
+             |    System.out.println("$expectedMessage");
+             |  }
+             |}
+             |""".stripMargin
+      ).fromRoot { root =>
+        val res =
+          os.proc(TestUtil.cli, extraCliFlags, "test", extraOptions, ".").call(cwd = root)
+        expect(res.out.text().contains(expectedMessage))
+      }
+    }
 
   test(s"zio-test warning when zio-test-sbt was not passed") {
     TestUtil.retryOnCi() {

--- a/website/docs/commands/test.md
+++ b/website/docs/commands/test.md
@@ -16,7 +16,7 @@ so [using directives](../guides/introduction/using-directives.md) can be used to
 
 A source file is treated as test source if:
 
-- the file name ends with `.test.scala`, or
+- the file name ends with `.test.scala` or `.test.java`, or
 - the file comes from a directory that is provided as input, and the relative path from that file to its original
   directory contains a `test` directory, or
 - it contains the `//> using target.scope test` directive
@@ -55,7 +55,7 @@ Given that directory structure, let's analyze what file(s) will be treated as te
 
 `scala-cli example` results in the following files being treated as test sources:
 
-- `a.test.scala`, since it ends with `.test.scala`
+- `a.test.scala`, since it ends with `.test.scala` (the same applies to `.test.java` for Java sources)
 - `src/test/scala/b.scala`, since the path to that directory contains a directory named `test`
 
 Note that `e.scala` is not treated as a test source since it lacks a parent directory in its relative path that is
@@ -71,7 +71,7 @@ contain `test` (the fact that the directory provided as input is named `test` do
 Directives take precedence over file or path names, so `using target.scope main` can be used to force `test/a.scala`
 or `a.test.scala` to not be treated as tests.
 
-As a rule of thumb, we recommend naming all of your test files with the `.test.scala` suffix.
+As a rule of thumb, we recommend naming all of your test files with the `.test.scala` (or `.test.java` for Java sources) suffix.
 
 ## Test directives
 

--- a/website/docs/reference/commands.md
+++ b/website/docs/reference/commands.md
@@ -390,11 +390,11 @@ Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [c
 
 ## test
 
-Compile and test Scala code.
+Compile and test Scala (or Java) code.
 
 Test sources are compiled separately (after the 'main' sources), and may use different dependencies, compiler options, and other configurations.
 A source file is treated as a test source if:
-  - the file name ends with `.test.scala`
+  - the file name ends with `.test.scala` or `.test.java`
   - the file comes from a directory that is provided as input, and the relative path from that file to its original directory contains a `test` directory
   - it contains the `//> using target.scope test` directive (Experimental)
 

--- a/website/docs/reference/scala-command/commands.md
+++ b/website/docs/reference/scala-command/commands.md
@@ -191,11 +191,11 @@ Accepts option groups: [benchmarking](./cli-options.md#benchmarking-options), [c
 
 ### test
 
-Compile and test Scala code.
+Compile and test Scala (or Java) code.
 
 Test sources are compiled separately (after the 'main' sources), and may use different dependencies, compiler options, and other configurations.
 A source file is treated as a test source if:
-  - the file name ends with `.test.scala`
+  - the file name ends with `.test.scala` or `.test.java`
   - the file comes from a directory that is provided as input, and the relative path from that file to its original directory contains a `test` directory
   - it contains the `//> using target.scope test` directive (Experimental)
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -4069,11 +4069,11 @@ Aliases: `--fmt-version`
 ## `test` command
 **SHOULD have for Scala Runner specification.**
 
-Compile and test Scala code.
+Compile and test Scala (or Java) code.
 
 Test sources are compiled separately (after the 'main' sources), and may use different dependencies, compiler options, and other configurations.
 A source file is treated as a test source if:
-  - the file name ends with `.test.scala`
+  - the file name ends with `.test.scala` or `.test.java`
   - the file comes from a directory that is provided as input, and the relative path from that file to its original directory contains a `test` directory
   - it contains the `//> using target.scope test` directive (Experimental)
 


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/4245

This adds full support of `*.test.java` inputs being recognised as test scope sources, automatically.

As public classes in Java inputs have to be in `PublicClassName.java` sources, arbitrarily, Scala CLI generates a `PublicClassName.java` source out of a `PublicClassName.test.java` under the hood to make `javac` happy. It's a bit hacky, but I think it's worth it for the consistent UX.

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)

## How much have your relied on LLM-based tools in this contribution?
Extensively, Cursor + Claude

## How was the solution tested?
included unit and integration tests for all the ways a Java input can be classified as a test scope source (directive, `.test.java`, `test` dir)