### PR TITLE
Improve error for when JVM-only dependencies are not found on other platforms

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/Runner.scala
+++ b/modules/build/src/main/scala/scala/build/internal/Runner.scala
@@ -413,6 +413,25 @@ object Runner {
     if frameworks.nonEmpty then Right(frameworks) else Left(new NoTestFrameworkFoundError)
   }
 
+  private def jvmOnlyScalaJarsOnPlatformClassPath(
+    classPath: Seq[Path],
+    scalaBinaryVersion: String,
+    platformSuffix: String,
+    userDeclaredDepNames: Set[String]
+  ): Seq[String] =
+    if userDeclaredDepNames.isEmpty then Nil
+    else {
+      val jvmSuffix      = s"_$scalaBinaryVersion"
+      val platformMarker = s"_${platformSuffix}_"
+      val prefixes       = userDeclaredDepNames.map(n => s"$n$jvmSuffix")
+      classPath.iterator
+        .map(_.getFileName.toString)
+        .filter(_.endsWith(".jar"))
+        .filterNot(_.contains(platformMarker))
+        .filter(name => prefixes.exists(p => name.startsWith(s"$p-") || name.startsWith(s"$p.")))
+        .toList
+    }
+
   def testJs(
     classPath: Seq[Path],
     entrypoint: File,
@@ -421,7 +440,10 @@ object Runner {
     predefinedTestFrameworks: Seq[String],
     logger: Logger,
     jsDom: Boolean,
-    esModule: Boolean
+    esModule: Boolean,
+    scalaBinaryVersion: String,
+    platformSuffix: String,
+    userDeclaredDepNames: Set[String]
   ): Either[TestError, Int] = either {
     import org.scalajs.jsenv.Input
     import org.scalajs.jsenv.nodejs.NodeJSEnv
@@ -485,7 +507,15 @@ object Runner {
                |""".stripMargin
           )
 
-        if finalTestFrameworks.isEmpty then Left(new NoFrameworkFoundByBridgeError)
+        if finalTestFrameworks.isEmpty then
+          Left(new NoFrameworkFoundByBridgeError(
+            jvmOnlyScalaJarsOnPlatformClassPath(
+              classPath,
+              scalaBinaryVersion,
+              platformSuffix,
+              userDeclaredDepNames
+            )
+          ))
         else runTests(classPath, finalTestFrameworks, requireTests, args, parentInspector, logger)
       }
       finally if adapter != null then adapter.close()
@@ -499,7 +529,10 @@ object Runner {
     predefinedTestFrameworks: Seq[String],
     requireTests: Boolean,
     args: Seq[String],
-    logger: Logger
+    logger: Logger,
+    scalaBinaryVersion: String,
+    platformSuffix: String,
+    userDeclaredDepNames: Set[String]
   ): Either[TestError, Int] = either {
     logger.debug("Preparing to run tests with Scala Native...")
     logger.debug(s"Native tests class path: $classPath")
@@ -551,7 +584,15 @@ object Runner {
                |""".stripMargin
           )
 
-        if finalTestFrameworks.isEmpty then Left(new NoFrameworkFoundByNativeBridgeError)
+        if finalTestFrameworks.isEmpty then
+          Left(new NoFrameworkFoundByNativeBridgeError(
+            jvmOnlyScalaJarsOnPlatformClassPath(
+              classPath,
+              scalaBinaryVersion,
+              platformSuffix,
+              userDeclaredDepNames
+            )
+          ))
         else runTests(classPath, finalTestFrameworks, requireTests, args, parentInspector, logger)
       }
       finally if adapter != null then adapter.close()

--- a/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/test/Test.scala
@@ -210,14 +210,19 @@ object Test extends ScalaCommand[TestOptions] {
             esModule
           ) { js =>
             Runner.testJs(
-              build.fullClassPath.map(_.toNIO),
-              js.toIO,
-              requireTests,
-              args,
-              predefinedTestFrameworks.map(_.value),
-              logger,
-              build.options.scalaJsOptions.dom.getOrElse(false),
-              esModule
+              classPath = build.fullClassPath.map(_.toNIO),
+              entrypoint = js.toIO,
+              requireTests = requireTests,
+              args = args,
+              predefinedTestFrameworks = predefinedTestFrameworks.map(_.value),
+              logger = logger,
+              jsDom = build.options.scalaJsOptions.dom.getOrElse(false),
+              esModule = esModule,
+              scalaBinaryVersion = build.scalaParams.map(_.scalaBinaryVersion).getOrElse("3"),
+              platformSuffix = build.scalaParams.flatMap(_.platform).getOrElse("sjs1"),
+              userDeclaredDepNames =
+                build.options.classPathOptions.allExtraDependencies.toSeq.iterator
+                  .map(_.value.name).toSet
             )
           }.flatten
         }
@@ -229,12 +234,17 @@ object Test extends ScalaCommand[TestOptions] {
             logger
           ) { launcher =>
             Runner.testNative(
-              build.fullClassPath.map(_.toNIO),
-              launcher.toIO,
-              predefinedTestFrameworks.map(_.value),
-              requireTests,
-              args,
-              logger
+              classPath = build.fullClassPath.map(_.toNIO),
+              launcher = launcher.toIO,
+              predefinedTestFrameworks = predefinedTestFrameworks.map(_.value),
+              requireTests = requireTests,
+              args = args,
+              logger = logger,
+              scalaBinaryVersion = build.scalaParams.map(_.scalaBinaryVersion).getOrElse("3"),
+              platformSuffix = build.scalaParams.flatMap(_.platform).getOrElse("native0.5"),
+              userDeclaredDepNames =
+                build.options.classPathOptions.allExtraDependencies.toSeq.iterator
+                  .map(_.value.name).toSet
             )
           }.flatten
         }

--- a/modules/core/src/main/scala/scala/build/errors/NoFrameworkFoundByBridgeError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/NoFrameworkFoundByBridgeError.scala
@@ -1,4 +1,17 @@
 package scala.build.errors
 
-final class NoFrameworkFoundByBridgeError
-    extends TestError("No framework found by Scala.js test bridge")
+final class NoFrameworkFoundByBridgeError(
+  suspiciousJvmOnlyJars: Seq[String] = Nil
+) extends TestError(
+      NoFrameworkFoundByBridgeError.message(suspiciousJvmOnlyJars)
+    )
+
+object NoFrameworkFoundByBridgeError {
+  private def message(jars: Seq[String]): String =
+    if jars.isEmpty then "No framework found by Scala.js test bridge"
+    else
+      s"""No framework found by Scala.js test bridge.
+         |The following JVM-only Scala dependencies are on the Scala.js classpath and likely caused the failure:
+         |${jars.map("  - " + _).mkString("\n")}
+         |Use the platform-aware dependency syntax (extra ':' before the version, e.g. 'org::name::version' / '//> using dep org::name::version') so the Scala.js artifact is fetched instead of the JVM one.""".stripMargin
+}

--- a/modules/core/src/main/scala/scala/build/errors/NoFrameworkFoundByNativeBridgeError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/NoFrameworkFoundByNativeBridgeError.scala
@@ -1,4 +1,17 @@
 package scala.build.errors
 
-final class NoFrameworkFoundByNativeBridgeError
-    extends TestError("No framework found by Scala Native test bridge")
+final class NoFrameworkFoundByNativeBridgeError(
+  suspiciousJvmOnlyJars: Seq[String] = Nil
+) extends TestError(
+      NoFrameworkFoundByNativeBridgeError.message(suspiciousJvmOnlyJars)
+    )
+
+object NoFrameworkFoundByNativeBridgeError {
+  private def message(jars: Seq[String]): String =
+    if jars.isEmpty then "No framework found by Scala Native test bridge"
+    else
+      s"""No framework found by Scala Native test bridge.
+         |The following JVM-only Scala dependencies are on the Scala Native classpath and likely caused the failure:
+         |${jars.map("  - " + _).mkString("\n")}
+         |Use the platform-aware dependency syntax (extra ':' before the version, e.g. 'org::name::version' / '//> using dep org::name::version') so the Scala Native artifact is fetched instead of the JVM one.""".stripMargin
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -518,6 +518,37 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
     TestUtil.retryOnCi()(utestNative())
   }
 
+  for {
+    (platformArgs, platformName) <- Seq(
+      (Seq("--native"), "Scala Native"),
+      (Seq("--js"), "Scala.js")
+    )
+  } test(s"utest on $platformName with JVM-only dep syntax produces an informative error") {
+    TestUtil.retryOnCi() {
+      TestInputs(
+        os.rel / "MyTests.test.scala" ->
+          s"""//> using dep com.lihaoyi::utest:$utestVersion
+             |import utest._
+             |
+             |object MyTests extends TestSuite {
+             |  val tests = Tests {
+             |    test("foo") { assert(2 + 2 == 4) }
+             |  }
+             |}
+             |""".stripMargin
+      ).fromRoot { root =>
+        val res = os.proc(TestUtil.cli, "test", extraOptions, ".", platformArgs)
+          .call(cwd = root, check = false, mergeErrIntoOut = true)
+        expect(res.exitCode != 0)
+        val out = res.out.text()
+        expect(out.contains(s"No framework found by $platformName test bridge"))
+        expect(out.contains("JVM-only Scala dependencies"))
+        expect(out.contains("utest"))
+        expect(out.contains("::"))
+      }
+    }
+  }
+
   test("junit") {
     successfulJunitInputs.fromRoot { root =>
       val output = os.proc(TestUtil.cli, "test", extraOptions, ".").call(cwd = root).out.text()


### PR DESCRIPTION
Fixes #4017 

New error looks like this:
```
[error]  No framework found by Scala.js test bridge.
The following JVM-only Scala dependencies are on the Scala.js classpath and likely caused the failure:
  - utest_3-0.8.3.jar
Use the platform-aware dependency syntax (extra ':' before the version, e.g. 'org::name::version' / '//> using dep org::name::version') so the Scala.js artifact is fetched instead of the JVM one.
```
The aim is to easier catch the culprit dependency with the improved error message.

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)

## How much have your relied on LLM-based tools in this contribution?
Extensively, Cursor + Claude

## How was the solution tested?
Added new tests