### PR TITLE
Compile the `directives-parser` example in Scala CLI v1.14.0 release notes

### DIFF
--- a/website/docs/release_notes.md
+++ b/website/docs/release_notes.md
@@ -61,9 +61,9 @@ This is transparent to users, but resolves long-standing directive parsing issue
 and unblocks future improvements to directive handling.
 
 The directives parser can be used as a standalone library, so you can now parse `using` directives in your own tools and applications with the same logic as Scala CLI.
-```scala 
+```scala compile
 //> using scala 3
-//> using dep org.virtuslab.scala-cli::directives-parser:latest.integration
+//> using dep org.virtuslab.scala-cli::directives-parser:1.14.0
 import scala.cli.parse.UsingDirectivesParser
 
 @main def parseDirectives(): Unit =


### PR DESCRIPTION
Just a follow-up to https://github.com/VirtusLab/scala-cli/pull/4270#discussion_r3242447101, since Scala CLI v1.14.0 artifacts have already been published to Maven Central, including `directives-parser`

## Checklist
- tested the solution locally and it works 

## How much have your relied on LLM-based tools in this contribution?
not at all

## How was the solution tested?
local run of:
```bash
./mill -i 'docs-tests[]'.test 'sclicheck.DocTests*release*1.14*'
```