### PR TITLE
[chore] Upgrade Scala Native to 0.5.12

### DIFF
--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -126,7 +126,7 @@ object Deps {
     def scalaMeta                         = "4.15.2"
     def scalafmt                          = "3.11.1"
     def scalaNative04                     = "0.4.17"
-    def scalaNative05                     = "0.5.11"
+    def scalaNative05                     = "0.5.12"
     def scalaNative                       = scalaNative05
     def maxScalaNativeForToolkit          = scalaNative05
     def maxScalaNativeForTypelevelToolkit = scalaNative05

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1437,7 +1437,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 ### `--native-version`
 
-Set the Scala Native version (0.5.11 by default).
+Set the Scala Native version (0.5.12 by default).
 
 ### `--native-mode`
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -553,7 +553,7 @@ Add Scala Native options
 
 `//> using nativeLto full`
 
-`//> using nativeVersion 0.5.11`
+`//> using nativeVersion 0.5.12`
 
 `//> using nativeCompile -flto=thin`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -932,7 +932,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 `SHOULD have` per Scala Runner specification
 
-Set the Scala Native version (0.5.11 by default).
+Set the Scala Native version (0.5.12 by default).
 
 ### `--native-mode`
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -350,7 +350,7 @@ Add Scala Native options
 
 `//> using nativeLto full`
 
-`//> using nativeVersion 0.5.11`
+`//> using nativeVersion 0.5.12`
 
 `//> using nativeCompile -flto=thin`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -178,7 +178,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.11 by default).
+Set the Scala Native version (0.5.12 by default).
 
 **--native-mode**
 
@@ -999,7 +999,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.11 by default).
+Set the Scala Native version (0.5.12 by default).
 
 **--native-mode**
 
@@ -1618,7 +1618,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.11 by default).
+Set the Scala Native version (0.5.12 by default).
 
 **--native-mode**
 
@@ -2273,7 +2273,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.11 by default).
+Set the Scala Native version (0.5.12 by default).
 
 **--native-mode**
 
@@ -2937,7 +2937,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.11 by default).
+Set the Scala Native version (0.5.12 by default).
 
 **--native-mode**
 
@@ -3577,7 +3577,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.11 by default).
+Set the Scala Native version (0.5.12 by default).
 
 **--native-mode**
 
@@ -4254,7 +4254,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.11 by default).
+Set the Scala Native version (0.5.12 by default).
 
 **--native-mode**
 
@@ -4991,7 +4991,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.11 by default).
+Set the Scala Native version (0.5.12 by default).
 
 **--native-mode**
 
@@ -5984,7 +5984,7 @@ Enable Scala Native. To show more options for Scala Native pass `--help-native`
 
 **--native-version**
 
-Set the Scala Native version (0.5.11 by default).
+Set the Scala Native version (0.5.12 by default).
 
 **--native-mode**
 


### PR DESCRIPTION
Upgrades default Scala Native verison to 0.5.12 (https://github.com/scala-native/scala-native/releases/tag/v0.5.12)