### PR TITLE
Bump misc deps

### DIFF
--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -122,7 +122,7 @@ object Deps {
     def coursierPublish                   = "0.4.4"
     def jmh                               = "1.37"
     def jsoniterScala                     = "2.38.8"
-    def jsoup                             = "1.22.1"
+    def jsoup                             = "1.22.2"
     def scalaMeta                         = "4.15.2"
     def scalafmt                          = "3.11.1"
     def scalaNative04                     = "0.4.17"

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -180,7 +180,7 @@ object Deps {
   def expecty       = mvn"com.eed3si9n.expecty::expecty:0.17.1"
   def fansi         = mvn"com.lihaoyi::fansi:0.5.1"
   def giter8        = mvn"org.foundweekends.giter8:giter8:0.18.0"
-  def guava         = mvn"com.google.guava:guava:33.5.0-jre"
+  def guava         = mvn"com.google.guava:guava:33.6.0-jre"
   def javaClassName =
     mvn"org.virtuslab.scala-cli.java-class-name:java-class-name_3:${Versions.javaClassName}"
       .exclude(

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -206,7 +206,7 @@ object Deps {
   def nativeTestRunner   = mvn"org.scala-native::test-runner:${Versions.scalaNative}"
   def nativeTools        = mvn"org.scala-native::tools:${Versions.scalaNative}"
   def osLib              = mvn"com.lihaoyi::os-lib:0.11.8"
-  def pprint             = mvn"com.lihaoyi::pprint:0.9.5"
+  def pprint             = mvn"com.lihaoyi::pprint:0.9.6"
   def pythonInterface    = mvn"io.github.alexarchambault.python:interface:0.1.0"
   def pythonNativeLibs   = mvn"ai.kien::python-native-libs:0.2.5"
   def scalac(sv: String) = mvn"org.scala-lang:scala-compiler:$sv"

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -142,7 +142,7 @@ object Deps {
     def mill012Version                    = "0.12.17"
     def mill1Version                      = BuildInfo.millVersion
     def mavenVersion                      = "3.8.1"
-    def mavenScalaCompilerPluginVersion   = "4.9.1"
+    def mavenScalaCompilerPluginVersion   = "4.9.10"
     def mavenExecPluginVersion            = "3.3.0"
     def mavenAppArtifactId                = "maven-app"
     def mavenAppGroupId                   = "com.example"

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -123,7 +123,7 @@ object Deps {
     def jmh                               = "1.37"
     def jsoniterScala                     = "2.38.14"
     def jsoup                             = "1.22.2"
-    def scalaMeta                         = "4.15.2"
+    def scalaMeta                         = "4.17.0"
     def scalafmt                          = "3.11.1"
     def scalaNative04                     = "0.4.17"
     def scalaNative05                     = "0.5.12"

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -188,7 +188,7 @@ object Deps {
         "org.jline" -> "jline-terminal",
         "org.jline" -> "jline-terminal-jna"
       )
-  def jgit                 = mvn"org.eclipse.jgit:org.eclipse.jgit:7.5.0.202512021534-r"
+  def jgit                 = mvn"org.eclipse.jgit:org.eclipse.jgit:7.6.0.202603022253-r"
   def jimfs                = mvn"com.google.jimfs:jimfs:1.3.1"
   def jmhGeneratorBytecode = mvn"org.openjdk.jmh:jmh-generator-bytecode:${Versions.jmh}"
   def jmhCore              = mvn"org.openjdk.jmh:jmh-core:${Versions.jmh}"

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -138,7 +138,7 @@ object Deps {
     def javaSemanticdb                    = "0.12.3"
     def javaClassName                     = "0.1.9"
     def bloop                             = "2.1.0"
-    def sbtVersion                        = "1.12.4"
+    def sbtVersion                        = "1.12.5"
     def mill012Version                    = "0.12.17"
     def mill1Version                      = BuildInfo.millVersion
     def mavenVersion                      = "3.8.1"

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -202,7 +202,7 @@ object Deps {
   def metaconfigTypesafe =
     mvn"org.scalameta::metaconfig-typesafe-config:0.18.6"
       .exclude(("org.scala-lang", "scala-compiler"))
-  def munit              = mvn"org.scalameta::munit:1.2.2"
+  def munit              = mvn"org.scalameta::munit:1.3.0"
   def nativeTestRunner   = mvn"org.scala-native::test-runner:${Versions.scalaNative}"
   def nativeTools        = mvn"org.scala-native::tools:${Versions.scalaNative}"
   def osLib              = mvn"com.lihaoyi::os-lib:0.11.8"

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -147,7 +147,7 @@ object Deps {
     def mavenAppArtifactId                = "maven-app"
     def mavenAppGroupId                   = "com.example"
     def mavenAppVersion                   = "0.1-SNAPSHOT"
-    def scalafix                          = "0.14.5"
+    def scalafix                          = "0.14.6"
   }
 
   def argonautShapeless    =

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -152,7 +152,7 @@ object Deps {
 
   def argonautShapeless    =
     mvn"com.github.alexarchambault:argonaut-shapeless_6.3_2.13:${Versions.argonautShapeless}"
-  def asm = mvn"org.ow2.asm:asm:9.9.1"
+  def asm = mvn"org.ow2.asm:asm:9.10.1"
   // Force using of 2.13 - is there a better way?
   def bloopConfig = mvn"ch.epfl.scala:bloop-config_2.13:2.3.3"
     .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-core_2.13"))

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -121,7 +121,7 @@ object Deps {
     def coursierCli                       = coursierDefault
     def coursierPublish                   = "0.4.4"
     def jmh                               = "1.37"
-    def jsoniterScala                     = "2.38.8"
+    def jsoniterScala                     = "2.38.14"
     def jsoup                             = "1.22.2"
     def scalaMeta                         = "4.15.2"
     def scalafmt                          = "3.11.1"

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -135,7 +135,7 @@ object Deps {
     def scalaPackager                     = "0.2.1"
     def signingCli                        = "0.2.13"
     def signingCliJvmVersion              = Java.defaultJava
-    def javaSemanticdb                    = "0.10.0"
+    def javaSemanticdb                    = "0.12.3"
     def javaClassName                     = "0.1.9"
     def bloop                             = "2.1.0"
     def sbtVersion                        = "1.12.4"

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -200,7 +200,7 @@ object Deps {
   def jsoup              = mvn"org.jsoup:jsoup:${Versions.jsoup}"
   def libsodiumjni       = mvn"org.virtuslab.scala-cli:libsodiumjni:0.0.4"
   def metaconfigTypesafe =
-    mvn"org.scalameta::metaconfig-typesafe-config:0.18.2"
+    mvn"org.scalameta::metaconfig-typesafe-config:0.18.6"
       .exclude(("org.scala-lang", "scala-compiler"))
   def munit              = mvn"org.scalameta::munit:1.2.2"
   def nativeTestRunner   = mvn"org.scala-native::test-runner:${Versions.scalaNative}"

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -220,7 +220,7 @@ object Deps {
       .exclude("org.scala-js" -> "scalajs-env-nodejs_2.13")
       .exclude("org.scala-js" -> "scalajs-js-envs_2.13")
   // Force using of 2.13 - is there a better way?
-  def scalaJsEnvNodeJs = mvn"org.scala-js::scalajs-env-nodejs:1.5.0"
+  def scalaJsEnvNodeJs = mvn"org.scala-js::scalajs-env-nodejs:1.6.0"
   def scalaJsLogging   = mvn"org.scala-js::scalajs-logging:1.2.0"
   // Force using of 2.13 - is there a better way?
   def scalaJsTestAdapter = mvn"org.scala-js:scalajs-sbt-test-adapter_2.13:${Scala.scalaJs}"

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -132,7 +132,7 @@ object Deps {
     def maxScalaNativeForTypelevelToolkit = scalaNative05
     def maxScalaNativeForScalaPy          = scalaNative04
     def maxScalaNativeForMillExport       = scalaNative05
-    def scalaPackager                     = "0.2.1"
+    def scalaPackager                     = "0.2.2"
     def signingCli                        = "0.2.13"
     def signingCliJvmVersion              = Java.defaultJava
     def javaSemanticdb                    = "0.12.3"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -384,7 +384,7 @@ Project name to be used on Mill build file
 
 ### `--sbt-version`
 
-Version of SBT to be used for the export (1.12.4 by default)
+Version of SBT to be used for the export (1.12.5 by default)
 
 ### `--mill-version`
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -396,7 +396,7 @@ Version of Maven Compiler Plugin to be used for the export (3.8.1 by default)
 
 ### `--mvn-scala-version`
 
-Version of Maven Scala Plugin to be used for the export (4.9.1 by default)
+Version of Maven Scala Plugin to be used for the export (4.9.10 by default)
 
 ### `--mvn-exec-plugin-version`
 


### PR DESCRIPTION
For as long as `scala-steward` doesn't work, we've got to do those manually from time to time

- `jsoup` bump to 1.22.2 (was 1.22.1): https://github.com/jhy/jsoup/releases/tag/jsoup-1.22.2
- `jsoniter-scala` bump to 2.38.14 (was 2.38.8): https://github.com/plokhotnyuk/jsoniter-scala/releases/tag/v2.38.14
- `scalaMeta` bump to 4.17.0 (was 4.15.2): https://github.com/scalameta/scalameta/releases/tag/v4.17.0
- `asm` bump to 9.10.1 (was 9.9.1)
- `javaSemanticdb` bump to 0.12.3 (was 0.10.0)
- `scalafix` bump to 0.14.6 (was 0.14.5): https://github.com/scalacenter/scalafix/releases/tag/v0.14.6
- `guava` bump to 33.6.0-jre (was 33.5.0-jre): https://github.com/google/guava/releases/tag/v33.6.0
- `jgit` bump to 7.6.0.202603022253-r (was 7.5.0.202512021534-r)
- `scalaPackager` bump to 0.2.2 (was 0.2.1): https://github.com/VirtusLab/scala-packager/releases/tag/v0.2.2
- `metaconfig-typesafe-config` bump to 0.18.6 (was 0.18.2): https://github.com/scalameta/metaconfig/releases/tag/v0.18.6
- `scalajs-env-nodejs` bump to 1.6.0 (was 1.5.0): https://github.com/scala-js/scala-js/releases/tag/v1.6.0
- `pprint` bump to 0.9.6 (was 0.9.5): https://github.com/com-lihaoyi/pprint/releases/tag/0.9.6
- `sbt `bump to 1.12.5 (was 1.12.4): https://github.com/sbt/sbt/releases/tag/v1.12.5
- `mavenScalaCompilerPlugin` bump to 4.9.10 (was 4.9.1)
- `munit` bump to 1.3.0 (was 1.2.2): https://github.com/scalameta/munit/releases/tag/v1.3.0
  - skipping 1.3.1 because of https://github.com/scalameta/munit/issues/1093

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)
- ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
moderately, for automatically fetching versions per dep, running separate validations per dep and investigating deprecations/api migrations (there were none, Bloop is handled in a separate PR at https://github.com/VirtusLab/scala-cli/pull/4295)

## How was the solution tested?
existing tests

## Additional notes
- MUnit: skipping 1.3.1 because of https://github.com/scalameta/munit/issues/1093
- Bloop was bumped in https://github.com/VirtusLab/scala-cli/pull/4295