### PR TITLE
Bump coursier to 2.1.25-M25

### DIFF
--- a/.github/scripts/get-latest-cs.sh
+++ b/.github/scripts/get-latest-cs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-CS_VERSION="2.1.25-M24"
+CS_VERSION="2.1.25-M25"
 
 DIR="$(cs get --archive "https://github.com/coursier/coursier/releases/download/v$CS_VERSION/cs-x86_64-pc-win32.zip")"
 

--- a/build.mill
+++ b/build.mill
@@ -4,7 +4,7 @@
 //| - io.github.alexarchambault.mill::mill-native-image-upload:0.2.4
 //| - com.goyeau::mill-scalafix::0.6.0
 //| - com.lumidion::sonatype-central-client-requests:0.6.0
-//| - io.get-coursier:coursier-launcher_2.13:2.1.25-M24
+//| - io.get-coursier:coursier-launcher_2.13:2.1.25-M25
 //| - org.eclipse.jgit:org.eclipse.jgit:7.5.0.202512021534-r
 package build
 

--- a/mill
+++ b/mill
@@ -2,7 +2,7 @@
 
 # Adapted from
 
-coursier_version="2.1.25-M24"
+coursier_version="2.1.25-M25"
 COMMAND=$@
 
 # necessary for Windows various shell environments

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -124,7 +124,7 @@ object Deps {
     def ammoniteForScala3Lts = ammonite
     def argonautShapeless    = "1.3.1"
     // jni-utils version may need to be sync-ed when bumping the coursier version
-    def coursierDefault                   = "2.1.25-M24"
+    def coursierDefault                   = "2.1.25-M25"
     def coursier                          = coursierDefault
     def coursierCli                       = coursierDefault
     def coursierPublish                   = "0.4.4"


### PR DESCRIPTION
https://github.com/coursier/coursier/releases/tag/v2.1.25-M25