### PR TITLE
[WIP] Respect Coursier cache override for Scala CLI local repo

### DIFF
--- a/modules/build/src/main/scala/scala/build/LocalRepo.scala
+++ b/modules/build/src/main/scala/scala/build/LocalRepo.scala
@@ -1,5 +1,7 @@
 package scala.build
+import coursier.cache.FileCache
 import coursier.paths.Util
+import coursier.util.Task
 
 import java.io.{BufferedInputStream, Closeable}
 import java.nio.channels.{FileChannel, FileLock}
@@ -11,6 +13,9 @@ import scala.build.internal.zip.WrappedZipInputStream
 object LocalRepo {
 
   private def resourcePath = Constants.localRepoResourcePath
+
+  private[build] def localRepoBaseDir(cache: FileCache[Task]): os.Path =
+    os.Path(cache.location, os.pwd) / "scalacli-local-repo"
 
   private def using[S <: Closeable, T](is: => S)(f: S => T): T = {
     var is0 = Option.empty[S]
@@ -51,10 +56,11 @@ object LocalRepo {
   }
 
   def localRepo(
-    baseDir: os.Path,
+    cache: FileCache[Task],
     logger: Logger,
     loader: ClassLoader = Thread.currentThread().getContextClassLoader
   ): Option[String] = {
+    val baseDir    = localRepoBaseDir(cache)
     val archiveUrl = loader.getResource(resourcePath)
     logger.debug(s"archive url: $archiveUrl")
 

--- a/modules/build/src/test/scala/scala/build/tests/ActionableDiagnosticTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ActionableDiagnosticTests.scala
@@ -16,16 +16,18 @@ import scala.build.Position.File
 import scala.build.actionable.ActionableDiagnostic.*
 import scala.build.actionable.ActionablePreprocessor
 import scala.build.options.{BuildOptions, InternalOptions, SuppressWarningOptions}
-import scala.build.{BuildThreads, Directories, LocalRepo}
+import scala.build.{BuildThreads, LocalRepo}
 import scala.jdk.CollectionConverters.*
 
 class ActionableDiagnosticTests extends TestUtil.ScalaCliBuildSuite {
 
-  val extraRepoTmpDir: os.Path = os.temp.dir(prefix = "scala-cli-tests-actionable-diagnostic-")
-  val directories: Directories = Directories.under(extraRepoTmpDir)
-  val baseOptions              = BuildOptions(
+  val extraRepoTmpDir: os.Path   = os.temp.dir(prefix = "scala-cli-tests-actionable-diagnostic-")
+  val testCache: FileCache[Task] =
+    FileCache().withLocation((extraRepoTmpDir / "cache").toIO)
+  val baseOptions = BuildOptions(
     internal = InternalOptions(
-      localRepository = LocalRepo.localRepo(directories.localRepoDir, TestLogger())
+      cache = Some(testCache),
+      localRepository = LocalRepo.localRepo(testCache, TestLogger())
     )
   )
   val buildThreads: BuildThreads = BuildThreads.create()

--- a/modules/build/src/test/scala/scala/build/tests/BspServerTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BspServerTests.scala
@@ -1,6 +1,8 @@
 package scala.build.tests
 
 import com.eed3si9n.expecty.Expecty.expect
+import coursier.cache.FileCache
+import coursier.util.Task
 
 import java.util.concurrent.TimeUnit
 
@@ -14,16 +16,18 @@ import scala.build.bsp.{
   WrappedSourcesResult
 }
 import scala.build.options.{BuildOptions, InternalOptions, Scope}
-import scala.build.{Build, BuildThreads, Directories, GeneratedSource, LocalRepo}
+import scala.build.{Build, BuildThreads, GeneratedSource, LocalRepo}
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters.*
 
 class BspServerTests extends TestUtil.ScalaCliBuildSuite {
-  val extraRepoTmpDir: os.Path = os.temp.dir(prefix = "scala-cli-tests-bsp-server-")
-  val directories: Directories = Directories.under(extraRepoTmpDir)
-  val baseOptions              = BuildOptions(
+  val extraRepoTmpDir: os.Path   = os.temp.dir(prefix = "scala-cli-tests-bsp-server-")
+  val testCache: FileCache[Task] =
+    FileCache().withLocation((extraRepoTmpDir / "cache").toIO)
+  val baseOptions = BuildOptions(
     internal = InternalOptions(
-      localRepository = LocalRepo.localRepo(directories.localRepoDir, TestLogger())
+      cache = Some(testCache),
+      localRepository = LocalRepo.localRepo(testCache, TestLogger())
     )
   )
   val buildThreads: BuildThreads = BuildThreads.create()

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -4,6 +4,7 @@ import com.eed3si9n.expecty.Expecty.assert as expect
 import coursier.Repositories
 import coursier.cache.FileCache
 import coursier.maven.MavenRepository
+import coursier.util.Task
 import coursier.version.Version
 import dependency.ScalaParameters
 
@@ -18,17 +19,19 @@ import scala.build.internal.Constants.*
 import scala.build.internal.Regexes.{scala2NightlyRegex, scala3LtsRegex}
 import scala.build.options.*
 import scala.build.tests.util.BloopServer
-import scala.build.{Build, BuildThreads, Directories, LocalRepo, Positioned, RepositoryUtils}
+import scala.build.{Build, BuildThreads, LocalRepo, Positioned, RepositoryUtils}
 import scala.concurrent.duration.DurationInt
 
 class BuildOptionsTests extends TestUtil.ScalaCliBuildSuite {
   override def munitFlakyOK: Boolean = TestUtil.isCI
   val extraRepoTmpDir: os.Path       = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
-  val directories: Directories       = Directories.under(extraRepoTmpDir)
-  val buildThreads: BuildThreads     = BuildThreads.create()
-  val baseOptions                    = BuildOptions(
+  val testCache: FileCache[Task]     =
+    FileCache().withLocation((extraRepoTmpDir / "cache").toIO)
+  val buildThreads: BuildThreads = BuildThreads.create()
+  val baseOptions                = BuildOptions(
     internal = InternalOptions(
-      localRepository = LocalRepo.localRepo(directories.localRepoDir, TestLogger()),
+      cache = Some(testCache),
+      localRepository = LocalRepo.localRepo(testCache, TestLogger()),
       keepDiagnostics = true
     )
   )
@@ -374,7 +377,8 @@ class BuildOptionsTests extends TestUtil.ScalaCliBuildSuite {
   test("User scalac options shadow internal ones") {
     val defaultOptions = BuildOptions(
       internal = InternalOptions(
-        localRepository = LocalRepo.localRepo(directories.localRepoDir, TestLogger())
+        cache = Some(testCache),
+        localRepository = LocalRepo.localRepo(testCache, TestLogger())
       )
     )
 

--- a/modules/build/src/test/scala/scala/build/tests/BuildProjectTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildProjectTests.scala
@@ -2,7 +2,7 @@ package scala.build.tests
 
 import bloop.rifle.BloopRifleLogger
 import com.eed3si9n.expecty.Expecty.expect
-import coursier.cache.CacheLogger
+import coursier.cache.{CacheLogger, FileCache}
 import org.scalajs.logging.{Logger as ScalaJsLogger, NullLogger}
 
 import java.io.PrintStream
@@ -61,13 +61,22 @@ class BuildProjectTests extends TestUtil.ScalaCliBuildSuite {
   }
 
   test("workspace for bsp") {
-    val options = BuildOptions(
-      internal = InternalOptions(localRepository =
-        LocalRepo.localRepo(scala.build.Directories.default().localRepoDir, TestLogger())
+    val cacheDir  = os.temp.dir(prefix = "scala-cli-tests-build-project-")
+    val testCache = FileCache().withLocation(cacheDir.toIO)
+    val options   = BuildOptions(
+      internal = InternalOptions(
+        cache = Some(testCache),
+        localRepository = LocalRepo.localRepo(testCache, TestLogger())
       )
     )
-    val inputs    = Inputs.empty("project")
-    val sources   = Sources(Nil, Nil, None, Nil, options)
+    val inputs  = Inputs.empty("project")
+    val sources = Sources(
+      paths = Nil,
+      inMemory = Nil,
+      defaultMainClass = None,
+      resourceDirs = Nil,
+      buildOptions = options
+    )
     val logger    = new LoggerMock()
     val artifacts = options.artifacts(logger, Scope.Test).orThrow
 

--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -5,6 +5,8 @@ import bloop.rifle.BloopRifleConfig
 import ch.epfl.scala.bsp4j
 import com.eed3si9n.expecty.Expecty.expect
 import com.google.gson.Gson
+import coursier.cache.FileCache
+import coursier.util.Task
 import dependency.parser.DependencyParser
 
 import java.io.IOException
@@ -19,7 +21,7 @@ import scala.build.options.*
 import scala.build.tastylib.TastyData
 import scala.build.tests.TestUtil.*
 import scala.build.tests.util.BloopServer
-import scala.build.{Build, BuildThreads, Directories, LocalRepo, Positioned}
+import scala.build.{Build, BuildThreads, LocalRepo, Positioned}
 import scala.jdk.CollectionConverters.*
 import scala.meta.internal.semanticdb.TextDocuments
 import scala.util.Properties
@@ -31,8 +33,9 @@ abstract class BuildTests(server: Boolean) extends TestUtil.ScalaCliBuildSuite {
   def bloopConfigOpt: Option[BloopRifleConfig] =
     if server then Some(BloopServer.bloopConfig) else None
 
-  val extraRepoTmpDir: os.Path = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
-  val directories: Directories = Directories.under(extraRepoTmpDir)
+  val extraRepoTmpDir: os.Path   = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
+  val testCache: FileCache[Task] =
+    FileCache().withLocation((extraRepoTmpDir / "cache").toIO)
 
   override def afterAll(): Unit = {
     TestInputs.tryRemoveAll(extraRepoTmpDir)
@@ -41,7 +44,8 @@ abstract class BuildTests(server: Boolean) extends TestUtil.ScalaCliBuildSuite {
 
   val baseOptions = BuildOptions(
     internal = InternalOptions(
-      localRepository = LocalRepo.localRepo(directories.localRepoDir, TestLogger()),
+      cache = Some(testCache),
+      localRepository = LocalRepo.localRepo(testCache, TestLogger()),
       keepDiagnostics = true
     )
   )

--- a/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
@@ -2,6 +2,8 @@ package scala.build.tests
 
 import bloop.rifle.BloopRifleConfig
 import com.eed3si9n.expecty.Expecty.expect
+import coursier.cache.FileCache
+import coursier.util.Task
 
 import scala.build.Ops.EitherThrowOps
 import scala.build.errors.{
@@ -19,13 +21,14 @@ import scala.build.options.{
   Scope
 }
 import scala.build.tests.util.BloopServer
-import scala.build.{Build, BuildThreads, Directories, LocalRepo, Position, Positioned}
+import scala.build.{Build, BuildThreads, LocalRepo, Position, Positioned}
 
 class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
   val buildThreads: BuildThreads               = BuildThreads.create()
   def bloopConfigOpt: Option[BloopRifleConfig] = Some(BloopServer.bloopConfig)
   val extraRepoTmpDir: os.Path                 = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
-  val directories: Directories                 = Directories.under(extraRepoTmpDir)
+  val testCache: FileCache[Task]               =
+    FileCache().withLocation((extraRepoTmpDir / "cache").toIO)
 
   override def afterAll(): Unit = {
     TestInputs.tryRemoveAll(extraRepoTmpDir)
@@ -34,7 +37,8 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
 
   val baseOptions = BuildOptions(
     internal = InternalOptions(
-      localRepository = LocalRepo.localRepo(directories.localRepoDir, TestLogger()),
+      cache = Some(testCache),
+      localRepository = LocalRepo.localRepo(testCache, TestLogger()),
       keepDiagnostics = true
     )
   )

--- a/modules/build/src/test/scala/scala/build/tests/InputsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/InputsTests.scala
@@ -2,22 +2,26 @@ package scala.build.tests
 
 import bloop.rifle.BloopRifleConfig
 import com.eed3si9n.expecty.Expecty.expect
+import coursier.cache.FileCache
+import coursier.util.Task
 
 import scala.build.input.*
 import scala.build.input.ElementsUtils.*
 import scala.build.internal.Constants
 import scala.build.options.{BuildOptions, InternalOptions}
 import scala.build.tests.util.BloopServer
-import scala.build.{Build, BuildThreads, Directories, LocalRepo}
+import scala.build.{Build, BuildThreads, LocalRepo}
 
 class InputsTests extends TestUtil.ScalaCliBuildSuite {
-  val buildThreads: BuildThreads               = BuildThreads.create()
-  val extraRepoTmpDir: os.Path                 = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
-  val directories: Directories                 = Directories.under(extraRepoTmpDir)
+  val buildThreads: BuildThreads = BuildThreads.create()
+  val extraRepoTmpDir: os.Path   = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
+  val testCache: FileCache[Task] =
+    FileCache().withLocation((extraRepoTmpDir / "cache").toIO)
   def bloopConfigOpt: Option[BloopRifleConfig] = Some(BloopServer.bloopConfig)
   val buildOptions: BuildOptions               = BuildOptions(
     internal = InternalOptions(
-      localRepository = LocalRepo.localRepo(directories.localRepoDir, TestLogger()),
+      cache = Some(testCache),
+      localRepository = LocalRepo.localRepo(testCache, TestLogger()),
       keepDiagnostics = true
     )
   )

--- a/modules/build/src/test/scala/scala/build/tests/LocalRepoTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/LocalRepoTests.scala
@@ -1,0 +1,13 @@
+package scala.build.tests
+
+import coursier.cache.FileCache
+
+import scala.build.LocalRepo
+
+class LocalRepoTests extends TestUtil.ScalaCliBuildSuite {
+  test("localRepoBaseDir is anchored to the coursier cache location") {
+    val cacheDir = os.temp.dir(prefix = "scala-cli-cache-")
+    val cache    = FileCache().withLocation(cacheDir.toIO)
+    assertEquals(LocalRepo.localRepoBaseDir(cache), cacheDir / "scalacli-local-repo")
+  }
+}

--- a/modules/build/src/test/scala/scala/build/tests/PackagingUsingDirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/PackagingUsingDirectiveTests.scala
@@ -2,21 +2,25 @@ package scala.build.tests
 
 import bloop.rifle.BloopRifleConfig
 import com.eed3si9n.expecty.Expecty.expect
+import coursier.cache.FileCache
+import coursier.util.Task
 
 import scala.build.options.{BuildOptions, InternalOptions, PackageType}
 import scala.build.tests.util.BloopServer
-import scala.build.{BuildThreads, Directories, LocalRepo}
+import scala.build.{BuildThreads, LocalRepo}
 
 class PackagingUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
   val buildThreads: BuildThreads            = BuildThreads.create()
   def bloopConfig: Option[BloopRifleConfig] = Some(BloopServer.bloopConfig)
 
-  val extraRepoTmpDir: os.Path = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
-  val directories: Directories = Directories.under(extraRepoTmpDir)
+  val extraRepoTmpDir: os.Path   = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
+  val testCache: FileCache[Task] =
+    FileCache().withLocation((extraRepoTmpDir / "cache").toIO)
 
   val buildOptions = BuildOptions(
     internal = InternalOptions(
-      localRepository = LocalRepo.localRepo(directories.localRepoDir, TestLogger()),
+      cache = Some(testCache),
+      localRepository = LocalRepo.localRepo(testCache, TestLogger()),
       keepDiagnostics = true
     )
   )

--- a/modules/build/src/test/scala/scala/build/tests/ScalaNativeUsingDirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ScalaNativeUsingDirectiveTests.scala
@@ -2,22 +2,26 @@ package scala.build.tests
 
 import bloop.rifle.BloopRifleConfig
 import com.eed3si9n.expecty.Expecty.expect
+import coursier.cache.FileCache
+import coursier.util.Task
 
 import scala.build.errors.UsingDirectiveValueNumError
 import scala.build.options.{BuildOptions, InternalOptions}
 import scala.build.tests.util.BloopServer
-import scala.build.{BuildThreads, Directories, LocalRepo}
+import scala.build.{BuildThreads, LocalRepo}
 
 class ScalaNativeUsingDirectiveTests extends TestUtil.ScalaCliBuildSuite {
   val buildThreads: BuildThreads            = BuildThreads.create()
   def bloopConfig: Option[BloopRifleConfig] = Some(BloopServer.bloopConfig)
 
-  val extraRepoTmpDir: os.Path = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
-  val directories: Directories = Directories.under(extraRepoTmpDir)
+  val extraRepoTmpDir: os.Path   = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
+  val testCache: FileCache[Task] =
+    FileCache().withLocation((extraRepoTmpDir / "cache").toIO)
 
   val buildOptions = BuildOptions(
     internal = InternalOptions(
-      localRepository = LocalRepo.localRepo(directories.localRepoDir, TestLogger()),
+      cache = Some(testCache),
+      localRepository = LocalRepo.localRepo(testCache, TestLogger()),
       keepDiagnostics = true
     )
   )

--- a/modules/build/src/test/scala/scala/build/tests/ScriptWrapperTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ScriptWrapperTests.scala
@@ -2,6 +2,8 @@ package scala.build.tests
 
 import bloop.rifle.BloopRifleConfig
 import com.eed3si9n.expecty.Expecty.expect
+import coursier.cache.FileCache
+import coursier.util.Task
 
 import scala.build.Ops.EitherThrowOps
 import scala.build.options.{
@@ -13,7 +15,7 @@ import scala.build.options.{
   ScriptOptions
 }
 import scala.build.tests.util.BloopServer
-import scala.build.{Build, BuildThreads, Directories, LocalRepo, Position, Positioned}
+import scala.build.{Build, BuildThreads, LocalRepo, Position, Positioned}
 
 class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
 
@@ -59,8 +61,9 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
   val buildThreads: BuildThreads               = BuildThreads.create()
   def bloopConfigOpt: Option[BloopRifleConfig] = Some(BloopServer.bloopConfig)
 
-  val extraRepoTmpDir: os.Path = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
-  val directories: Directories = Directories.under(extraRepoTmpDir)
+  val extraRepoTmpDir: os.Path   = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
+  val testCache: FileCache[Task] =
+    FileCache().withLocation((extraRepoTmpDir / "cache").toIO)
 
   override def afterAll(): Unit = {
     TestInputs.tryRemoveAll(extraRepoTmpDir)
@@ -69,7 +72,8 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
 
   val baseOptions = BuildOptions(
     internal = InternalOptions(
-      localRepository = LocalRepo.localRepo(directories.localRepoDir, TestLogger()),
+      cache = Some(testCache),
+      localRepository = LocalRepo.localRepo(testCache, TestLogger()),
       keepDiagnostics = true
     )
   )

--- a/modules/build/src/test/scala/scala/build/tests/SourceGeneratorTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/SourceGeneratorTests.scala
@@ -1,12 +1,14 @@
 package scala.build.tests
 
 import com.eed3si9n.expecty.Expecty.expect
+import coursier.cache.FileCache
+import coursier.util.Task
 
 import scala.Console.println
 import scala.build.Ops.EitherThrowOps
 import scala.build.options.{BuildOptions, InternalOptions}
 import scala.build.tests.util.BloopServer
-import scala.build.{Build, BuildThreads, Directories, LocalRepo}
+import scala.build.{Build, BuildThreads, LocalRepo}
 
 class SourceGeneratorTests extends TestUtil.ScalaCliBuildSuite {
 
@@ -14,8 +16,9 @@ class SourceGeneratorTests extends TestUtil.ScalaCliBuildSuite {
 
   def bloopConfigOpt = Some(BloopServer.bloopConfig)
 
-  val extraRepoTmpDir = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
-  val directories     = Directories.under(extraRepoTmpDir)
+  val extraRepoTmpDir            = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
+  val testCache: FileCache[Task] =
+    FileCache().withLocation((extraRepoTmpDir / "cache").toIO)
 
   override def afterAll(): Unit = {
     TestInputs.tryRemoveAll(extraRepoTmpDir)
@@ -24,7 +27,8 @@ class SourceGeneratorTests extends TestUtil.ScalaCliBuildSuite {
 
   val baseOptions = BuildOptions(
     internal = InternalOptions(
-      localRepository = LocalRepo.localRepo(directories.localRepoDir, TestLogger()),
+      cache = Some(testCache),
+      localRepository = LocalRepo.localRepo(testCache, TestLogger()),
       keepDiagnostics = true
     )
   )

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -457,7 +457,7 @@ final case class SharedOptions(
         ),
         internal = scala.build.options.InternalOptions(
           cache = Some(coursierCache),
-          localRepository = LocalRepo.localRepo(Directories.directories.localRepoDir, logger),
+          localRepository = LocalRepo.localRepo(coursierCache, logger),
           verbosity = Some(logging.verbosity),
           strictBloopJsonCheck = strictBloopJsonCheck,
           interactive = Some(() => interactive),

--- a/modules/cli/src/test/scala/cli/tests/CachedBinaryTests.scala
+++ b/modules/cli/src/test/scala/cli/tests/CachedBinaryTests.scala
@@ -3,12 +3,14 @@ package scala.cli.tests
 import bloop.rifle.BloopRifleConfig
 import cli.tests.TestUtil
 import com.eed3si9n.expecty.Expecty.assert as expect
+import coursier.cache.FileCache
+import coursier.util.Task
 import os.Path
 
 import scala.build.options.{BuildOptions, InternalOptions}
 import scala.build.tests.util.BloopServer
 import scala.build.tests.{TestInputs, TestLogger}
-import scala.build.{Build, BuildThreads, Directories, LocalRepo}
+import scala.build.{Build, BuildThreads, LocalRepo}
 import scala.cli.internal.CachedBinary
 import scala.util.{Properties, Random}
 
@@ -31,12 +33,14 @@ class CachedBinaryTests extends TestUtil.ScalaCliSuite {
          |""".stripMargin
   )
 
-  val extraRepoTmpDir: Path    = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
-  val directories: Directories = Directories.under(extraRepoTmpDir)
+  val extraRepoTmpDir: Path      = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
+  val testCache: FileCache[Task] =
+    FileCache().withLocation((extraRepoTmpDir / "cache").toIO)
 
   val defaultOptions: BuildOptions = BuildOptions(
     internal = InternalOptions(
-      localRepository = LocalRepo.localRepo(directories.localRepoDir, TestLogger())
+      cache = Some(testCache),
+      localRepository = LocalRepo.localRepo(testCache, TestLogger())
     )
   )
 

--- a/modules/cli/src/test/scala/cli/tests/PackageTests.scala
+++ b/modules/cli/src/test/scala/cli/tests/PackageTests.scala
@@ -2,6 +2,8 @@ package cli.tests
 
 import bloop.rifle.BloopRifleConfig
 import com.eed3si9n.expecty.Expecty.expect
+import coursier.cache.FileCache
+import coursier.util.Task
 
 import java.nio.file.FileSystems
 
@@ -9,7 +11,7 @@ import scala.build.Ops.*
 import scala.build.options.{BuildOptions, InternalOptions, PackageType}
 import scala.build.tests.util.BloopServer
 import scala.build.tests.{TestInputs, TestLogger}
-import scala.build.{BuildThreads, Directories, LocalRepo}
+import scala.build.{BuildThreads, LocalRepo}
 import scala.cli.commands.package0.Package
 import scala.cli.packaging.Library
 
@@ -17,12 +19,14 @@ class PackageTests extends TestUtil.ScalaCliSuite {
   val buildThreads: BuildThreads    = BuildThreads.create()
   def bloopConfig: BloopRifleConfig = BloopServer.bloopConfig
 
-  val extraRepoTmpDir: os.Path = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
-  val directories: Directories = Directories.under(extraRepoTmpDir)
+  val extraRepoTmpDir: os.Path   = os.temp.dir(prefix = "scala-cli-tests-extra-repo-")
+  val testCache: FileCache[Task] =
+    FileCache().withLocation((extraRepoTmpDir / "cache").toIO)
 
   val defaultOptions = BuildOptions(
     internal = InternalOptions(
-      localRepository = LocalRepo.localRepo(directories.localRepoDir, TestLogger())
+      cache = Some(testCache),
+      localRepository = LocalRepo.localRepo(testCache, TestLogger())
     )
   )
 

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -2558,4 +2558,34 @@ abstract class RunTestDefinitions
       expect(output == message)
     }
   }
+
+  private def cacheRedirectsLocalRepoTest(modeArgs: Seq[String], cacheSuffix: String): Unit =
+    TestInputs(os.rel / "simple.sc" -> """println("ok")""").fromRoot { root =>
+      val cacheDir     = root / s"custom-cache-$cacheSuffix"
+      val isolatedHome = root / s"scala-cli-home-$cacheSuffix"
+      os.makeDir.all(isolatedHome)
+      val env = Map("SCALA_CLI_HOME" -> isolatedHome.toString)
+      os.proc(
+        TestUtil.cli,
+        "run",
+        "simple.sc",
+        modeArgs,
+        "--cache",
+        cacheDir.toString,
+        extraOptions
+      ).call(cwd = root, env = env)
+
+      val localRepoUnderCache = cacheDir / "scalacli-local-repo"
+      expect(os.exists(localRepoUnderCache))
+      expect(os.list(localRepoUnderCache).nonEmpty)
+
+      val localRepoUnderHome = isolatedHome / "cache" / "local-repo"
+      expect(!os.exists(localRepoUnderHome) || os.list(localRepoUnderHome).isEmpty)
+    }
+
+  test("--cache redirects local-repo extraction (issue #3523)") {
+    for (modeArgs, cacheSuffix) <-
+        Seq((Nil, "bloop"), (Seq("--server=false"), "no-server"))
+    do cacheRedirectsLocalRepoTest(modeArgs, cacheSuffix)
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/3523

## Checklist
- [ ] tested the solution locally and it works 
- [ ] ran the code formatter (`scala-cli fmt .`)
- [ ] ran `scalafix` (`./mill -i __.fix`)
- [ ] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Cursor + Claude

## How was the solution tested?
added new automated tests