### PR TITLE
Add support for ```java snippets in Markdown inputs

### DIFF
--- a/modules/build/src/main/scala/scala/build/Sources.scala
+++ b/modules/build/src/main/scala/scala/build/Sources.scala
@@ -120,7 +120,7 @@ object Sources {
   ): Seq[Preprocessor] =
     Seq(
       ScriptPreprocessor,
-      MarkdownPreprocessor,
+      MarkdownPreprocessor(archiveCache, javaClassNameVersionOpt, javaCommand),
       JavaPreprocessor(archiveCache, javaClassNameVersionOpt, javaCommand),
       ScalaPreprocessor,
       DataPreprocessor,

--- a/modules/build/src/main/scala/scala/build/internal/markdown/MarkdownCodeBlock.scala
+++ b/modules/build/src/main/scala/scala/build/internal/markdown/MarkdownCodeBlock.scala
@@ -22,15 +22,28 @@ case class MarkdownCodeBlock(
   endLine: Int
 ) {
 
+  private def supportedLanguage: Boolean =
+    info.headOption.exists(lang => lang == "scala" || lang == "java")
+
   /** @return
     *   `true` if this snippet should be ignored, `false` otherwise
     */
-  def shouldIgnore: Boolean = info.head != "scala" || info.contains("ignore")
+  def shouldIgnore: Boolean = !supportedLanguage || info.contains("ignore")
+
+  /** @return
+    *   `true` if this snippet is a Scala snippet, `false` otherwise
+    */
+  def isScala: Boolean = info.headOption.contains("scala")
+
+  /** @return
+    *   `true` if this snippet is a Java snippet, `false` otherwise
+    */
+  def isJava: Boolean = info.headOption.contains("java")
 
   /** @return
     *   `true` if this snippet should have its scope reset, `false` otherwise
     */
-  def resetScope: Boolean = info.contains("reset")
+  def resetScope: Boolean = isScala && info.contains("reset")
 
   /** @return
     *   `true` if this snippet is a test snippet, `false` otherwise
@@ -38,9 +51,10 @@ case class MarkdownCodeBlock(
   def isTest: Boolean = info.contains("test")
 
   /** @return
-    *   `true` if this snippet is a raw snippet, `false` otherwise
+    *   `true` if this snippet is a raw snippet, `false` otherwise. Only meaningful for Scala
+    *   snippets; Java snippets are always emitted as raw `.java` sources.
     */
-  def isRaw: Boolean = info.contains("raw")
+  def isRaw: Boolean = isScala && info.contains("raw")
 }
 
 object MarkdownCodeBlock {

--- a/modules/build/src/main/scala/scala/build/preprocessing/MarkdownCodeBlockProcessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/MarkdownCodeBlockProcessor.scala
@@ -14,7 +14,9 @@ object MarkdownCodeBlockProcessor {
     logger: Logger,
     maybeRecoverOnError: BuildException => Option[BuildException]
   ): Either[BuildException, PreprocessedMarkdown] = either {
-    val (rawCodeBlocks, remaining)         = codeBlocks.partition(_.isRaw)
+    val (javaBlocks, scalaBlocks)          = codeBlocks.partition(_.isJava)
+    val (javaTestBlocks, javaMainBlocks)   = javaBlocks.partition(_.isTest)
+    val (rawCodeBlocks, remaining)         = scalaBlocks.partition(_.isRaw)
     val (testCodeBlocks, scriptCodeBlocks) = remaining.partition(_.isTest)
     def preprocessCodeBlocks(cbs: Seq[MarkdownCodeBlock])
       : Either[BuildException, PreprocessedMarkdownCodeBlocks] = either {
@@ -39,7 +41,9 @@ object MarkdownCodeBlockProcessor {
     PreprocessedMarkdown(
       value(preprocessCodeBlocks(scriptCodeBlocks)),
       value(preprocessCodeBlocks(rawCodeBlocks)),
-      value(preprocessCodeBlocks(testCodeBlocks))
+      value(preprocessCodeBlocks(testCodeBlocks)),
+      value(preprocessCodeBlocks(javaMainBlocks)),
+      value(preprocessCodeBlocks(javaTestBlocks))
     )
   }
 }

--- a/modules/build/src/main/scala/scala/build/preprocessing/MarkdownPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/MarkdownPreprocessor.scala
@@ -1,16 +1,34 @@
 package scala.build.preprocessing
 
+import coursier.cache.ArchiveCache
+import coursier.util.Task
+
 import java.nio.charset.StandardCharsets
 
 import scala.build.EitherCps.{either, value}
 import scala.build.Logger
 import scala.build.errors.BuildException
 import scala.build.input.{MarkdownFile, ScalaCliInvokeData, SingleElement, VirtualMarkdownFile}
+import scala.build.internal.JavaParserProxyMaker
 import scala.build.internal.markdown.{MarkdownCodeBlock, MarkdownCodeWrapper}
 import scala.build.options.SuppressWarningOptions
 import scala.build.preprocessing.ScalaPreprocessor.ProcessingOutput
+import scala.build.preprocessing.directives.PreprocessedDirectives
 
-case object MarkdownPreprocessor extends Preprocessor {
+/** Markdown source preprocessor.
+  *
+  * @param archiveCache
+  *   when using a java-class-name external binary to infer a class name (see [[JavaParserProxy]]),
+  *   a cache to download that binary with
+  * @param javaClassNameVersionOpt
+  *   when using a java-class-name external binary to infer a class name (see [[JavaParserProxy]]),
+  *   this forces the java-class-name version to download
+  */
+final case class MarkdownPreprocessor(
+  archiveCache: ArchiveCache[Task],
+  javaClassNameVersionOpt: Option[String],
+  javaCommand: () => String
+) extends Preprocessor {
   def preprocess(
     input: SingleElement,
     logger: Logger,
@@ -23,15 +41,18 @@ case object MarkdownPreprocessor extends Preprocessor {
         val res = either {
           val content      = value(PreprocessingUtil.maybeRead(markdown.path))
           val preprocessed = value {
-            MarkdownPreprocessor.preprocess(
-              Right(markdown.path),
-              content,
-              markdown.subPath,
-              ScopePath.fromPath(markdown.path),
-              logger,
-              maybeRecoverOnError,
-              allowRestrictedFeatures,
-              suppressWarningOptions
+            preprocessContent(
+              archiveCache = archiveCache,
+              javaClassNameVersionOpt = javaClassNameVersionOpt,
+              javaCommand = javaCommand,
+              reportingPath = Right(markdown.path),
+              content = content,
+              subPath = markdown.subPath,
+              scopePath = ScopePath.fromPath(markdown.path),
+              logger = logger,
+              maybeRecoverOnError = maybeRecoverOnError,
+              allowRestrictedFeatures = allowRestrictedFeatures,
+              suppressWarningOptions = suppressWarningOptions
             )
           }
           preprocessed
@@ -41,15 +62,18 @@ case object MarkdownPreprocessor extends Preprocessor {
         val content = new String(markdown.content, StandardCharsets.UTF_8)
         val res     = either {
           val preprocessed = value {
-            MarkdownPreprocessor.preprocess(
-              Left(markdown.source),
-              content,
-              markdown.wrapperPath,
-              markdown.scopePath,
-              logger,
-              maybeRecoverOnError,
-              allowRestrictedFeatures,
-              suppressWarningOptions
+            preprocessContent(
+              archiveCache = archiveCache,
+              javaClassNameVersionOpt = javaClassNameVersionOpt,
+              javaCommand = javaCommand,
+              reportingPath = Left(markdown.source),
+              content = content,
+              subPath = markdown.wrapperPath,
+              scopePath = markdown.scopePath,
+              logger = logger,
+              maybeRecoverOnError = maybeRecoverOnError,
+              allowRestrictedFeatures = allowRestrictedFeatures,
+              suppressWarningOptions = suppressWarningOptions
             )
           }
           preprocessed
@@ -59,7 +83,10 @@ case object MarkdownPreprocessor extends Preprocessor {
         None
     }
 
-  private def preprocess(
+  private def preprocessContent(
+    archiveCache: ArchiveCache[Task],
+    javaClassNameVersionOpt: Option[String],
+    javaCommand: () => String,
     reportingPath: Either[String, os.Path],
     content: String,
     subPath: os.SubPath,
@@ -106,6 +133,38 @@ case object MarkdownPreprocessor extends Preprocessor {
           }
       }
 
+    def emitJavaSnippets(
+      blocks: PreprocessedMarkdownCodeBlocks,
+      isTest: Boolean
+    ): Either[BuildException, List[PreprocessedSource.InMemory]] =
+      either {
+        val javaParser =
+          (new JavaParserProxyMaker)
+            .get(
+              archiveCache,
+              javaClassNameVersionOpt,
+              logger,
+              () => javaCommand()
+            )
+        blocks.codeBlocks.zipWithIndex.map { (block, index) =>
+          value {
+            emitJavaSnippet(
+              block = block,
+              index = index,
+              isTest = isTest,
+              subPath = subPath,
+              scopePath = scopePath,
+              reportingPath = reportingPath,
+              javaParser = javaParser,
+              logger = logger,
+              allowRestrictedFeatures = allowRestrictedFeatures,
+              suppressWarningOptions = suppressWarningOptions,
+              maybeRecoverOnError = maybeRecoverOnError
+            )
+          }
+        }.toList
+      }
+
     val codeBlocks: Seq[MarkdownCodeBlock] =
       value(MarkdownCodeBlock.findCodeBlocks(subPath, content, maybeRecoverOnError))
     val preprocessedMarkdown: PreprocessedMarkdown =
@@ -123,8 +182,60 @@ case object MarkdownPreprocessor extends Preprocessor {
     val maybeMainFile = value(preprocessSnippets(mainScalaCode, ".scala"))
     val maybeRawFile  = value(preprocessSnippets(rawScalaCode, ".raw.scala"))
     val maybeTestFile = value(preprocessSnippets(testScalaCode, ".test.scala"))
+    val javaFiles     = value(emitJavaSnippets(preprocessedMarkdown.javaCodeBlocks, isTest = false))
+    val javaTestFiles =
+      value(emitJavaSnippets(preprocessedMarkdown.javaTestCodeBlocks, isTest = true))
 
-    maybeMainFile.toList ++ maybeTestFile ++ maybeRawFile
+    maybeMainFile.toList ++ maybeTestFile ++ maybeRawFile ++ javaFiles ++ javaTestFiles
   }
 
+  private def emitJavaSnippet(
+    block: MarkdownCodeBlock,
+    index: Int,
+    isTest: Boolean,
+    subPath: os.SubPath,
+    scopePath: ScopePath,
+    reportingPath: Either[String, os.Path],
+    javaParser: scala.build.internal.JavaParserProxy,
+    logger: Logger,
+    allowRestrictedFeatures: Boolean,
+    suppressWarningOptions: SuppressWarningOptions,
+    maybeRecoverOnError: BuildException => Option[BuildException]
+  )(using ScalaCliInvokeData): Either[BuildException, PreprocessedSource.InMemory] = either {
+    val classNameOpt = value {
+      javaParser.className(block.body.getBytes(StandardCharsets.UTF_8))
+    }
+    val mdBaseName   = subPath.last.stripSuffix(".md")
+    val baseName     = classNameOpt.getOrElse(s"${mdBaseName}_md_snippet$index")
+    val javaFileName =
+      if isTest then s"$baseName.test.java"
+      else s"$baseName.java"
+    val generatedRelPath =
+      if isTest then os.rel / (subPath / os.up) / s"$baseName.java"
+      else os.rel / (subPath / os.up) / javaFileName
+    val snippetScopePath = scopePath.copy(subPath = (subPath / os.up) / javaFileName)
+    val preprocessedDirectives: PreprocessedDirectives = value {
+      DirectivesPreprocessor(
+        reportingPath,
+        snippetScopePath,
+        logger,
+        allowRestrictedFeatures,
+        suppressWarningOptions,
+        maybeRecoverOnError
+      ).preprocess(block.body)
+    }
+    PreprocessedSource.InMemory(
+      originalPath = reportingPath.map(subPath -> _),
+      relPath = generatedRelPath,
+      content = block.body.getBytes(StandardCharsets.UTF_8),
+      wrapperParamsOpt = None,
+      options = Some(preprocessedDirectives.globalUsings),
+      optionsWithTargetRequirements = preprocessedDirectives.usingsWithReqs,
+      requirements = Some(preprocessedDirectives.globalReqs),
+      scopedRequirements = preprocessedDirectives.scopedReqs,
+      mainClassOpt = None,
+      scopePath = snippetScopePath,
+      directivesPositions = preprocessedDirectives.directivesPositions
+    )
+  }
 }

--- a/modules/build/src/main/scala/scala/build/preprocessing/PreprocessedMarkdown.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/PreprocessedMarkdown.scala
@@ -15,7 +15,9 @@ object PreprocessedMarkdownCodeBlocks {
 case class PreprocessedMarkdown(
   scriptCodeBlocks: PreprocessedMarkdownCodeBlocks = PreprocessedMarkdownCodeBlocks.empty,
   rawCodeBlocks: PreprocessedMarkdownCodeBlocks = PreprocessedMarkdownCodeBlocks.empty,
-  testCodeBlocks: PreprocessedMarkdownCodeBlocks = PreprocessedMarkdownCodeBlocks.empty
+  testCodeBlocks: PreprocessedMarkdownCodeBlocks = PreprocessedMarkdownCodeBlocks.empty,
+  javaCodeBlocks: PreprocessedMarkdownCodeBlocks = PreprocessedMarkdownCodeBlocks.empty,
+  javaTestCodeBlocks: PreprocessedMarkdownCodeBlocks = PreprocessedMarkdownCodeBlocks.empty
 )
 
 object PreprocessedMarkdown {

--- a/modules/build/src/test/scala/scala/build/tests/PreprocessingTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/PreprocessingTests.scala
@@ -1,12 +1,32 @@
 package scala.build.tests
 
 import com.eed3si9n.expecty.Expecty.expect
+import coursier.cache.Cache.Fetch
+import coursier.cache.{ArchiveCache, ArtifactError, Cache}
+import coursier.util.{Artifact, EitherT, Task}
 
+import java.io.File
+
+import scala.build.Sources
 import scala.build.input.{MarkdownFile, ScalaCliInvokeData, Script, SourceScalaFile}
 import scala.build.options.SuppressWarningOptions
 import scala.build.preprocessing.{MarkdownPreprocessor, ScalaPreprocessor, ScriptPreprocessor}
+import scala.concurrent.ExecutionContext
 
 class PreprocessingTests extends TestUtil.ScalaCliBuildSuite {
+  private val markdownPreprocessor: MarkdownPreprocessor =
+    Sources.defaultPreprocessors(
+      ArchiveCache().withCache(
+        new Cache[Task] {
+          def fetch: Fetch[Task] = _ => sys.error("shouldn't be used")
+          def file(artifact: Artifact): EitherT[Task, ArtifactError, File] =
+            sys.error("shouldn't be used")
+          def ec: ExecutionContext = sys.error("shouldn't be used")
+        }
+      ),
+      javaClassNameVersionOpt = None,
+      javaCommand = () => sys.error("shouldn't be used")
+    ).collectFirst { case m: MarkdownPreprocessor => m }.get
   test("Report error if scala file not exists") {
     val logger    = TestLogger()
     val scalaFile = SourceScalaFile(os.temp.dir(), os.SubPath("NotExists.scala"))
@@ -45,7 +65,7 @@ class PreprocessingTests extends TestUtil.ScalaCliBuildSuite {
     val logger       = TestLogger()
     val markdownFile = MarkdownFile(os.temp.dir(), os.SubPath("NotExists.md"))
 
-    val res = MarkdownPreprocessor.preprocess(
+    val res = markdownPreprocessor.preprocess(
       markdownFile,
       logger,
       allowRestrictedFeatures = false,

--- a/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownCodeBlockTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownCodeBlockTests.scala
@@ -185,6 +185,92 @@ class MarkdownCodeBlockTests extends TestUtil.ScalaCliBuildSuite {
     expect(actualResult == expectedResult)
   }
 
+  test("a simple Java code block is extracted correctly from markdown") {
+    val code =
+      """public class Main {
+        |  public static void main(String[] args) {
+        |    System.out.println("Hello");
+        |  }
+        |}""".stripMargin
+    val markdown =
+      s"""# Some snippet
+         |
+         |```java
+         |$code
+         |```
+         |""".stripMargin
+    val expectedResult =
+      MarkdownCodeBlock(
+        info = PlainJavaInfo,
+        body = code,
+        startLine = 3,
+        endLine = 7
+      )
+    val path         = os.sub / "Example.md"
+    val actualResult =
+      MarkdownCodeBlock.findCodeBlocks(path, markdown)
+        .getOrElse(sys.error("failed while finding code blocks"))
+        .head
+    expect(actualResult == expectedResult)
+  }
+
+  test("a test Java snippet is extracted correctly from markdown") {
+    val code =
+      """public class MyTest {
+        |  public void test() {}
+        |}""".stripMargin
+    val markdown =
+      s"""# Some snippet
+         |
+         |```java test
+         |$code
+         |```
+         |""".stripMargin
+    val expectedResult =
+      MarkdownCodeBlock(
+        info = TestJavaInfo,
+        body = code,
+        startLine = 3,
+        endLine = 5
+      )
+    val path         = os.sub / "Example.md"
+    val actualResult =
+      MarkdownCodeBlock.findCodeBlocks(path, markdown)
+        .getOrElse(sys.error("failed while finding code blocks"))
+        .head
+    expect(actualResult == expectedResult)
+  }
+
+  test("a Java code block is skipped when it's tagged as `ignore` in markdown") {
+    val code =
+      """public class Main {
+        |  public static void main(String[] args) {
+        |    System.out.println("Hello");
+        |  }
+        |}""".stripMargin
+    val markdown =
+      s"""# Some snippet
+         |
+         |```java ignore
+         |$code
+         |```
+         |""".stripMargin
+    val path = os.sub / "Example.md"
+    expect(MarkdownCodeBlock.findCodeBlocks(path, markdown) == Right(Seq.empty))
+  }
+
+  test("non-Scala/Java code blocks are ignored in markdown") {
+    val markdown =
+      """# Some snippet
+        |
+        |```python
+        |print("Hello")
+        |```
+        |""".stripMargin
+    val path = os.sub / "Example.md"
+    expect(MarkdownCodeBlock.findCodeBlocks(path, markdown) == Right(Seq.empty))
+  }
+
   test("a Scala code block is skipped when it's tagged as `ignore` in markdown") {
     val code     = """println("Hello")"""
     val markdown =

--- a/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownCodeWrapperTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownCodeWrapperTests.scala
@@ -162,6 +162,44 @@ class MarkdownCodeWrapperTests extends TestUtil.ScalaCliBuildSuite {
 
   def stringPrep(s: String): String = AmmUtil.normalizeNewlines(s)
 
+  test("markdown with only Java snippets produces no wrapped Scala code") {
+    val code =
+      """public class Main {
+        |  public static void main(String[] args) {
+        |    System.out.println("Hello");
+        |  }
+        |}""".stripMargin
+    val codeBlock              = MarkdownCodeBlock(PlainJavaInfo, code, 3, 7)
+    val preprocessedCodeBlocks = PreprocessedMarkdownCodeBlocks(Seq(codeBlock))
+    val markdown               = PreprocessedMarkdown(javaCodeBlocks = preprocessedCodeBlocks)
+    val result                 = MarkdownCodeWrapper(os.sub / "Example.md", markdown)
+    expect(result == (None, None, None))
+  }
+
+  test("markdown with Scala and Java snippets wraps only Scala code") {
+    val scalaSnippet = """println("Hello")"""
+    val scalaBlock   = MarkdownCodeBlock(PlainScalaInfo, scalaSnippet, 3, 3)
+    val javaCode     =
+      """public class Helper {
+        |  public static String msg() { return "world"; }
+        |}""".stripMargin
+    val javaBlock         = MarkdownCodeBlock(PlainJavaInfo, javaCode, 8, 10)
+    val preprocessedScala = PreprocessedMarkdownCodeBlocks(Seq(scalaBlock))
+    val preprocessedJava  = PreprocessedMarkdownCodeBlocks(Seq(javaBlock))
+    val markdown          =
+      PreprocessedMarkdown(scriptCodeBlocks = preprocessedScala, javaCodeBlocks = preprocessedJava)
+    val expectedScala = MarkdownCodeWrapper.WrappedMarkdownCode(
+      s"""object Example_md { @annotation.nowarn("msg=pure expression does nothing") def main(args: Array[String]): Unit = { Scope; }
+         |
+         |object Scope {
+         |$scalaSnippet
+         |}}""".stripMargin
+    )
+    val result = MarkdownCodeWrapper(os.sub / "Example.md", markdown)
+    showDiffs(result, expectedScala.code)
+    expect(result == (Some(expectedScala), None, None))
+  }
+
   test("multiple test Scala snippets are glued together correctly") {
     val snippet1 = stringPrep(
       """//> using dep org.scalameta::munit:0.7.29

--- a/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownPreprocessorTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownPreprocessorTests.scala
@@ -1,0 +1,172 @@
+package scala.build.tests.markdown
+
+import com.eed3si9n.expecty.Expecty.expect
+import coursier.cache.Cache.Fetch
+import coursier.cache.{ArchiveCache, ArtifactError, Cache}
+import coursier.util.{Artifact, EitherT, Task}
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+
+import scala.build.Ops.*
+import scala.build.input.ScalaCliInvokeData
+import scala.build.options.{BuildOptions, Scope, SuppressWarningOptions}
+import scala.build.preprocessing.Preprocessor
+import scala.build.tests.{TestInputs, TestLogger, TestUtil}
+import scala.build.{CrossSources, Sources}
+import scala.concurrent.ExecutionContext
+
+class MarkdownPreprocessorTests extends TestUtil.ScalaCliBuildSuite {
+  given ScalaCliInvokeData = ScalaCliInvokeData.dummy
+
+  private val preprocessors: Seq[Preprocessor] = Sources.defaultPreprocessors(
+    ArchiveCache().withCache(
+      new Cache[Task] {
+        def fetch: Fetch[Task] = _ => sys.error("shouldn't be used")
+        def file(artifact: Artifact): EitherT[Task, ArtifactError, File] =
+          sys.error("shouldn't be used")
+        def ec: ExecutionContext = sys.error("shouldn't be used")
+      }
+    ),
+    javaClassNameVersionOpt = None,
+    javaCommand = () => sys.error("shouldn't be used")
+  )
+
+  test("a markdown file with a public Java class emits a matching .java source") {
+    val mdPath = os.rel / "Example.md"
+    TestInputs(
+      mdPath ->
+        """# Example
+          |
+          |```java
+          |public class Foo {
+          |  public static void main(String[] args) {
+          |    System.out.println("Hello");
+          |  }
+          |}
+          |```""".stripMargin
+    ).withInputs { (root, inputs) =>
+      val (crossSources, _) =
+        CrossSources.forInputs(
+          inputs,
+          preprocessors,
+          TestLogger(),
+          SuppressWarningOptions()
+        ).orThrow
+
+      val mainSources =
+        crossSources.scopedSources(BuildOptions()).orThrow
+          .sources(Scope.Main, crossSources.sharedOptions(BuildOptions()), root, TestLogger())
+          .orThrow
+
+      val generatedRelPath = mainSources.inMemory.head.generatedRelPath
+      val expectedRelPath  = os.rel / "Foo.java"
+      expect(mainSources.paths.isEmpty)
+      expect(mainSources.inMemory.length == 1)
+      expect(generatedRelPath == expectedRelPath)
+      expect(
+        new String(mainSources.inMemory.head.content, StandardCharsets.UTF_8).contains("class Foo")
+      )
+    }
+  }
+
+  test(
+    "a markdown file with a Java snippet without a public class emits a synthetic .java source"
+  ) {
+    val mdPath = os.rel / "Example.md"
+    TestInputs(
+      mdPath ->
+        """# Example
+          |
+          |```java
+          |class Helper {
+          |  static String msg() { return "Hello"; }
+          |}
+          |```""".stripMargin
+    ).withInputs { (root, inputs) =>
+      val (crossSources, _) =
+        CrossSources.forInputs(
+          inputs,
+          preprocessors,
+          TestLogger(),
+          SuppressWarningOptions()
+        ).orThrow
+
+      val mainSources =
+        crossSources.scopedSources(BuildOptions()).orThrow
+          .sources(Scope.Main, crossSources.sharedOptions(BuildOptions()), root, TestLogger())
+          .orThrow
+
+      val generatedRelPath = mainSources.inMemory.head.generatedRelPath
+      val expectedRelPath  = os.rel / "Example_md_snippet0.java"
+      expect(mainSources.inMemory.length == 1)
+      expect(generatedRelPath == expectedRelPath)
+    }
+  }
+
+  test("a markdown file with a java test snippet is routed to the test scope") {
+    val mdPath = os.rel / "Example.md"
+    TestInputs(
+      mdPath ->
+        """# Example
+          |
+          |```java test
+          |public class BarTest {
+          |  public void test() {}
+          |}
+          |```""".stripMargin
+    ).withInputs { (root, inputs) =>
+      val (crossSources, _) =
+        CrossSources.forInputs(
+          inputs,
+          preprocessors,
+          TestLogger(),
+          SuppressWarningOptions()
+        ).orThrow
+
+      val testSources =
+        crossSources.scopedSources(BuildOptions()).orThrow
+          .sources(Scope.Test, crossSources.sharedOptions(BuildOptions()), root, TestLogger())
+          .orThrow
+
+      val generatedRelPath = testSources.inMemory.head.generatedRelPath
+      val expectedRelPath  = os.rel / "BarTest.java"
+      expect(testSources.paths.isEmpty)
+      expect(testSources.inMemory.length == 1)
+      expect(generatedRelPath == expectedRelPath)
+    }
+  }
+
+  test("a markdown file ignores java snippets tagged as ignore") {
+    val mdPath = os.rel / "Example.md"
+    TestInputs(
+      mdPath ->
+        """# Example
+          |
+          |```java ignore
+          |public class Ignored {
+          |  public static void main(String[] args) {}
+          |}
+          |```
+          |
+          |```scala
+          |println("Hello")
+          |```""".stripMargin
+    ).withInputs { (root, inputs) =>
+      val (crossSources, _) =
+        CrossSources.forInputs(
+          inputs,
+          preprocessors,
+          TestLogger(),
+          SuppressWarningOptions()
+        ).orThrow
+
+      val mainSources =
+        crossSources.scopedSources(BuildOptions()).orThrow
+          .sources(Scope.Main, crossSources.sharedOptions(BuildOptions()), root, TestLogger())
+          .orThrow
+
+      expect(mainSources.inMemory.forall(!_.generatedRelPath.last.endsWith(".java")))
+    }
+  }
+}

--- a/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownTestUtil.scala
+++ b/modules/build/src/test/scala/scala/build/tests/markdown/MarkdownTestUtil.scala
@@ -5,4 +5,6 @@ object MarkdownTestUtil {
   val RawScalaInfo: Seq[String]   = Seq("scala", "raw")
   val TestScalaInfo: Seq[String]  = Seq("scala", "test")
   val ResetScalaInfo: Seq[String] = Seq("scala", "reset")
+  val PlainJavaInfo: Seq[String]  = Seq("java")
+  val TestJavaInfo: Seq[String]   = Seq("java", "test")
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/MarkdownTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/MarkdownTests.scala
@@ -284,6 +284,119 @@ class MarkdownTests extends ScalaCliSuite {
       expect(result.out.trim() == expectedOutput)
     }
   }
+  test("run a simple .md file with a java snippet") {
+    val expectedOutput = "Hello from Java"
+    TestInputs(
+      os.rel / "sample.md" ->
+        s"""# Sample Markdown file
+           |A simple Java snippet.
+           |```java
+           |public class Main {
+           |  public static void main(String[] args) {
+           |    System.out.println("$expectedOutput");
+           |  }
+           |}
+           |```
+           |""".stripMargin
+    ).fromRoot { root =>
+      val result = os.proc(TestUtil.cli, "sample.md").call(cwd = root)
+      expect(result.out.trim() == expectedOutput)
+    }
+  }
+
+  test("run a .md file with scala and java snippets") {
+    val expectedOutput = "Hello world"
+    TestInputs(
+      os.rel / "sample.md" ->
+        s"""# Sample Markdown file
+           |```java
+           |public class Greeter {
+           |  public static String greet() { return "world"; }
+           |}
+           |```
+           |
+           |```scala
+           |println("Hello " + Greeter.greet())
+           |```
+           |""".stripMargin
+    ).fromRoot { root =>
+      val result = os.proc(TestUtil.cli, "sample.md").call(cwd = root)
+      expect(result.out.trim() == expectedOutput)
+    }
+  }
+
+  test("run a .md file with scala and java snippets, both with main methods, main by directive") {
+    val expectedOutput  = "Hello from Java"
+    val mainClassToPick = "JavaMain"
+    TestInputs(
+      os.rel / "sample.md" ->
+        s"""# Sample Markdown file
+           |```java
+           |//> using mainClass $mainClassToPick
+           |public class $mainClassToPick {
+           |  public static void main(String[] args) {
+           |    System.out.println("$expectedOutput");
+           |  }
+           |}
+           |```
+           |
+           |```scala raw
+           |@main def main() = println("Hello from Scala")
+           |```
+           |""".stripMargin
+    ).fromRoot { root =>
+      val result = os.proc(TestUtil.cli, "sample.md").call(cwd = root)
+      println(result.out.trim())
+      expect(result.out.trim() == expectedOutput)
+    }
+  }
+
+  test("test a .md file with a java test snippet") {
+    TestInputs(
+      os.rel / "sample.md" ->
+        """# Sample Markdown file
+          |```java test
+          |//> using test.dep junit:junit:4.13.2
+          |//> using test.dep com.novocode:junit-interface:0.11
+          |import org.junit.Test;
+          |import static org.junit.Assert.assertEquals;
+          |
+          |public class ExampleTest {
+          |  @Test public void foo() { assertEquals(4, 2 + 2); }
+          |}
+          |```""".stripMargin
+    ).fromRoot { root =>
+      val result = os.proc(TestUtil.cli, "test", "sample.md").call(cwd = root)
+      val output = result.out.text()
+      expect(output.contains("ExampleTest"))
+      expect(output.contains("foo"))
+      expect(output.contains("0 failed"))
+    }
+  }
+
+  test("run a .md file with an ignored java snippet") {
+    val expectedOutput = "Hello"
+    TestInputs(
+      os.rel / "sample.md" ->
+        s"""# Sample Markdown file
+           |```java ignore
+           |public class Ignored {
+           |  public static void main(String[] args) {
+           |    System.out.println("ignored");
+           |  }
+           |}
+           |```
+           |
+           |```scala
+           |println("$expectedOutput")
+           |```
+           |""".stripMargin
+    ).fromRoot { root =>
+      val result = os.proc(TestUtil.cli, "sample.md").call(cwd = root)
+      expect(result.out.trim() == expectedOutput)
+    }
+  }
+
   test("source file name start with a number") {
     val fileNameWithNumber = "01-intro.md"
     TestInputs(

--- a/modules/integration/src/test/scala/scala/cli/integration/RunSnippetTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunSnippetTestDefinitions.scala
@@ -75,6 +75,32 @@ trait RunSnippetTestDefinitions { this: RunTestDefinitions =>
     }
   }
 
+  test("correctly run a markdown snippet with a java code block") {
+    emptyInputs.fromRoot { root =>
+      val msg       = "Hello world"
+      val quotation = TestUtil.argQuotationMark
+      val res       =
+        os.proc(
+          TestUtil.cli,
+          "--power",
+          "run",
+          "--markdown-snippet",
+          s"""# A Markdown snippet
+             |With some Java code
+             |```java
+             |public class Main {
+             |  public static void main(String[] args) {
+             |    System.out.println($quotation$msg$quotation);
+             |  }
+             |}
+             |```""".stripMargin,
+          extraOptions
+        )
+          .call(cwd = root)
+      expect(res.out.trim() == msg)
+    }
+  }
+
   test("correctly run multiple snippets") {
     emptyInputs.fromRoot { root =>
       val quotation = TestUtil.argQuotationMark

--- a/website/docs/guides/power/markdown.md
+++ b/website/docs/guides/power/markdown.md
@@ -262,6 +262,70 @@ Hello from Markdown
 
 </ChainedSnippets>
 
+### `java` snippets
+
+You can include Java code in Markdown with `java` code blocks. They are treated as `.java` inputs: the snippet body is
+emitted as Java source without any script-like wrapping.).
+
+````markdown title=JavaExample.md
+# Java snippet
+
+```java compile
+public class Main {
+  public static void main(String[] args) {
+    System.out.println("Hello from Java");
+  }
+}
+```
+````
+
+<ChainedSnippets>
+
+```bash
+scala-cli --power JavaExample.md
+```
+
+```text
+Hello from Java
+```
+
+</ChainedSnippets>
+
+You can combine `java` snippets with `scala` snippets in the same Markdown file. Scala snippets can reference classes
+from Java snippets in the same project.
+
+### `java test` snippets
+
+Java test snippets are marked with `java test`. They are emitted into the test scope, similarly to `scala test`
+snippets and `.test.java` files.
+
+````markdown title=JavaTestExample.md
+# Java test snippet
+
+```java test
+//> using test.dep junit:junit:4.13.2
+//> using test.dep com.novocode:junit-interface:0.11
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class ExampleTest {
+  @Test public void foo() { assertEquals(4, 2 + 2); }
+}
+```
+````
+
+<ChainedSnippets>
+
+```bash
+scala-cli --power test JavaTestExample.md
+```
+
+</ChainedSnippets>
+
+### `java ignore` snippets
+
+Java snippets can be skipped with the `ignore` keyword, similarly to `scala ignore`.
+
 ### `scala test` snippets
 
 It is possible to run tests from `scala` code blocks marked as `test`. This is similar to `raw` snippets in that the


### PR DESCRIPTION
Closes https://github.com/VirtusLab/scala-cli/issues/1602
Closes https://github.com/VirtusLab/scala-cli/issues/1601

Rather than the `scala` and `scala raw` snippets we have for Scala in Markdown (which mirror `.sc` and `.scala` inputs, respectively), I believe we'll just have `java` snippets for `.java` inputs. This is due to wrapping script-like Java snippets being difficult, due to how imports and other syntax is handled. We could simply wrap code in a main method, but that seems too limiting in comparison to what we have in Scala.

Perhaps we could have `jshell` snippets and/or `.jsh` input support at some point, as that would deliver some of what we could possibly want from Java scripts... Eespecially as we now have JShell support in the REPL. But that is definitely out of scope here (and I'm not sure how feasible, either).

And so, this change allows for markdown inputs like this:

````markdown
## Some Markdown Stuff
blah blah Java snippet
```java
public class Snippet {
  public static void main(String[] args) {
    System.out.println("Hello");
  }
}
```
````

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)
- ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
Extensively, Cursor + Claude

## How was the solution tested?
new automated tests