### PR TITLE
[WIP] Auto-detect min/max supported JVM for a given Scala version

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -629,6 +629,9 @@ object Build {
     val classesDir0                           = classesRootDir(inputs.workspace, inputs.projectName)
     val (crossSources: CrossSources, inputs0) = value(allInputs(inputs, options, logger))
     val buildOptions                          = crossSources.sharedOptions(options)
+    // Resolve JVM and emit Scala/JVM compatibility warnings before compilation.
+    if buildOptions.platform.value == Platform.JVM then
+      buildOptions.checkAndResolveJavaHome(logger)
     if !buildOptions.suppressWarningOptions.suppressDeprecatedFeatureWarning.getOrElse(false) &&
       buildOptions.scalaParams.exists(_.exists(_.scalaVersion == "2.12.4") &&
       !buildOptions.useBuildServer.contains(false))

--- a/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
+++ b/modules/build/src/main/scala/scala/build/bsp/BspImpl.scala
@@ -578,7 +578,7 @@ final class BspImpl(
         )
       case Right(preBuildProject) =>
         lazy val projectJavaHome = preBuildProject.mainScope.buildOptions
-          .javaHome()
+          .checkAndResolveJavaHome(reloadableOptions.logger)
           .value
 
         val finalBloopSession =

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -11,6 +11,7 @@ import scala.build.Ops.*
 import scala.build.errors.{
   InvalidBinaryScalaVersionError,
   NoValidScalaVersionFoundError,
+  ScalaJvmIncompatibleError,
   ScalaVersionError,
   UnsupportedScalaVersionError
 }
@@ -449,6 +450,19 @@ class BuildOptionsTests extends TestUtil.ScalaCliBuildSuite {
 
     val semanticDbVersion = buildOptions.findSemanticDbVersion(scalaVersion, TestLogger())
     expect(semanticDbVersion == "4.8.4")
+  }
+
+  test("explicit too-old JVM for Scala 3.8+ fails with a clear error") {
+    val scalaVersion =
+      if defaultScalaVersion.startsWith("3.8") then defaultScalaVersion
+      else "3.8.3"
+    val options = BuildOptions(
+      scalaOptions = ScalaOptions(scalaVersion = Some(MaybeScalaVersion(scalaVersion))),
+      javaOptions = JavaOptions(jvmIdOpt = Some(Positioned.none("11")))
+    )
+    val ex = intercept[Exception](options.checkAndResolveJavaHome(TestLogger())).getCause
+      .asInstanceOf[ScalaJvmIncompatibleError]
+    expect(ex.getMessage.contains("requires at least Java 17"))
   }
 
   test("skip setting release option when -release or -java-output-version is set by user") {

--- a/modules/build/src/test/scala/scala/build/tests/ScalaJdkCompatTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ScalaJdkCompatTests.scala
@@ -1,0 +1,64 @@
+package scala.build.tests
+
+import com.eed3si9n.expecty.Expecty.assert as expect
+
+import scala.build.internal.ScalaJdkCompat
+
+class ScalaJdkCompatTests extends munit.FunSuite {
+
+  test("normalizeScalaVersion strips suffixes") {
+    expect(ScalaJdkCompat.normalizeScalaVersion("3.7.4-RC1") == "3.7.4")
+    expect(ScalaJdkCompat.normalizeScalaVersion("3.8.3-nightly-20250101") == "3.8.3")
+    expect(ScalaJdkCompat.normalizeScalaVersion("2.13.18-bin-abcd") == "2.13.18")
+    expect(ScalaJdkCompat.normalizeScalaVersion("3.3.7") == "3.3.7")
+  }
+
+  test("Scala 3.8+ requires JDK 17") {
+    val compat = ScalaJdkCompat.forScalaVersion("3.8.3").get
+    expect(compat.minJdk == 17)
+    expect(compat.maxRecommendedJdk == 26)
+    expect(ScalaJdkCompat.forScalaVersion("3.8.0-RC2").get.minJdk == 17)
+  }
+
+  test("Scala 3.7.4 supports JDK 8-25") {
+    val compat = ScalaJdkCompat.forScalaVersion("3.7.4").get
+    expect(compat.minJdk == 8)
+    expect(compat.maxRecommendedJdk == 25)
+    expect(ScalaJdkCompat.forScalaVersion("3.7.4-RC1").get == compat)
+  }
+
+  test("Scala 3.7.0 supports JDK 8-21") {
+    val compat = ScalaJdkCompat.forScalaVersion("3.7.0").get
+    expect(compat.maxRecommendedJdk == 21)
+  }
+
+  test("Scala 3.3 LTS patch-dependent max JDK") {
+    expect(ScalaJdkCompat.forScalaVersion("3.3.0").get.maxRecommendedJdk == 17)
+    expect(ScalaJdkCompat.forScalaVersion("3.3.1").get.maxRecommendedJdk == 21)
+    expect(ScalaJdkCompat.forScalaVersion("3.3.7").get.maxRecommendedJdk == 25)
+    expect(ScalaJdkCompat.forScalaVersion("3.3.8").get.maxRecommendedJdk == 26)
+  }
+
+  test("Scala 3.4-3.6 supports JDK 8-21") {
+    expect(ScalaJdkCompat.forScalaVersion("3.4.0").get.maxRecommendedJdk == 21)
+    expect(ScalaJdkCompat.forScalaVersion("3.6.4").get.maxRecommendedJdk == 21)
+  }
+
+  test("Scala 2.13 patch-dependent max JDK") {
+    expect(ScalaJdkCompat.forScalaVersion("2.13.5").get.maxRecommendedJdk == 11)
+    expect(ScalaJdkCompat.forScalaVersion("2.13.10").get.maxRecommendedJdk == 17)
+    expect(ScalaJdkCompat.forScalaVersion("2.13.17").get.maxRecommendedJdk == 25)
+    expect(ScalaJdkCompat.forScalaVersion("2.13.18").get.maxRecommendedJdk == 26)
+  }
+
+  test("Scala 2.12 patch-dependent max JDK") {
+    expect(ScalaJdkCompat.forScalaVersion("2.12.3").get.maxRecommendedJdk == 8)
+    expect(ScalaJdkCompat.forScalaVersion("2.12.18").get.maxRecommendedJdk == 21)
+    expect(ScalaJdkCompat.forScalaVersion("2.12.21").get.maxRecommendedJdk == 26)
+  }
+
+  test("unknown Scala version returns None") {
+    expect(ScalaJdkCompat.forScalaVersion("4.0.0").isEmpty)
+    expect(ScalaJdkCompat.forScalaVersion("not-a-version").isEmpty)
+  }
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
@@ -14,7 +14,7 @@ import scala.build.EitherCps.{either, value}
 import scala.build.Ops.*
 import scala.build.errors.{BuildException, CompositeBuildException}
 import scala.build.input.*
-import scala.build.internal.{Constants, Runner, ScalaJsLinkerConfig}
+import scala.build.internal.{Constants, Runner, ScalaJdkCompat, ScalaJsLinkerConfig}
 import scala.build.internals.ConsoleUtils.ScalaCliConsole
 import scala.build.internals.ConsoleUtils.ScalaCliConsole.warnPrefix
 import scala.build.internals.EnvVar
@@ -81,9 +81,13 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
         jvmIdOpt = baseOptions.javaOptions.jvmIdOpt.orElse {
           runMode(options) match {
             case _: RunMode.Spark | RunMode.HadoopJar =>
-              val sparkOrHadoopDefaultJvm = "8"
+              val javaMin  = Constants.mainJavaVersions.min
+              val scalaMin = baseOptions.scalaParams.toOption.flatten
+                .flatMap(sp => ScalaJdkCompat.forScalaVersion(sp.scalaVersion).map(_.minJdk))
+                .getOrElse(javaMin)
+              val sparkOrHadoopDefaultJvm = math.max(javaMin, scalaMin).toString
               logger.message(
-                s"Defaulting the JVM to  $sparkOrHadoopDefaultJvm for Spark/Hadoop runs."
+                s"Defaulting the JVM to $sparkOrHadoopDefaultJvm for Spark/Hadoop runs."
               )
               Some(Positioned.none(sparkOrHadoopDefaultJvm))
             case RunMode.Default => None

--- a/modules/core/src/main/scala/scala/build/errors/ScalaJvmIncompatibleError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/ScalaJvmIncompatibleError.scala
@@ -1,0 +1,14 @@
+package scala.build.errors
+
+import scala.build.Position
+
+final class ScalaJvmIncompatibleError(
+  scalaVersion: String,
+  jvmVersion: Int,
+  minJdk: Int,
+  jvmOrigin: String,
+  override val positions: Seq[Position] = Nil
+) extends BuildException(
+      s"""Scala $scalaVersion requires at least Java $minJdk, but $jvmOrigin is Java $jvmVersion.
+         |Pass `--jvm $minJdk` or higher, or use `//> using jvm $minJdk`.""".stripMargin
+    )

--- a/modules/core/src/main/scala/scala/build/internal/ScalaJdkCompat.scala
+++ b/modules/core/src/main/scala/scala/build/internal/ScalaJdkCompat.scala
@@ -1,0 +1,55 @@
+package scala.build.internal
+
+/** Scala version ↔ JDK compatibility ranges.
+  *
+  * Sourced from https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
+  *
+  * Non-stable versions (RC, nightly, custom suffixes) are normalised by stripping everything from
+  * the first `-` onward (e.g. `3.7.4-RC1` → `3.7.4`).
+  *
+  * @param maxRecommendedJdk
+  *   highest JDK version Scala is tested with for this line; warn when a newer JDK is used. For
+  *   Scala 3.8+, this tracks the latest released JDK and should be bumped when new JDKs ship.
+  */
+final case class ScalaJdkCompat(minJdk: Int, maxRecommendedJdk: Int)
+
+object ScalaJdkCompat {
+
+  def normalizeScalaVersion(scalaVersion: String): String =
+    val dash = scalaVersion.indexOf('-')
+    if dash < 0 then scalaVersion
+    else scalaVersion.substring(0, dash)
+
+  def forScalaVersion(scalaVersion: String): Option[ScalaJdkCompat] =
+    parseVersion(normalizeScalaVersion(scalaVersion)).flatMap(compatFor.tupled)
+
+  private def parseVersion(version: String): Option[(Int, Int, Int)] =
+    val parts = version.split('.')
+    if parts.length < 2 then None
+    else
+      for
+        major <- parts(0).toIntOption
+        minor <- parts(1).toIntOption
+        patch = if parts.length >= 3 then parts(2).takeWhile(_.isDigit).toIntOption.getOrElse(0)
+        else 0
+      yield (major, minor, patch)
+
+  private def patchTable(table: Seq[(Int, Int)])(patch: Int): Int =
+    table.reverseIterator.collectFirst { case (threshold, jdk) if patch >= threshold => jdk }
+      .getOrElse(table.head._2)
+
+  private val table_2_12 = Seq(0 -> 8, 4 -> 11, 15 -> 17, 18 -> 21, 21 -> 26)
+  private val table_2_13 = Seq(0 -> 11, 6 -> 17, 11 -> 21, 17 -> 25, 18 -> 26)
+  private val table_3_3  = Seq(0 -> 17, 1 -> 21, 6 -> 25, 8 -> 26)
+
+  private def compatFor(major: Int, minor: Int, patch: Int): Option[ScalaJdkCompat] =
+    (major, minor) match
+      case (2, 12)          => Some(ScalaJdkCompat(8, patchTable(table_2_12)(patch)))
+      case (2, 13)          => Some(ScalaJdkCompat(8, patchTable(table_2_13)(patch)))
+      case (3, m) if m >= 8 => Some(ScalaJdkCompat(17, 26))
+      case (3, 7)           => Some(ScalaJdkCompat(8, if patch >= 1 then 25 else 21))
+      case (3, m) if m >= 4 => Some(ScalaJdkCompat(8, 21))
+      case (3, 3)           => Some(ScalaJdkCompat(8, patchTable(table_3_3)(patch)))
+      case (3, _)           => Some(ScalaJdkCompat(8, 17))
+      case _                => None
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplJShellTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplJShellTestDefinitions.scala
@@ -172,7 +172,12 @@ trait ReplJShellTestDefinitions { this: ReplTestDefinitions =>
     }
   }
 
-  for javaVersion <- Constants.allJavaVersions.filter(_ >= 11) do
+  private def minJdkForCurrentScala: Int =
+    if actualScalaVersion.startsWith("3.8") || actualScalaVersion.startsWith("3.9")
+    then Constants.scala38MinJavaVersion
+    else 11
+
+  for javaVersion <- Constants.allJavaVersions.filter(_ >= minJdkForCurrentScala) do
     test(s"$runInJShellPrefix simple on JDK $javaVersion") {
       val versionSpecific = javaVersion match {
         case v if v >= 23 =>

--- a/modules/integration/src/test/scala/scala/cli/integration/RunJdkTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunJdkTestDefinitions.scala
@@ -151,4 +151,81 @@ trait RunJdkTestDefinitions { this: RunTestDefinitions =>
         }
       }
   }
+
+  if (isScala38OrNewer)
+    for (oldJvm <- Seq(11, 8).filter(Constants.allJavaVersions.contains)) {
+      test(
+        s"auto-falls back from JAVA_HOME $oldJvm when Scala $actualScalaVersion requires a newer JDK"
+      ) {
+        TestUtil.retryOnCi() {
+          TestInputs(
+            os.rel / "check_java_version.sc" ->
+              """println(System.getProperty("java.version"))""".stripMargin
+          ).fromRoot { root =>
+            val javaHome =
+              os.Path(
+                os.proc(TestUtil.cs, "java-home", "--jvm", oldJvm).call().out.trim(),
+                os.pwd
+              )
+            val res = os
+              .proc(TestUtil.cli, "run", ".", extraOptions)
+              .call(cwd = root, env = Map("JAVA_HOME" -> javaHome.toString), stderr = os.Pipe)
+            val reportedVersion = res.out.trim()
+            expect(
+              reportedVersion.startsWith("17") ||
+              reportedVersion.startsWith("21") ||
+              reportedVersion.startsWith("23") ||
+              reportedVersion.startsWith("24") ||
+              reportedVersion.startsWith("25") ||
+              reportedVersion.startsWith("26")
+            )
+            expect(
+              res.err.text().contains(s"requires at least Java ${Constants.scala38MinJavaVersion}")
+            )
+          }
+        }
+      }
+
+      test(s"errors on explicit --jvm $oldJvm when Scala $actualScalaVersion requires a newer JDK") {
+        TestUtil.retryOnCi() {
+          TestInputs(
+            os.rel / "hello.sc" -> """println("ok")"""
+          ).fromRoot { root =>
+            val res = os
+              .proc(TestUtil.cli, "run", "hello.sc", extraOptions, "--jvm", oldJvm)
+              .call(cwd = root, check = false, stderr = os.Pipe)
+            expect(res.exitCode != 0)
+            expect(
+              res.err.text().contains(s"requires at least Java ${Constants.scala38MinJavaVersion}")
+            )
+          }
+        }
+      }
+    }
+
+  {
+    val newJavaVersion = Constants.allJavaVersions.max
+    if newJavaVersion > 17 && actualScalaVersion == Constants.defaultScala then
+      test(s"warns when JVM $newJavaVersion is newer than Scala 3.0.2 supports") {
+        TestUtil.retryOnCi() {
+          TestInputs(
+            os.rel / "hello.sc" -> """println("ok")"""
+          ).fromRoot { root =>
+            val res = os
+              .proc(
+                TestUtil.cli,
+                "run",
+                "hello.sc",
+                TestUtil.extraOptions,
+                "--jvm",
+                newJavaVersion,
+                "-S",
+                "3.0.2"
+              )
+              .call(cwd = root, check = false, stderr = os.Pipe)
+            expect(res.err.text().contains("only tested up to JDK 17"))
+          }
+        }
+      }
+  }
 }

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -10,6 +10,7 @@ import java.io.File
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.build.EitherCps.{either, value}
 import scala.build.actionable.ActionablePreprocessor
@@ -22,7 +23,7 @@ import scala.build.internal.Regexes.{
   scala3RcNicknameRegex,
   scala3RcRegex
 }
-import scala.build.internal.{Constants, OsLibc, Util}
+import scala.build.internal.{Constants, OsLibc, ScalaJdkCompat, Util}
 import scala.build.internals.EnvVar
 import scala.build.options.validation.BuildOptionsRule
 import scala.build.{Artifacts, Logger, Os, Position, Positioned, RepositoryUtils}
@@ -260,19 +261,99 @@ final case class BuildOptions(
 
   lazy val archiveCache: ArchiveCache[Task] = ArchiveCache().withCache(finalCache)
 
-  private lazy val javaCommand0: Positioned[JavaHomeInfo] =
-    javaHomeLocation().map(JavaHomeInfo(_))
+  private def userSetJvm: Boolean =
+    javaOptions.javaHomeOpt.isDefined || javaOptions.jvmIdOpt.isDefined
+
+  private lazy val autoJvmMinOpt: Option[Int] =
+    if userSetJvm then None
+    else
+      scalaParams.toOption.flatten
+        .flatMap(sp => ScalaJdkCompat.forScalaVersion(sp.scalaVersion).map(_.minJdk))
+
+  private lazy val effectiveJavaOptions: JavaOptions =
+    autoJvmMinOpt match
+      case Some(minJdk) if !localJvmVersionOpt.exists(_ >= minJdk) =>
+        javaOptions.copy(jvmIdOpt =
+          Some(Positioned(Position.Custom("DEFAULT"), minJdk.toString))
+        )
+      case _ => javaOptions
 
   def javaHomeLocationOpt(): Option[Positioned[os.Path]] =
-    javaOptions.javaHomeLocationOpt(archiveCache, finalCache, internal.verbosityOrDefault)
+    effectiveJavaOptions.javaHomeLocationOpt(archiveCache, finalCache, internal.verbosityOrDefault)
 
   def javaHomeLocation(): Positioned[os.Path] =
-    javaOptions.javaHomeLocation(archiveCache, finalCache, internal.verbosityOrDefault)
+    effectiveJavaOptions.javaHomeLocation(archiveCache, finalCache, internal.verbosityOrDefault)
 
-  def javaHome(): Positioned[JavaHomeInfo] = javaCommand0
+  private lazy val resolvedJavaHome: Positioned[JavaHomeInfo] =
+    javaHomeLocation().map(JavaHomeInfo(_))
+
+  def javaHome(): Positioned[JavaHomeInfo] = resolvedJavaHome
+
+  /** Resolve the JVM and emit Scala/JVM compatibility warnings.
+    *
+    * Errors (`logger.exit`) fire on every call; warnings fire at most once per `BuildOptions`. Call
+    * from the top-level build pipeline (e.g. `Build.build`).
+    */
+  def checkAndResolveJavaHome(logger: Logger): Positioned[JavaHomeInfo] =
+    val home = resolvedJavaHome
+    for
+      scalaVersion <- scalaParams.toOption.flatten.map(_.scalaVersion)
+      compat       <- ScalaJdkCompat.forScalaVersion(scalaVersion)
+    do checkJvmCompat(home, scalaVersion, compat, logger)
+    home
+
+  private val compatWarningsEmitted: AtomicBoolean = AtomicBoolean(false)
+
+  private def jvmOriginDescription: String =
+    javaOptions.jvmIdOpt.map(_.value)
+      .orElse(javaOptions.javaHomeOpt.map(_.value.toString))
+      .getOrElse("the selected JVM")
+
+  private def checkJvmCompat(
+    home: Positioned[JavaHomeInfo],
+    scalaVersion: String,
+    compat: ScalaJdkCompat,
+    logger: Logger
+  ): Unit =
+    val jvmVersion = home.value.version
+    if userSetJvm && jvmVersion < compat.minJdk then
+      logger.exit(
+        ScalaJvmIncompatibleError(
+          scalaVersion,
+          jvmVersion,
+          compat.minJdk,
+          jvmOriginDescription,
+          home.positions
+        )
+      )
+    if compatWarningsEmitted.compareAndSet(false, true) then
+      if autoJvmMinOpt.isDefined && localJvmVersionOpt.exists(_ < compat.minJdk) then
+        logger.message(
+          s"""Using JDK ${compat.minJdk} because Scala $scalaVersion requires at least Java ${compat.minJdk}.""".stripMargin
+        )
+      if jvmVersion > compat.maxRecommendedJdk then
+        logger.message(
+          s"""Scala $scalaVersion is only tested up to JDK ${compat.maxRecommendedJdk}, but JDK $jvmVersion is being used.
+             |Consider passing `-S` with a newer Scala version or `--jvm` with an older JDK.""".stripMargin
+        )
+      else if !userSetJvm then
+        for localVersion <- localJvmVersionOpt if localVersion > compat.maxRecommendedJdk do
+          logger.message(
+            s"""The JVM in JAVA_HOME (Java $localVersion) is newer than what Scala $scalaVersion is tested with (up to JDK ${compat.maxRecommendedJdk}).
+               |Using Java $jvmVersion instead.""".stripMargin
+          )
+
+  private def localJvmVersionOpt: Option[Int] =
+    javaOptions.javaHomeLocationOpt(archiveCache, finalCache, internal.verbosityOrDefault)
+      .map(_.value)
+      .orElse {
+        Option(System.getenv("JAVA_HOME")).filter(_.nonEmpty).map(os.Path(_, os.pwd))
+      }
+      .orElse(sys.props.get("java.home").map(os.Path(_, os.pwd)))
+      .map(path => OsLibc.javaHomeVersion(path)._1)
 
   lazy val javaHomeManager: JavaHome =
-    javaOptions.javaHomeManager(archiveCache, finalCache, internal.verbosityOrDefault)
+    effectiveJavaOptions.javaHomeManager(archiveCache, finalCache, internal.verbosityOrDefault)
 
   private val scala2NightlyRepo = Seq(coursier.Repositories.scalaIntegration.root)
   private val scala3NightlyRepo = Seq(RepositoryUtils.scala3NightlyRepository.root)


### PR DESCRIPTION
Fixes #4260 

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)
- ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
Extensively, Cursor + Claude

## How was the solution tested?
New automated tests