### PR TITLE
Address updateCentosPackages `GPG_TTY` warnings

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -2006,6 +2006,7 @@ object ci extends Module {
     val cmd = Seq[os.Shellable](
       "docker",
       "run",
+      "-t",
       "-v",
       s"$packagesDir:/packages",
       "-w",


### PR DESCRIPTION
This should solve the `GPG_TTY` warnings from the `update-centos` CI job.

```
warning: Could not set GPG_TTY to stdin: Inappropriate ioctl for device
```
