### PR TITLE
Retire legacy `KEYGRIP` secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2205,7 +2205,6 @@ jobs:
       - run: ./mill -i ci.updateCentOsPackages
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          KEYGRIP: ${{ secrets.KEYGRIP }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           GPG_EMAIL: ${{ secrets.GPG_EMAIL }}
 

--- a/build.mill
+++ b/build.mill
@@ -2016,8 +2016,6 @@ object ci extends Module {
       "PGP_PASSPHRASE",
       "--env",
       "GPG_EMAIL",
-      "--env",
-      "KEYGRIP",
       "--privileged",
       "fedora:40",
       "sh",


### PR DESCRIPTION
Follow-up to https://github.com/VirtusLab/scala-cli-packages/pull/20
the `KEYGRIP` env is no longer necessary.