### PR TITLE
Bump MacOS CI jobs' timeouts to deal with runner slowdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -824,7 +824,7 @@ jobs:
 
   native-macos-tests-default:
     needs: [changes, generate-macos-launcher]
-    timeout-minutes: 150
+    timeout-minutes: 240
     runs-on: "macOS-15-intel"
     env:
       SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
@@ -873,7 +873,7 @@ jobs:
 
   native-macos-tests-rc:
     needs: [changes, generate-macos-launcher]
-    timeout-minutes: 150
+    timeout-minutes: 240
     runs-on: "macOS-15-intel"
     env:
       SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
@@ -967,7 +967,7 @@ jobs:
 
   native-macos-arm64-tests-default:
     needs: [changes, generate-macos-arm64-launcher]
-    timeout-minutes: 150
+    timeout-minutes: 240
     runs-on: "macOS-15"
     env:
       SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
@@ -1016,7 +1016,7 @@ jobs:
 
   native-macos-arm64-tests-lts:
     needs: [changes, generate-macos-arm64-launcher]
-    timeout-minutes: 150
+    timeout-minutes: 240
     runs-on: "macOS-15"
     env:
       SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
@@ -1065,7 +1065,7 @@ jobs:
 
   native-macos-arm64-tests-rc:
     needs: [changes, generate-macos-arm64-launcher]
-    timeout-minutes: 150
+    timeout-minutes: 240
     runs-on: "macOS-15"
     env:
       SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}


### PR DESCRIPTION
MacOS runners have become particularly slow recently, with the `macos-tests-default` check in particular timeouting consistently.
This is just a bandaid and will need a proper follow-up.

## How much have your relied on LLM-based tools in this contribution?
moderately, to analyze logs and estimate how much more time would the builds realistically need with current configuration to pass consistently.

## How was the solution tested?
running on CI is the only way to test it.

## Additional notes
- bumping priority on https://github.com/VirtusLab/scala-cli/issues/2937
- to consider, whether the `*-default` suites should be split into multiple jobs down the line, or if perhaps only a subset of the tests would be run on platforms other than JVM & Linux native (which have the highest availability)