### PR TITLE
Bump `scalafmt` to 3.11.1 (was 3.11.0)

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.11.0"
+version = "3.11.1"
 
 align.preset = more
 maxColumn = 100

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -124,7 +124,7 @@ object Deps {
     def jsoniterScala                     = "2.38.8"
     def jsoup                             = "1.22.1"
     def scalaMeta                         = "4.15.2"
-    def scalafmt                          = "3.11.0"
+    def scalafmt                          = "3.11.1"
     def scalaNative04                     = "0.4.17"
     def scalaNative05                     = "0.5.11"
     def scalaNative                       = scalaNative05

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -505,7 +505,7 @@ Pass a global dialect for scalafmt. This overrides whatever value is configured 
 
 Aliases: `--fmt-version`
 
-Pass scalafmt version before running it (3.11.0 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
+Pass scalafmt version before running it (3.11.1 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
 
 ## Global suppress warning options
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -390,7 +390,7 @@ Aliases: `--fmt-version`
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Pass scalafmt version before running it (3.11.0 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
+Pass scalafmt version before running it (3.11.1 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
 
 ## Global suppress warning options
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -4105,7 +4105,7 @@ Aliases: `--dialect`
 
 **--scalafmt-version**
 
-Pass scalafmt version before running it (3.11.0 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
+Pass scalafmt version before running it (3.11.1 by default). If passed, this overrides whatever value is configured in the .scalafmt.conf file.
 
 Aliases: `--fmt-version`
 


### PR DESCRIPTION
https://github.com/scalameta/scalafmt/releases/tag/v3.11.1

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
none

## How was the solution tested?
existing tests