### PR TITLE
Add explicit overrides in `ScalaCliScalafixModule`

### DIFF
--- a/project/settings/package.mill
+++ b/project/settings/package.mill
@@ -807,13 +807,13 @@ trait ScalaCliScalafixModule extends ScalafixModule {
     if (scalaVersion().startsWith("2.")) super.scalafixConfig()
     else Some(BuildCtx.workspaceRoot / ".scalafix3.conf")
   }
-  def scalacPluginMvnDeps: T[Seq[Dep]] = super.scalacPluginMvnDeps() ++ {
+  override def scalacPluginMvnDeps: T[Seq[Dep]] = super.scalacPluginMvnDeps() ++ {
     if (scalaVersion().startsWith("2.")) Seq(Deps.semanticDbScalac)
     else Nil
   }
   // Explicitly setting sourceroot, so that Scala CLI doesn't use a wrong one.
   // Using BuildCtx.workspaceRoot is more or less required, for scalafix stuff to work fine.
-  def scalacOptions: T[Seq[String]] = Task {
+  override def scalacOptions: T[Seq[String]] = Task {
     val sv            = scalaVersion()
     val isScala2      = sv.startsWith("2.")
     val sourceRoot    = BuildCtx.workspaceRoot
@@ -845,11 +845,11 @@ trait ScalaCliScalafixModule extends ScalafixModule {
 trait ScalaCliCrossSbtModule extends CrossSbtModule with ScalaCliModule
 
 trait ScalaCliModule extends ScalaModule {
-  def javacOptions: T[Seq[String]] = super.javacOptions() ++ Seq(
+  override def javacOptions: T[Seq[String]] = super.javacOptions() ++ Seq(
     "--release",
     "16"
   )
-  def scalacOptions: T[Seq[String]] = Task {
+  override def scalacOptions: T[Seq[String]] = Task {
     val sv           = scalaVersion()
     val isScala213   = sv.startsWith("2.13.")
     val extraOptions =


### PR DESCRIPTION
Related to https://github.com/com-lihaoyi/mill/discussions/5974
It seems `mill-moduledefs` plugin adding the `override` keywords at typer intermittently crashes incremental compilation when changing branches in the `scala-cli` repo.
Making them explicit seems to make the problem go away. 🤷 

## Checklist
- tested the solution locally and it works 

## How much have your relied on LLM-based tools in this contribution?
extensively, Claude found the likely cause for me

## How was the solution tested?
re-compiling and switching between branches with changes in the Mill build

## Additional notes
cc @lihaoyi in case you'd like to minimize this.
Without the changes, the intermittent incremental compilation failures look somewhat like this:

<details>

```scala
build.mill-68] compile compiling 2 Scala sources to out/mill-build/compile.dest/classes ...
build.mill-68] [error] build.mill:212:10
build.mill-68]   object test extends ScalaCliTests with ScalaCliScalafixModule {
build.mill-68]          ^
build.mill-68] error overriding method scalacPluginMvnDeps in trait ScalaTests of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]];
build.mill-68]   method scalacPluginMvnDeps² in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]] module class test$ inherits conflicting members:
build.mill-68]   method scalacPluginMvnDeps in trait ScalaTests of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]]  and
build.mill-68]   method scalacPluginMvnDeps in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]]
build.mill-68] (Note: this can be resolved by declaring an override in module class test$.);
build.mill-68] other members with override errors are:: method scalacOptions
build.mill-68] 
build.mill-68] where:    scalacPluginMvnDeps  is a method in trait ScalaTests
build.mill-68]           scalacPluginMvnDeps² is a method in trait ScalaCliScalafixModule
build.mill-68] 
build.mill-68] 
build.mill-68] [error] build.mill:318:10
build.mill-68]   object test extends ScalaCliTests with ScalaCliScalafixModule {
build.mill-68]          ^
build.mill-68] error overriding method scalacPluginMvnDeps in trait ScalaTests of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]];
build.mill-68]   method scalacPluginMvnDeps in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]] module class test$ inherits conflicting members:
build.mill-68]   method scalacPluginMvnDeps in trait ScalaTests of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]]  and
build.mill-68]   method scalacPluginMvnDeps in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]]
build.mill-68] (Note: this can be resolved by declaring an override in module class test$.)
build.mill-68] 
build.mill-68] [error] build.mill:392:7
build.mill-68] trait ProtoBuildModule extends ScalaCliPublishModule with HasTests
build.mill-68]       ^
build.mill-68] error overriding method scalacOptions in trait HasTests of type => mill.api.Task.Simple[Seq[String]];
build.mill-68]   method scalacOptions in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[String]] trait ProtoBuildModule inherits conflicting members:
build.mill-68]   method scalacOptions in trait HasTests of type => mill.api.Task.Simple[Seq[String]]  and
build.mill-68]   method scalacOptions in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[String]]
build.mill-68] (Note: this can be resolved by declaring an override in trait ProtoBuildModule.)
build.mill-68] 
build.mill-68] [error] build.mill:715:10
build.mill-68]   object test extends ScalaCliTests with ScalaCliScalafixModule {
build.mill-68]          ^
build.mill-68] error overriding method scalacPluginMvnDeps in trait ScalaTests of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]];
build.mill-68]   method scalacPluginMvnDeps in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]] module class test$ inherits conflicting members:
build.mill-68]   method scalacPluginMvnDeps in trait ScalaTests of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]]  and
build.mill-68]   method scalacPluginMvnDeps in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]]
build.mill-68] (Note: this can be resolved by declaring an override in module class test$.)
build.mill-68] 
build.mill-68] [error] build.mill:764:10
build.mill-68]   object test extends ScalaCliTests with ScalaCliScalafixModule {
build.mill-68]          ^
build.mill-68] error overriding method scalacPluginMvnDeps in trait ScalaTests of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]];
build.mill-68]   method scalacPluginMvnDeps in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]] module class test$ inherits conflicting members:
build.mill-68]   method scalacPluginMvnDeps in trait ScalaTests of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]]  and
build.mill-68]   method scalacPluginMvnDeps in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]]
build.mill-68] (Note: this can be resolved by declaring an override in module class test$.)
build.mill-68] 
build.mill-68] [error] build.mill:818:10
build.mill-68]   object test extends ScalaCliTests with ScalaCliScalafixModule
build.mill-68]          ^
build.mill-68] error overriding method scalacPluginMvnDeps in trait ScalaTests of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]];
build.mill-68]   method scalacPluginMvnDeps² in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]] module class test$ inherits conflicting members:
build.mill-68]   method scalacPluginMvnDeps in trait ScalaTests of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]]  and
build.mill-68]   method scalacPluginMvnDeps in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]]
build.mill-68] (Note: this can be resolved by declaring an override in module class test$.);
build.mill-68] other members with override errors are:: method scalacOptions
build.mill-68] 
build.mill-68] where:    scalacPluginMvnDeps  is a method in trait ScalaTests
build.mill-68]           scalacPluginMvnDeps² is a method in trait ScalaCliScalafixModule
build.mill-68] 
build.mill-68] 
build.mill-68] [error] build.mill:811:7
build.mill-68] trait DirectivesParserModule extends ScalaCliCrossSbtModule
build.mill-68]       ^
build.mill-68] error overriding method scalacOptions in trait HasTests of type => mill.api.Task.Simple[Seq[String]];
build.mill-68]   method scalacOptions² in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[String]] trait DirectivesParserModule inherits conflicting members:
build.mill-68]   method scalacOptions in trait HasTests of type => mill.api.Task.Simple[Seq[String]]  and
build.mill-68]   method scalacOptions in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[String]]
build.mill-68] (Note: this can be resolved by declaring an override in trait DirectivesParserModule.)
build.mill-68] 
build.mill-68] where:    scalacOptions  is a method in trait HasTests
build.mill-68]           scalacOptions² is a method in trait ScalaCliScalafixModule
build.mill-68] 
build.mill-68] 
build.mill-68] [error] build.mill:999:10
build.mill-68]   object test extends ScalaCliTests with ScalaCliScalafixModule {
build.mill-68]          ^
build.mill-68] error overriding method scalacPluginMvnDeps in trait ScalaTests of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]];
build.mill-68]   method scalacPluginMvnDeps² in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]] module class test$ inherits conflicting members:
build.mill-68]   method scalacPluginMvnDeps in trait ScalaTests of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]]  and
build.mill-68]   method scalacPluginMvnDeps in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]]
build.mill-68] (Note: this can be resolved by declaring an override in module class test$.);
build.mill-68] other members with override errors are:: method scalacOptions
build.mill-68] 
build.mill-68] where:    scalacPluginMvnDeps  is a method in trait ScalaTests
build.mill-68]           scalacPluginMvnDeps² is a method in trait ScalaCliScalafixModule
build.mill-68] 
build.mill-68] 
build.mill-68] [error] build.mill:1038:9
build.mill-68]   trait IntegrationScalaTests extends super.ScalaCliTests with ScalaCliScalafixModule {
build.mill-68]         ^
build.mill-68] error overriding method scalacPluginMvnDeps in trait ScalaTests of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]];
build.mill-68]   method scalacPluginMvnDeps² in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]] trait IntegrationScalaTests inherits conflicting members:
build.mill-68]   method scalacPluginMvnDeps in trait ScalaTests of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]]  and
build.mill-68]   method scalacPluginMvnDeps in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[mill.scalalib.Dep]]
build.mill-68] (Note: this can be resolved by declaring an override in trait IntegrationScalaTests.);
build.mill-68] other members with override errors are:: method scalacOptions
build.mill-68] 
build.mill-68] where:    scalacPluginMvnDeps  is a method in trait ScalaTests
build.mill-68]           scalacPluginMvnDeps² is a method in trait ScalaCliScalafixModule
build.mill-68] 
build.mill-68] 
build.mill-68] [error] build.mill:1361:7
build.mill-68] trait TastyLib extends ScalaCliCrossSbtModule
build.mill-68]       ^
build.mill-68] error overriding method scalacOptions in trait ScalaCliModule of type => mill.api.Task.Simple[Seq[String]];
build.mill-68]   method scalacOptions in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[String]] trait TastyLib inherits conflicting members:
build.mill-68]   method scalacOptions in trait ScalaCliModule of type => mill.api.Task.Simple[Seq[String]]  and
build.mill-68]   method scalacOptions in trait ScalaCliScalafixModule of type => mill.api.Task.Simple[Seq[String]]
build.mill-68] (Note: this can be resolved by declaring an override in trait TastyLib.)
build.mill-68] 
build.mill-68] [error] 10 errors found
68/73+, 1 FAILED] ~/IdeaProjects/scala-cli/millw generate-reference-doc[].run 7s
```

</details
