### PR TITLE
Add JUnit 5 / Jupiter support

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1095,6 +1095,7 @@ trait CliIntegration extends SbtModule
            |  def bloopVersion                 = "${Deps.bloopRifle.dep.versionConstraint.asString}"
            |  def pprintVersion                = "${TestDeps.pprint.dep.versionConstraint.asString}"
            |  def munitVersion                 = "${TestDeps.munit.dep.versionConstraint.asString}"
+           |  def jupiterInterfaceVersion      = "${Deps.jupiterInterface.dep.versionConstraint.asString}"
            |  def dockerTestImage              = "${Docker.testImage}"
            |  def dockerAlpineTestImage        = "${Docker.alpineTestImage}"
            |  def authProxyTestImage           = "${Docker.authProxyTestImage}"
@@ -1322,6 +1323,9 @@ trait TestRunner extends CrossSbtModule
     Deps.collectionCompat,
     Deps.testInterface
   )
+  override def compileMvnDeps: T[Seq[Dep]] = super.compileMvnDeps() ++ Seq(
+    Deps.jupiterInterface
+  )
   override def mainClass: T[Option[String]] = Some("scala.build.testrunner.DynamicTestRunner")
 }
 
@@ -1331,6 +1335,9 @@ trait JavaTestRunner extends JavaModule
   override def mvnDeps: T[Seq[Dep]] = super.mvnDeps() ++ Seq(
     Deps.asm,
     Deps.testInterface
+  )
+  override def compileMvnDeps: T[Seq[Dep]] = super.compileMvnDeps() ++ Seq(
+    Deps.jupiterInterface
   )
   override def mainClass: T[Option[String]] = Some("scala.build.testrunner.JavaDynamicTestRunner")
 }

--- a/modules/build/src/main/scala/scala/build/internal/Runner.scala
+++ b/modules/build/src/main/scala/scala/build/internal/Runner.scala
@@ -562,13 +562,10 @@ object Runner {
 
         val finalTestFrameworks =
           loadedFrameworks
-            // .filter(
-            //  _.name() != "Scala Native JUnit test framework" ||
-            //    !loadedFrameworks.exists(_.name() == "munit")
-            // )
-            // TODO: add support for JUnit and then only hardcode filtering it out when passed with munit
-            // https://github.com/VirtusLab/scala-cli/issues/3627
-            .filter(_.name() != "Scala Native JUnit test framework")
+            .filter(
+              !_.name().toLowerCase.contains("junit") ||
+              !loadedFrameworks.exists(_.name().toLowerCase.contains("munit"))
+            )
         if finalTestFrameworks.nonEmpty then
           logger.log(
             s"""Final list of test frameworks found:

--- a/modules/build/src/test/scala/scala/build/tests/FrameworkDiscoveryTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/FrameworkDiscoveryTests.scala
@@ -1,11 +1,100 @@
 package scala.build.tests
 
+import org.objectweb.asm.{ClassWriter, Opcodes}
+import sbt.testing.{AnnotatedFingerprint, Fingerprint}
+
+import java.io.ByteArrayInputStream
 import java.nio.file.Files
 
 import scala.build.errors.NoFrameworkFoundByNativeBridgeError
 import scala.build.testrunner.{AsmTestRunner, Logger as TestRunnerLogger}
 
 class FrameworkDiscoveryTests extends TestUtil.ScalaCliBuildSuite {
+
+  private val testAnnotation     = "my.Test"
+  private val testAnnotationDesc = s"L${testAnnotation.replace('.', '/')};"
+
+  private def annotatedFingerprint: AnnotatedFingerprint = new AnnotatedFingerprint {
+    override def annotationName(): String = testAnnotation
+    override def isModule(): Boolean      = false
+  }
+
+  private def matchAnnotated(
+    className: String,
+    bytes: Array[Byte]
+  ): Option[Fingerprint] = {
+    val parentInspector = new AsmTestRunner.ParentInspector(Seq.empty, TestRunnerLogger(0))
+    AsmTestRunner.matchFingerprints(
+      className,
+      () => new ByteArrayInputStream(bytes),
+      Seq(annotatedFingerprint),
+      parentInspector
+    )
+  }
+
+  private def writePublicInit(cw: ClassWriter): Unit = {
+    val init = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null)
+    init.visitCode()
+    init.visitVarInsn(Opcodes.ALOAD, 0)
+    init.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+    init.visitInsn(Opcodes.RETURN)
+    init.visitMaxs(1, 1)
+    init.visitEnd()
+  }
+
+  private def newTestClassWriter: ClassWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS)
+
+  private def classWithClassAnnotation: Array[Byte] = {
+    val cw = newTestClassWriter
+    cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "pkg/MyTest", null, "java/lang/Object", null)
+    cw.visitAnnotation(testAnnotationDesc, true).visitEnd()
+    writePublicInit(cw)
+    cw.visitEnd()
+    cw.toByteArray
+  }
+
+  private def classWithMethodAnnotation: Array[Byte] = {
+    val cw = newTestClassWriter
+    cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "pkg/MyTest", null, "java/lang/Object", null)
+    writePublicInit(cw)
+    val method = cw.visitMethod(Opcodes.ACC_PUBLIC, "test", "()V", null, null)
+    method.visitAnnotation(testAnnotationDesc, true).visitEnd()
+    method.visitCode()
+    method.visitInsn(Opcodes.RETURN)
+    method.visitMaxs(1, 1)
+    method.visitEnd()
+    cw.visitEnd()
+    cw.toByteArray
+  }
+
+  private def classWithoutAnnotations: Array[Byte] = {
+    val cw = newTestClassWriter
+    cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "pkg/MyTest", null, "java/lang/Object", null)
+    writePublicInit(cw)
+    cw.visitEnd()
+    cw.toByteArray
+  }
+
+  test("matchFingerprints matches AnnotatedFingerprint on class-level annotation") {
+    val matched = matchAnnotated("pkg/MyTest", classWithClassAnnotation)
+    assert(matched.collect { case f: AnnotatedFingerprint => f.annotationName() }.contains(
+      testAnnotation
+    ))
+  }
+
+  test("matchFingerprints matches AnnotatedFingerprint on public method-level annotation") {
+    val matched = matchAnnotated("pkg/MyTest", classWithMethodAnnotation)
+    assert(matched.collect { case f: AnnotatedFingerprint => f.annotationName() }.contains(
+      testAnnotation
+    ))
+  }
+
+  test("matchFingerprints returns None when AnnotatedFingerprint annotation is absent") {
+    assertEquals(
+      matchAnnotated("pkg/MyTest", classWithoutAnnotations),
+      None
+    )
+  }
 
   test(
     "findFrameworkServices parses Java ServiceLoader format (trim, skip comments and empty lines)"

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -3,7 +3,7 @@ package scala.cli.integration
 import com.eed3si9n.expecty.Expecty.expect
 
 import scala.annotation.tailrec
-import scala.cli.integration.Constants.munitVersion
+import scala.cli.integration.Constants.{jupiterInterfaceVersion, munitVersion}
 import scala.cli.integration.TestUtil.{ProcOps, StringOps}
 import scala.concurrent.duration.DurationInt
 import scala.util.Properties
@@ -127,6 +127,61 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
         |  }
         |}
         |""".stripMargin
+  )
+
+  val successfulJupiterInputs: TestInputs = TestInputs(
+    os.rel / "MyJupiterTests.test.scala" ->
+      s"""//> using test.dep com.github.sbt.junit:jupiter-interface:$jupiterInterfaceVersion
+         |import org.junit.jupiter.api.Test
+         |import org.junit.jupiter.api.Assertions._
+         |
+         |class MyJupiterTests {
+         |  @Test
+         |  def addition(): Unit = {
+         |    assertEquals(4, 2 + 2)
+         |    println("Hello from Jupiter tests")
+         |  }
+         |}
+         |""".stripMargin
+  )
+
+  val failingJupiterInputs: TestInputs = TestInputs(
+    os.rel / "MyJupiterTests.test.scala" ->
+      s"""//> using test.dep com.github.sbt.junit:jupiter-interface:$jupiterInterfaceVersion
+         |import org.junit.jupiter.api.Test
+         |import org.junit.jupiter.api.Assertions._
+         |
+         |class MyJupiterTests {
+         |  @Test
+         |  def failing(): Unit = assertEquals(5, 2 + 2)
+         |}
+         |""".stripMargin
+  )
+
+  val jupiterTestOnlyInputs: TestInputs = TestInputs(
+    os.rel / "MyJupiterTests.test.scala" ->
+      s"""//> using test.dep com.github.sbt.junit:jupiter-interface:$jupiterInterfaceVersion
+         |import org.junit.jupiter.api.Test
+         |import org.junit.jupiter.api.Assertions._
+         |
+         |class MyJupiterTests {
+         |  @Test
+         |  def failing(): Unit = assertEquals(5, 2 + 2)
+         |}
+         |""".stripMargin,
+    os.rel / "OtherJupiterTests.test.scala" ->
+      s"""//> using test.dep com.github.sbt.junit:jupiter-interface:$jupiterInterfaceVersion
+         |import org.junit.jupiter.api.Test
+         |import org.junit.jupiter.api.Assertions._
+         |
+         |class OtherJupiterTests {
+         |  @Test
+         |  def passing(): Unit = {
+         |    assertEquals(4, 2 + 2)
+         |    println("Hello from other Jupiter tests")
+         |  }
+         |}
+         |""".stripMargin
   )
 
   val severalTestsInputs: TestInputs = TestInputs(
@@ -555,6 +610,99 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
       expect(output.contains("Hello from tests"))
     }
   }
+
+  if actualScalaVersion.coursierVersion >= "3.3.0".coursierVersion then
+    for javaVersion <- Constants.allJavaVersions.filter(_ >= 17)
+    do
+      test(s"jupiter on Java $javaVersion") {
+        successfulJupiterInputs.fromRoot { root =>
+          val output =
+            os.proc(TestUtil.cli, "test", extraOptions, ".", "--jvm", javaVersion)
+              .call(cwd = root)
+              .out
+              .text()
+          expect(output.contains("Hello from Jupiter tests"))
+        }
+      }
+
+      test(s"failing jupiter on Java $javaVersion") {
+        failingJupiterInputs.fromRoot { root =>
+          val res =
+            os.proc(TestUtil.cli, "test", extraOptions, ".", "--jvm", javaVersion)
+              .call(cwd = root, check = false, mergeErrIntoOut = true)
+          expect(res.exitCode != 0)
+        }
+      }
+
+      test(s"jupiter --test-only on Java $javaVersion") {
+        jupiterTestOnlyInputs.fromRoot { root =>
+          val res =
+            os.proc(
+              TestUtil.cli,
+              "test",
+              extraOptions,
+              ".",
+              "--jvm",
+              javaVersion,
+              "--test-only",
+              "OtherJupiterTests"
+            ).call(cwd = root)
+          val output = res.out.text()
+          expect(res.exitCode == 0)
+          expect(output.contains("Hello from other Jupiter tests"))
+        }
+      }
+
+    for javaVersion <- Constants.allJavaVersions.filter(_ >= 17)
+    do
+      test(s"successful pure Java test with JUnit 5 (Jupiter) on Java $javaVersion") {
+        TestInputs(
+          os.rel / "MyJupiterTests.test.java" ->
+            s"""//> using test.dep com.github.sbt.junit:jupiter-interface:$jupiterInterfaceVersion
+               |import org.junit.jupiter.api.Test;
+               |import static org.junit.jupiter.api.Assertions.assertEquals;
+               |
+               |public class MyJupiterTests {
+               |  @Test
+               |  public void addition() {
+               |    assertEquals(4, 2 + 2);
+               |    System.out.println("Hello from pure Java Jupiter");
+               |  }
+               |}
+               |""".stripMargin
+        ).fromRoot { root =>
+          val res =
+            os.proc(TestUtil.cli, "test", extraOptions, ".", "--jvm", javaVersion)
+              .call(cwd = root)
+          expect(res.out.text().contains("Hello from pure Java Jupiter"))
+        }
+      }
+
+  if scalaVersionOpt.isEmpty then
+    for javaVersion <- Constants.allJavaVersions.filter(_ >= 17)
+    do
+      test(s"pure Java (java-test-runner) JUnit 5 (Jupiter) on Java $javaVersion") {
+        TestInputs(
+          os.rel / "MyJupiterTests.test.java" ->
+            s"""//> using test.dep com.github.sbt.junit:jupiter-interface:$jupiterInterfaceVersion
+               |import org.junit.jupiter.api.Test;
+               |import static org.junit.jupiter.api.Assertions.assertEquals;
+               |
+               |public class MyJupiterTests {
+               |  @Test
+               |  public void addition() {
+               |    assertEquals(4, 2 + 2);
+               |    System.out.println("Hello from pure Java Jupiter");
+               |  }
+               |}
+               |""".stripMargin
+        ).fromRoot { root =>
+          val res =
+            os.proc(TestUtil.cli, "test", TestUtil.extraOptions, ".", "--jvm", javaVersion)
+              .call(cwd = root)
+          expect(res.out.text().contains("Hello from pure Java Jupiter"))
+        }
+      }
 
   test("several tests") {
     severalTestsInputs.fromRoot { root =>

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -611,6 +611,24 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
     }
   }
 
+  for {
+    (platformArgs, platformName) <- Seq(
+      (Seq("--native"), "Scala Native"),
+      (Seq("--js"), "Scala.js")
+    )
+  } test(s"junit on $platformName does not crash with NotImplementedError") {
+    TestUtil.retryOnCi(maxAttempts = if (platformName.contains("native")) 3 else 1) {
+      successfulJunitInputs.fromRoot { root =>
+        val res =
+          os.proc(TestUtil.cli, "test", extraOptions ++ platformArgs, ".")
+            .call(cwd = root, check = false, mergeErrIntoOut = true)
+        val output = res.out.text()
+        expect(!output.contains("an implementation is missing"))
+        expect(!output.contains("NotImplementedError"))
+      }
+    }
+  }
+
   if actualScalaVersion.coursierVersion >= "3.3.0".coursierVersion then
     for javaVersion <- Constants.allJavaVersions.filter(_ >= 17)
     do

--- a/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaDynamicTestRunner.java
+++ b/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaDynamicTestRunner.java
@@ -118,20 +118,29 @@ public class JavaDynamicTestRunner {
                 }
             }
 
-            List<TaskDef> taskDefs = new ArrayList<>();
-            for (Class<?> cls : classes) {
-                Optional<Fingerprint> fp = JavaFrameworkUtils.matchFingerprints(
-                    classLoader, cls, fingerprints, logger
+            final List<TaskDef> taskDefs;
+            if (JavaFrameworkUtils.isJupiterFramework(framework)) {
+                taskDefs = JavaFrameworkUtils.filterTaskDefsByClassName(
+                    JavaFrameworkUtils.jupiterTaskDefs(classPath0, classLoader, logger),
+                    testOnlyFinal,
+                    (pattern, className) -> globPattern(pattern).matcher(className).matches()
                 );
-                if (!fp.isPresent()) continue;
-                String clsName = cls.getName().endsWith("$")
-                    ? cls.getName().substring(0, cls.getName().length() - 1)
-                    : cls.getName();
-                if (testOnlyFinal.isPresent()) {
-                    Pattern pat = globPattern(testOnlyFinal.get());
-                    if (!pat.matcher(clsName).matches()) continue;
+            } else {
+                taskDefs = new ArrayList<>();
+                for (Class<?> cls : classes) {
+                    Optional<Fingerprint> fp = JavaFrameworkUtils.matchFingerprints(
+                        classLoader, cls, fingerprints, logger
+                    );
+                    if (!fp.isPresent()) continue;
+                    String clsName = cls.getName().endsWith("$")
+                        ? cls.getName().substring(0, cls.getName().length() - 1)
+                        : cls.getName();
+                    if (testOnlyFinal.isPresent()) {
+                        Pattern pat = globPattern(testOnlyFinal.get());
+                        if (!pat.matcher(clsName).matches()) continue;
+                    }
+                    taskDefs.add(new TaskDef(clsName, fp.get(), false, new Selector[]{new SuiteSelector()}));
                 }
-                taskDefs.add(new TaskDef(clsName, fp.get(), false, new Selector[]{new SuiteSelector()}));
             }
 
             Task[] initialTasks = runner.tasks(taskDefs.toArray(new TaskDef[0]));

--- a/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaFrameworkUtils.java
+++ b/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaFrameworkUtils.java
@@ -1,17 +1,110 @@
 package scala.build.testrunner;
 
+import com.github.sbt.junit.jupiter.api.JupiterTestCollector;
 import sbt.testing.*;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.stream.Stream;
 
 public class JavaFrameworkUtils {
+
+    private static final String JupiterFrameworkClass =
+        "com.github.sbt.junit.jupiter.api.JupiterFramework";
+
+    public static boolean isJupiterFramework(Framework framework) {
+        return JupiterFrameworkClass.equals(framework.getClass().getName()) ||
+            "Jupiter".equals(framework.name());
+    }
+
+    public static List<TaskDef> jupiterTaskDefs(
+        List<Path> classPath,
+        ClassLoader loader,
+        JavaTestLogger logger
+    ) {
+        try {
+            URL[] runtimeClasspath = classPathUrls(classPath);
+            return classPath.stream()
+                .filter(Files::isDirectory)
+                .flatMap(dir -> collectJupiterTests(dir, loader, runtimeClasspath, logger).stream())
+                .map(JavaFrameworkUtils::jupiterItemToTaskDef)
+                .collect(Collectors.collectingAndThen(
+                    Collectors.toMap(
+                        td -> td.fullyQualifiedName() + "\0" + td.fingerprint(),
+                        td -> td,
+                        (a, b) -> a,
+                        LinkedHashMap::new
+                    ),
+                    m -> new ArrayList<>(m.values())
+                ));
+        } catch (LinkageError e) {
+            logger.error("JUnit 5 test discovery failed: " + e.getMessage());
+            return Collections.emptyList();
+        } catch (Exception t) {
+            logger.error("JUnit 5 test discovery failed: " + t);
+            return Collections.emptyList();
+        }
+    }
+
+    private static URL[] classPathUrls(List<Path> classPath) {
+        return classPath.stream()
+            .map(path -> {
+                try {
+                    return path.toUri().toURL();
+                } catch (Exception e) {
+                    return null;
+                }
+            })
+            .filter(Objects::nonNull)
+            .toArray(URL[]::new);
+    }
+
+    private static List<JupiterTestCollector.Item> collectJupiterTests(
+        Path classDirectory,
+        ClassLoader loader,
+        URL[] runtimeClasspath,
+        JavaTestLogger logger
+    ) {
+        try {
+            logger.debug("Discovering JUnit 5 tests in " + classDirectory.toAbsolutePath());
+            JupiterTestCollector collector = new JupiterTestCollector.Builder()
+                .withClassDirectory(classDirectory.toFile())
+                .withClassLoader(loader)
+                .withRuntimeClassPath(runtimeClasspath)
+                .build();
+            return new ArrayList<>(collector.collectTests().getDiscoveredTests());
+        } catch (Exception e) {
+            logger.log("Could not discover JUnit 5 tests in " + classDirectory + ": " + e);
+            return Collections.emptyList();
+        }
+    }
+
+    private static TaskDef jupiterItemToTaskDef(JupiterTestCollector.Item item) {
+        return new TaskDef(
+            item.getFullyQualifiedClassName(),
+            item.getFingerprint(),
+            item.isExplicit(),
+            item.getSelectors()
+        );
+    }
+
+    public static List<TaskDef> filterTaskDefsByClassName(
+        List<TaskDef> taskDefs,
+        Optional<String> testOnly,
+        java.util.function.BiPredicate<String, String> classNameMatcher
+    ) {
+        return taskDefs.stream()
+            .filter(td -> testOnly.map(pattern -> classNameMatcher.test(pattern, td.fullyQualifiedName()))
+                .orElse(true))
+            .collect(Collectors.toList());
+    }
 
     public static List<Framework> findFrameworkServices(ClassLoader loader) {
         List<Framework> result = new ArrayList<>();

--- a/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaTestRunner.java
+++ b/modules/java-test-runner/src/main/java/scala/build/testrunner/JavaTestRunner.java
@@ -19,7 +19,10 @@ public class JavaTestRunner {
         // Only pure-Java-compatible frameworks belong here.
         // Scala-only frameworks (munit, utest, ScalaCheck, ZIO Test, ScalaTest, weaver)
         // live in the Scala test-runner's TestRunner.commonTestFrameworks instead.
-        return Arrays.asList("com.novocode.junit.JUnitFramework");
+        return Arrays.asList(
+            "com.novocode.junit.JUnitFramework",
+            "com.github.sbt.junit.jupiter.api.JupiterFramework"
+        );
     }
 
     public static List<Path> classPath(ClassLoader loader, JavaTestLogger logger) {

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/AsmTestRunner.scala
@@ -85,15 +85,8 @@ object AsmTestRunner {
           parentInspector.allParents(checker.name)
             .contains(f.superclassName().replace('.', '/'))
 
-        case _: AnnotatedFingerprint =>
-          // val annotationCls = loader.loadClass(f.annotationName())
-          //   .asInstanceOf[Class[Annotation]]
-          // f.isModule == isModule && (
-          //   cls.isAnnotationPresent(annotationCls) ||
-          //   cls.getDeclaredMethods.exists(_.isAnnotationPresent(annotationCls)) ||
-          //   cls.getMethods.exists(m => m.isAnnotationPresent(annotationCls) && Modifier.isPublic(m.getModifiers()))
-          // )
-          ??? // TODO: this is necessary to support JUnit, check https://github.com/VirtusLab/scala-cli/issues/3627
+        case f: AnnotatedFingerprint =>
+          f.isModule == isModule && checker.hasAnnotation(annotationDescriptor(f.annotationName()))
       }
   }
 
@@ -280,17 +273,34 @@ object AsmTestRunner {
       .toList
   }
 
+  private def annotationDescriptor(annotationName: String): String =
+    "L" + annotationName.replace('.', '/') + ";"
+
   private class TestClassChecker extends asm.ClassVisitor(asm.Opcodes.ASM9) {
     private var nameOpt                 = Option.empty[String]
     private var publicConstructorCount0 = 0
     private var isInterfaceOpt          = Option.empty[Boolean]
     private var isAbstractOpt           = Option.empty[Boolean]
     private var implements0             = List.empty[String]
-    def name: String                    = nameOpt.getOrElse(sys.error("Class not visited"))
-    def publicConstructorCount: Int     = publicConstructorCount0
-    def implements: Seq[String]         = implements0
-    def isAbstract: Boolean             = isAbstractOpt.getOrElse(sys.error("Class not visited"))
-    def isInterface: Boolean            = isInterfaceOpt.getOrElse(sys.error("Class not visited"))
+    private var classAnnotations0       = List.empty[String]
+    private var methodAnnotations0      = List.empty[String]
+
+    def name: String                   = nameOpt.getOrElse(sys.error("Class not visited"))
+    def publicConstructorCount: Int    = publicConstructorCount0
+    def implements: Seq[String]        = implements0
+    def isAbstract: Boolean            = isAbstractOpt.getOrElse(sys.error("Class not visited"))
+    def isInterface: Boolean           = isInterfaceOpt.getOrElse(sys.error("Class not visited"))
+    def classAnnotations: Seq[String]  = classAnnotations0
+    def methodAnnotations: Seq[String] = methodAnnotations0
+
+    def hasAnnotation(descriptor: String): Boolean =
+      classAnnotations.contains(descriptor) || methodAnnotations.contains(descriptor)
+
+    override def visitAnnotation(descriptor: String, visible: Boolean): asm.AnnotationVisitor = {
+      classAnnotations0 = descriptor :: classAnnotations0
+      null
+    }
+
     override def visit(
       version: Int,
       access: Int,
@@ -306,6 +316,7 @@ object AsmTestRunner {
       if (interfaces.nonEmpty)
         implements0 = interfaces.toList ::: implements0
     }
+
     override def visitMethod(
       access: Int,
       name: String,
@@ -313,10 +324,18 @@ object AsmTestRunner {
       signature: String,
       exceptions: Array[String]
     ): asm.MethodVisitor = {
-      def isPublic = (access & asm.Opcodes.ACC_PUBLIC) != 0
+      val isPublic = (access & asm.Opcodes.ACC_PUBLIC) != 0
       if (name == "<init>" && isPublic)
         publicConstructorCount0 += 1
-      null
+      if (isPublic && name != "<init>" && name != "<clinit>")
+        new asm.MethodVisitor(asm.Opcodes.ASM9) {
+          override def visitAnnotation(desc: String, visible: Boolean): asm.AnnotationVisitor = {
+            methodAnnotations0 = desc :: methodAnnotations0
+            null
+          }
+        }
+      else
+        null
     }
   }
 

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/DynamicTestRunner.scala
@@ -133,24 +133,28 @@ object DynamicTestRunner {
           val fingerprints = framework.fingerprints()
           val runner       = framework.runner(args0.toArray, Array(), classLoader)
 
-          def clsFingerprints = classes.flatMap { cls =>
-            matchFingerprints(classLoader, cls, fingerprints, logger)
-              .map((cls, _))
-              .iterator
-          }
+          def matchesTestOnly(pattern: String, className: String): Boolean =
+            globPattern(pattern).matcher(className).matches()
 
-          val taskDefs = clsFingerprints
-            .filter {
-              case (cls, _) =>
-                testOnly.forall(pattern =>
-                  globPattern(pattern).matcher(cls.getName.stripSuffix("$")).matches()
-                )
-            }
-            .map {
-              case (cls, fp) =>
-                new TaskDef(cls.getName.stripSuffix("$"), fp, false, Array(new SuiteSelector))
-            }
-            .toVector
+          val taskDefs =
+            if isJupiterFramework(framework) then
+              filterTaskDefsByClassName(
+                jupiterTaskDefs(classPath0, classLoader, logger),
+                testOnly,
+                matchesTestOnly
+              )
+            else
+              classes
+                .flatMap { cls =>
+                  matchFingerprints(classLoader, cls, fingerprints, logger)
+                    .map(fp => (cls.getName.stripSuffix("$"), fp))
+                    .iterator
+                }
+                .filter { case (className, _) => testOnly.forall(matchesTestOnly(_, className)) }
+                .map { case (className, fp) =>
+                  new TaskDef(className, fp, false, Array(new SuiteSelector))
+                }
+                .toVector
           val initialTasks = runner.tasks(taskDefs.toArray).toSeq
           val events       = TestRunner.runTasks(initialTasks, out)
           val failed       = events.exists { ev =>

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/FrameworkUtils.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/FrameworkUtils.scala
@@ -1,15 +1,89 @@
 package scala.build.testrunner
 
-import sbt.testing.{AnnotatedFingerprint, Fingerprint, Framework, SubclassFingerprint}
+import com.github.sbt.junit.jupiter.api.JupiterTestCollector
+import sbt.testing.{AnnotatedFingerprint, Fingerprint, Framework, SubclassFingerprint, TaskDef}
 
 import java.lang.annotation.Annotation
 import java.lang.reflect.Modifier
+import java.net.URL
 import java.nio.file.{Files, Path}
 import java.util.ServiceLoader
 
 import scala.jdk.CollectionConverters.*
+import scala.util.control.NonFatal
 
 object FrameworkUtils {
+
+  private val JupiterFrameworkClass = "com.github.sbt.junit.jupiter.api.JupiterFramework"
+
+  def isJupiterFramework(framework: Framework): Boolean =
+    framework.getClass.getName == JupiterFrameworkClass || framework.name() == "Jupiter"
+
+  def jupiterTaskDefs(
+    classPath: Seq[Path],
+    loader: ClassLoader,
+    logger: Logger
+  ): Seq[TaskDef] =
+    try
+      val runtimeClasspath = classPathUrls(classPath)
+      val classDirectories = classPath.filter(p => Files.isDirectory(p))
+      val discovered       =
+        for
+          dir  <- classDirectories
+          item <- collectJupiterTests(dir, loader, runtimeClasspath, logger)
+        yield jupiterItemToTaskDef(item)
+      distinctBy(discovered)(td => (td.fullyQualifiedName(), td.fingerprint()))
+    catch
+      case e: LinkageError =>
+        logger.error(s"JUnit 5 test discovery failed: ${e.getMessage}")
+        Nil
+      case NonFatal(t) =>
+        logger.error(s"JUnit 5 test discovery failed: $t")
+        Nil
+
+  private def classPathUrls(classPath: Seq[Path]): Array[URL] =
+    classPath.flatMap { path =>
+      try Iterator(path.toUri.toURL)
+      catch
+        case _: Exception => Iterator.empty
+    }.toArray
+
+  private def collectJupiterTests(
+    classDirectory: Path,
+    loader: ClassLoader,
+    runtimeClasspath: Array[URL],
+    logger: Logger
+  ): Seq[JupiterTestCollector.Item] =
+    try
+      logger.debug(s"Discovering JUnit 5 tests in ${classDirectory.toAbsolutePath}")
+      val collector = new JupiterTestCollector.Builder()
+        .withClassDirectory(classDirectory.toFile)
+        .withClassLoader(loader)
+        .withRuntimeClassPath(runtimeClasspath)
+        .build()
+      collector.collectTests().getDiscoveredTests.asScala.toSeq
+    catch
+      case NonFatal(e) =>
+        logger.log(s"Could not discover JUnit 5 tests in $classDirectory: $e")
+        Nil
+
+  def filterTaskDefsByClassName(
+    taskDefs: Seq[TaskDef],
+    testOnly: Option[String],
+    classNameMatcher: (String, String) => Boolean
+  ): Seq[TaskDef] =
+    taskDefs.filter(td =>
+      testOnly.forall(pattern => classNameMatcher(pattern, td.fullyQualifiedName()))
+    )
+
+  private def jupiterItemToTaskDef(item: JupiterTestCollector.Item): TaskDef =
+    new TaskDef(
+      item.getFullyQualifiedClassName,
+      item.getFingerprint,
+      item.isExplicit,
+      item.getSelectors
+    )
+
   // needed for Scala 2.12
   def distinctBy[A, B](seq: Seq[A])(f: A => B): Seq[A] = {
     @annotation.tailrec

--- a/modules/test-runner/src/main/scala/scala/build/testrunner/TestRunner.scala
+++ b/modules/test-runner/src/main/scala/scala/build/testrunner/TestRunner.scala
@@ -16,6 +16,7 @@ object TestRunner {
     "zio.test.sbt.ZTestFramework",
     "org.scalatest.tools.Framework",
     "com.novocode.junit.JUnitFramework",
+    "com.github.sbt.junit.jupiter.api.JupiterFramework",
     "org.scalajs.junit.JUnitFramework",
     "weaver.framework.CatsEffect"
   )

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -261,6 +261,7 @@ object Deps {
   def svm                       = mvn"org.graalvm.nativeimage:svm:$graalSvmVersion"
   def swoval                    = mvn"com.swoval:file-tree-views:2.1.12"
   def testInterface             = mvn"org.scala-sbt:test-interface:1.0"
+  def jupiterInterface          = mvn"com.github.sbt.junit:jupiter-interface:0.19.0"
   val toolkitVersion            = "0.9.2"
   val toolkitVersionForNative04 = "0.3.0"
   val toolkitVersionForNative05 = toolkitVersion

--- a/website/docs/commands/test.md
+++ b/website/docs/commands/test.md
@@ -99,6 +99,8 @@ Some of the most popular test frameworks in Scala are:
 - [ScalaTest](https://www.scalatest.org): `org.scalatest::scalatest::3.2.19`
 - [JUnit 4](https://junit.org/junit4), which can be used via
   a [dedicated interface](https://github.com/sbt/junit-interface): `com.github.sbt:junit-interface:0.13.3`
+- [JUnit 5](https://junit.org/junit5/) (Jupiter), via
+  a [dedicated interface](https://github.com/sbt/junit-interface): `com.github.sbt.junit:jupiter-interface:0.19.0`
 - [Weaver](https://disneystreaming.github.io/weaver-test/): `com.disneystreaming::weaver-cats:0.8.3`. You may need to
   specify weaver's test framework with `//> using testFramework weaver.framework.CatsEffect` if you had other test
   framework in your dependencies.


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/3627

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)
- ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Cursor + Claude

## How was the solution tested?
included new unit + integration tests

## Additional notes
- loosely inspired by https://github.com/scalacenter/bloop/pull/2938 to get feature parity with Bloop's test runner