### PR TITLE
`update-installation-script`, `update-centos` and `update-debian` can't run in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2080,6 +2080,9 @@ jobs:
       - launchers
       - publish
     runs-on: ubuntu-24.04
+    concurrency:
+      group: scala-cli-packages-${{ github.ref }}
+      cancel-in-progress: false
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'VirtusLab/scala-cli'
     steps:
       - uses: actions/checkout@v6
@@ -2136,6 +2139,9 @@ jobs:
       - launchers
       - publish
     runs-on: ubuntu-24.04
+    concurrency:
+      group: scala-cli-packages-${{ github.ref }}
+      cancel-in-progress: false
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'VirtusLab/scala-cli'
     steps:
       - uses: actions/checkout@v6
@@ -2175,6 +2181,9 @@ jobs:
       - launchers
       - publish
     runs-on: ubuntu-24.04
+    concurrency:
+      group: scala-cli-packages-${{ github.ref }}
+      cancel-in-progress: false
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'VirtusLab/scala-cli'
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The following jobs all push commits to https://github.com/VirtusLab/scala-cli-packages upon release:
- `update-installation-script`
- `update-centos`
- `update-debian`

They shouldn't run in parallel, as otherwise they fail due to parallel write errors.

Example error log from v1.14.0 release (https://github.com/VirtusLab/scala-cli/actions/runs/25888654616/job/76165582895):
```
4] Trying to push on main branch
4] To key-45d2d067fd6cd3e1f1cf7588ef3946f022780ced97a778f790fe0d6cec431837.github.com:Virtuslab/scala-cli-packages.git
4]  ! [rejected]        main -> main (fetch first)
4] error: failed to push some refs to 'key-45d2d067fd6cd3e1f1cf7588ef3946f022780ced97a778f790fe0d6cec431837.github.com:Virtuslab/scala-cli-packages.git'
4] hint: Updates were rejected because the remote contains work that you do not
4] hint: have locally. This is usually caused by another repository pushing to
4] hint: the same ref. If you want to integrate the remote changes, use
4] hint: 'git pull' before pushing again.
4] hint: See the 'Note about fast-forwards' in 'git push --help' for details.
4/4, 1 FAILED] /home/runner/work/scala-cli/scala-cli/millw ci.updateDebianPackages 272s
Error: 4] [error] ci.updateDebianPackages
os.SubprocessException: Result of git…: 1

  os.SubprocessException$.apply(Model.scala:211)
  os.proc.call(ProcessOps.scala:232)
  build_.package_.build_$package_$$commitChanges(build.mill:1597)
  build_.package_$ci$.updateDebianPackages$$anonfun$1(build.mill:1935)
  mill.api.Task$Named.evaluate(Task.scala:443)
  mill.api.Task$Named.evaluate$(Task.scala:428)
  mill.api.Task$Command.evaluate(Task.scala:525)
```

## How much have your relied on LLM-based tools in this contribution?
Moderately, Cursor + Claude

## How was the solution tested?
wasn't, would have to run another release
