### PR TITLE
Bump Munit to 1.3.3 (was 1.3.0)

### DIFF
--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -202,7 +202,7 @@ object Deps {
   def metaconfigTypesafe =
     mvn"org.scalameta::metaconfig-typesafe-config:0.18.6"
       .exclude(("org.scala-lang", "scala-compiler"))
-  def munit              = mvn"org.scalameta::munit:1.3.0"
+  def munit              = mvn"org.scalameta::munit:1.3.3"
   def nativeTestRunner   = mvn"org.scala-native::test-runner:${Versions.scalaNative}"
   def nativeTools        = mvn"org.scala-native::tools:${Versions.scalaNative}"
   def osLib              = mvn"com.lihaoyi::os-lib:0.11.8"


### PR DESCRIPTION
https://github.com/scalameta/munit/releases/tag/v1.3.3
Will 3rd time be the charm? 😅 

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)
- ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
not at all

## How was the solution tested?
existing tests