### PR TITLE
Run integration tests which don't check connectivity with `--offline`

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/ArgsFileTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ArgsFileTests.scala
@@ -21,11 +21,12 @@ class ArgsFileTests extends ScalaCliSuite {
     )
 
     inputs.fromRoot { root =>
-      val res = os.proc(TestUtil.cli, serverArgs, "@args.txt", fileName).call(
-        cwd = root,
-        check = false,
-        stderr = os.Pipe
-      )
+      val res =
+        os.proc(TestUtil.cli, serverArgs, "@args.txt", fileName).call(
+          cwd = root,
+          check = false,
+          stderr = os.Pipe
+        )
       assert(res.exitCode == 1)
 
       val compilationError = res.err.text()
@@ -78,7 +79,9 @@ class ArgsFileTests extends ScalaCliSuite {
 
       os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "compile",
+        TestUtil.offlineOptions,
         "--scala-opt",
         "-d",
         "--scala-opt",
@@ -91,7 +94,9 @@ class ArgsFileTests extends ScalaCliSuite {
       os.makeDir.all(compileOutput)
       val runRes = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "@args.txt",
         "--server=false",
         "@args2.txt",

--- a/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BloopTests.scala
@@ -8,7 +8,8 @@ import scala.concurrent.duration.Duration
 import scala.util.Properties
 
 class BloopTests extends ScalaCliSuite {
-  def runScalaCli(args: String*): os.proc = os.proc(TestUtil.cli, args)
+  def runScalaCli(args: String*): os.proc =
+    os.proc(TestUtil.cli, args)
 
   private lazy val bloopDaemonDir =
     BloopUtil.bloopDaemonDir(runScalaCli("--power", "directories").call().out.text())
@@ -33,7 +34,7 @@ class BloopTests extends ScalaCliSuite {
       val bloop = BloopUtil.bloop(currentBloopVersion, bloopDaemonDir)
       bloop(Seq("about")).call(cwd = root, stdout = os.Inherit)
 
-      val output = os.proc(TestUtil.cli, "run", ".")
+      val output = os.proc(TestUtil.cli, TestUtil.powerOptions, "run", TestUtil.offlineOptions, ".")
         .call(cwd = root, stderr = os.Pipe, mergeErrIntoOut = true)
         .out.text()
       expect(output.contains("Hello from test"))
@@ -112,7 +113,7 @@ class BloopTests extends ScalaCliSuite {
     )
     inputs.fromRoot { root =>
 
-      os.proc(TestUtil.cli, "compile", ".")
+      os.proc(TestUtil.cli, TestUtil.powerOptions, "compile", TestUtil.offlineOptions, ".")
         .call(cwd = root, stdin = os.Inherit, stdout = os.Inherit)
 
       val projRes = os.proc(TestUtil.cli, "--power", "bloop", "projects")
@@ -152,7 +153,15 @@ class BloopTests extends ScalaCliSuite {
           sourcePath -> content("Hello")
         )
         inputs.fromRoot { root =>
-          val proc = os.proc(TestUtil.cli, "run", "--power", "--offline", "-w", ".")
+          val proc = os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "run",
+            TestUtil.offlineOptions,
+            "--offline",
+            "-w",
+            "."
+          )
             .spawn(cwd = root)
           val firstLine = TestUtil.readLine(proc.stdout, ec, timeout)
           expect(firstLine == "Hello")

--- a/modules/integration/src/test/scala/scala/cli/integration/BspSuite.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspSuite.scala
@@ -127,7 +127,14 @@ trait BspSuite { this: ScalaCliSuite =>
       val stderr: os.ProcessOutput                = stdErrPathOpt.getOrElse(os.Inherit)
 
       val proc = trackSubprocess(
-        os.proc(TestUtil.cli, "bsp", bspOptions ++ extraOptionsOverride, args)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "bsp",
+          TestUtil.offlineOptions,
+          bspOptions ++ extraOptionsOverride,
+          args
+        )
           .spawn(cwd = root, stderr = stderr, env = bspEnvs)
       )
       var remoteServer

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -21,7 +21,8 @@ abstract class BspTestDefinitions extends ScalaCliSuite
     with ScriptWrapperTestDefinitions
     with CoursierScalaInstallationTestHelper {
   this: TestScalaVersion =>
-  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
+  protected lazy val extraOptions: Seq[String] =
+    scalaVersionArgs ++ TestUtil.extraOptionsWithOffline
 
   test("setup-ide") {
     val inputs = TestInputs(
@@ -31,7 +32,14 @@ abstract class BspTestDefinitions extends ScalaCliSuite
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "setup-ide", ".", extraOptions).call(cwd = root, stdout = os.Inherit)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "setup-ide",
+        TestUtil.offlineOptions,
+        ".",
+        extraOptions
+      ).call(cwd = root, stdout = os.Inherit)
       val details = readBspConfig(root)
       expect(details.argv.length >= 2)
       expect(details.argv.dropWhile(_ != TestUtil.cliPath).drop(1).head == "bsp")
@@ -123,7 +131,9 @@ abstract class BspTestDefinitions extends ScalaCliSuite
     importPprintOnlyProject.fromRoot { root =>
       os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "setup-ide",
+        TestUtil.offlineOptions,
         ".",
         extraOptions,
         "--dependency",
@@ -137,7 +147,9 @@ abstract class BspTestDefinitions extends ScalaCliSuite
 
       val p = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "setup-ide",
+        TestUtil.offlineOptions,
         ".",
         extraOptions,
         "--dependency",
@@ -903,7 +915,14 @@ abstract class BspTestDefinitions extends ScalaCliSuite
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "setup-ide", ".", extraOptions)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "setup-ide",
+        TestUtil.offlineOptions,
+        ".",
+        extraOptions
+      )
         .call(
           cwd = root,
           stdout = os.Inherit
@@ -922,7 +941,14 @@ abstract class BspTestDefinitions extends ScalaCliSuite
             expect(resp.getStatusCode == b.StatusCode.ERROR)
 
             val dependencyOptions = List("--dependency", "com.lihaoyi::os-lib::0.8.0")
-            os.proc(TestUtil.cli, "setup-ide", ".", dependencyOptions ++ extraOptions)
+            os.proc(
+              TestUtil.cli,
+              TestUtil.powerOptions,
+              "setup-ide",
+              TestUtil.offlineOptions,
+              ".",
+              dependencyOptions ++ extraOptions
+            )
               .call(
                 cwd = root,
                 stdout = os.Inherit
@@ -954,7 +980,14 @@ abstract class BspTestDefinitions extends ScalaCliSuite
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "setup-ide", ".", extraOptions)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "setup-ide",
+        TestUtil.offlineOptions,
+        ".",
+        extraOptions
+      )
         .call(
           cwd = root,
           stdout = os.Inherit
@@ -1013,7 +1046,14 @@ abstract class BspTestDefinitions extends ScalaCliSuite
       os.rel / dir2 / "MissingCaseClass.scala" -> "case class MissingCaseClass(value: String)"
     )
     extraInputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "setup-ide", dir1, extraOptions)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "setup-ide",
+        TestUtil.offlineOptions,
+        dir1,
+        extraOptions
+      )
         .call(
           cwd = root,
           stdout = os.Inherit
@@ -1029,7 +1069,15 @@ abstract class BspTestDefinitions extends ScalaCliSuite
                 .asScala.await
             expect(resp.getStatusCode == b.StatusCode.ERROR)
 
-            os.proc(TestUtil.cli, "setup-ide", dir1, dir2, extraOptions)
+            os.proc(
+              TestUtil.cli,
+              TestUtil.powerOptions,
+              "setup-ide",
+              TestUtil.offlineOptions,
+              dir1,
+              dir2,
+              extraOptions
+            )
               .call(
                 cwd = root,
                 stdout = os.Inherit
@@ -1152,7 +1200,16 @@ abstract class BspTestDefinitions extends ScalaCliSuite
           cwd = root,
           stdout = os.Inherit
         )
-      os.proc(TestUtil.cli, "setup-ide", ".", "--jvm", "11", extraOptions)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "setup-ide",
+        TestUtil.offlineOptions,
+        ".",
+        "--jvm",
+        "11",
+        extraOptions
+      )
         .call(
           cwd = root,
           stdout = os.Inherit
@@ -1178,7 +1235,17 @@ abstract class BspTestDefinitions extends ScalaCliSuite
               "19"
             )
 
-            os.proc(TestUtil.cli, "setup-ide", ".", "--jvm", "19", javacOptions, extraOptions)
+            os.proc(
+              TestUtil.cli,
+              TestUtil.powerOptions,
+              "setup-ide",
+              TestUtil.offlineOptions,
+              ".",
+              "--jvm",
+              "19",
+              javacOptions,
+              extraOptions
+            )
               .call(
                 cwd = root,
                 stdout = os.Inherit
@@ -1220,7 +1287,14 @@ abstract class BspTestDefinitions extends ScalaCliSuite
           cwd = root,
           stdout = os.Inherit
         )
-      os.proc(TestUtil.cli, "setup-ide", ".", extraOptions)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "setup-ide",
+        TestUtil.offlineOptions,
+        ".",
+        extraOptions
+      )
         .call(
           cwd = root,
           stdout = os.Inherit
@@ -1313,7 +1387,14 @@ abstract class BspTestDefinitions extends ScalaCliSuite
           cwd = root,
           stdout = os.Inherit
         )
-      os.proc(TestUtil.cli, "setup-ide", ".", extraOptions)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "setup-ide",
+        TestUtil.offlineOptions,
+        ".",
+        extraOptions
+      )
         .call(
           cwd = root,
           stdout = os.Inherit
@@ -1721,8 +1802,9 @@ abstract class BspTestDefinitions extends ScalaCliSuite
       // package the library jar
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         jarSources,
         "--library",
         "-o",
@@ -1733,8 +1815,9 @@ abstract class BspTestDefinitions extends ScalaCliSuite
       // package the sources jar
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         jarSources,
         "--with-sources",
         "-o",
@@ -1942,7 +2025,13 @@ abstract class BspTestDefinitions extends ScalaCliSuite
             os.proc(TestUtil.cs, "java-home", "--jvm", s"zulu:$javaVersion").call().out.trim(),
             os.pwd
           )
-        os.proc(TestUtil.cli, "setup-ide", "check-java.sc")
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "setup-ide",
+          TestUtil.offlineOptions,
+          "check-java.sc"
+        )
           .call(cwd = root, env = Map("JAVA_HOME" -> java23Home.toString()))
         val ideOptionsPath = root / Constants.workspaceDirName / "ide-options-v2.json"
         expect(ideOptionsPath.toNIO.toFile.exists())
@@ -1982,7 +2071,15 @@ abstract class BspTestDefinitions extends ScalaCliSuite
             os.proc(TestUtil.cs, "java-home", "--jvm", s"zulu:$javaVersion").call().out.trim(),
             os.pwd
           )
-        os.proc(TestUtil.cli, "setup-ide", "check-java.sc", "--java-home", java22Home.toString())
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "setup-ide",
+          TestUtil.offlineOptions,
+          "check-java.sc",
+          "--java-home",
+          java22Home.toString()
+        )
           .call(cwd = root)
         val ideOptionsPath = root / Constants.workspaceDirName / "ide-options-v2.json"
         expect(ideOptionsPath.toNIO.toFile.exists())
@@ -2096,7 +2193,14 @@ abstract class BspTestDefinitions extends ScalaCliSuite
       s"""//> using python
          |println("scalapy is experimental")""".stripMargin)
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "setup-ide", scriptName, extraOptions).call(cwd = root)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "setup-ide",
+        TestUtil.offlineOptions,
+        scriptName,
+        extraOptions
+      ).call(cwd = root)
       val ideEnvsPath = root / Constants.workspaceDirName / "ide-envs.json"
       expect(ideEnvsPath.toNIO.toFile.exists())
       val jsonOptions = List("--envs-file", ideEnvsPath.toString)
@@ -2114,7 +2218,14 @@ abstract class BspTestDefinitions extends ScalaCliSuite
             expect(compileBeforeReloadResult.getStatusCode == b.StatusCode.ERROR)
 
             // enable --power mode via env for setup-ide
-            os.proc(TestUtil.cli, "setup-ide", scriptName, extraOptions)
+            os.proc(
+              TestUtil.cli,
+              TestUtil.powerOptions,
+              "setup-ide",
+              TestUtil.offlineOptions,
+              scriptName,
+              extraOptions
+            )
               .call(cwd = root, env = Map("SCALA_CLI_POWER" -> "true"))
 
             // compilation should now succeed
@@ -2142,7 +2253,14 @@ abstract class BspTestDefinitions extends ScalaCliSuite
     inputs.fromRoot { root =>
       val configFile = os.rel / "config" / "config.json"
       val configEnvs = Map("SCALA_CLI_CONFIG" -> configFile.toString())
-      os.proc(TestUtil.cli, "setup-ide", scriptName, extraOptions).call(
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "setup-ide",
+        TestUtil.offlineOptions,
+        scriptName,
+        extraOptions
+      ).call(
         cwd = root,
         env = configEnvs
       )
@@ -2369,7 +2487,14 @@ abstract class BspTestDefinitions extends ScalaCliSuite
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "setup-ide", ".", "-v").call(cwd = root)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "setup-ide",
+        TestUtil.offlineOptions,
+        ".",
+        "-v"
+      ).call(cwd = root)
       val ideOptionsPath = root / Constants.workspaceDirName / "ide-options-v2.json"
       val jsonOptions    = List("--json-options", ideOptionsPath.toString)
       withBsp(

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTests2Definitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTests2Definitions.scala
@@ -9,7 +9,7 @@ trait BspTests2Definitions { this: BspTestDefinitions =>
       (s"//> using scala $actualScalaVersion", Seq("--scala", actualScalaVersion))
     )
     extraOptionsOverride =
-      if (useDirectives) TestUtil.extraOptions else TestUtil.extraOptions ++ options
+      if (useDirectives) TestUtil.extraOptionsWithOffline else TestUtil.extraOptionsWithOffline ++ options
     testNameSuffix = if (useDirectives) directive else options.mkString(" ")
   } test(s"BSP App object wrapper forced with $testNameSuffix") {
     val (script1, script2) = "script1.sc" -> "script2.sc"

--- a/modules/integration/src/test/scala/scala/cli/integration/CleanTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CleanTests.scala
@@ -19,7 +19,10 @@ class CleanTests extends ScalaCliSuite {
       val dir      = root / Constants.workspaceDirName
       val bspEntry = root / ".bsp" / "scala-cli.json"
 
-      val res = os.proc(TestUtil.cli, "run", ".").call(cwd = root)
+      val res =
+        os.proc(TestUtil.cli, TestUtil.powerOptions, "run", TestUtil.offlineOptions, ".").call(cwd =
+          root
+        )
       expect(res.out.trim() == "Hello")
       expect(os.exists(dir))
       expect(os.exists(bspEntry))

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileScalacCompatTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileScalacCompatTestDefinitions.scala
@@ -18,7 +18,13 @@ trait CompileScalacCompatTestDefinitions { this: CompileTestDefinitions =>
            |def takesTuple(tpl: Tuple) = ???
            |def withTuple() = takesTuple(1, 2)
            |""".stripMargin).fromRoot { root =>
-        val res = os.proc(TestUtil.cli, "compile", sourceFileName)
+        val res = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "compile",
+          TestUtil.offlineOptions,
+          sourceFileName
+        )
           .call(cwd = root, check = false, stderr = os.Pipe)
         expect(res.exitCode == 1)
         val errOutput                   = res.err.trim()
@@ -99,7 +105,14 @@ trait CompileScalacCompatTestDefinitions { this: CompileTestDefinitions =>
            |def takesTuple(tpl: Tuple) = ???
            |def withTuple() = takesTuple(1, 2)
            |""".stripMargin).fromRoot { root =>
-        val res = os.proc(TestUtil.cli, "compile", sourceFileName, cliOpts)
+        val res = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "compile",
+          TestUtil.offlineOptions,
+          sourceFileName,
+          cliOpts
+        )
           .call(cwd = root, check = false, stderr = os.Pipe)
         println(res.err.trim())
         expect(res.exitCode == 1)
@@ -145,7 +158,9 @@ trait CompileScalacCompatTestDefinitions { this: CompileTestDefinitions =>
         val cliRes =
           os.proc(
             TestUtil.cli,
+            TestUtil.powerOptions,
             "compile",
+            TestUtil.offlineOptions,
             sourceFileName,
             "--server=false",
             if (useDirective) Nil else warningConfOptions
@@ -184,7 +199,9 @@ trait CompileScalacCompatTestDefinitions { this: CompileTestDefinitions =>
           val r =
             os.proc(
               TestUtil.cli,
+              TestUtil.powerOptions,
               "compile",
+              TestUtil.offlineOptions,
               sourceFileName,
               if (useDirective) Nil else unusedLintOptions
             )
@@ -219,7 +236,9 @@ trait CompileScalacCompatTestDefinitions { this: CompileTestDefinitions =>
            |""".stripMargin).fromRoot { root =>
         os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "compile",
+          TestUtil.offlineOptions,
           file,
           s"$option2:false",
           extraOptions
@@ -250,7 +269,14 @@ trait CompileScalacCompatTestDefinitions { this: CompileTestDefinitions =>
              |  Iterator(1)
              |    .map(_ + file.count())
              |""".stripMargin).fromRoot { root =>
-          os.proc(TestUtil.cli, "compile", input, buildServerOpts).call(cwd = root)
+          os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "compile",
+            TestUtil.offlineOptions,
+            input,
+            buildServerOpts
+          ).call(cwd = root)
         }
       }
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -15,10 +15,16 @@ abstract class CompileTestDefinitions
     with CompilerPluginTestDefinitions
     with CompileScalacCompatTestDefinitions
     with SemanticDbTestDefinitions { this: TestScalaVersion =>
-  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
+  protected lazy val extraOptions: Seq[String] =
+    scalaVersionArgs ++ TestUtil.extraOptionsWithOffline
 
   private lazy val bloopDaemonDir = BloopUtil.bloopDaemonDir {
-    os.proc(TestUtil.cli, "--power", "directories").call().out.text()
+    os.proc(
+      TestUtil.cli,
+      TestUtil.powerOptions,
+      "directories",
+      TestUtil.offlineOptions
+    ).call().out.text()
   }
 
   val simpleInputs: TestInputs = TestInputs(
@@ -84,7 +90,15 @@ abstract class CompileTestDefinitions
     test("Pure Java with --server=false: no warning about .java files not being compiled") {
       inputs.fromRoot { root =>
         val warningMessage = ".java files are not compiled to .class files"
-        val output         = os.proc(TestUtil.cli, "compile", "--server=false", extraOptions, ".")
+        val output         = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "compile",
+          TestUtil.offlineOptions,
+          "--server=false",
+          extraOptions,
+          "."
+        )
           .call(cwd = root, stderr = os.Pipe).err.text()
         expect(!output.contains(warningMessage))
       }
@@ -111,7 +125,15 @@ abstract class CompileTestDefinitions
           |""".stripMargin
     ).fromRoot { root =>
       val warningMessage = "Using directives detected in multiple files"
-      val output         = os.proc(TestUtil.cli, "compile", ".", "--test", extraOptions)
+      val output         = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        ".",
+        "--test",
+        extraOptions
+      )
         .call(cwd = root, stderr = os.Pipe).err.trim()
       expect(!output.contains(warningMessage))
     }
@@ -142,7 +164,15 @@ abstract class CompileTestDefinitions
           |""".stripMargin
     ).fromRoot { root =>
       val warningMessage = "Using directives detected in multiple files"
-      val output         = os.proc(TestUtil.cli, "compile", ".", "--test", extraOptions)
+      val output         = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        ".",
+        "--test",
+        extraOptions
+      )
         .call(cwd = root, stderr = os.Pipe).err.trim()
       expect(output.contains(warningMessage))
     }
@@ -166,7 +196,14 @@ abstract class CompileTestDefinitions
 
     inputs.fromRoot { root =>
       val warningMessage = "Using directives detected in multiple files"
-      val output         = os.proc(TestUtil.cli, "--power", "compile", extraOptions, ".")
+      val output         = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        extraOptions,
+        "."
+      )
         .call(cwd = root).err.trim()
       expect(!output.contains(warningMessage))
       expect(!output.contains(".java files are not compiled to .class files"))
@@ -188,7 +225,14 @@ abstract class CompileTestDefinitions
     test("warn about directives in multiple files") {
       inputs.fromRoot { root =>
         val warningMessage = "Using directives detected in multiple files"
-        val output         = os.proc(TestUtil.cli, "--power", "compile", extraOptions, ".")
+        val output         = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "compile",
+          TestUtil.offlineOptions,
+          extraOptions,
+          "."
+        )
           .call(cwd = root, stderr = os.Pipe).err.trim()
         expect(output.contains(warningMessage))
       }
@@ -198,7 +242,15 @@ abstract class CompileTestDefinitions
       inputs.fromRoot { root =>
         val warningMessage = ".java files are not compiled to .class files"
         val output         =
-          os.proc(TestUtil.cli, "--power", "compile", extraOptions, ".", "--server=false")
+          os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "compile",
+            TestUtil.offlineOptions,
+            extraOptions,
+            ".",
+            "--server=false"
+          )
             .call(cwd = root, stderr = os.Pipe).err.trim()
         expect(output.contains(warningMessage))
         expect(output.contains(javaSourceFile))
@@ -267,7 +319,16 @@ abstract class CompileTestDefinitions
   test("copy compile output") {
     mainAndTestInputs.fromRoot { root =>
       val tempOutput = root / "output"
-      os.proc(TestUtil.cli, "compile", "--compile-output", tempOutput, extraOptions, ".").call(cwd =
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        "--compile-output",
+        tempOutput,
+        extraOptions,
+        "."
+      ).call(cwd =
         root
       )
       checkIfCompileOutputIsCopied("Main", tempOutput)
@@ -280,7 +341,9 @@ abstract class CompileTestDefinitions
       val output     =
         os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "compile",
+          TestUtil.offlineOptions,
           "--test",
           "--compile-output",
           tempOutput,
@@ -326,7 +389,15 @@ abstract class CompileTestDefinitions
           |""".stripMargin
     )
     inputs.fromRoot { root =>
-      val res = os.proc(TestUtil.cli, "compile", "--test", extraOptions, ".")
+      val res = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        "--test",
+        extraOptions,
+        "."
+      )
         .call(cwd = root, check = false, stderr = os.Pipe, mergeErrIntoOut = true)
       expect(res.exitCode == 1)
       val expectedInOutput =
@@ -578,7 +649,9 @@ abstract class CompileTestDefinitions
       val res =
         os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "compile",
+          TestUtil.offlineOptions,
           "--print-class-path",
           extraOptions,
           "."
@@ -625,11 +698,18 @@ abstract class CompileTestDefinitions
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "compile", "--test", ".")
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        "--test",
+        "."
+      )
         .call(cwd = root, stdin = os.Inherit, stdout = os.Inherit)
-      os.proc(TestUtil.cli, "run", ".")
+      os.proc(TestUtil.cli, TestUtil.powerOptions, "run", TestUtil.offlineOptions, ".")
         .call(cwd = root, stdin = os.Inherit, stdout = os.Inherit)
-      os.proc(TestUtil.cli, "test", ".")
+      os.proc(TestUtil.cli, TestUtil.powerOptions, "test", TestUtil.offlineOptions, ".")
         .call(cwd = root, stdin = os.Inherit, stdout = os.Inherit)
     }
   }
@@ -655,8 +735,9 @@ abstract class CompileTestDefinitions
       val res =
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "compile",
+          TestUtil.offlineOptions,
           "--python",
           "--print-class-path",
           ".",
@@ -682,7 +763,9 @@ abstract class CompileTestDefinitions
       .fromRoot { root =>
         val compileRes = os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "compile",
+          TestUtil.offlineOptions,
           "s.sc",
           "--print-classpath",
           extraOptions
@@ -691,7 +774,9 @@ abstract class CompileTestDefinitions
         expect(!compileRes.out.trim().contains(compilerArtifactName))
         val compileWithCompilerRes = os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "compile",
+          TestUtil.offlineOptions,
           "s.sc",
           "-with-compiler",
           "--print-classpath",
@@ -710,7 +795,9 @@ abstract class CompileTestDefinitions
       .fromRoot { root =>
         val firstRes = os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "compile",
+          TestUtil.offlineOptions,
           "main.scala"
         ).call(cwd = root, mergeErrIntoOut = true)
 
@@ -722,7 +809,9 @@ abstract class CompileTestDefinitions
 
         val differentRes = os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "compile",
+          TestUtil.offlineOptions,
           "main.scala",
           "--jvm",
           Constants.scala38MinJavaVersion.toString
@@ -736,7 +825,9 @@ abstract class CompileTestDefinitions
 
         val secondRes = os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "compile",
+          TestUtil.offlineOptions,
           "main.scala"
         ).call(cwd = root, mergeErrIntoOut = true)
 
@@ -761,7 +852,9 @@ abstract class CompileTestDefinitions
     inputs.fromRoot { root =>
       val res = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "compile",
+        TestUtil.offlineOptions,
         "--scalac-option=-J-XX:MaxHeapSize=1k",
         "--server=false",
         extraOptions,
@@ -845,7 +938,14 @@ abstract class CompileTestDefinitions
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      val result = os.proc(TestUtil.cli, "compile", ".", extraOptions).call(
+      val result = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        ".",
+        extraOptions
+      ).call(
         cwd = root,
         check = false,
         mergeErrIntoOut = true
@@ -866,7 +966,14 @@ abstract class CompileTestDefinitions
            |""".stripMargin
       )
 
-      val result2 = os.proc(TestUtil.cli, "compile", ".", extraOptions).call(
+      val result2 = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        ".",
+        extraOptions
+      ).call(
         cwd = root,
         check = false,
         mergeErrIntoOut = true
@@ -900,7 +1007,14 @@ abstract class CompileTestDefinitions
            |""".stripMargin
       )
 
-      val result3 = os.proc(TestUtil.cli, "compile", ".", extraOptions).call(
+      val result3 = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        ".",
+        extraOptions
+      ).call(
         cwd = root,
         check = false,
         mergeErrIntoOut = true
@@ -923,7 +1037,14 @@ abstract class CompileTestDefinitions
     )
 
     inputs.fromRoot { root =>
-      val result = os.proc(TestUtil.cli, "compile", ".", extraOptions).call(
+      val result = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        ".",
+        extraOptions
+      ).call(
         cwd = root,
         check = false,
         mergeErrIntoOut = true
@@ -947,7 +1068,14 @@ abstract class CompileTestDefinitions
     )
 
     inputs.fromRoot { root =>
-      val result = os.proc(TestUtil.cli, "compile", ".", extraOptions).call(
+      val result = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        ".",
+        extraOptions
+      ).call(
         cwd = root,
         check = false,
         mergeErrIntoOut = true
@@ -977,8 +1105,9 @@ abstract class CompileTestDefinitions
         TestUtil.withProcessWatching(
           proc = os.proc(
             TestUtil.cli,
-            "--power",
+            TestUtil.powerOptions,
             "compile",
+            TestUtil.offlineOptions,
             ".",
             "--watch",
             "--watching",

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTests213.scala
@@ -44,7 +44,14 @@ class CompileTests213 extends CompileTestDefinitions with Test213 {
            |  }
            |}""".stripMargin
     ).fromRoot { root =>
-      val result = os.proc(TestUtil.cli, "test", ".", extraOptions).call(
+      val result = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "test",
+        TestUtil.offlineOptions,
+        ".",
+        extraOptions
+      ).call(
         cwd = root,
         check = false,
         mergeErrIntoOut = true

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTests3StableDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTests3StableDefinitions.scala
@@ -9,7 +9,14 @@ trait CompileTests3StableDefinitions { this: CompileTestDefinitions =>
     TestInputs(os.rel / "simple.sc" -> s"""println("Hello")""")
       .fromRoot { root =>
         val result =
-          os.proc(TestUtil.cli, "compile", ".", extraOptions)
+          os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "compile",
+            TestUtil.offlineOptions,
+            ".",
+            extraOptions
+          )
             .call(cwd = root, stderr = os.Pipe)
         expect(result.exitCode == 0)
         expect(!result.err.text().contains("cannot post process TASTY files"))
@@ -53,8 +60,9 @@ trait CompileTests3StableDefinitions { this: CompileTestDefinitions =>
 
       val asJarOut = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "compile",
+        TestUtil.offlineOptions,
         extraOptions,
         ".",
         "--print-class-path",

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestsDefault.scala
@@ -9,7 +9,16 @@ class CompileTestsDefault extends CompileTestDefinitions with CompileTests3Stabl
     simpleInputs
       .add(os.rel / "project.scala" -> s"//> using scala ${crossVersions.mkString(" ")}")
       .fromRoot { root =>
-        os.proc(TestUtil.cli, "compile", ".", "--cross", "--power", extraOptions).call(cwd = root)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "compile",
+          TestUtil.offlineOptions,
+          ".",
+          "--cross",
+          "--power",
+          extraOptions
+        ).call(cwd = root)
       }
   }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/CompilerPluginTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompilerPluginTestDefinitions.scala
@@ -35,7 +35,9 @@ trait CompilerPluginTestDefinitions { this: CompileTestDefinitions =>
           // build the compiler plugin
           os.proc(
             TestUtil.cli,
+            TestUtil.powerOptions,
             "package",
+            TestUtil.offlineOptions,
             s"$pluginName.scala",
             "--power",
             "--with-compiler",
@@ -49,7 +51,9 @@ trait CompilerPluginTestDefinitions { this: CompileTestDefinitions =>
           // verify the plugin is loaded
           val pluginListResult = os.proc(
             TestUtil.cli,
+            TestUtil.powerOptions,
             "compile",
+            TestUtil.offlineOptions,
             s"-Xplugin:$outputJar",
             "-Xplugin-list",
             extraOptions
@@ -59,7 +63,9 @@ trait CompilerPluginTestDefinitions { this: CompileTestDefinitions =>
           // verify the compiler plugin phase is being added correctly
           os.proc(
             TestUtil.cli,
+            TestUtil.powerOptions,
             "compile",
+            TestUtil.offlineOptions,
             s"-Xplugin:$outputJar",
             "-Xshow-phases",
             extraOptions
@@ -71,7 +77,9 @@ trait CompilerPluginTestDefinitions { this: CompileTestDefinitions =>
           // TODO: this shouldn't require running with --server=false
           val res = os.proc(
             TestUtil.cli,
+            TestUtil.powerOptions,
             "compile",
+            TestUtil.offlineOptions,
             pluginOptions,
             usePluginFile,
             "--server=false",

--- a/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ConfigTests.scala
@@ -58,12 +58,25 @@ class ConfigTests extends ScalaCliSuite {
     ).fromRoot { root =>
       val bspEntry = root / ".bsp" / "scala-cli.json"
 
-      os.proc(TestUtil.cli, "config", "ide.auto-setup", "false").call(cwd = root, env = configEnv)
+      os.proc(TestUtil.cli, "config", "ide.auto-setup", "false").call(
+        cwd = root,
+        env = configEnv
+      )
 
-      os.proc(TestUtil.cli, "compile", ".").call(cwd = root, env = configEnv)
+      os.proc(TestUtil.cli, TestUtil.powerOptions, "compile", TestUtil.offlineOptions, ".").call(
+        cwd = root,
+        env = configEnv
+      )
       assert(!os.exists(bspEntry))
 
-      os.proc(TestUtil.cli, "compile", "--auto-setup-ide=true", ".").call(
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        "--auto-setup-ide=true",
+        "."
+      ).call(
         cwd = root,
         env = configEnv
       )
@@ -185,8 +198,9 @@ class ConfigTests extends ScalaCliSuite {
       val confFile = confDir / "test-config.json"
       val extraEnv = Map("SCALA_CLI_CONFIG" -> confFile.toString)
 
-      val res = os.proc(TestUtil.cli, "--power", "config", "httpProxy.address", proxyAddr)
-        .call(cwd = root, env = extraEnv, check = false, mergeErrIntoOut = true)
+      val res =
+        os.proc(TestUtil.cli, "--power", "config", "httpProxy.address", proxyAddr)
+          .call(cwd = root, env = extraEnv, check = false, mergeErrIntoOut = true)
       val output = res.out.trim()
       expect(output.contains(" has wrong permissions"))
     }
@@ -335,8 +349,9 @@ class ConfigTests extends ScalaCliSuite {
       else
         expect(pgpPasswordOpt.isDefined)
 
-      val passwordInConfig = os.proc(TestUtil.cli, "--power", "config", "pgp.secret-key-password")
-        .call(cwd = root, env = extraEnv, stderr = os.Pipe)
+      val passwordInConfig =
+        os.proc(TestUtil.cli, "--power", "config", "pgp.secret-key-password")
+          .call(cwd = root, env = extraEnv, stderr = os.Pipe)
       expect(passwordInConfig.out.text().isEmpty())
 
       val secretKey = os.proc(TestUtil.cli, "--power", "config", "pgp.secret-key")
@@ -426,8 +441,9 @@ class ConfigTests extends ScalaCliSuite {
       val repoPath = root / "the-repo"
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "--publish-repo",
         repoPath.toNIO.toUri.toASCIIString,
         "messages",
@@ -598,12 +614,13 @@ class ConfigTests extends ScalaCliSuite {
       )
 
       // override some values should throw error without force flag
-      val res = os.proc(TestUtil.cli, "--power", "config", key, props, props2, props3).call(
-        cwd = root,
-        env = configEnv,
-        check = false,
-        mergeErrIntoOut = true
-      )
+      val res =
+        os.proc(TestUtil.cli, "--power", "config", key, props, props2, props3).call(
+          cwd = root,
+          env = configEnv,
+          check = false,
+          mergeErrIntoOut = true
+        )
 
       expect(res.exitCode == 1)
       expect(res.out.trim().contains("pass -f or --force"))
@@ -656,8 +673,9 @@ class ConfigTests extends ScalaCliSuite {
 
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "--publish-repo",
         repoPath.toNIO.toUri.toASCIIString,
         "messages",
@@ -681,7 +699,9 @@ class ConfigTests extends ScalaCliSuite {
 
       val res = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "--repository",
         fakeRepoUrl,
         "hello"
@@ -793,8 +813,9 @@ class ConfigTests extends ScalaCliSuite {
 
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "--publish-repo",
         repoPath.toNIO.toUri.toASCIIString,
         "messages",
@@ -818,7 +839,9 @@ class ConfigTests extends ScalaCliSuite {
 
       val res = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "hello"
       ).call(cwd = root, env = extraEnv)
       expect(res.out.trim() == "Hello World")
@@ -858,8 +881,9 @@ class ConfigTests extends ScalaCliSuite {
 
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "--publish-repo",
         repoPath.toNIO.toUri.toASCIIString,
         "messages",
@@ -892,7 +916,9 @@ class ConfigTests extends ScalaCliSuite {
 
       val res = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "hello"
       ).call(cwd = root, env = extraEnv)
       expect(res.out.trim() == "Hello World")

--- a/modules/integration/src/test/scala/scala/cli/integration/DefaultTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DefaultTests.scala
@@ -3,7 +3,7 @@ package scala.cli.integration
 import com.eed3si9n.expecty.Expecty.expect
 
 class DefaultTests extends WithWarmUpScalaCliSuite with LegacyScalaRunnerTestDefinitions {
-  override def warmUpExtraTestOptions: Seq[String] = TestUtil.extraOptions
+  override def warmUpExtraTestOptions: Seq[String] = TestUtil.extraOptionsWithOffline
 
   test("running scala-cli with no args should default to repl") {
     TestInputs.empty.fromRoot { root =>
@@ -45,7 +45,7 @@ class DefaultTests extends WithWarmUpScalaCliSuite with LegacyScalaRunnerTestDef
           TestUtil.cli,
           "--execute-scala",
           s"@main def main() = println($quotation$msg$quotation)",
-          TestUtil.extraOptions
+          TestUtil.extraOptionsWithOffline
         )
           .call(cwd = root)
       expect(res.out.trim() == msg)
@@ -61,7 +61,7 @@ class DefaultTests extends WithWarmUpScalaCliSuite with LegacyScalaRunnerTestDef
           TestUtil.cli,
           "--execute-java",
           s"public class Main { public static void main(String[] args) { System.out.println($quotation$msg$quotation); } }",
-          TestUtil.extraOptions
+          TestUtil.extraOptionsWithOffline
         )
           .call(cwd = root)
       expect(res.out.trim() == msg)
@@ -82,7 +82,7 @@ class DefaultTests extends WithWarmUpScalaCliSuite with LegacyScalaRunnerTestDef
              |```scala
              |println($quotation$msg$quotation)
              |```""".stripMargin,
-          TestUtil.extraOptions
+          TestUtil.bloopTimeoutOptions
         )
           .call(cwd = root)
       expect(res.out.trim() == msg)
@@ -100,6 +100,7 @@ class DefaultTests extends WithWarmUpScalaCliSuite with LegacyScalaRunnerTestDef
       // first, precompile to an explicitly specified output directory with -d
       os.proc(
         TestUtil.cli,
+        TestUtil.extraOptionsWithOffline,
         ".",
         "-d",
         compilationOutputDir
@@ -108,6 +109,7 @@ class DefaultTests extends WithWarmUpScalaCliSuite with LegacyScalaRunnerTestDef
       // next, run while relying on the pre-compiled class instead of passing inputs
       val runRes = os.proc(
         TestUtil.cli,
+        TestUtil.extraOptionsWithOffline,
         "--main-class",
         mainClassName,
         "-classpath",
@@ -128,6 +130,7 @@ class DefaultTests extends WithWarmUpScalaCliSuite with LegacyScalaRunnerTestDef
       // first, precompile to an explicitly specified output directory with -d
       os.proc(
         TestUtil.cli,
+        TestUtil.extraOptionsWithOffline,
         ".",
         "-d",
         compilationOutputDir
@@ -146,14 +149,14 @@ class DefaultTests extends WithWarmUpScalaCliSuite with LegacyScalaRunnerTestDef
 
   test("ensure --help-native works with the default command") {
     TestInputs.empty.fromRoot { root =>
-      val res = os.proc(TestUtil.cli, "--help-native").call(cwd = root)
+      val res = os.proc(TestUtil.cli, TestUtil.extraOptionsWithOffline, "--help-native").call(cwd = root)
       expect(res.out.trim().contains("Scala Native options:"))
     }
   }
 
   test("ensure --help-js works with the default command") {
     TestInputs.empty.fromRoot { root =>
-      val res = os.proc(TestUtil.cli, "--help-js").call(cwd = root)
+      val res = os.proc(TestUtil.cli, TestUtil.extraOptionsWithOffline, "--help-js").call(cwd = root)
       expect(res.out.trim().contains("Scala.js options:"))
     }
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/DeprecationTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DeprecationTests.scala
@@ -13,8 +13,9 @@ class DeprecationTests extends ScalaCliSuite {
     TestInputs(inputPath -> """println("hello")""").fromRoot { root =>
       val res = os.proc(
         TestUtil.cli,
+
         "run",
-        TestUtil.extraOptions,
+        TestUtil.extraOptionsWithOffline,
         inputPath,
         "--deprecated-test-option"
       ).call(cwd = root, stderr = os.Pipe)
@@ -30,8 +31,9 @@ class DeprecationTests extends ScalaCliSuite {
     TestInputs(inputPath -> """println("hello")""").fromRoot { root =>
       val res = os.proc(
         TestUtil.cli,
+
         "run",
-        TestUtil.extraOptions,
+        TestUtil.extraOptionsWithOffline,
         inputPath,
         "--deprecated-test-alias"
       ).call(cwd = root, stderr = os.Pipe)
@@ -47,7 +49,7 @@ class DeprecationTests extends ScalaCliSuite {
       """//> using lib "com.lihaoyi::os-lib:0.11.4"
         |println("hello")
         |""".stripMargin).fromRoot { root =>
-      val res = os.proc(TestUtil.cli, "run", TestUtil.extraOptions, inputPath)
+      val res = os.proc(TestUtil.cli, "run", TestUtil.extraOptionsWithOffline, inputPath)
         .call(cwd = root, stderr = os.Pipe)
       val err = res.err.trim()
       expect(err.contains("deprecated"))
@@ -60,8 +62,9 @@ class DeprecationTests extends ScalaCliSuite {
     TestInputs(inputPath -> """println("hello")""").fromRoot { root =>
       val res = os.proc(
         TestUtil.cli,
+
         "run",
-        TestUtil.extraOptions,
+        TestUtil.extraOptionsWithOffline,
         inputPath,
         "--deprecated-test-option",
         "--suppress-deprecated-warnings"
@@ -78,8 +81,9 @@ class DeprecationTests extends ScalaCliSuite {
         .call(cwd = root, env = configEnvs)
       val res = os.proc(
         TestUtil.cli,
+
         "run",
-        TestUtil.extraOptions,
+        TestUtil.extraOptionsWithOffline,
         inputPath,
         "--deprecated-test-option"
       ).call(cwd = root, stderr = os.Pipe, env = configEnvs)
@@ -93,8 +97,9 @@ class DeprecationTests extends ScalaCliSuite {
     TestInputs(inputPath -> """println("hello")""").fromRoot { root =>
       val res = os.proc(
         TestUtil.cli,
+
         "run",
-        TestUtil.extraOptions,
+        TestUtil.extraOptionsWithOffline,
         inputPath,
         "--deprecated-test-option",
         "--deprecated-test-alias"

--- a/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
@@ -7,7 +7,8 @@ import scala.jdk.CollectionConverters.*
 
 abstract class DocTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
   this: TestScalaVersion =>
-  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
+  protected lazy val extraOptions: Seq[String] =
+    scalaVersionArgs ++ TestUtil.extraOptionsWithOffline
 
   for {
     useTestScope <- Seq(true, false)
@@ -95,7 +96,16 @@ abstract class DocTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
              |class RootLoggerConfigurer:
              |  @Autowired var sentryClient: String = uninitialized
              |""".stripMargin
-      ).fromRoot(root => os.proc(TestUtil.cli, "doc", ".", extraOptions).call(cwd = root))
+      ).fromRoot(root =>
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "doc",
+          TestUtil.offlineOptions,
+          ".",
+          extraOptions
+        ).call(cwd = root)
+      )
     }
 
   if actualScalaVersion.startsWith("3") then
@@ -171,7 +181,9 @@ abstract class DocTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
     ).fromRoot { root =>
       os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "doc",
+        TestUtil.offlineOptions,
         "--cross",
         "--power",
         extraOptions,

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportCommonTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportCommonTestDefinitions.scala
@@ -8,7 +8,7 @@ import scala.util.Properties
 
 trait ExportCommonTestDefinitions { this: ScalaCliSuite & TestScalaVersionArgs =>
   protected lazy val extraOptions: Seq[String] =
-    scalaVersionArgs ++ TestUtil.extraOptions ++ Seq("--suppress-experimental-warning")
+    scalaVersionArgs ++ TestUtil.extraOptionsWithOffline ++ Seq("--suppress-experimental-warning")
 
   protected def commonTestDescriptionSuffix: String = ""
 

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportJsonTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportJsonTestDefinitions.scala
@@ -43,7 +43,16 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
 
       val exportJsonProc =
         // Test --power placed after subcommand name
-        os.proc(TestUtil.cli, "export", "--power", "--json", ".", "--jvm", "temurin:11")
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "export",
+          TestUtil.offlineOptions,
+          "--json",
+          ".",
+          "--jvm",
+          "temurin:11"
+        )
           .call(cwd = root)
 
       val jsonContents = readJson(exportJsonProc.out.text())
@@ -102,7 +111,15 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
     )
 
     inputs.fromRoot { root =>
-      val exportJsonProc = os.proc(TestUtil.cli, "--power", "export", "--json", ".", "--native")
+      val exportJsonProc = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "export",
+        TestUtil.offlineOptions,
+        "--json",
+        ".",
+        "--native"
+      )
         .call(cwd = root)
 
       val jsonContents = readJson(exportJsonProc.out.text())
@@ -201,8 +218,9 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
     inputs.fromRoot { root =>
       val exportJsonProc = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "export",
+        TestUtil.offlineOptions,
         "--json",
         "--output",
         "json_dir",
@@ -259,8 +277,9 @@ abstract class ExportJsonTestDefinitions extends ScalaCliSuite with TestScalaVer
 
       val exportToExistingProc = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "export",
+        TestUtil.offlineOptions,
         "--json",
         "--output",
         "json_dir",

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMavenTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMavenTestDefinitions.scala
@@ -6,8 +6,9 @@ abstract class ExportMavenTestDefinitions extends ScalaCliSuite
   override def exportCommand(args: String*): os.proc =
     os.proc(
       TestUtil.cli,
-      "--power",
+      TestUtil.powerOptions,
       "export",
+      TestUtil.offlineOptions,
       extraOptions,
       "--mvn",
       "-o",

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportMillTestDefinitions.scala
@@ -16,8 +16,9 @@ abstract class ExportMillTestDefinitions extends ScalaCliSuite
   override def exportCommand(args: String*): os.proc =
     os.proc(
       TestUtil.cli,
-      "--power",
+      TestUtil.powerOptions,
       "export",
+      TestUtil.offlineOptions,
       extraOptions,
       "--mill",
       "-o",

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestDefinitions.scala
@@ -7,8 +7,9 @@ abstract class ExportSbtTestDefinitions extends ScalaCliSuite
   override def exportCommand(args: String*): os.proc =
     os.proc(
       TestUtil.cli,
-      "--power",
+      TestUtil.powerOptions,
       "export",
+      TestUtil.offlineOptions,
       extraOptions,
       "--sbt",
       "-o",

--- a/modules/integration/src/test/scala/scala/cli/integration/FixBuiltInRulesTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixBuiltInRulesTestDefinitions.scala
@@ -27,8 +27,9 @@ trait FixBuiltInRulesTestDefinitions { this: FixTestDefinitions =>
 
       val fixOutput = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "fix",
+        TestUtil.offlineOptions,
         ".",
         "-v",
         "-v",
@@ -68,7 +69,14 @@ trait FixBuiltInRulesTestDefinitions { this: FixTestDefinitions =>
           |""".stripMargin
       )
 
-      val runProc = os.proc(TestUtil.cli, "--power", "compile", ".", extraOptions)
+      val runProc = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        ".",
+        extraOptions
+      )
         .call(cwd = root, stderr = os.Pipe)
 
       expect(!runProc.err.trim().contains("Using directives detected in multiple files"))
@@ -96,8 +104,9 @@ trait FixBuiltInRulesTestDefinitions { this: FixTestDefinitions =>
       val fixOutput =
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "fix",
+          TestUtil.offlineOptions,
           ".",
           "-v",
           "-v",
@@ -135,7 +144,14 @@ trait FixBuiltInRulesTestDefinitions { this: FixTestDefinitions =>
           |""".stripMargin
       )
 
-      val runProc = os.proc(TestUtil.cli, "--power", "compile", ".", extraOptions)
+      val runProc = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        ".",
+        extraOptions
+      )
         .call(cwd = root, stderr = os.Pipe)
 
       expect(!runProc.err.trim().contains("Using directives detected in multiple files"))
@@ -181,8 +197,9 @@ trait FixBuiltInRulesTestDefinitions { this: FixTestDefinitions =>
       val fixOutput =
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "fix",
+          TestUtil.offlineOptions,
           ".",
           "-v",
           "-v",
@@ -242,7 +259,14 @@ trait FixBuiltInRulesTestDefinitions { this: FixTestDefinitions =>
           |""".stripMargin
       )
 
-      val runProc = os.proc(TestUtil.cli, "--power", "compile", ".", extraOptions)
+      val runProc = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        ".",
+        extraOptions
+      )
         .call(cwd = root, stderr = os.Pipe)
 
       expect(!runProc.err.trim().contains("Using directives detected in multiple files"))
@@ -323,8 +347,9 @@ trait FixBuiltInRulesTestDefinitions { this: FixTestDefinitions =>
       inputs.fromRoot { root =>
         val res = os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "fix",
+          TestUtil.offlineOptions,
           ".",
           "--script-snippet",
           "//> using toolkit default",
@@ -440,9 +465,23 @@ trait FixBuiltInRulesTestDefinitions { this: FixTestDefinitions =>
              |}
              |""".stripMargin
       ).fromRoot { root =>
-        os.proc(TestUtil.cli, "--power", "fix", ".", extraOptions)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "fix",
+          TestUtil.offlineOptions,
+          ".",
+          extraOptions
+        )
           .call(cwd = root, stderr = os.Pipe)
-        val r = os.proc(TestUtil.cli, "--power", "run", ".", extraOptions)
+        val r = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          ".",
+          extraOptions
+        )
           .call(cwd = root, stderr = os.Pipe)
         expect(r.out.trim() == expectedMessage)
       }
@@ -468,14 +507,28 @@ trait FixBuiltInRulesTestDefinitions { this: FixTestDefinitions =>
         s"dont extract directives into project.scala for a single-file project: $inputFileName"
       ) {
         testInputs.fromRoot { root =>
-          val fixResult = os.proc(TestUtil.cli, "--power", "fix", ".", extraOptions)
+          val fixResult = os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "fix",
+            TestUtil.offlineOptions,
+            ".",
+            extraOptions
+          )
             .call(cwd = root, stderr = os.Pipe)
           expect(fixResult.err.trim().contains(
             "No need to migrate directives for a single source file project"
           ))
           expect(!os.exists(root / projectFileName))
           expect(os.read(root / inputFileName) == code)
-          val runResult = os.proc(TestUtil.cli, "run", ".", extraOptions)
+          val runResult = os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "run",
+            TestUtil.offlineOptions,
+            ".",
+            extraOptions
+          )
             .call(cwd = root, stderr = os.Pipe)
           expect(runResult.out.trim() == root.toString)
         }
@@ -512,7 +565,14 @@ trait FixBuiltInRulesTestDefinitions { this: FixTestDefinitions =>
                            |}
                            |""".stripMargin
       ).fromRoot { root =>
-        os.proc(TestUtil.cli, "--power", "fix", ".", extraOptions).call(cwd = root)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "fix",
+          TestUtil.offlineOptions,
+          ".",
+          extraOptions
+        ).call(cwd = root)
         val expectedProjectFileContents =
           s"""// Test
              |$osLibTestDepDirective
@@ -524,7 +584,14 @@ trait FixBuiltInRulesTestDefinitions { this: FixTestDefinitions =>
         expect(!mainFileContents.contains("//> using"))
         val testFileContents = os.read(root / testFilePath)
         expect(!testFileContents.contains("//> using"))
-        os.proc(TestUtil.cli, "test", ".", extraOptions).call(cwd = root)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "test",
+          TestUtil.offlineOptions,
+          ".",
+          extraOptions
+        ).call(cwd = root)
       }
     }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/FixScalafixRulesTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixScalafixRulesTestDefinitions.scala
@@ -41,7 +41,15 @@ trait FixScalafixRulesTestDefinitions {
 
   test("simple") {
     simpleInputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "fix", ".", "--power", scalaVersionArgs).call(cwd = root)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fix",
+        TestUtil.offlineOptions,
+        ".",
+        "--power",
+        scalaVersionArgs
+      ).call(cwd = root)
       val updatedContent = noCrLf(os.read(root / "Hello.scala"))
       expect(updatedContent == expectedContent)
     }
@@ -49,7 +57,15 @@ trait FixScalafixRulesTestDefinitions {
 
   test("with --check") {
     simpleInputs.fromRoot { root =>
-      val res = os.proc(TestUtil.cli, "fix", "--power", "--check", ".", scalaVersionArgs).call(
+      val res = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fix",
+        TestUtil.offlineOptions,
+        "--check",
+        ".",
+        scalaVersionArgs
+      ).call(
         cwd = root,
         check = false
       )
@@ -93,7 +109,14 @@ trait FixScalafixRulesTestDefinitions {
     }
 
     semanticRuleInputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "fix", "--power", ".", scalaVersionArgs).call(cwd = root)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fix",
+        TestUtil.offlineOptions,
+        ".",
+        scalaVersionArgs
+      ).call(cwd = root)
       val updatedContent = noCrLf(os.read(root / "Hello.scala"))
       expect(updatedContent == expectedContent)
     }
@@ -123,7 +146,9 @@ trait FixScalafixRulesTestDefinitions {
     input.fromRoot { root =>
       os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "fix",
+        TestUtil.offlineOptions,
         ".",
         "--scalafix-rules",
         "RedundantSyntax",
@@ -177,7 +202,9 @@ trait FixScalafixRulesTestDefinitions {
     inputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "fix",
+        TestUtil.offlineOptions,
         ".",
         "--scalafix-arg=--settings.RedundantSyntax.finalObject=false",
         "--power",
@@ -218,7 +245,9 @@ trait FixScalafixRulesTestDefinitions {
     inputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "fix",
+        TestUtil.offlineOptions,
         ".",
         s"--scalafix-conf=$confFileName",
         "--power",
@@ -256,7 +285,15 @@ trait FixScalafixRulesTestDefinitions {
     }
 
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "fix", ".", "--power", scalaVersionArgs).call(cwd = root)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fix",
+        TestUtil.offlineOptions,
+        ".",
+        "--power",
+        scalaVersionArgs
+      ).call(cwd = root)
       val updatedContent = noCrLf(os.read(root / "Hello.scala"))
       expect(updatedContent == expectedContent)
     }
@@ -289,7 +326,15 @@ trait FixScalafixRulesTestDefinitions {
     }
 
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "fix", ".", "--power", scalaVersionArgs).call(cwd = root)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fix",
+        TestUtil.offlineOptions,
+        ".",
+        "--power",
+        scalaVersionArgs
+      ).call(cwd = root)
       val updatedContent = noCrLf(os.read(root / "Hello.scala"))
       expect(updatedContent == expectedContent)
     }
@@ -349,7 +394,16 @@ trait FixScalafixRulesTestDefinitions {
             |}
             |""".stripMargin
       ).fromRoot { root =>
-        val res = os.proc(TestUtil.cli, "fix", ".", "--power", semanticDbOptions, extraOptions)
+        val res = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "fix",
+          TestUtil.offlineOptions,
+          ".",
+          "--power",
+          semanticDbOptions,
+          extraOptions
+        )
           .call(cwd = root, check = false, stderr = os.Pipe)
         val successful = res.exitCode == 0
         expect(successful == expectedSuccess)

--- a/modules/integration/src/test/scala/scala/cli/integration/FixTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixTestDefinitions.scala
@@ -9,7 +9,7 @@ abstract class FixTestDefinitions
     with FixScalafixRulesTestDefinitions { this: TestScalaVersion =>
   val projectFileName           = "project.scala"
   val extraOptions: Seq[String] =
-    scalaVersionArgs ++ TestUtil.extraOptions ++ Seq("--suppress-experimental-feature-warning")
+    scalaVersionArgs ++ TestUtil.extraOptionsWithOffline ++ Seq("--suppress-experimental-feature-warning")
   def enableRulesOptions(
     enableScalafix: Boolean = true,
     enableBuiltIn: Boolean = true
@@ -58,13 +58,28 @@ abstract class FixTestDefinitions
           |]
           |""".stripMargin
     ).fromRoot { root =>
-      os.proc(TestUtil.cli, "fix", ".", extraOptions, "--power").call(cwd = root)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fix",
+        TestUtil.offlineOptions,
+        ".",
+        extraOptions,
+        "--power"
+      ).call(cwd = root)
       val projectFileContents = os.read(root / projectFileName)
       expect(projectFileContents.contains(mergedDirective1And2))
       expect(projectFileContents.contains(directive3))
       val mainFileContents = os.read(root / mainFileName)
       expect(!mainFileContents.contains(unusedValName))
-      os.proc(TestUtil.cli, "compile", ".", extraOptions).call(cwd = root)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        ".",
+        extraOptions
+      ).call(cwd = root)
     }
   }
 
@@ -84,8 +99,9 @@ abstract class FixTestDefinitions
     ).fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "fix",
+        TestUtil.offlineOptions,
         ".",
         extraOptions
       ).call(cwd = root)

--- a/modules/integration/src/test/scala/scala/cli/integration/FmtTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FmtTests.scala
@@ -80,7 +80,9 @@ class FmtTests extends ScalaCliSuite {
 
   test("simple") {
     simpleInputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "fmt", ".").call(cwd = root)
+      os.proc(TestUtil.cli, TestUtil.powerOptions, "fmt", TestUtil.offlineOptions, ".").call(cwd =
+        root
+      )
       val updatedContent = noCrLf(os.read(root / "Foo.scala"))
       expect(updatedContent == expectedSimpleInputsFormattedContent)
     }
@@ -88,7 +90,7 @@ class FmtTests extends ScalaCliSuite {
 
   test("no inputs") {
     simpleInputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "fmt").call(cwd = root)
+      os.proc(TestUtil.cli, TestUtil.powerOptions, "fmt", TestUtil.offlineOptions).call(cwd = root)
       val updatedContent = noCrLf(os.read(root / "Foo.scala"))
       expect(updatedContent == expectedSimpleInputsFormattedContent)
     }
@@ -96,7 +98,13 @@ class FmtTests extends ScalaCliSuite {
 
   test("with --check") {
     simpleInputs.fromRoot { root =>
-      val res = os.proc(TestUtil.cli, "fmt", "--check").call(cwd = root, check = false)
+      val res = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fmt",
+        TestUtil.offlineOptions,
+        "--check"
+      ).call(cwd = root, check = false)
       expect(res.exitCode == 1)
       val out            = res.out.text()
       val updatedContent = noCrLf(os.read(root / "Foo.scala"))
@@ -107,15 +115,35 @@ class FmtTests extends ScalaCliSuite {
 
   test("filter correctly with --check") {
     simpleInputsWithFilter.fromRoot { root =>
-      val out = os.proc(TestUtil.cli, "fmt", ".", "--check").call(cwd = root).out.trim()
+      val out = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fmt",
+        TestUtil.offlineOptions,
+        ".",
+        "--check"
+      ).call(cwd = root).out.trim()
       expect(out == "All files are formatted with scalafmt :)")
     }
   }
 
   test("--scalafmt-help") {
     emptyInputs.fromRoot { root =>
-      val out1 = os.proc(TestUtil.cli, "fmt", "--scalafmt-help").call(cwd = root).out.trim()
-      val out2 = os.proc(TestUtil.cli, "fmt", "-F", "--help").call(cwd = root).out.trim()
+      val out1 = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fmt",
+        TestUtil.offlineOptions,
+        "--scalafmt-help"
+      ).call(cwd = root).out.trim()
+      val out2 = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fmt",
+        TestUtil.offlineOptions,
+        "-F",
+        "--help"
+      ).call(cwd = root).out.trim()
       expect(out1.nonEmpty)
       expect(out1 == out2)
       val outLines       = out1.linesIterator.toSeq
@@ -128,7 +156,14 @@ class FmtTests extends ScalaCliSuite {
 
   test("--save-scalafmt-conf") {
     simpleInputsWithDialectOnly.fromRoot { root =>
-      os.proc(TestUtil.cli, "fmt", ".", "--save-scalafmt-conf").call(cwd = root)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fmt",
+        TestUtil.offlineOptions,
+        ".",
+        "--save-scalafmt-conf"
+      ).call(cwd = root)
       val confLines      = os.read.lines(root / confFileName)
       val versionInConf  = confLines(0).stripPrefix("version = ")
       val updatedContent = noCrLf(os.read(root / "Foo.scala"))
@@ -139,7 +174,15 @@ class FmtTests extends ScalaCliSuite {
 
   test("--scalafmt-dialect") {
     simpleInputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "fmt", ".", "--scalafmt-dialect", "scala3").call(cwd = root)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fmt",
+        TestUtil.offlineOptions,
+        ".",
+        "--scalafmt-dialect",
+        "scala3"
+      ).call(cwd = root)
       val confLines      = os.read.lines(root / Constants.workspaceDirName / confFileName)
       val dialectInConf  = confLines(1).stripPrefix("runner.dialect = ").trim
       val updatedContent = noCrLf(os.read(root / "Foo.scala"))
@@ -150,7 +193,15 @@ class FmtTests extends ScalaCliSuite {
 
   test("--scalafmt-version") {
     simpleInputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "fmt", ".", "--scalafmt-version", "3.5.5").call(cwd = root)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fmt",
+        TestUtil.offlineOptions,
+        ".",
+        "--scalafmt-version",
+        "3.5.5"
+      ).call(cwd = root)
       val confLines      = os.read.lines(root / Constants.workspaceDirName / confFileName)
       val versionInConf  = confLines(0).stripPrefix("version = ").trim
       val updatedContent = noCrLf(os.read(root / "Foo.scala"))
@@ -161,7 +212,15 @@ class FmtTests extends ScalaCliSuite {
 
   test("--scalafmt-conf") {
     simpleInputsWithCustomConfLocation.fromRoot { root =>
-      os.proc(TestUtil.cli, "fmt", ".", "--scalafmt-conf", "custom.conf").call(cwd = root)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fmt",
+        TestUtil.offlineOptions,
+        ".",
+        "--scalafmt-conf",
+        "custom.conf"
+      ).call(cwd = root)
       val confLines      = os.read.lines(root / Constants.workspaceDirName / confFileName)
       val versionInConf  = confLines(0).stripPrefix("version = ").trim
       val dialectInConf  = confLines(1).stripPrefix("runner.dialect = ").trim
@@ -176,7 +235,15 @@ class FmtTests extends ScalaCliSuite {
     simpleInputsWithVersionOnly.fromRoot { root =>
       val confStr =
         s"""version = 3.5.7${System.lineSeparator}runner.dialect = scala213${System.lineSeparator}"""
-      os.proc(TestUtil.cli, "fmt", ".", "--scalafmt-conf-str", s"$confStr").call(cwd = root)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fmt",
+        TestUtil.offlineOptions,
+        ".",
+        "--scalafmt-conf-str",
+        s"$confStr"
+      ).call(cwd = root)
       val confLines      = os.read.lines(root / Constants.workspaceDirName / confFileName)
       val versionInConf  = confLines(0).stripPrefix("version = ")
       val dialectInConf  = confLines(1).stripPrefix("runner.dialect = ")
@@ -189,7 +256,9 @@ class FmtTests extends ScalaCliSuite {
 
   test("complete .scalafmt.conf is not duplicated under .scala-build") {
     simpleInputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "fmt", ".").call(cwd = root)
+      os.proc(TestUtil.cli, TestUtil.powerOptions, "fmt", TestUtil.offlineOptions, ".").call(cwd =
+        root
+      )
       val updatedContent = noCrLf(os.read(root / "Foo.scala"))
       expect(updatedContent == expectedSimpleInputsFormattedContent)
       expectNoWorkspaceScalafmtConf(root)
@@ -200,7 +269,9 @@ class FmtTests extends ScalaCliSuite {
     simpleInputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "fmt",
+        TestUtil.offlineOptions,
         ".",
         "--scalafmt-version",
         Constants.defaultScalafmtVersion
@@ -213,7 +284,15 @@ class FmtTests extends ScalaCliSuite {
 
   test("complete .scalafmt.conf + matching --scalafmt-dialect still avoids .scala-build") {
     simpleInputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "fmt", ".", "--scalafmt-dialect", "scala213").call(cwd = root)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fmt",
+        TestUtil.offlineOptions,
+        ".",
+        "--scalafmt-dialect",
+        "scala213"
+      ).call(cwd = root)
       val updatedContent = noCrLf(os.read(root / "Foo.scala"))
       expect(updatedContent == expectedSimpleInputsFormattedContent)
       expectNoWorkspaceScalafmtConf(root)
@@ -226,7 +305,9 @@ class FmtTests extends ScalaCliSuite {
       val subdir = root / "subdir"
       os.makeDir.all(subdir)
       os.move(root / "Foo.scala", subdir / "Foo.scala")
-      os.proc(TestUtil.cli, "fmt", ".").call(cwd = subdir)
+      os.proc(TestUtil.cli, TestUtil.powerOptions, "fmt", TestUtil.offlineOptions, ".").call(cwd =
+        subdir
+      )
       val updatedContent = noCrLf(os.read(subdir / "Foo.scala"))
       expect(updatedContent == expectedSimpleInputsFormattedContent)
       expectNoWorkspaceScalafmtConf(subdir)
@@ -241,7 +322,9 @@ class FmtTests extends ScalaCliSuite {
       TestUtil.initializeGit(root)
       val confPath = workspaceConfPath(root)
       expect(!os.exists(confPath))
-      os.proc(TestUtil.cli, "fmt", ".").call(cwd = root)
+      os.proc(TestUtil.cli, TestUtil.powerOptions, "fmt", TestUtil.offlineOptions, ".").call(cwd =
+        root
+      )
       expect(os.exists(confPath))
       val updatedContent = noCrLf(os.read(root / "Foo.scala"))
       expect(updatedContent == expectedSimpleInputsFormattedContent)
@@ -252,7 +335,9 @@ class FmtTests extends ScalaCliSuite {
     simpleInputsWithDialectOnly.fromRoot { root =>
       val confPath = workspaceConfPath(root)
       expect(!os.exists(confPath))
-      os.proc(TestUtil.cli, "fmt", ".").call(cwd = root)
+      os.proc(TestUtil.cli, TestUtil.powerOptions, "fmt", TestUtil.offlineOptions, ".").call(cwd =
+        root
+      )
       expect(os.exists(confPath))
       val updatedContent = noCrLf(os.read(root / "Foo.scala"))
       expect(updatedContent == expectedSimpleInputsFormattedContent)
@@ -261,7 +346,9 @@ class FmtTests extends ScalaCliSuite {
 
   test("scalafmt conf without version") {
     simpleInputsWithDialectOnly.fromRoot { root =>
-      os.proc(TestUtil.cli, "fmt", ".").call(cwd = root)
+      os.proc(TestUtil.cli, TestUtil.powerOptions, "fmt", TestUtil.offlineOptions, ".").call(cwd =
+        root
+      )
       val confLines      = os.read.lines(root / Constants.workspaceDirName / confFileName)
       val versionInConf  = confLines(0).stripPrefix("version = ").trim
       val updatedContent = noCrLf(os.read(root / "Foo.scala"))
@@ -272,7 +359,9 @@ class FmtTests extends ScalaCliSuite {
 
   test("scalafmt conf without dialect") {
     simpleInputsWithVersionOnly.fromRoot { root =>
-      os.proc(TestUtil.cli, "fmt", ".").call(cwd = root)
+      os.proc(TestUtil.cli, TestUtil.powerOptions, "fmt", TestUtil.offlineOptions, ".").call(cwd =
+        root
+      )
       val confLines      = os.read.lines(root / Constants.workspaceDirName / confFileName)
       val dialectInConf  = confLines(1).stripPrefix("runner.dialect = ")
       val updatedContent = noCrLf(os.read(root / "Foo.scala"))
@@ -283,7 +372,13 @@ class FmtTests extends ScalaCliSuite {
 
   test("default values in help") {
     TestInputs.empty.fromRoot { root =>
-      val res            = os.proc(TestUtil.cli, "fmt", "--help").call(cwd = root)
+      val res = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fmt",
+        TestUtil.offlineOptions,
+        "--help"
+      ).call(cwd = root)
       val lines          = removeAnsiColors(res.out.trim()).linesIterator.toVector
       val fmtVersionHelp = lines.find(_.contains("--fmt-version")).getOrElse("")
       expect(fmtVersionHelp.contains(s"(${Constants.defaultScalafmtVersion} by default)"))
@@ -300,7 +395,9 @@ class FmtTests extends ScalaCliSuite {
             |""".stripMargin
     )
       .fromRoot { root =>
-        os.proc(TestUtil.cli, "fmt", ".").call(cwd = root)
+        os.proc(TestUtil.cli, TestUtil.powerOptions, "fmt", TestUtil.offlineOptions, ".").call(cwd =
+          root
+        )
         val updatedContent = noCrLf(os.read(root / projectFileName))
         expect(updatedContent == expectedSimpleInputsFormattedContent)
       }
@@ -323,7 +420,13 @@ class FmtTests extends ScalaCliSuite {
 
   test("sbt file is formatted when passed explicitly") {
     sbtInputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "fmt", "build.sbt").call(cwd = root)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "fmt",
+        TestUtil.offlineOptions,
+        "build.sbt"
+      ).call(cwd = root)
       val updatedContent = noCrLf(os.read(root / "build.sbt"))
       expect(updatedContent == expectedSbtFormattedContent)
     }
@@ -331,7 +434,9 @@ class FmtTests extends ScalaCliSuite {
 
   test("sbt file is formatted when directory is passed") {
     sbtInputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "fmt", ".").call(cwd = root)
+      os.proc(TestUtil.cli, TestUtil.powerOptions, "fmt", TestUtil.offlineOptions, ".").call(cwd =
+        root
+      )
       val updatedContent = noCrLf(os.read(root / "build.sbt"))
       expect(updatedContent == expectedSbtFormattedContent)
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/HadoopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/HadoopTests.scala
@@ -3,7 +3,8 @@ package scala.cli.integration
 import com.eed3si9n.expecty.Expecty.expect
 
 class HadoopTests extends munit.FunSuite {
-  protected lazy val extraOptions: Seq[String] = TestUtil.extraOptions
+  protected lazy val extraOptions: Seq[String] =
+    TestUtil.extraOptionsWithOffline
 
   for {
     withTestScope <- Seq(true, false)
@@ -89,9 +90,10 @@ class HadoopTests extends munit.FunSuite {
         inputs.fromRoot { root =>
           val res = os.proc(
             TestUtil.cli,
-            "--power",
+            TestUtil.powerOptions,
             "run",
-            TestUtil.extraOptions,
+            TestUtil.offlineOptions,
+            TestUtil.extraOptionsWithOffline,
             ".",
             "--hadoop",
             "--command",

--- a/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/HelpTests.scala
@@ -4,7 +4,8 @@ import com.eed3si9n.expecty.Expecty.expect
 
 class HelpTests extends ScalaCliSuite {
   for (helpOptions <- HelpTests.variants) {
-    lazy val help         = os.proc(TestUtil.cli, helpOptions).call(check = false)
+    lazy val help =
+      os.proc(TestUtil.cli, helpOptions).call(check = false)
     lazy val helpOutput   = help.out.trim()
     val helpOptionsString = helpOptions.mkString(" ")
     test(s"$helpOptionsString works correctly") {
@@ -41,7 +42,8 @@ class HelpTests extends ScalaCliSuite {
   }
 
   for (fullHelpOptions <- HelpTests.fullHelpVariants) {
-    lazy val fullHelp         = os.proc(TestUtil.cli, fullHelpOptions).call(check = false)
+    lazy val fullHelp =
+      os.proc(TestUtil.cli, fullHelpOptions).call(check = false)
     lazy val fullHelpOutput   = fullHelp.out.trim()
     val fullHelpOptionsString = fullHelpOptions.mkString(" ")
     test(s"$fullHelpOptionsString works correctly") {
@@ -57,7 +59,8 @@ class HelpTests extends ScalaCliSuite {
   }
 
   test("name aliases limited for standard help") {
-    val help       = os.proc(TestUtil.cli, "run", "--help").call()
+    val help =
+      os.proc(TestUtil.cli, TestUtil.powerOptions, "run", TestUtil.offlineOptions, "--help").call()
     val helpOutput = help.out.trim()
 
     expect(TestUtil.removeAnsiColors(helpOutput).contains(
@@ -66,7 +69,13 @@ class HelpTests extends ScalaCliSuite {
   }
 
   test("name aliases not limited for full help") {
-    val help       = os.proc(TestUtil.cli, "run", "--full-help").call()
+    val help = os.proc(
+      TestUtil.cli,
+      TestUtil.powerOptions,
+      "run",
+      TestUtil.offlineOptions,
+      "--full-help"
+    ).call()
     val helpOutput = help.out.trim()
     expect(TestUtil.removeAnsiColors(helpOutput).contains(
       "-cp, --jar, --jars, --class, --classes, -classpath, --extra-jar, --classpath, --extra-jars, --class-path, --extra-class, --extra-classes, --extra-class-path paths"
@@ -92,8 +101,9 @@ class HelpTests extends ScalaCliSuite {
   for (withPower <- Seq(true, false))
     test("envs help" + (if (withPower) " with power" else "")) {
       val powerOptions = if (withPower) Seq("--power") else Nil
-      val help         = os.proc(TestUtil.cli, "--envs-help", powerOptions).call()
-      val helpOutput   = help.out.trim()
+      val help         =
+        os.proc(TestUtil.cli, "--envs-help", powerOptions).call()
+      val helpOutput = help.out.trim()
       if (!withPower) expect(!helpOutput.contains("(power)"))
       expect(helpOutput.nonEmpty)
       expect(helpOutput.contains("environment variables"))

--- a/modules/integration/src/test/scala/scala/cli/integration/InstallHomeTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/InstallHomeTests.scala
@@ -28,8 +28,9 @@ class InstallHomeTests extends ScalaCliSuite {
   private def packageDummyScalaCli(root: os.Path, dummyScalaCliFileName: String, output: String) = {
     val cmd = Seq[os.Shellable](
       TestUtil.cli,
-      "--power",
+      TestUtil.powerOptions,
       "package",
+      TestUtil.offlineOptions,
       dummyScalaCliFileName,
       "-o",
       output
@@ -49,6 +50,7 @@ class InstallHomeTests extends ScalaCliSuite {
   ) = {
     val cmdInstallVersion = Seq[os.Shellable](
       TestUtil.cli,
+      TestUtil.powerOptions,
       "install-home",
       "--env",
       "--scala-cli-binary-path",
@@ -73,6 +75,7 @@ class InstallHomeTests extends ScalaCliSuite {
   ) = {
     val cmdUninstall = Seq[os.Shellable](
       TestUtil.cli,
+      TestUtil.powerOptions,
       "uninstall",
       "--binary-name",
       dummyScalaCliBinName,

--- a/modules/integration/src/test/scala/scala/cli/integration/JmhTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/JmhTests.scala
@@ -13,7 +13,8 @@ import scala.util.Properties
 
 class JmhTests extends ScalaCliSuite with JmhSuite with BspSuite {
   override def group: ScalaCliSuite.TestGroup      = ScalaCliSuite.TestGroup.First
-  override protected val extraOptions: Seq[String] = TestUtil.extraOptions
+  override protected val extraOptions: Seq[String] =
+    TestUtil.extraOptionsWithOffline
 
   for {
     useDirective <- Seq(None, Some("//> using jmh"))
@@ -37,14 +38,30 @@ class JmhTests extends ScalaCliSuite with JmhSuite with BspSuite {
 
     test(s"compile ($testMessage)") {
       simpleBenchmarkingInputs(directiveString).fromRoot { root =>
-        os.proc(TestUtil.cli, "compile", "--power", extraOptions, ".", jmhOptions)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "compile",
+          TestUtil.offlineOptions,
+          extraOptions,
+          ".",
+          jmhOptions
+        )
           .call(cwd = root)
       }
     }
 
     test(s"doc ($testMessage)") {
       simpleBenchmarkingInputs(directiveString).fromRoot { root =>
-        val res = os.proc(TestUtil.cli, "doc", "--power", extraOptions, ".", jmhOptions)
+        val res = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "doc",
+          TestUtil.offlineOptions,
+          extraOptions,
+          ".",
+          jmhOptions
+        )
           .call(cwd = root, stderr = os.Pipe)
         expect(!res.err.trim().contains("Error"))
       }
@@ -53,7 +70,15 @@ class JmhTests extends ScalaCliSuite with JmhSuite with BspSuite {
     test(s"setup-ide ($testMessage)") {
       // TODO fix setting jmh via a reload & add tests for it
       simpleBenchmarkingInputs(directiveString).fromRoot { root =>
-        os.proc(TestUtil.cli, "setup-ide", "--power", extraOptions, ".", jmhOptions)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "setup-ide",
+          TestUtil.offlineOptions,
+          extraOptions,
+          ".",
+          jmhOptions
+        )
           .call(cwd = root)
       }
     }
@@ -77,7 +102,15 @@ class JmhTests extends ScalaCliSuite with JmhSuite with BspSuite {
     test(s"setup-ide + bsp ($testMessage)") {
       val inputs = simpleBenchmarkingInputs(directiveString)
       inputs.fromRoot { root =>
-        os.proc(TestUtil.cli, "setup-ide", "--power", extraOptions, ".", jmhOptions)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "setup-ide",
+          TestUtil.offlineOptions,
+          extraOptions,
+          ".",
+          jmhOptions
+        )
           .call(cwd = root)
         val ideOptionsPath = root / Constants.workspaceDirName / "ide-options-v2.json"
         expect(ideOptionsPath.toNIO.toFile.exists())
@@ -120,9 +153,10 @@ class JmhTests extends ScalaCliSuite with JmhSuite with BspSuite {
           }
           os.proc(
             TestUtil.cli,
+            TestUtil.powerOptions,
             "package",
-            "--power",
-            TestUtil.extraOptions,
+            TestUtil.offlineOptions,
+            TestUtil.extraOptionsWithOffline,
             ".",
             jmhOptions,
             "-o",
@@ -140,7 +174,15 @@ class JmhTests extends ScalaCliSuite with JmhSuite with BspSuite {
     test(s"export ($testMessage)") {
       simpleBenchmarkingInputs(directiveString).fromRoot { root =>
         // TODO add proper support for JMH export, we're checking if it doesn't fail the command for now
-        os.proc(TestUtil.cli, "export", "--power", extraOptions, ".", jmhOptions)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "export",
+          TestUtil.offlineOptions,
+          extraOptions,
+          ".",
+          jmhOptions
+        )
           .call(cwd = root)
       }
     }
@@ -158,7 +200,15 @@ class JmhTests extends ScalaCliSuite with JmhSuite with BspSuite {
   } test(s"should not compile when jmh is explicitly disabled ($testMessage)") {
     simpleBenchmarkingInputs(directiveString).fromRoot { root =>
       val res =
-        os.proc(TestUtil.cli, "compile", "--power", extraOptions, ".", jmhOptions)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "compile",
+          TestUtil.offlineOptions,
+          extraOptions,
+          ".",
+          jmhOptions
+        )
           .call(cwd = root, check = false)
       expect(res.exitCode == 1)
     }
@@ -184,7 +234,15 @@ class JmhTests extends ScalaCliSuite with JmhSuite with BspSuite {
   } test(s"should use the passed jmh version ($testMessage)") {
     simpleBenchmarkingInputs(directiveString).fromRoot { root =>
       val res =
-        os.proc(TestUtil.cli, "run", "--power", extraOptions, ".", jmhOptions)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          extraOptions,
+          ".",
+          jmhOptions
+        )
           .call(cwd = root)
       val output = res.out.trim()
       expect(output.contains(expectedInBenchmarkingOutput))

--- a/modules/integration/src/test/scala/scala/cli/integration/LegacyScalaRunnerTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/LegacyScalaRunnerTestDefinitions.scala
@@ -7,7 +7,7 @@ trait LegacyScalaRunnerTestDefinitions { this: DefaultTests =>
       val msg       = "Hello world"
       val quotation = TestUtil.argQuotationMark
       val res       =
-        os.proc(TestUtil.cli, "-e", s"println($quotation$msg$quotation)", TestUtil.extraOptions)
+        os.proc(TestUtil.cli, "-e", s"println($quotation$msg$quotation)", TestUtil.bloopTimeoutOptions)
           .call(cwd = root)
       expect(res.out.trim() == msg)
     }
@@ -22,7 +22,7 @@ trait LegacyScalaRunnerTestDefinitions { this: DefaultTests =>
           "-e",
           "println()",
           replSpecificOption,
-          TestUtil.extraOptions
+          TestUtil.bloopTimeoutOptions
         )
           .call(cwd = root, mergeErrIntoOut = true, check = false)
       expect(res.exitCode == 1)
@@ -43,7 +43,7 @@ trait LegacyScalaRunnerTestDefinitions { this: DefaultTests =>
       (legacyHtrOption, inputFile, root) =>
         Seq("object", "script", "jar", "repl", "guess", "invalid").foreach { htrValue =>
           val res =
-            os.proc(TestUtil.cli, legacyHtrOption, htrValue, inputFile, TestUtil.extraOptions)
+            os.proc(TestUtil.cli, legacyHtrOption, htrValue, inputFile, TestUtil.bloopTimeoutOptions)
               .call(cwd = root, stderr = os.Pipe)
           expect(res.err.trim().contains(deprecatedOptionWarning(legacyHtrOption)))
           expect(res.err.trim().contains(htrValue))
@@ -62,7 +62,7 @@ trait LegacyScalaRunnerTestDefinitions { this: DefaultTests =>
           legacyOption,
           anotherInputFile,
           "--repl-dry-run",
-          TestUtil.extraOptions
+          TestUtil.bloopTimeoutOptions
         )
           .call(cwd = root, stderr = os.Pipe)
         expect(res.err.trim().contains(deprecatedOptionWarning(legacyOption)))
@@ -78,7 +78,7 @@ trait LegacyScalaRunnerTestDefinitions { this: DefaultTests =>
   test("ensure -run works with the default command") {
     legacyOptionBackwardsCompatTest("-run") {
       (legacyOption, inputFile, root) =>
-        val res = os.proc(TestUtil.cli, legacyOption, inputFile, ".", TestUtil.extraOptions)
+        val res = os.proc(TestUtil.cli, legacyOption, inputFile, ".", TestUtil.bloopTimeoutOptions)
           .call(cwd = root, stderr = os.Pipe)
         expect(res.err.trim().contains(deprecatedOptionWarning(legacyOption)))
         expect(res.err.trim().contains(inputFile))
@@ -96,7 +96,7 @@ trait LegacyScalaRunnerTestDefinitions { this: DefaultTests =>
                 legacyOption,
                 legacyOptionValue,
                 inputFile,
-                TestUtil.extraOptions
+                TestUtil.bloopTimeoutOptions
               )
                 .call(cwd = root, stderr = os.Pipe)
             expect(res.err.trim().contains(deprecatedOptionWarning(legacyOption)))
@@ -108,7 +108,7 @@ trait LegacyScalaRunnerTestDefinitions { this: DefaultTests =>
   private def simpleLegacyOptionBackwardsCompatTest(optionAliases: String*): Unit =
     abstractLegacyOptionBackwardsCompatTest(optionAliases) {
       (legacyOption, expectedMsg, _, root) =>
-        val res = os.proc(TestUtil.cli, legacyOption, "s.sc", TestUtil.extraOptions)
+        val res = os.proc(TestUtil.cli, legacyOption, "s.sc", TestUtil.bloopTimeoutOptions)
           .call(cwd = root, stderr = os.Pipe)
         expect(res.out.trim() == expectedMsg)
         expect(res.err.trim().contains(deprecatedOptionWarning(legacyOption)))

--- a/modules/integration/src/test/scala/scala/cli/integration/MarkdownTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/MarkdownTests.scala
@@ -366,7 +366,13 @@ class MarkdownTests extends ScalaCliSuite {
           |}
           |```""".stripMargin
     ).fromRoot { root =>
-      val result = os.proc(TestUtil.cli, "test", "sample.md").call(cwd = root)
+      val result = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "test",
+        TestUtil.offlineOptions,
+        "sample.md"
+      ).call(cwd = root)
       val output = result.out.text()
       expect(output.contains("ExampleTest"))
       expect(output.contains("foo"))
@@ -410,7 +416,8 @@ class MarkdownTests extends ScalaCliSuite {
            |```
            |""".stripMargin
     ).fromRoot { root =>
-      val result = os.proc(TestUtil.cli, fileNameWithNumber).call(cwd = root)
+      val result =
+        os.proc(TestUtil.cli, fileNameWithNumber).call(cwd = root)
       expect(result.out.trim() == "Hello")
     }
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
@@ -32,9 +32,10 @@ class NativePackagerTests extends ScalaCliSuite {
         val pkgAppFile = s"$appName.pkg"
         val cmd        = Seq[os.Shellable](
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "package",
-          TestUtil.extraOptions,
+          TestUtil.offlineOptions,
+          TestUtil.extraOptionsWithOffline,
           helloWorldFileName,
           "--pkg",
           "--output",
@@ -76,9 +77,10 @@ class NativePackagerTests extends ScalaCliSuite {
 
         val cmd = Seq[os.Shellable](
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "package",
-          TestUtil.extraOptions,
+          TestUtil.offlineOptions,
+          TestUtil.extraOptionsWithOffline,
           helloWorldFileName,
           "--dmg",
           "--output",
@@ -143,9 +145,10 @@ class NativePackagerTests extends ScalaCliSuite {
 
         val cmd = Seq[os.Shellable](
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "package",
-          TestUtil.extraOptions,
+          TestUtil.offlineOptions,
+          TestUtil.extraOptionsWithOffline,
           helloWorldFileName,
           "--deb",
           "--output",
@@ -218,9 +221,10 @@ class NativePackagerTests extends ScalaCliSuite {
 
         val cmd = Seq[os.Shellable](
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "package",
-          TestUtil.extraOptions,
+          TestUtil.offlineOptions,
+          TestUtil.extraOptionsWithOffline,
           helloWorldFileName,
           "--rpm",
           "--output",
@@ -255,8 +259,9 @@ class NativePackagerTests extends ScalaCliSuite {
 
         val cmd = Seq[os.Shellable](
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "package",
+          TestUtil.offlineOptions,
           helloWorldFileName,
           "--msi",
           "--output",
@@ -291,8 +296,9 @@ class NativePackagerTests extends ScalaCliSuite {
 
       val cmd = Seq[os.Shellable](
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         helloWorldFileName,
         "--docker",
         "--docker-image-repository",
@@ -329,8 +335,9 @@ class NativePackagerTests extends ScalaCliSuite {
 
       val cmd = Seq[os.Shellable](
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         helloWorldFileName,
         "--js",
         "--docker",
@@ -370,8 +377,9 @@ class NativePackagerTests extends ScalaCliSuite {
 
       val cmd = Seq[os.Shellable](
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         helloWorldFileName,
         "--native",
         "-S",

--- a/modules/integration/src/test/scala/scala/cli/integration/NewTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/NewTests.scala
@@ -31,11 +31,12 @@ class NewTests extends ScalaCliSuite {
 
   test("error missing template argument") {
     TestInputs.empty.fromRoot { root =>
-      val result = os.proc(TestUtil.cli, "--power", "new").call(
-        cwd = root,
-        check = false,
-        mergeErrIntoOut = true
-      )
+      val result =
+        os.proc(TestUtil.cli, TestUtil.powerOptions, "new", TestUtil.offlineOptions).call(
+          cwd = root,
+          check = false,
+          mergeErrIntoOut = true
+        )
       val lines = removeAnsiColors(result.out.text()).linesIterator.toVector
       assert(result.exitCode == 1)
       expect(lines.contains("Error: Missing argument <template>"))

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -15,8 +15,9 @@ import scala.util.{Properties, Using}
 
 abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
   this: TestScalaVersion =>
-  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
-  protected lazy val node: String              = TestUtil.fromPath("node").getOrElse("node")
+  protected lazy val extraOptions: Seq[String] =
+    scalaVersionArgs ++ TestUtil.extraOptionsWithOffline
+  protected lazy val node: String = TestUtil.fromPath("node").getOrElse("node")
 
   test("simple script") {
     val fileName = "simple.sc"
@@ -32,7 +33,14 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
       fileName.stripSuffix(".sc") + ext
     }
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "--power", "package", extraOptions, fileName).call(
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "package",
+        TestUtil.offlineOptions,
+        extraOptions,
+        fileName
+      ).call(
         cwd = root,
         stdin = os.Inherit,
         stdout = os.Inherit
@@ -58,7 +66,14 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
            |""".stripMargin
     )
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "--power", "package", extraOptions, ".").call(
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "package",
+        TestUtil.offlineOptions,
+        extraOptions,
+        "."
+      ).call(
         cwd = root,
         stdin = os.Inherit,
         stdout = os.Inherit
@@ -89,7 +104,14 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
       os.rel / "input" -> message
     )
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "--power", "package", extraOptions, ".").call(
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "package",
+        TestUtil.offlineOptions,
+        extraOptions,
+        "."
+      ).call(
         cwd = root,
         stdin = os.Inherit,
         stdout = os.Inherit
@@ -120,8 +142,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     inputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         extraOptions,
         ".",
         "-o",
@@ -156,7 +179,15 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     inputs.asZip { (root, zipPath) =>
       val message = "1,2"
 
-      os.proc(TestUtil.cli, "--power", "package", zipPath, extraOptions, ".").call(
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "package",
+        TestUtil.offlineOptions,
+        zipPath,
+        extraOptions,
+        "."
+      ).call(
         cwd = root,
         stdin = os.Inherit,
         stdout = os.Inherit
@@ -183,7 +214,15 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     )
     val destName = fileName.stripSuffix(".sc") + ".js"
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "--power", "package", extraOptions, fileName, "--js").call(
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "package",
+        TestUtil.offlineOptions,
+        extraOptions,
+        fileName,
+        "--js"
+      ).call(
         cwd = root,
         stdin = os.Inherit,
         stdout = os.Inherit
@@ -213,8 +252,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     inputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         extraOptions,
         fileName,
         "--js",
@@ -256,8 +296,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     inputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         extraOptions,
         fileName,
         "--js",
@@ -300,8 +341,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
       val extraArgs = if (jvm) Seq("--js-cli-on-jvm") else Nil
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         extraOptions,
         fileName,
         "--js",
@@ -340,8 +382,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     inputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         extraOptions,
         fileName,
         "--js",
@@ -380,8 +423,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     inputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         extraOptions,
         fileName,
         "--js",
@@ -444,7 +488,15 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
       fileName.stripSuffix(".sc") + ext
     }
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "--power", "package", extraOptions, fileName, "--native").call(
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "package",
+        TestUtil.offlineOptions,
+        extraOptions,
+        fileName,
+        "--native"
+      ).call(
         cwd = root,
         stdin = os.Inherit,
         stdout = os.Inherit
@@ -495,7 +547,15 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     }
 
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "--power", "package", extraOptions, nativeTargetOpts, fileName).call(
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "package",
+        TestUtil.offlineOptions,
+        extraOptions,
+        nativeTargetOpts,
+        fileName
+      ).call(
         cwd = root,
         stdin = os.Inherit,
         stdout = os.Inherit
@@ -550,7 +610,15 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
       )
       val launcherName = fileName.stripSuffix(".sc") + ".jar"
       inputs.fromRoot { root =>
-        os.proc(TestUtil.cli, "--power", "package", extraOptions, "--assembly", fileName).call(
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "package",
+          TestUtil.offlineOptions,
+          extraOptions,
+          "--assembly",
+          fileName
+        ).call(
           cwd = root,
           stdin = os.Inherit,
           stdout = os.Inherit
@@ -600,8 +668,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     inputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         extraOptions,
         "--assembly",
         "-o",
@@ -641,8 +710,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     inputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         extraOptions,
         "--assembly",
         "-o",
@@ -705,8 +775,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
 
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         extraOptions,
         "--main-class",
         "app.Hello",
@@ -753,8 +824,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     inputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         extraOptions,
         "--assembly",
         "-o",
@@ -829,7 +901,14 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
            |}""".stripMargin
     )
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "--power", "package", extraOptions, ".").call(
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "package",
+        TestUtil.offlineOptions,
+        extraOptions,
+        "."
+      ).call(
         cwd = root,
         stdin = os.Inherit,
         stdout = os.Inherit
@@ -873,8 +952,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     simpleInputWithScalaAndSc.fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         extraOptions,
         ".",
         "-o",
@@ -916,7 +996,17 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
   test("doc JAR") {
     val dest = os.rel / "doc.jar"
     simpleInputWithScalaAndSc.fromRoot { root =>
-      os.proc(TestUtil.cli, "--power", "package", extraOptions, ".", "-o", dest, "--doc").call(
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "package",
+        TestUtil.offlineOptions,
+        extraOptions,
+        ".",
+        "-o",
+        dest,
+        "--doc"
+      ).call(
         cwd = root,
         stdin = os.Inherit,
         stdout = os.Inherit
@@ -974,8 +1064,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     inputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         extraOptions,
         ".",
         "--native-image",
@@ -1023,8 +1114,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
       inputs.fromRoot { root =>
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "package",
+          TestUtil.offlineOptions,
           extraOptions,
           ".",
           "--native-image",
@@ -1063,8 +1155,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     inputs.fromRoot { root =>
       val res = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         extraOptions,
         ".",
         "--list-main-classes"
@@ -1097,8 +1190,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     inputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         fileName,
         "-o",
         destFile,
@@ -1130,8 +1224,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
           "Simple.jar" // the `out` directory doesn't exist and should be created
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         ".",
         "--library",
         "-o",
@@ -1156,8 +1251,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     inputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         fileName,
         "--docker",
         "--docker-image-repository",
@@ -1200,8 +1296,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
     inputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         codePath,
         "--docker",
         "--docker-image-repository",
@@ -1233,7 +1330,14 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
 
   test("default values in help") {
     TestInputs.empty.fromRoot { root =>
-      val res = os.proc(TestUtil.cli, "--power", "package", extraOptions, "--help").call(cwd = root)
+      val res = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "package",
+        TestUtil.offlineOptions,
+        extraOptions,
+        "--help"
+      ).call(cwd = root)
       val lines = removeAnsiColors(res.out.trim()).linesIterator.toVector
 
       val graalVmVersionHelp     = lines.find(_.contains("--graalvm-version")).getOrElse("")
@@ -1268,7 +1372,17 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
       else "hello"
 
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "--power", "package", "--python", ".", "-o", dest, extraOptions)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "package",
+        TestUtil.offlineOptions,
+        "--python",
+        ".",
+        "-o",
+        dest,
+        extraOptions
+      )
         .call(cwd = root, stdin = os.Inherit, stdout = os.Inherit)
 
       val launcher = root / dest
@@ -1291,8 +1405,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
       val fatJarPath = root / "OsLibFatJar.jar"
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         "OsLibFatJar.scala",
         "-o",
         fatJarPath,
@@ -1305,8 +1420,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
       val launcher    = root / outputName
       val packageCmds = Seq[os.Shellable](
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         "Hello.scala",
         "-M",
         "Main",
@@ -1351,8 +1467,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
           val outputJarPath = root / "Hello.jar"
           val res           = os.proc(
             TestUtil.cli,
-            "--power",
+            TestUtil.powerOptions,
             "package",
+            TestUtil.offlineOptions,
             inputPath,
             "-o",
             outputJarPath,
@@ -1384,8 +1501,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
         val outputJarPath = root / "Hello.jar"
         val res           = os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "package",
+          TestUtil.offlineOptions,
           inputPath,
           "-o",
           outputJarPath,
@@ -1417,8 +1535,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
       val outputJarPath = root / "hello.jar"
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         extraOptions,
         "--library",
         s"$mainClass.scala",
@@ -1432,7 +1551,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
       val res =
         os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "run",
+          TestUtil.offlineOptions,
           "--jar",
           outputJarPath,
           "--main-class",
@@ -1475,8 +1596,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
           ).fromRoot { root =>
             os.proc(
               TestUtil.cli,
-              "--power",
+              TestUtil.powerOptions,
               "package",
+              TestUtil.offlineOptions,
               "--test",
               extraOptions,
               ".",
@@ -1487,7 +1609,13 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
             expect(os.isFile(outputFilePath))
             val output =
               if (packageDescription == libraryArg)
-                os.proc(TestUtil.cli, "run", outputFilePath).call(cwd = root).out.trim()
+                os.proc(
+                  TestUtil.cli,
+                  TestUtil.powerOptions,
+                  "run",
+                  TestUtil.offlineOptions,
+                  outputFilePath
+                ).call(cwd = root).out.trim()
               else if (packageDescription == jsArg)
                 os.proc(node, outputFilePath).call(cwd = root).out.trim()
               else {
@@ -1522,8 +1650,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
             ).fromRoot { root =>
               os.proc(
                 TestUtil.cli,
-                "--power",
+                TestUtil.powerOptions,
                 "package",
+                TestUtil.offlineOptions,
                 "--cross",
                 extraOptions,
                 ".",
@@ -1558,7 +1687,16 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
              |""".stripMargin
       ).fromRoot { root =>
         val res =
-          os.proc(TestUtil.cli, "package", ".", "--js", "--power", extraOptions)
+          os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "package",
+            TestUtil.offlineOptions,
+            ".",
+            "--js",
+            "--power",
+            extraOptions
+          )
             .call(cwd = root, mergeErrIntoOut = true, stderr = os.Pipe)
         expect(res.out.trim().contains(s"$moduleName.js"))
       }
@@ -1579,8 +1717,9 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
         TestUtil.withProcessWatching(
           proc = os.proc(
             TestUtil.cli,
-            "--power",
+            TestUtil.powerOptions,
             "package",
+            TestUtil.offlineOptions,
             ".",
             "--watch",
             "--watching",
@@ -1615,7 +1754,14 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
            |""".stripMargin,
       os.rel / "build.sbt" -> """name := "my-project""""
     ).fromRoot { root =>
-      os.proc(TestUtil.cli, "--power", "package", extraOptions, ".").call(
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "package",
+        TestUtil.offlineOptions,
+        extraOptions,
+        "."
+      ).call(
         cwd = root,
         stdin = os.Inherit,
         stdout = os.Inherit

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestsDefault.scala
@@ -18,13 +18,31 @@ class PackageTestsDefault extends PackageTestDefinitions with TestDefault {
             |""".stripMargin
       )
       inputs.fromRoot { root =>
-        val runRes = os.proc(TestUtil.cli, "run", "--native", ".", extraOptions)
+        val runRes = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          "--native",
+          ".",
+          extraOptions
+        )
           .call(cwd = root)
         val runOutput = runRes.out.trim().linesIterator.filter(!_.startsWith("[info] ")).toVector
         expect(runOutput == Seq("Hello"))
 
         val packageRes =
-          os.proc(TestUtil.cli, "--power", "package", "--native", ".", "-o", "hello", extraOptions)
+          os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "package",
+            TestUtil.offlineOptions,
+            "--native",
+            ".",
+            "-o",
+            "hello",
+            extraOptions
+          )
             .call(cwd = root, mergeErrIntoOut = true)
         val packageOutput    = packageRes.out.trim()
         val topPackageOutput =
@@ -58,8 +76,9 @@ class PackageTestsDefault extends PackageTestDefinitions with TestDefault {
         ).fromRoot { root =>
           os.proc(
             TestUtil.cli,
-            "--power",
+            TestUtil.powerOptions,
             "package",
+            TestUtil.offlineOptions,
             "--cross",
             extraOptions,
             ".",
@@ -93,8 +112,9 @@ class PackageTestsDefault extends PackageTestDefinitions with TestDefault {
         ).fromRoot { root =>
           val r = os.proc(
             TestUtil.cli,
-            "--power",
+            TestUtil.powerOptions,
             "package",
+            TestUtil.offlineOptions,
             extraOptions,
             ".",
             packageOpts

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishLocalTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishLocalTestDefinitions.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
   this: TestScalaVersion =>
   protected def extraOptions: Seq[String] =
-    scalaVersionArgs ++ TestUtil.extraOptions ++ Seq("--suppress-experimental-feature-warning")
+    scalaVersionArgs ++ TestUtil.extraOptionsWithOffline ++ Seq("--suppress-experimental-feature-warning")
 
   def testedPublishedScalaVersion: String =
     if (actualScalaVersion.startsWith("3"))
@@ -100,8 +100,9 @@ abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaV
             else Seq.empty
           os.proc(
             TestUtil.cli,
-            "--power",
+            TestUtil.powerOptions,
             "publish",
+            TestUtil.offlineOptions,
             "local",
             ".",
             "--ivy2-home",
@@ -132,7 +133,9 @@ abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaV
       def publishLocal(): os.CommandResult =
         os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "publish",
+          TestUtil.offlineOptions,
           "local",
           ".",
           "--ivy2-home",
@@ -175,8 +178,9 @@ abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaV
       def publishLocal(): os.CommandResult =
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "publish",
+          TestUtil.offlineOptions,
           "local",
           ".",
           "--working-dir",
@@ -210,8 +214,9 @@ abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaV
       def publishLocal(): os.CommandResult =
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "publish",
+          TestUtil.offlineOptions,
           "local",
           ".",
           "--working-dir",
@@ -246,8 +251,9 @@ abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaV
         val failPublishAsGenyIsntProvided =
           os.proc(
             TestUtil.cli,
-            "--power",
+            TestUtil.powerOptions,
             "publish",
+            TestUtil.offlineOptions,
             "local",
             ".",
             extraOptions
@@ -257,8 +263,9 @@ abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaV
         val genyDep = "com.lihaoyi::geny:1.1.1"
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "publish",
+          TestUtil.offlineOptions,
           "local",
           ".",
           "--compile-dep",
@@ -268,10 +275,26 @@ abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaV
           .call(cwd = root)
         val publishedDep =
           s"${PublishTestInputs.testOrg}:${PublishTestInputs.testName}_$testedPublishedScalaVersion:$testPublishVersion"
-        val failRunAsGenyIsntProvided = os.proc(TestUtil.cli, "run", "--dep", publishedDep)
+        val failRunAsGenyIsntProvided = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          "--dep",
+          publishedDep
+        )
           .call(cwd = root, check = false)
         expect(failRunAsGenyIsntProvided.exitCode == 1)
-        os.proc(TestUtil.cli, "run", "--dep", publishedDep, "--dep", genyDep).call(cwd = root)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          "--dep",
+          publishedDep,
+          "--dep",
+          genyDep
+        ).call(cwd = root)
       }
     }
 
@@ -298,8 +321,9 @@ abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaV
         .fromRoot { root =>
           os.proc(
             TestUtil.cli,
-            "--power",
+            TestUtil.powerOptions,
             "publish",
+            TestUtil.offlineOptions,
             "local",
             ".",
             "--ivy2-home",
@@ -333,8 +357,9 @@ abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaV
         else Nil
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "local",
         ".",
         "--test",
@@ -344,7 +369,15 @@ abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaV
         .call(cwd = root)
       val publishedDep =
         s"${PublishTestInputs.testOrg}:${PublishTestInputs.testName}_$testedPublishedScalaVersion:$testPublishVersion"
-      val r = os.proc(TestUtil.cli, "run", "--dep", publishedDep, extraOptions).call(cwd = root)
+      val r = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "run",
+        TestUtil.offlineOptions,
+        "--dep",
+        publishedDep,
+        extraOptions
+      ).call(cwd = root)
       expect(r.out.trim() == expectedMessage)
     }
   }
@@ -373,8 +406,9 @@ abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaV
       .fromRoot { root =>
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "publish",
+          TestUtil.offlineOptions,
           "local",
           ".",
           "--m2",
@@ -410,8 +444,9 @@ abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaV
       def publishLocal(): os.CommandResult =
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "publish",
+          TestUtil.offlineOptions,
           "local",
           ".",
           "--m2",
@@ -492,8 +527,9 @@ abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaV
     ).fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "local",
         ".",
         "--ivy2-home",
@@ -556,8 +592,9 @@ abstract class PublishLocalTestDefinitions extends ScalaCliSuite with TestScalaV
           else Nil
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "publish",
+          TestUtil.offlineOptions,
           "local",
           ".",
           scalaVersionArgs,

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishLocalTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishLocalTestsDefault.scala
@@ -12,8 +12,9 @@ class PublishLocalTestsDefault extends PublishLocalTestDefinitions with TestDefa
       .fromRoot { root =>
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "publish",
+          TestUtil.offlineOptions,
           "local",
           ".",
           extraOptions,
@@ -23,11 +24,21 @@ class PublishLocalTestsDefault extends PublishLocalTestDefinitions with TestDefa
         def publishedDep(scalaVersionSuffix: String) =
           s"${PublishTestInputs.testOrg}:${PublishTestInputs.testName}_$scalaVersionSuffix:$testPublishVersion"
         val r3 =
-          os.proc(TestUtil.cli, "run", "--dep", publishedDep("3"), extraOptions).call(cwd = root)
+          os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "run",
+            TestUtil.offlineOptions,
+            "--dep",
+            publishedDep("3"),
+            extraOptions
+          ).call(cwd = root)
         expect(r3.out.trim() == expectedMessage)
         val r213 = os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "run",
+          TestUtil.offlineOptions,
           "--dep",
           publishedDep("2.13"),
           "-S",
@@ -37,7 +48,9 @@ class PublishLocalTestsDefault extends PublishLocalTestDefinitions with TestDefa
         expect(r213.out.trim() == expectedMessage)
         val r212 = os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "run",
+          TestUtil.offlineOptions,
           "--dep",
           publishedDep("2.12"),
           "-S",

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishSetupTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishSetupTests.scala
@@ -98,8 +98,9 @@ class PublishSetupTests extends ScalaCliSuite {
       gitInit(root / projDir)
       val res = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "setup",
         "--dummy",
         "-R",
@@ -151,8 +152,9 @@ class PublishSetupTests extends ScalaCliSuite {
       val res =
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "publish",
+          TestUtil.offlineOptions,
           "setup",
           "--ci",
           "--dummy",
@@ -182,7 +184,16 @@ class PublishSetupTests extends ScalaCliSuite {
       configSetup(root / configFile, root)
       gitInit(root / projDir)
       val res =
-        os.proc(TestUtil.cli, "--power", "publish", "setup", "--ci", "--dummy", projDir).call(
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "publish",
+          TestUtil.offlineOptions,
+          "setup",
+          "--ci",
+          "--dummy",
+          projDir
+        ).call(
           cwd = root,
           mergeErrIntoOut = true,
           check = false,
@@ -227,8 +238,9 @@ class PublishSetupTests extends ScalaCliSuite {
         val res =
           os.proc(
             TestUtil.cli,
-            "--power",
+            TestUtil.powerOptions,
             "publish",
+            TestUtil.offlineOptions,
             "setup",
             "-v",
             "-v",
@@ -271,8 +283,9 @@ class PublishSetupTests extends ScalaCliSuite {
       gitInit(root / projDir)
       val res = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "setup",
         "--dummy",
         "--publish-repository",
@@ -314,8 +327,9 @@ class PublishSetupTests extends ScalaCliSuite {
       gitInit(root / projDir)
       val res = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "setup",
         "--ci",
         "--publish-repository",
@@ -390,8 +404,9 @@ class PublishSetupTests extends ScalaCliSuite {
 
       val res = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "setup",
         "--dummy",
         "-R",
@@ -471,8 +486,9 @@ class PublishSetupTests extends ScalaCliSuite {
 
       val res = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "setup",
         "--dummy",
         "-R",
@@ -499,8 +515,9 @@ class PublishSetupTests extends ScalaCliSuite {
 
       val res2 = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "setup",
         "--dummy",
         "--secret-key-password",
@@ -551,8 +568,9 @@ class PublishSetupTests extends ScalaCliSuite {
 
       val res = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "setup",
         "--dummy",
         "-R",
@@ -589,8 +607,9 @@ class PublishSetupTests extends ScalaCliSuite {
       gitInit(root / projDir)
       val res = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "setup",
         "--dummy",
         "-R",

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
@@ -11,7 +11,8 @@ import scala.util.Properties
 
 abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
   this: TestScalaVersion =>
-  protected def extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
+  protected def extraOptions: Seq[String] =
+    scalaVersionArgs ++ TestUtil.extraOptionsWithOffline
 
   protected object TestCase {
     val expectedMessage    = "Hello"
@@ -119,8 +120,9 @@ abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersio
       TestCase.testInputs(useTestScope).fromRoot { root =>
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "publish",
+          TestUtil.offlineOptions,
           extraOptions,
           signingOptions,
           "project",
@@ -179,7 +181,9 @@ abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersio
 
         val r = os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "run",
+          TestUtil.offlineOptions,
           "--dep",
           TestCase.dependency,
           "-r",
@@ -230,8 +234,9 @@ abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersio
         TestCase.testInputs().fromRoot { root =>
           val publishRes = os.proc(
             TestUtil.cli,
-            "--power",
+            TestUtil.powerOptions,
             "publish",
+            TestUtil.offlineOptions,
             extraOptions,
             signingOptions,
             "project",
@@ -323,8 +328,9 @@ abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersio
     TestCase.testInputs().fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         extraOptions,
         "project",
         "--js",
@@ -364,8 +370,9 @@ abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersio
     TestCase.testInputs().fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         extraOptions,
         "--with-sources=false",
         "--doc=false",
@@ -405,8 +412,9 @@ abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersio
     inputs.fromRoot { root =>
       val res = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         extraOptions,
         ".",
         "--list-main-classes"
@@ -415,8 +423,9 @@ abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersio
       val output   = res.out.trim()
       val resLocal = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "local",
         extraOptions,
         ".",
@@ -468,8 +477,9 @@ abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersio
 
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         extraOptions,
         signingOptions,
         "project",
@@ -559,8 +569,9 @@ abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersio
 
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "publish",
+          TestUtil.offlineOptions,
           extraOptions,
           "--signer",
           "bc",
@@ -661,8 +672,9 @@ abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersio
 
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         extraOptions,
         "--secret-key",
         "value:INCORRECT_KEY",
@@ -727,8 +739,9 @@ abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersio
 
       val wrongPasswordProc = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         extraOptions,
         "--secret-key",
         "file:new_key.skr",
@@ -751,8 +764,9 @@ abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersio
 
       val noPasswordProc = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         extraOptions,
         "--secret-key",
         "file:new_key.skr",

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestsDefault.scala
@@ -46,7 +46,16 @@ class PublishTestsDefault extends PublishTestDefinitions with TestDefault {
 
     val repoRelPath = os.rel / "test-repo"
     inputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "--power", "publish", extraOptions, ".", "-R", repoRelPath)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "publish",
+        TestUtil.offlineOptions,
+        extraOptions,
+        ".",
+        "-R",
+        repoRelPath
+      )
         .call(stdin = os.Inherit, stdout = os.Inherit, cwd = root)
       val repoRoot = root / repoRelPath
       val baseDir  = repoRoot / testOrg.split('.').toSeq / testName / testVersion
@@ -103,8 +112,9 @@ class PublishTestsDefault extends PublishTestDefinitions with TestDefault {
       val repoRoot = root / "tmp-repo"
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "--python",
         "--publish-repo",
         repoRoot,
@@ -145,7 +155,15 @@ class PublishTestsDefault extends PublishTestDefinitions with TestDefault {
       for (f <- os.list(root))
         os.copy.into(f, tmpDir)
       val publishRepo = root / "the-repo"
-      val res = os.proc(TestUtil.cli, "--power", "publish", "--publish-repo", publishRepo, tmpDir)
+      val res         = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "publish",
+        TestUtil.offlineOptions,
+        "--publish-repo",
+        publishRepo,
+        tmpDir
+      )
         .call(cwd = root, check = false, mergeErrIntoOut = true)
       val output = res.out.text()
       expect(output.contains("Missing organization"))
@@ -193,12 +211,30 @@ class PublishTestsDefault extends PublishTestDefinitions with TestDefault {
       )
     inputs.fromRoot { root =>
       val failRes =
-        os.proc(TestUtil.cli, "--power", "publish", "--dummy", "--signer", "none", "messages")
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "publish",
+          TestUtil.offlineOptions,
+          "--dummy",
+          "--signer",
+          "none",
+          "messages"
+        )
           .call(cwd = root, mergeErrIntoOut = true)
       checkWarnings(failRes.out.text(), hasWarnings = true)
       checkCredentialsWarning(failRes.out.text())
 
-      val okRes = os.proc(TestUtil.cli, "--power", "publish", "--dummy", "--signer", "none", ".")
+      val okRes = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "publish",
+        TestUtil.offlineOptions,
+        "--dummy",
+        "--signer",
+        "none",
+        "."
+      )
         .call(cwd = root, mergeErrIntoOut = true)
       checkWarnings(okRes.out.text(), hasWarnings = false)
       checkCredentialsWarning(okRes.out.text())
@@ -225,8 +261,9 @@ class PublishTestsDefault extends PublishTestDefinitions with TestDefault {
     TestCase.testInputs().fromRoot { root =>
       val r = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         extraOptions,
         signingOptions,
         "project",

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplJShellTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplJShellTestDefinitions.scala
@@ -17,7 +17,9 @@ trait ReplJShellTestDefinitions { this: ReplTestDefinitions =>
     testInputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "repl",
+        TestUtil.offlineOptions,
         ".",
         "--jshell",
         "--repl-dry-run",
@@ -47,7 +49,9 @@ trait ReplJShellTestDefinitions { this: ReplTestDefinitions =>
       runAfterRepl(
         os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "repl",
+          TestUtil.offlineOptions,
           ".",
           "--jshell",
           "--repl-quit-after-init",
@@ -131,7 +135,9 @@ trait ReplJShellTestDefinitions { this: ReplTestDefinitions =>
       val jshellRes = os
         .proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "repl",
+          TestUtil.offlineOptions,
           ".",
           "--jshell",
           "--repl-dry-run",
@@ -231,7 +237,7 @@ trait ReplJShellTestDefinitions { this: ReplTestDefinitions =>
           |var inst = c.getField("MODULE$").get(null);
           |System.out.println(c.getMethod("hello").invoke(inst));
           |""".stripMargin,
-      replCliOptions = TestUtil.extraOptions,
+      replCliOptions = TestUtil.extraOptionsWithOffline,
       testInputs = TestInputs(
         os.rel / "demo" / "JavaPart.java" ->
           """package demo;
@@ -261,7 +267,7 @@ trait ReplJShellTestDefinitions { this: ReplTestDefinitions =>
           |var inst = c.getField("MODULE$").get(null);
           |System.out.println(c.getMethod("smth").invoke(inst));
           |""".stripMargin,
-      replCliOptions = TestUtil.extraOptions,
+      replCliOptions = TestUtil.extraOptionsWithOffline,
       testInputs = TestInputs(
         os.rel / "Smth.scala" ->
           """package demo

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
@@ -7,7 +7,8 @@ import scala.util.Properties
 
 abstract class ReplTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
   this: TestScalaVersion =>
-  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
+  protected lazy val extraOptions: Seq[String] =
+    scalaVersionArgs ++ TestUtil.extraOptionsWithOffline
 
   protected lazy val canRunInRepl: Boolean =
     (actualScalaVersion.startsWith("3.3") &&
@@ -43,11 +44,13 @@ abstract class ReplTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
       runAfterRepl(
         os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "repl",
+          TestUtil.offlineOptions,
           ".",
           "--repl-quit-after-init",
           initScriptArgs,
-          if skipScalaVersionArgs then TestUtil.extraOptions else extraOptions,
+          if skipScalaVersionArgs then TestUtil.extraOptionsWithOffline else extraOptions,
           cliOptions,
           potentiallyExtraCliOpts
         )
@@ -69,7 +72,9 @@ abstract class ReplTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
     testInputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "repl",
+        TestUtil.offlineOptions,
         "--repl-dry-run",
         cliOptions,
         if useExtraOptions then extraOptions else Seq.empty
@@ -127,7 +132,9 @@ abstract class ReplTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
   test("calling repl with -Xshow-phases flag") {
     val cmd = Seq[os.Shellable](
       TestUtil.cli,
+      TestUtil.powerOptions,
       "repl",
+      TestUtil.offlineOptions,
       "-Xshow-phases",
       extraOptions
     )

--- a/modules/integration/src/test/scala/scala/cli/integration/RunGistTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunGistTestDefinitions.scala
@@ -22,9 +22,10 @@ trait RunGistTestDefinitions { this: RunTestDefinitions =>
         "https://gist.github.com/alexarchambault/f972d941bc4a502d70267cfbbc4d6343/raw/b0285fa0305f76856897517b06251970578565af/test.sc"
       val expectedMessage = "Hello from GitHub Gist"
       testInputs(url).fromRoot { root =>
-        val output = os.proc(TestUtil.cli, "run", extraOptions, args(url))
-          .call(cwd = root)
-          .out.trim()
+        val output =
+          os.proc(TestUtil.cli, "run", scalaVersionArgs ++ TestUtil.bloopTimeoutOptions, args(url))
+            .call(cwd = root)
+            .out.trim()
         expect(output == expectedMessage)
       }
     }
@@ -34,7 +35,7 @@ trait RunGistTestDefinitions { this: RunTestDefinitions =>
         "https://gist.github.com/alexarchambault/f972d941bc4a502d70267cfbbc4d6343/raw/2691c01984c9249936a625a42e29a822a357b0f6/Test.scala"
       val message = "Hello from Scala GitHub Gist"
       testInputs(url).fromRoot { root =>
-        val output = os.proc(TestUtil.cli, extraOptions, args(url))
+        val output = os.proc(TestUtil.cli, scalaVersionArgs ++ TestUtil.bloopTimeoutOptions, args(url))
           .call(cwd = root)
           .out.trim()
         expect(output == message)
@@ -46,7 +47,7 @@ trait RunGistTestDefinitions { this: RunTestDefinitions =>
         "https://gist.github.com/alexarchambault/f972d941bc4a502d70267cfbbc4d6343/raw/2691c01984c9249936a625a42e29a822a357b0f6/Test.java"
       val message = "Hello from Java GitHub Gist"
       testInputs(url).fromRoot { root =>
-        val output = os.proc(TestUtil.cli, extraOptions, args(url))
+        val output = os.proc(TestUtil.cli, scalaVersionArgs ++ TestUtil.bloopTimeoutOptions, args(url))
           .call(cwd = root)
           .out.trim()
         expect(output == message)
@@ -60,7 +61,7 @@ trait RunGistTestDefinitions { this: RunTestDefinitions =>
             "https://gist.github.com/alexarchambault/7b4ec20c4033690dd750ffd601e540ec"
           val message = "Hello"
           testInputs(url).fromRoot { root =>
-            val output = os.proc(TestUtil.cli, extraOptions, args(url))
+            val output = os.proc(TestUtil.cli, scalaVersionArgs ++ TestUtil.bloopTimeoutOptions, args(url))
               .call(cwd = root)
               .out.trim()
             expect(output == message)

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
@@ -246,8 +246,14 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
     }
 
   test("help js") {
-    val helpJsOption  = "--help-js"
-    val helpJs        = os.proc(TestUtil.cli, "run", helpJsOption).call(check = false)
+    val helpJsOption = "--help-js"
+    val helpJs       = os.proc(
+      TestUtil.cli,
+      TestUtil.powerOptions,
+      "run",
+      TestUtil.offlineOptions,
+      helpJsOption
+    ).call(check = false)
     val lines         = removeAnsiColors(helpJs.out.trim()).linesIterator.toVector
     val jsVersionHelp = lines.find(_.contains("--js-version")).getOrElse("")
     expect(jsVersionHelp.contains(s"(${Constants.scalaJsVersion} by default)"))
@@ -313,8 +319,9 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
 
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         "run.scala",
         "--js",
         "-o",
@@ -339,8 +346,9 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
     inputs.fromRoot { root =>
       val output = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "Hello.scala",
         "--js-emit-wasm",
         "--js-module-kind",
@@ -364,8 +372,9 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
     inputs.fromRoot { root =>
       val output = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "Hello.scala",
         "--js-emit-wasm",
         "--js-module-kind",
@@ -389,8 +398,9 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
       // rather than silently overriding the module kind.
       val output = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "Hello.scala",
         "--js-emit-wasm",
         extraOptions
@@ -413,8 +423,9 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
     inputs.fromRoot { root =>
       val output = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "Hello.scala",
         extraOptions
       ).call(cwd = root).out.trim()
@@ -440,8 +451,9 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
     inputs.fromRoot { root =>
       val output = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "Hello.scala",
         "--js-emit-wasm",
         "--js-module-kind",
@@ -470,8 +482,9 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
       inputs.fromRoot { root =>
         val output = os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "run",
+          TestUtil.offlineOptions,
           "Hello.scala",
           "--js-emit-wasm",
           "--js-module-kind",
@@ -496,8 +509,9 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
       inputs.fromRoot { root =>
         val output = os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "run",
+          TestUtil.offlineOptions,
           "Hello.scala",
           "--js-emit-wasm",
           "--js-module-kind",
@@ -531,8 +545,9 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
     inputs.fromRoot { root =>
       val output = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "Hello.scala",
         "--js-emit-wasm",
         "--js-module-kind",
@@ -577,8 +592,9 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
     inputs.fromRoot { root =>
       val output = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "Main.scala",
         "Greeter.scala",
         "--js-emit-wasm",
@@ -612,8 +628,9 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
     inputs.fromRoot { root =>
       val output = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "Hello.scala",
         "--js-emit-wasm",
         "--js-module-kind",
@@ -646,8 +663,9 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
     inputs.fromRoot { root =>
       val output = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "Hello.scala",
         "--js-emit-wasm",
         "--js-module-kind",
@@ -676,8 +694,9 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
       inputs.fromRoot { root =>
         val output = os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "run",
+          TestUtil.offlineOptions,
           "Hello.scala",
           "--js-emit-wasm",
           "--js-module-kind",
@@ -727,8 +746,9 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
       os.makeDir.all(absOutDir)
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         fileName,
         "--js",
         "--js-module-kind",
@@ -774,8 +794,9 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
       os.makeDir.all(absOutDir)
       val result = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         fileName,
         "--js",
         "--js-module-kind",
@@ -826,8 +847,9 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
       os.makeDir.all(absOutDir)
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         fileName,
         "--js",
         "--js-module-kind",
@@ -866,7 +888,14 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
              |}
              |""".stripMargin
       ).fromRoot { root =>
-        val result = os.proc(TestUtil.cli, "run", "toolkit.scala", extraOptions).call(cwd = root)
+        val result = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          "toolkit.scala",
+          extraOptions
+        ).call(cwd = root)
         expect(result.out.trim() == msg)
       }
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
@@ -259,8 +259,14 @@ trait RunScalaNativeTestDefinitions { this: RunTestDefinitions =>
     }
 
   test("help native") {
-    val helpNativeOption  = "--help-native"
-    val helpNative        = os.proc(TestUtil.cli, "run", helpNativeOption).call(check = false)
+    val helpNativeOption = "--help-native"
+    val helpNative       = os.proc(
+      TestUtil.cli,
+      TestUtil.powerOptions,
+      "run",
+      TestUtil.offlineOptions,
+      helpNativeOption
+    ).call(check = false)
     val lines             = removeAnsiColors(helpNative.out.trim()).linesIterator.toVector
     val nativeVersionHelp = lines.find(_.contains("--native-version")).getOrElse("")
     expect(nativeVersionHelp.contains(s"(${Constants.scalaNativeVersion} by default)"))
@@ -296,11 +302,27 @@ trait RunScalaNativeTestDefinitions { this: RunTestDefinitions =>
         val configEnv = Map("SCALA_CLI_CONFIG" -> (configDir / "config.json").toString)
         os.proc(TestUtil.cli, "config", "interactive", "true")
           .call(cwd = root, env = configEnv)
-        val output1 = os.proc(TestUtil.cli, "run", "--native", ".", extraOptions)
+        val output1 = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          "--native",
+          ".",
+          extraOptions
+        )
           .call(cwd = root, env = configEnv ++ Seq("SCALA_CLI_INTERACTIVE_INPUTS" -> "foo.Main1"))
           .out.lines().last
         expect(output1 == "Hello from Main1")
-        val output2 = os.proc(TestUtil.cli, "run", "--native", ".", extraOptions)
+        val output2 = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          "--native",
+          ".",
+          extraOptions
+        )
           .call(cwd = root, env = configEnv ++ Seq("SCALA_CLI_INTERACTIVE_INPUTS" -> "foo.Main2"))
           .out.lines().last
         expect(output2 == "Hello from Main2")
@@ -358,7 +380,15 @@ trait RunScalaNativeTestDefinitions { this: RunTestDefinitions =>
                    |}
                    |""".stripMargin
             ).fromRoot { root =>
-              val result = os.proc(TestUtil.cli, "run", "toolkit.scala", cmdLineOpts, extraOptions)
+              val result = os.proc(
+                TestUtil.cli,
+                TestUtil.powerOptions,
+                "run",
+                TestUtil.offlineOptions,
+                "toolkit.scala",
+                cmdLineOpts,
+                extraOptions
+              )
                 .call(cwd = root, stderr = os.Pipe)
               expect(result.out.trim() == expectedMessage)
               if (
@@ -401,7 +431,15 @@ trait RunScalaNativeTestDefinitions { this: RunTestDefinitions =>
                  |}
                  |""".stripMargin
           ).fromRoot { root =>
-            val result = os.proc(TestUtil.cli, "run", "toolkit.scala", cmdLineOpts, extraOptions)
+            val result = os.proc(
+              TestUtil.cli,
+              TestUtil.powerOptions,
+              "run",
+              TestUtil.offlineOptions,
+              "toolkit.scala",
+              cmdLineOpts,
+              extraOptions
+            )
               .call(cwd = root, stderr = os.Pipe)
             expect(result.out.trim() == root.toString)
             if (Constants.scalaNativeVersion != Constants.toolkiMaxScalaNative) {

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaPyTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaPyTestDefinitions.scala
@@ -32,7 +32,15 @@ trait RunScalaPyTestDefinitions { this: RunTestDefinitions =>
 
     inputs.fromRoot { root =>
       val res =
-        os.proc(TestUtil.cli, "--power", "run", extraOptions, ".", maybeCliArg).call(cwd = root)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          extraOptions,
+          ".",
+          maybeCliArg
+        ).call(cwd = root)
       val output         = res.out.trim()
       val expectedOutput = "Length is 3"
       expect(output == expectedOutput)
@@ -70,7 +78,15 @@ trait RunScalaPyTestDefinitions { this: RunTestDefinitions =>
 
     inputs.fromRoot { root =>
       val res =
-        os.proc(TestUtil.cli, "--power", "run", extraOptions, ".", maybeCliArg)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          extraOptions,
+          ".",
+          maybeCliArg
+        )
           .call(cwd = root, stderr = os.Pipe)
       val output = res.out.trim()
         .linesIterator
@@ -134,7 +150,15 @@ trait RunScalaPyTestDefinitions { this: RunTestDefinitions =>
     inputs.fromRoot { root =>
 
       // Script dir shouldn't be added to PYTHONPATH if PYTHONSAFEPATH is non-empty
-      val errorRes = os.proc(TestUtil.cli, "--power", "run", extraOptions, nativeOpt, "src")
+      val errorRes = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "run",
+        TestUtil.offlineOptions,
+        extraOptions,
+        nativeOpt,
+        "src"
+      )
         .call(
           cwd = root,
           env = Map("PYTHONSAFEPATH" -> "foo"),
@@ -145,7 +169,15 @@ trait RunScalaPyTestDefinitions { this: RunTestDefinitions =>
       val errorOutput = errorRes.out.text()
       expect(errorOutput.contains("No module named 'helpers'"))
 
-      val res = os.proc(TestUtil.cli, "--power", "run", extraOptions, nativeOpt, "src")
+      val res = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "run",
+        TestUtil.offlineOptions,
+        extraOptions,
+        nativeOpt,
+        "src"
+      )
         .call(cwd = root)
       val output = res.out.trim()
       if (native)

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalacCompatTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalacCompatTestDefinitions.scala
@@ -174,7 +174,14 @@ trait RunScalacCompatTestDefinitions {
     emptyInputs.fromRoot { root =>
       val res =
         (
-          if (explicitSubcommand) os.proc(TestUtil.cli, "run", printOption, extraOptions)
+          if (explicitSubcommand) os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "run",
+            TestUtil.offlineOptions,
+            printOption,
+            extraOptions
+          )
           else os.proc(TestUtil.cli, printOption, extraOptions)
         ).call(cwd = root, mergeErrIntoOut = true)
       expect(res.exitCode == 0)
@@ -198,7 +205,9 @@ trait RunScalacCompatTestDefinitions {
       // first, precompile to an explicitly specified output directory with -d
       os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "compile",
+        TestUtil.offlineOptions,
         preCompiledInput,
         "-d",
         preCompileOutputDir.toString,
@@ -208,7 +217,9 @@ trait RunScalacCompatTestDefinitions {
       // next, run while relying on the pre-compiled class, specifying the path with -classpath
       val runRes = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         mainInput,
         "-classpath",
         (os.rel / os.up / preCompileDir / preCompileOutputDir).toString,
@@ -234,7 +245,9 @@ trait RunScalacCompatTestDefinitions {
       // first, precompile to an explicitly specified output directory with -O -d
       val compileRes = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "compile",
+        TestUtil.offlineOptions,
         preCompiledInput,
         "-O",
         "-d",
@@ -247,7 +260,9 @@ trait RunScalacCompatTestDefinitions {
       // next, run while relying on the pre-compiled class, specifying the path with -O -classpath
       val runRes = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         mainInput,
         "-O",
         "-classpath",
@@ -269,7 +284,9 @@ trait RunScalacCompatTestDefinitions {
       // first, precompile to an explicitly specified output directory with -d
       os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "compile",
+        TestUtil.offlineOptions,
         ".",
         "-d",
         compilationOutputDir,
@@ -279,7 +296,9 @@ trait RunScalacCompatTestDefinitions {
       // next, run while relying on the pre-compiled class instead of passing inputs
       val runRes = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "-classpath",
         (os.rel / compilationOutputDir).toString,
         extraOptions
@@ -310,7 +329,9 @@ trait RunScalacCompatTestDefinitions {
     shutdownBloop()
     val output = os.proc(
       TestUtil.cli,
+      TestUtil.powerOptions,
       "run",
+      TestUtil.offlineOptions,
       "--dep",
       s"software.amazon.smithy:smithy-cli:$smithyVersion",
       "--",
@@ -335,7 +356,9 @@ trait RunScalacCompatTestDefinitions {
       // first, precompile to an explicitly specified output directory with -d
       os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "compile",
+        TestUtil.offlineOptions,
         "-d",
         compilationOutputDir,
         `lib.scala`,
@@ -348,7 +371,9 @@ trait RunScalacCompatTestDefinitions {
 
       os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "compile",
+        TestUtil.offlineOptions,
         "-d",
         compilationOutputDir,
         "-cp",
@@ -374,8 +399,9 @@ trait RunScalacCompatTestDefinitions {
       val jarPath = os.rel / "Main.jar"
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         ".",
         "--library",
         "-o",
@@ -386,7 +412,9 @@ trait RunScalacCompatTestDefinitions {
       // next, run while relying on the jar instead of passing inputs
       val runRes = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "-classpath",
         jarPath,
         extraOptions
@@ -405,8 +433,9 @@ trait RunScalacCompatTestDefinitions {
       val jarPath            = jarParentDirectory / "Main.jar"
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         ".",
         "--library",
         "-o",
@@ -417,7 +446,9 @@ trait RunScalacCompatTestDefinitions {
       // next, run while relying on the jar instead of passing inputs
       val runRes = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "-cp",
         jarParentDirectory,
         extraOptions
@@ -431,7 +462,16 @@ trait RunScalacCompatTestDefinitions {
       root =>
         val scala212VersionString = s"2.12.$scalaPatchVersion"
         val res                   =
-          os.proc(TestUtil.cli, "run", ".", "-S", scala212VersionString, TestUtil.extraOptions)
+          os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "run",
+            TestUtil.offlineOptions,
+            ".",
+            "-S",
+            scala212VersionString,
+            TestUtil.extraOptionsWithOffline
+          )
             .call(cwd = root)
         expect(res.out.trim() == scala212VersionString)
     }
@@ -454,8 +494,9 @@ trait RunScalacCompatTestDefinitions {
     val inputRelPath   = os.rel / s"$mainClass.scala"
     TestInputs(inputRelPath -> s"""object $mainClass extends App { println("$expectedOutput") }""")
       .fromRoot { root =>
-        val res = os.proc(TestUtil.cli, ".", "--scalac-verbose", extraOptions)
-          .call(cwd = root, stderr = os.Pipe)
+        val res =
+          os.proc(TestUtil.cli, ".", "--scalac-verbose", extraOptions)
+            .call(cwd = root, stderr = os.Pipe)
         val errLines = res.err.trim().lines.toList.asScala
         // there should be a lot of logs, but different stuff is logged depending on the Scala version
         expect(errLines.length > 100)
@@ -602,7 +643,9 @@ trait RunScalacCompatTestDefinitions {
       ).fromRoot { root =>
         val r = os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "run",
+          TestUtil.offlineOptions,
           ".",
           if (useDirective) Nil else macroSettingOptions,
           "-S",
@@ -644,8 +687,23 @@ trait RunScalacCompatTestDefinitions {
              |}
              |""".stripMargin
       ).fromRoot { root =>
-        os.proc(TestUtil.cli, "--power", "publish", "local", depDir, extraOptions).call(cwd = root)
-        val res = os.proc(TestUtil.cli, "run", mainDir, extraOptions).call(cwd = root)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "publish",
+          TestUtil.offlineOptions,
+          "local",
+          depDir,
+          extraOptions
+        ).call(cwd = root)
+        val res = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          mainDir,
+          extraOptions
+        ).call(cwd = root)
         expect(res.out.trim() == expectedMessage)
       }
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
@@ -564,7 +564,8 @@ trait RunScriptTestDefinitions { this: RunTestDefinitions =>
   test("CLI args passed to script") {
     val inputs = TestInputs(os.rel / "f.sc" -> "println(args(0))")
     inputs.fromRoot { root =>
-      val p = os.proc(TestUtil.cli, "f.sc", "--", "16").call(cwd = root)
+      val p =
+        os.proc(TestUtil.cli, "f.sc", "--", "16").call(cwd = root)
       expect(p.out.trim() == "16")
     }
   }
@@ -734,8 +735,9 @@ trait RunScriptTestDefinitions { this: RunTestDefinitions =>
           "[warn]  Annotation @main in .sc scripts is not supported, use .scala format instead"
         ))
 
-        val noBloopRes = os.proc(TestUtil.cli, "--server=false", "script.sc")
-          .call(cwd = root, mergeErrIntoOut = true, check = false, stdout = os.Pipe)
+        val noBloopRes =
+          os.proc(TestUtil.cli, "--server=false", "script.sc")
+            .call(cwd = root, mergeErrIntoOut = true, check = false, stdout = os.Pipe)
 
         val noBloopOutputNormalized: String = normalizeConsoleOutput(noBloopRes.out.text())
 
@@ -771,8 +773,9 @@ trait RunScriptTestDefinitions { this: RunTestDefinitions =>
         expect(!normalizeConsoleOutput(res.out.text())
           .contains("Annotation @main in .sc scripts is not supported"))
 
-        val noBloopRes = os.proc(TestUtil.cli, "--server=false", "main.scala")
-          .call(cwd = root, mergeErrIntoOut = true, check = false)
+        val noBloopRes =
+          os.proc(TestUtil.cli, "--server=false", "main.scala")
+            .call(cwd = root, mergeErrIntoOut = true, check = false)
 
         expect(!normalizeConsoleOutput(noBloopRes.out.text())
           .contains("Annotation @main in .sc scripts is not supported"))
@@ -828,7 +831,15 @@ trait RunScriptTestDefinitions { this: RunTestDefinitions =>
         )
           .fromRoot { root =>
             val wrapperOptions = if (useObjectWrapper) Seq("--power", "--object-wrapper") else Nil
-            val r = os.proc(TestUtil.cli, "run", sourceFileName, wrapperOptions, extraOptions)
+            val r              = os.proc(
+              TestUtil.cli,
+              TestUtil.powerOptions,
+              "run",
+              TestUtil.offlineOptions,
+              sourceFileName,
+              wrapperOptions,
+              extraOptions
+            )
               .call(cwd = root)
             expect(r.out.trim() == expectedMessage)
           }
@@ -857,7 +868,15 @@ trait RunScriptTestDefinitions { this: RunTestDefinitions =>
         )
           .fromRoot { root =>
             val wrapperOptions = if (useObjectWrapper) Seq("--power", "--object-wrapper") else Nil
-            val r = os.proc(TestUtil.cli, "run", sourceFileName, wrapperOptions, extraOptions)
+            val r              = os.proc(
+              TestUtil.cli,
+              TestUtil.powerOptions,
+              "run",
+              TestUtil.offlineOptions,
+              sourceFileName,
+              wrapperOptions,
+              extraOptions
+            )
               .call(cwd = root)
             expect(r.out.trim() == expectedMessage)
           }
@@ -896,6 +915,7 @@ trait RunScriptTestDefinitions { this: RunTestDefinitions =>
         printf(
           "TestUtil.cli: [%s]\njavaHome: [%s]\nnewPath: [%s]\n",
           TestUtil.cli,
+          TestUtil.powerOptions,
           javaHome,
           newPath
         )

--- a/modules/integration/src/test/scala/scala/cli/integration/RunSnippetTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunSnippetTestDefinitions.scala
@@ -10,7 +10,9 @@ trait RunSnippetTestDefinitions { this: RunTestDefinitions =>
       val res       =
         os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "run",
+          TestUtil.offlineOptions,
           "--script-snippet",
           s"println($quotation$msg$quotation)",
           extraOptions
@@ -27,7 +29,9 @@ trait RunSnippetTestDefinitions { this: RunTestDefinitions =>
       val res       =
         os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "run",
+          TestUtil.offlineOptions,
           "--scala-snippet",
           s"object Hello extends App { println($quotation$msg$quotation) }",
           extraOptions
@@ -43,7 +47,9 @@ trait RunSnippetTestDefinitions { this: RunTestDefinitions =>
       val msg       = "Hello world"
       val res       = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         "--java-snippet",
         s"public class Main { public static void main(String[] args) { System.out.println($quotation$msg$quotation); } }",
         extraOptions
@@ -60,8 +66,9 @@ trait RunSnippetTestDefinitions { this: RunTestDefinitions =>
       val res       =
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "run",
+          TestUtil.offlineOptions,
           "--markdown-snippet",
           s"""# A Markdown snippet
              |With some scala code
@@ -82,8 +89,9 @@ trait RunSnippetTestDefinitions { this: RunTestDefinitions =>
       val res       =
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "run",
+          TestUtil.offlineOptions,
           "--markdown-snippet",
           s"""# A Markdown snippet
              |With some Java code
@@ -142,7 +150,9 @@ trait RunSnippetTestDefinitions { this: RunTestDefinitions =>
 
       val res = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         scriptSnippetOption,
         script0,
         scriptSnippetOption,

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -24,8 +24,9 @@ abstract class RunTestDefinitions
     with RunZipTestDefinitions
     with RunJdkTestDefinitions
     with CoursierScalaInstallationTestHelper { this: TestScalaVersion =>
-  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
-  protected val emptyInputs: TestInputs        = TestInputs(os.rel / ".placeholder" -> "")
+  protected lazy val extraOptions: Seq[String] =
+    scalaVersionArgs ++ TestUtil.extraOptionsWithOffline
+  protected val emptyInputs: TestInputs = TestInputs(os.rel / ".placeholder" -> "")
 
   override def warmUpExtraTestOptions: Seq[String] = extraOptions
 
@@ -40,13 +41,15 @@ abstract class RunTestDefinitions
   ): String =
     os.proc(
       TestUtil.cli,
+      TestUtil.powerOptions,
       "run",
+      TestUtil.offlineOptions,
       "-e",
       "println(dotty.tools.dotc.config.Properties.simpleVersionString)",
       "-S",
       scalaVersionIndex,
       "--with-compiler",
-      TestUtil.extraOptions
+      TestUtil.extraOptionsWithOffline
     )
       .call(cwd = root, check = check, mergeErrIntoOut = mergeErrIntoOut)
       .out
@@ -233,7 +236,9 @@ abstract class RunTestDefinitions
   test("setting root dir with virtual input") {
     val url = "https://gist.github.com/alexarchambault/7b4ec20c4033690dd750ffd601e540ec"
     emptyInputs.fromRoot { root =>
-      os.proc(TestUtil.cli, extraOptions, escapedUrls(url)).call(cwd = root)
+      os.proc(TestUtil.cli, scalaVersionArgs ++ TestUtil.bloopTimeoutOptions, escapedUrls(url)).call(cwd =
+        root
+      )
       val path = root / ".scala-build"
       expect(!os.exists(path)) // virtual source should not create workspace dir in cwd
     }
@@ -605,7 +610,8 @@ abstract class RunTestDefinitions
   private def forbiddenDirTest(): Unit = {
     simpleDirInputs.fromRoot { root =>
       def run(options: String*): String = {
-        val res = os.proc(TestUtil.cli, "dir", options).call(cwd = root)
+        val res =
+          os.proc(TestUtil.cli, "dir", options).call(cwd = root)
         res.out.trim()
       }
 
@@ -644,7 +650,15 @@ abstract class RunTestDefinitions
   test("resources via command line") {
     val expectedMessage = "hello"
     resourcesInputs(resourceContent = expectedMessage).fromRoot { root =>
-      val res = os.proc(TestUtil.cli, "run", "src", "--resource-dirs", "./src/proj/resources")
+      val res = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "run",
+        TestUtil.offlineOptions,
+        "src",
+        "--resource-dirs",
+        "./src/proj/resources"
+      )
         .call(cwd = root)
       expect(res.out.trim() == expectedMessage)
     }
@@ -656,7 +670,13 @@ abstract class RunTestDefinitions
       resourceContent = expectedMessage
     )
       .fromRoot { root =>
-        val res = os.proc(TestUtil.cli, "run", ".").call(cwd = root)
+        val res = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          "."
+        ).call(cwd = root)
         expect(res.out.trim() == expectedMessage)
       }
   }
@@ -667,11 +687,18 @@ abstract class RunTestDefinitions
       resourceContent = expectedMessage
     )
       .fromRoot { root =>
-        val err = os.proc(TestUtil.cli, "run", ".")
+        val err = os.proc(TestUtil.cli, TestUtil.powerOptions, "run", TestUtil.offlineOptions, ".")
           .call(cwd = root, check = false, stderr = os.Pipe)
         expect(err.err.trim().contains("java.lang.NullPointerException"))
         expect(err.exitCode == 1)
-        val res = os.proc(TestUtil.cli, "run", ".", "--test")
+        val res = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          ".",
+          "--test"
+        )
           .call(cwd = root)
         expect(res.out.trim() == expectedMessage)
       }
@@ -772,7 +799,10 @@ abstract class RunTestDefinitions
             """object Main extends App { println(System.getProperty("java.version"))}"""
         )
       inputs.fromRoot { root =>
-        val p   = os.proc(TestUtil.cli, "run.scala", "--jvm", jvm).call(cwd = root)
+        val p =
+          os.proc(TestUtil.cli, "run.scala", "--jvm", jvm).call(cwd =
+            root
+          )
         val res = p.out.trim()
         expect(res.startsWith(s"1.$jvm") || res.startsWith(s"$jvm."))
       }
@@ -829,9 +859,10 @@ abstract class RunTestDefinitions
           |}""".stripMargin
     )
     inputs.fromRoot { root =>
-      val res = os.proc(TestUtil.cli, "Hello.scala", "-Dfoo=bar").call(
-        cwd = root
-      )
+      val res =
+        os.proc(TestUtil.cli, "Hello.scala", "-Dfoo=bar").call(
+          cwd = root
+        )
       expect(res.out.trim() == "bar")
     }
   }
@@ -880,11 +911,15 @@ abstract class RunTestDefinitions
         """Using directives detected in multiple files:
           |- Foo.scala:1:1-22
           |- Hello.java:1:1-17""".stripMargin
-      val output1 = os.proc(TestUtil.cli, ".").call(cwd = root, stderr = os.Pipe).err.trim()
-      val output2 = os.proc(TestUtil.cli, "Foo.scala", "Bar.scala").call(
+      val output1 = os.proc(TestUtil.cli, ".").call(
         cwd = root,
         stderr = os.Pipe
       ).err.trim()
+      val output2 =
+        os.proc(TestUtil.cli, "Foo.scala", "Bar.scala").call(
+          cwd = root,
+          stderr = os.Pipe
+        ).err.trim()
       expect(output1.contains(warningMessage))
       expect(!output2.contains("Using directives detected in multiple files"))
     }
@@ -1170,7 +1205,9 @@ abstract class RunTestDefinitions
       inputs.fromRoot { root =>
         val res = os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "run",
+          TestUtil.offlineOptions,
           ".",
           extraOptions
         )
@@ -1301,12 +1338,23 @@ abstract class RunTestDefinitions
     inputs.fromRoot { root =>
       // build jar
       val helloJarPath = root / "Hello.jar"
-      os.proc(TestUtil.cli, "--power", "package", ".", "--library", "-o", helloJarPath).call(cwd =
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "package",
+        TestUtil.offlineOptions,
+        ".",
+        "--library",
+        "-o",
+        helloJarPath
+      ).call(cwd =
         root
       )
 
       // run jar
-      val output = os.proc(TestUtil.cli, helloJarPath).call(cwd = root).out.trim()
+      val output = os.proc(TestUtil.cli, helloJarPath).call(cwd =
+        root
+      ).out.trim()
       expect(output == "Hello World")
     }
   }
@@ -1380,7 +1428,9 @@ abstract class RunTestDefinitions
     inputs.fromRoot { root =>
       val output = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "test",
+        TestUtil.offlineOptions,
         ".",
         "--toolkit",
         s"typelevel:${Constants.typelevelToolkitVersion}"
@@ -1403,14 +1453,30 @@ abstract class RunTestDefinitions
     )
       .fromRoot { root =>
         val resWithColon =
-          os.proc(TestUtil.cli, "run", relPath.toString, extraOptions)
+          os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "run",
+            TestUtil.offlineOptions,
+            relPath.toString,
+            extraOptions
+          )
             .call(cwd = root, check = false, stderr = os.Pipe)
         expect(resWithColon.exitCode == 1)
         expect(resWithColon.err.trim().contains(
           "you can force your workspace with the '--workspace' option:"
         ))
         val resFixedWorkspace = // should run fine for a forced workspace with no classpath separator on path
-          os.proc(TestUtil.cli, "run", relPath.toString, "--workspace", ".", extraOptions)
+          os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "run",
+            TestUtil.offlineOptions,
+            relPath.toString,
+            "--workspace",
+            ".",
+            extraOptions
+          )
             .call(cwd = root)
         expect(resFixedWorkspace.out.trim() == msg)
       }
@@ -1428,7 +1494,8 @@ abstract class RunTestDefinitions
              |""".stripMargin
       )
       inputs.fromRoot { root =>
-        val proc = if (command == "") os.proc(TestUtil.cli, "print.hehe")
+        val proc = if (command == "")
+          os.proc(TestUtil.cli, "print.hehe")
         else os.proc(TestUtil.cli, command, "print.hehe")
         val output = proc.call(cwd = root, check = false, stderr = os.Pipe)
           .err.trim()
@@ -1444,7 +1511,8 @@ abstract class RunTestDefinitions
              |""".stripMargin
       )
       inputs.fromRoot { root =>
-        val proc = if (command == "") os.proc(TestUtil.cli, "nonexisten.no")
+        val proc = if (command == "")
+          os.proc(TestUtil.cli, "nonexisten.no")
         else os.proc(TestUtil.cli, command, "nonexisten.no")
         val output = proc.call(cwd = root, check = false, stderr = os.Pipe)
           .err.trim()
@@ -1503,15 +1571,36 @@ abstract class RunTestDefinitions
           |""".stripMargin
     ).fromRoot { root =>
       // running `invalidMainFile` should fail, as it's in the main scope and depends on test scope deps
-      val res1 = os.proc(TestUtil.cli, "run", projectFile, invalidMainFile)
+      val res1 = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "run",
+        TestUtil.offlineOptions,
+        projectFile,
+        invalidMainFile
+      )
         .call(cwd = root, check = false)
       expect(res1.exitCode == 1)
       // running `validMainFile` should succeed, since it only depends on main scope deps
-      val res2 = os.proc(TestUtil.cli, "run", projectFile, validMainFile)
+      val res2 = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "run",
+        TestUtil.offlineOptions,
+        projectFile,
+        validMainFile
+      )
         .call(cwd = root)
       expect(res2.out.trim() == root.toString())
       // test scope should have access to both main and test deps
-      os.proc(TestUtil.cli, "test", projectFile, testFile)
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "test",
+        TestUtil.offlineOptions,
+        projectFile,
+        testFile
+      )
         .call(cwd = root, stderr = os.Pipe)
     }
   }
@@ -1566,8 +1655,9 @@ abstract class RunTestDefinitions
       for ((jarPath, sourcePath) <- jarPathsWithFiles)
         os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "package",
+          TestUtil.offlineOptions,
           sourcePath,
           "--library",
           "-o",
@@ -1576,15 +1666,39 @@ abstract class RunTestDefinitions
         )
           .call(cwd = root)
       // running `invalidMainFile` should fail, as it's in the main scope and depends on the test scope jar
-      val res1 = os.proc(TestUtil.cli, "run", projectFile, invalidMainFile, extraOptions)
+      val res1 = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "run",
+        TestUtil.offlineOptions,
+        projectFile,
+        invalidMainFile,
+        extraOptions
+      )
         .call(cwd = root, check = false)
       expect(res1.exitCode == 1)
       // running `validMainFile` should succeed, since it only depends on the main scope jar
-      val res2 = os.proc(TestUtil.cli, "run", projectFile, validMainFile, extraOptions)
+      val res2 = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "run",
+        TestUtil.offlineOptions,
+        projectFile,
+        validMainFile,
+        extraOptions
+      )
         .call(cwd = root)
       expect(res2.out.trim() == expectedMessage1)
       // test scope should have access to both main and test deps
-      val res3 = os.proc(TestUtil.cli, "test", projectFile, testFile, extraOptions)
+      val res3 = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "test",
+        TestUtil.offlineOptions,
+        projectFile,
+        testFile,
+        extraOptions
+      )
         .call(cwd = root, stderr = os.Pipe)
       expect(res3.out.trim().contains(s"$expectedMessage1$expectedMessage2"))
     }
@@ -1629,7 +1743,14 @@ abstract class RunTestDefinitions
 
       val configEnv = Map("SCALA_CLI_CONFIG" -> confFile.toString)
 
-      val proc = os.proc(TestUtil.cli, "run", "--interactive", fileName)
+      val proc = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "run",
+        TestUtil.offlineOptions,
+        "--interactive",
+        fileName
+      )
         .call(
           cwd = root,
           mergeErrIntoOut = true,
@@ -1798,8 +1919,9 @@ abstract class RunTestDefinitions
       val repoPath = root / "the-repo"
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "publish",
+        TestUtil.offlineOptions,
         "--publish-repo",
         repoPath.toNIO.toUri.toASCIIString,
         "messages",
@@ -1817,7 +1939,9 @@ abstract class RunTestDefinitions
         {
           val resWithNoCreds = os.proc(
             TestUtil.cli,
+            TestUtil.powerOptions,
             "run",
+            TestUtil.offlineOptions,
             "--repository",
             s"http://$host:$port",
             "hello",
@@ -1840,7 +1964,9 @@ abstract class RunTestDefinitions
         {
           val resWithEnvVar = os.proc(
             TestUtil.cli,
+            TestUtil.powerOptions,
             "run",
+            TestUtil.offlineOptions,
             "--repository",
             s"http://$host:$port",
             "hello",
@@ -1871,7 +1997,9 @@ abstract class RunTestDefinitions
           )
           val resWithConfig = os.proc(
             TestUtil.cli,
+            TestUtil.powerOptions,
             "run",
+            TestUtil.offlineOptions,
             "--repository",
             s"http://$host:$port",
             "hello",
@@ -1895,7 +2023,9 @@ abstract class RunTestDefinitions
 
           val resWithProps = os.proc(
             TestUtil.cli,
+            TestUtil.powerOptions,
             "run",
+            TestUtil.offlineOptions,
             "--repository",
             s"http://$host:$port",
             "hello",
@@ -1941,7 +2071,9 @@ abstract class RunTestDefinitions
     ).fromRoot { root =>
       val res = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "compile",
+        TestUtil.offlineOptions,
         "Main.scala",
         "--suppress-directives-in-multiple-files-warning"
       )
@@ -2287,7 +2419,14 @@ abstract class RunTestDefinitions
       // ensure the test will be run on a fresh Bloop instance
       os.proc(TestUtil.cli, "bloop", "exit", "--power").call(cwd = root)
       (0 to 2).foreach { _ =>
-        val res = os.proc(TestUtil.cli, "run", input, extraOptions)
+        val res = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          input,
+          extraOptions
+        )
           .call(cwd = root, stderr = os.Pipe)
         expect(res.out.trim() == msg)
         expect(!res.err.trim().toLowerCase.contains("error"))
@@ -2301,7 +2440,15 @@ abstract class RunTestDefinitions
       .fromRoot { root =>
         val invalidOpt = "--invalid"
         val validOpt   = "-Dfoo=bar"
-        val res        = os.proc(TestUtil.cli, "run", "example.sc", "--server=false", extraOptions)
+        val res        = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          "example.sc",
+          "--server=false",
+          extraOptions
+        )
           .call(cwd = root, env = Map("JAVA_OPTS" -> s"$invalidOpt $validOpt"), stderr = os.Pipe)
         val errOutput = res.err.trim()
         expect(errOutput.contains(
@@ -2325,7 +2472,14 @@ abstract class RunTestDefinitions
            |""".stripMargin
     )
       .fromRoot { root =>
-        val res = os.proc(TestUtil.cli, "run", "example.sc", extraOptions)
+        val res = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          "example.sc",
+          extraOptions
+        )
           .call(cwd = root, stderr = os.Pipe)
         val errOutput = res.err.trim()
         expect(errOutput.contains(s"Only java properties are supported in .scala-jvmopts file"))
@@ -2372,14 +2526,31 @@ abstract class RunTestDefinitions
 
           // pass classpath via -cp
           val res =
-            os.proc(TestUtil.cli, "run", inputPathToCall, extraOptions, "-cp", dependencyJar)
+            os.proc(
+              TestUtil.cli,
+              TestUtil.powerOptions,
+              "run",
+              TestUtil.offlineOptions,
+              inputPathToCall,
+              extraOptions,
+              "-cp",
+              dependencyJar
+            )
               .call(cwd = root)
           expect(res.out.trim() == expectedMessage)
 
           // pass classpath via args file
           val argsFileName = "args.txt"
           os.write(root / argsFileName, s"-cp $dependencyJar")
-          val res2 = os.proc(TestUtil.cli, "run", inputPathToCall, extraOptions, s"@$argsFileName")
+          val res2 = os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "run",
+            TestUtil.offlineOptions,
+            inputPathToCall,
+            extraOptions,
+            s"@$argsFileName"
+          )
             .call(cwd = root)
           expect(res2.out.trim() == expectedMessage)
         }
@@ -2398,7 +2569,14 @@ abstract class RunTestDefinitions
            |@main def $main2() = println("$main2")
            |""".stripMargin
     ).fromRoot { root =>
-      val res = os.proc(TestUtil.cli, "run", input, extraOptions)
+      val res = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "run",
+        TestUtil.offlineOptions,
+        input,
+        extraOptions
+      )
         .call(cwd = root, stderr = os.Pipe, check = false)
       val err = res.err.trim()
       expect(err.contains("Found several main classes"))
@@ -2435,7 +2613,9 @@ abstract class RunTestDefinitions
             val processes: Seq[(os.SubProcess, Int)] = (0 until parallelInstancesCount).map { i =>
               os.proc(
                 TestUtil.cli,
+                TestUtil.powerOptions,
                 "run",
+                TestUtil.offlineOptions,
                 input.toString(),
                 extraOptions,
                 "--",
@@ -2465,7 +2645,16 @@ abstract class RunTestDefinitions
         os.rel / "example.test.scala" ->
           s"""object Main extends App { println("$expectedMessage") }"""
       ).fromRoot { root =>
-        val res = os.proc(TestUtil.cli, "run", ".", "--test", extraOptions, platformOpts)
+        val res = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          ".",
+          "--test",
+          extraOptions,
+          platformOpts
+        )
           .call(cwd = root)
         expect(res.out.trim().contains(expectedMessage))
       }
@@ -2482,7 +2671,9 @@ abstract class RunTestDefinitions
     ).fromRoot { root =>
       val res = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         ".",
         "--test",
         "--list-main-classes",
@@ -2507,7 +2698,17 @@ abstract class RunTestDefinitions
       TestInputs(os.rel / "script.sc" -> s"""println("$expectedMessage")""")
         .fromRoot { root =>
           val res =
-            os.proc(TestUtil.cli, "run", ".", "--runner", extraOptions, "--jvm", javaVersion)
+            os.proc(
+              TestUtil.cli,
+              TestUtil.powerOptions,
+              "run",
+              TestUtil.offlineOptions,
+              ".",
+              "--runner",
+              extraOptions,
+              "--jvm",
+              javaVersion
+            )
               .call(cwd = root, stderr = os.Pipe)
           expect(res.out.trim() == expectedMessage)
           val legacyWarningCheck = {
@@ -2536,7 +2737,7 @@ abstract class RunTestDefinitions
         os.remove.all(localRepoPath)
 
         val processes = (0 until parallelInstancesCount).map { _ =>
-          os.proc(TestUtil.cli, "--version")
+          os.proc(TestUtil.cli, "--version", "--offline")
             .spawn(cwd = root)
         }.zipWithIndex
         processes.foreach { case (p, _) => p.waitFor() }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTests212.scala
@@ -32,11 +32,13 @@ class RunTests212 extends RunTestDefinitions with Test212 {
         val res =
           os.proc(
             TestUtil.cli,
+            TestUtil.powerOptions,
             "run",
+            TestUtil.offlineOptions,
             ".",
             "-S",
             "2.12.nightly",
-            TestUtil.extraOptions
+            TestUtil.extraOptionsWithOffline
           )
             .call(cwd = root)
         val version = res.out.trim()

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTests213.scala
@@ -10,13 +10,15 @@ class RunTests213 extends RunTestDefinitions with Test213 {
         val res                  =
           os.proc(
             TestUtil.cli,
+            TestUtil.powerOptions,
             "run",
+            TestUtil.offlineOptions,
             ".",
             "--repository",
             "https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots",
             "-S",
             snapshotScalaVersion,
-            TestUtil.extraOptions
+            TestUtil.extraOptionsWithOffline
           )
             .call(cwd = root)
         expect(res.out.trim() == "2.13.11-20221128-143922-89f3de5")
@@ -28,11 +30,13 @@ class RunTests213 extends RunTestDefinitions with Test213 {
         val res =
           os.proc(
             TestUtil.cli,
+            TestUtil.powerOptions,
             "run",
+            TestUtil.offlineOptions,
             ".",
             "-S",
             "2.13.nightly",
-            TestUtil.extraOptions
+            TestUtil.extraOptionsWithOffline
           )
             .call(cwd = root)
         val version = res.out.trim()

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
@@ -63,7 +63,7 @@ class RunTestsDefault extends RunTestDefinitions
             ".",
             "-S",
             "3.nightly",
-            TestUtil.extraOptions
+            TestUtil.bloopTimeoutOptions
           )
             .call(cwd = root)
         expect(res.out.trim() == "Hello World")
@@ -92,7 +92,15 @@ class RunTestsDefault extends RunTestDefinitions
       val output = res.out.text()
       expect(output.contains("java.lang.AssertionError: assertion failed: Not only files"))
 
-      os.proc(TestUtil.cli, "--power", "run", extraOptions, ".", "--as-jar")
+      os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "run",
+        TestUtil.offlineOptions,
+        extraOptions,
+        ".",
+        "--as-jar"
+      )
         .call(cwd = root)
     }
   }
@@ -104,7 +112,7 @@ class RunTestsDefault extends RunTestDefinitions
         |import tabby.Grid
         |@main def main = println(Grid("a", "b", "c")(1, 2, 3))
         |""".stripMargin).fromRoot { root =>
-      val res = os.proc(TestUtil.cli, "run", extraOptions, inputPath)
+      val res = os.proc(TestUtil.cli, "run", scalaVersionArgs ++ TestUtil.bloopTimeoutOptions, inputPath)
         .call(cwd = root)
       val out = res.out.trim()
       expect(out.contains("a, b, c"))
@@ -181,7 +189,9 @@ class RunTestsDefault extends RunTestDefinitions
           val r =
             os.proc(
               TestUtil.cli,
+              TestUtil.powerOptions,
               "run",
+              TestUtil.offlineOptions,
               ".",
               "--cross",
               "--power",
@@ -203,7 +213,9 @@ class RunTestsDefault extends RunTestDefinitions
           val r =
             os.proc(
               TestUtil.cli,
+              TestUtil.powerOptions,
               "run",
+              TestUtil.offlineOptions,
               ".",
               extraOptions,
               scopeOptions,
@@ -230,7 +242,17 @@ class RunTestsDefault extends RunTestDefinitions
     ) {
       TestInputs(os.rel / "script.sc" -> s"""println("$expectedMessage")""").fromRoot { root =>
         val res =
-          os.proc(TestUtil.cli, "run", ".", "-S", scalaVersion, TestUtil.extraOptions, "--runner")
+          os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "run",
+            TestUtil.offlineOptions,
+            ".",
+            "-S",
+            scalaVersion,
+            TestUtil.extraOptionsWithOffline,
+            "--runner"
+          )
             .call(cwd = root, stderr = os.Pipe)
         expect(res.out.trim() == expectedMessage)
         expect(res.err.trim().contains(expectedWarning))
@@ -258,7 +280,15 @@ class RunTestsDefault extends RunTestDefinitions
             |""".stripMargin
       ).fromRoot { root =>
         val res =
-          os.proc(TestUtil.cli, "run", buildServerOptions, extraOptions, ".").call(cwd = root)
+          os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "run",
+            TestUtil.offlineOptions,
+            buildServerOptions,
+            extraOptions,
+            "."
+          ).call(cwd = root)
         expect(res.out.text().contains("No Scala on classpath!"))
       }
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunWithWatchTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunWithWatchTestDefinitions.scala
@@ -62,7 +62,15 @@ trait RunWithWatchTestDefinitions { this: RunTestDefinitions =>
       test(s"simple --watch ${inputPath.last}") {
         inputs.fromRoot { root =>
           TestUtil.withProcessWatching(
-            proc = os.proc(TestUtil.cli, "run", inputPath.toString(), "--watch", extraOptions)
+            proc = os.proc(
+              TestUtil.cli,
+              TestUtil.powerOptions,
+              "run",
+              TestUtil.offlineOptions,
+              inputPath.toString(),
+              "--watch",
+              extraOptions
+            )
               .spawn(cwd = root, stderr = os.Pipe),
             timeout = 120.seconds
           ) { (proc, timeout, ec) =>
@@ -97,8 +105,9 @@ trait RunWithWatchTestDefinitions { this: RunTestDefinitions =>
         TestUtil.withProcessWatching(
           proc = os.proc(
             TestUtil.cli,
-            "--power",
+            TestUtil.powerOptions,
             "run",
+            TestUtil.offlineOptions,
             ".",
             "--watch",
             "--watching",
@@ -137,7 +146,15 @@ trait RunWithWatchTestDefinitions { this: RunTestDefinitions =>
         externalFile -> "Hello"
       ).fromRoot { root =>
         TestUtil.withProcessWatching(
-          proc = os.proc(TestUtil.cli, "--power", "run", ".", "--watch", extraOptions)
+          proc = os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "run",
+            TestUtil.offlineOptions,
+            ".",
+            "--watch",
+            extraOptions
+          )
             .spawn(cwd = root, stderr = os.Pipe),
           timeout = 120.seconds
         ) { (proc, timeout, ec) =>
@@ -176,8 +193,9 @@ trait RunWithWatchTestDefinitions { this: RunTestDefinitions =>
           proc =
             os.proc(
               TestUtil.cli,
-              "--power",
+              TestUtil.powerOptions,
               "run",
+              TestUtil.offlineOptions,
               ".",
               "--watch",
               "--watching",
@@ -231,7 +249,9 @@ trait RunWithWatchTestDefinitions { this: RunTestDefinitions =>
             proc =
               os.proc(
                 TestUtil.cli,
+                TestUtil.powerOptions,
                 "run",
+                TestUtil.offlineOptions,
                 inputPath.toString(),
                 "--watch",
                 "--test",
@@ -271,7 +291,15 @@ trait RunWithWatchTestDefinitions { this: RunTestDefinitions =>
       val configEnv = Map("SCALA_CLI_CONFIG" -> confFile.toString)
 
       TestUtil.withProcessWatching(
-        proc = os.proc(TestUtil.cli, "run", "--watch", "--interactive", fileName)
+        proc = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "run",
+          TestUtil.offlineOptions,
+          "--watch",
+          "--interactive",
+          fileName
+        )
           .spawn(
             cwd = root,
             mergeErrIntoOut = true,
@@ -367,8 +395,9 @@ trait RunWithWatchTestDefinitions { this: RunTestDefinitions =>
         def publishLib(): Unit =
           os.proc(
             TestUtil.cli,
-            "--power",
+            TestUtil.powerOptions,
             "publish",
+            TestUtil.offlineOptions,
             "--offline",
             "--publish-repo",
             testRepo,
@@ -381,8 +410,9 @@ trait RunWithWatchTestDefinitions { this: RunTestDefinitions =>
         TestUtil.withProcessWatching(
           os.proc(
             TestUtil.cli,
-            "--power",
+            TestUtil.powerOptions,
             "run",
+            TestUtil.offlineOptions,
             "--offline",
             "app",
             "-w",
@@ -414,7 +444,14 @@ trait RunWithWatchTestDefinitions { this: RunTestDefinitions =>
           |""".stripMargin
     ).fromRoot { root =>
       TestUtil.withProcessWatching(
-        proc = os.proc(TestUtil.cli, "test", "-w", "watch.scala")
+        proc = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "test",
+          TestUtil.offlineOptions,
+          "-w",
+          "watch.scala"
+        )
           .spawn(cwd = root, mergeErrIntoOut = true),
         timeout = 10.seconds
       ) { (proc, timeout, ec) =>
@@ -456,7 +493,15 @@ trait RunWithWatchTestDefinitions { this: RunTestDefinitions =>
 
       TestInputs(inputPath -> code(includeDirective = true)).fromRoot { root =>
         TestUtil.withProcessWatching(
-          os.proc(TestUtil.cli, "run", ".", "--watch", extraOptions)
+          os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "run",
+            TestUtil.offlineOptions,
+            ".",
+            "--watch",
+            extraOptions
+          )
             .spawn(cwd = root, stderr = os.Pipe)
         ) { (proc, timeout, ec) =>
           val output1 = TestUtil.readLine(proc.stdout, ec, timeout)
@@ -497,7 +542,9 @@ trait RunWithWatchTestDefinitions { this: RunTestDefinitions =>
         TestUtil.withProcessWatching(
           os.proc(
             TestUtil.cli,
+            TestUtil.powerOptions,
             "run",
+            TestUtil.offlineOptions,
             "src",
             "--watch",
             resourceOptions,

--- a/modules/integration/src/test/scala/scala/cli/integration/SharedRunTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SharedRunTests.scala
@@ -18,7 +18,7 @@ class SharedRunTests extends ScalaCliSuite {
   )
   test("Scala version 2.12") {
     printScalaVersionInputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, TestUtil.extraOptions, ".", "--scala", "2.12")
+      val output = os.proc(TestUtil.cli, TestUtil.bloopTimeoutOptions, ".", "--scala", "2.12")
         .call(cwd = root)
         .out.trim()
       expect(output.startsWith("2.12."))
@@ -26,7 +26,7 @@ class SharedRunTests extends ScalaCliSuite {
   }
   test("Scala version 2.13") {
     printScalaVersionInputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, TestUtil.extraOptions, ".", "--scala", "2.13")
+      val output = os.proc(TestUtil.cli, TestUtil.bloopTimeoutOptions, ".", "--scala", "2.13")
         .call(cwd = root)
         .out.trim()
       expect(output.startsWith("2.13."))
@@ -34,7 +34,7 @@ class SharedRunTests extends ScalaCliSuite {
   }
   test("Scala version 2") {
     printScalaVersionInputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, TestUtil.extraOptions, ".", "--scala", "2")
+      val output = os.proc(TestUtil.cli, TestUtil.bloopTimeoutOptions, ".", "--scala", "2")
         .call(cwd = root)
         .out.trim()
       expect(output.startsWith("2.13."))
@@ -42,7 +42,7 @@ class SharedRunTests extends ScalaCliSuite {
   }
   test("Scala version 3") {
     printScalaVersionInputs3.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, TestUtil.extraOptions, ".", "--scala", "3.0.2")
+      val output = os.proc(TestUtil.cli, TestUtil.bloopTimeoutOptions, ".", "--scala", "3.0.2")
         .call(cwd = root)
         .out.trim()
       // Scala 3.0 uses the 2.13 standard library
@@ -60,7 +60,7 @@ class SharedRunTests extends ScalaCliSuite {
     )
     inputs.fromRoot { root =>
       val output =
-        os.proc(TestUtil.cli, TestUtil.extraOptions, ".").call(cwd = root).out.trim()
+        os.proc(TestUtil.cli, TestUtil.bloopTimeoutOptions, ".").call(cwd = root).out.trim()
       expect(output == confSv)
     }
   }

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -29,7 +29,11 @@ class SipScalaTests extends ScalaCliSuite
       newCliPath
     }
   }
-  def powerArgs(isPowerMode: Boolean): Seq[String] = if (isPowerMode) Seq("--power") else Nil
+  def powerArgs(isPowerMode: Boolean): Seq[String]        = if (isPowerMode) Seq("--power") else Nil
+  def powerOfflineArgs(isPowerMode: Boolean): Seq[String] =
+    if (isPowerMode) TestUtil.powerOptions else Nil
+  def offlineAfterSubcommand(isPowerMode: Boolean): Seq[String] =
+    if (isPowerMode) TestUtil.offlineOptions else Nil
   def suppressExperimentalWarningArgs(areWarningsSuppressed: Boolean): Seq[String] =
     if (areWarningsSuppressed) Seq("--suppress-experimental-feature-warning") else Nil
 
@@ -52,7 +56,7 @@ class SipScalaTests extends ScalaCliSuite
 
   def testDirectoriesCommand(isPowerMode: Boolean): Unit =
     TestInputs.empty.fromRoot { root =>
-      val res = os.proc(TestUtil.cli, powerArgs(isPowerMode), "directories").call(
+      val res = os.proc(TestUtil.cli, powerOfflineArgs(isPowerMode), "directories").call(
         cwd = root,
         check = false,
         mergeErrIntoOut = true
@@ -148,7 +152,7 @@ class SipScalaTests extends ScalaCliSuite
 
   def testExportCommandHelp(isPowerMode: Boolean): Unit =
     TestInputs.empty.fromRoot { root =>
-      val res = os.proc(TestUtil.cli, powerArgs(isPowerMode), "export", "-h").call(
+      val res = os.proc(TestUtil.cli, powerOfflineArgs(isPowerMode), "export", "-h").call(
         cwd = root,
         stderr = os.Pipe
       )
@@ -160,7 +164,7 @@ class SipScalaTests extends ScalaCliSuite
   def testConfigCommandHelp(isPowerMode: Boolean, isFullHelp: Boolean): Unit =
     TestInputs.empty.fromRoot { root =>
       val helpParams = if (isFullHelp) Seq("--full-help") else Seq("-h")
-      val helpOutput = os.proc(TestUtil.cli, powerArgs(isPowerMode), "config", helpParams)
+      val helpOutput = os.proc(TestUtil.cli, powerOfflineArgs(isPowerMode), "config", helpParams)
         .call(cwd = root, stderr = os.Pipe)
         .out.trim()
       if (isPowerMode) {
@@ -279,7 +283,9 @@ class SipScalaTests extends ScalaCliSuite
   def testDefaultHelpOutput(isPowerMode: Boolean): Unit = TestInputs.empty.fromRoot { root =>
     for (helpOptions <- HelpTests.variants) {
       val output =
-        os.proc(TestUtil.cli, powerArgs(isPowerMode), helpOptions).call(cwd = root).out.trim()
+        os.proc(TestUtil.cli, powerOfflineArgs(isPowerMode), helpOptions).call(cwd =
+          root
+        ).out.trim()
       val restrictedFeaturesMentioned = output.contains("package")
       if (!isPowerMode) expect(!restrictedFeaturesMentioned)
       else expect(restrictedFeaturesMentioned)
@@ -288,7 +294,7 @@ class SipScalaTests extends ScalaCliSuite
 
   def testReplHelpOutput(isPowerMode: Boolean): Unit = TestInputs.empty.fromRoot { root =>
     val output =
-      os.proc(TestUtil.cli, powerArgs(isPowerMode), "repl", "--help-full").call(cwd =
+      os.proc(TestUtil.cli, powerOfflineArgs(isPowerMode), "repl", "--help-full").call(cwd =
         root
       ).out.trim()
     val restrictedFeaturesMentioned   = output.contains("compute-version")
@@ -370,7 +376,7 @@ class SipScalaTests extends ScalaCliSuite
   test("test global config suppressing warnings for an experimental sub-command") {
     testConfigSuppressingExperimentalFeatureWarnings("`export` sub-command") {
       (root: os.Path, homeEnv: Map[String, String]) =>
-        val res = os.proc(TestUtil.cli, "--power", "export")
+        val res = os.proc(TestUtil.cli, TestUtil.powerOptions, "export", TestUtil.offlineOptions)
           .call(cwd = root, check = false, env = homeEnv, stderr = os.Pipe)
         expect(res.exitCode == 1)
         res
@@ -485,7 +491,9 @@ class SipScalaTests extends ScalaCliSuite
       val continuationsVersion = "1.0.3"
       val res                  = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "compile",
+        TestUtil.offlineOptions,
         sourceFileName,
         "--compiler-plugin",
         s"org.scala-lang.plugins:::scala-continuations-plugin:$continuationsVersion",
@@ -552,7 +560,14 @@ class SipScalaTests extends ScalaCliSuite
     ) {
       TestInputs.empty.fromRoot { root =>
         val r =
-          os.proc(TestUtil.cli, "--cli-default-scala-version", sv, "version", "--scala-version")
+          os.proc(
+            TestUtil.cli,
+            "--cli-default-scala-version",
+            sv,
+            "version",
+            "--offline",
+            "--scala-version"
+          )
             .call(cwd = root)
         expect(r.out.trim() == sv)
       }
@@ -562,7 +577,7 @@ class SipScalaTests extends ScalaCliSuite
       s"default Scala version overridden with $sv by a launcher parameter is respected when printing versions"
     ) {
       TestInputs.empty.fromRoot { root =>
-        val r = os.proc(TestUtil.cli, "--cli-default-scala-version", sv, "version")
+        val r = os.proc(TestUtil.cli, "--cli-default-scala-version", sv, "version", "--offline")
           .call(cwd = root)
         expect(r.out.trim().contains(sv))
       }
@@ -573,7 +588,7 @@ class SipScalaTests extends ScalaCliSuite
     TestInputs.empty.fromRoot { root =>
       val (sv1, sv2)  = (Constants.scala212, Constants.scala213)
       val launcherOpt = "--cli-default-scala-version"
-      val r           = os.proc(TestUtil.cli, launcherOpt, sv1, launcherOpt, sv2, "version")
+      val r = os.proc(TestUtil.cli, launcherOpt, sv1, launcherOpt, sv2, "version", "--offline")
         .call(cwd = root, check = false, stderr = os.Pipe)
       expect(r.exitCode == 1)
       expect(r.err.trim().contains(launcherOpt))
@@ -770,7 +785,9 @@ class SipScalaTests extends ScalaCliSuite
         |""".stripMargin).fromRoot { root =>
       val res = os.proc(
         TestUtil.cli,
+        TestUtil.powerOptions,
         "compile",
+        TestUtil.offlineOptions,
         "example.sc",
         "--with-compiler"
       ).call(cwd = root)

--- a/modules/integration/src/test/scala/scala/cli/integration/SparkTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SparkTestDefinitions.scala
@@ -55,7 +55,8 @@ abstract class SparkTestDefinitions extends ScalaCliSuite with TestScalaVersionA
   this: TestScalaVersion =>
   import SparkTestDefinitions.*
 
-  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
+  protected lazy val extraOptions: Seq[String] =
+    scalaVersionArgs ++ TestUtil.extraOptionsWithOffline
 
   protected def defaultMaster                                                     = "local[4]"
   protected def simpleJobInputs(spark: Spark, withTestScope: Boolean): TestInputs = TestInputs(
@@ -138,8 +139,9 @@ abstract class SparkTestDefinitions extends ScalaCliSuite with TestScalaVersionA
       val scopeOptions = if (withTestScope) Seq("--test") else Nil
       val res          = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         extraOptions,
         "--spark-standalone",
         ".",
@@ -195,8 +197,9 @@ abstract class SparkTestDefinitions extends ScalaCliSuite with TestScalaVersionA
         val extraEnv = maybeHadoopHomeForWinutils(root / "hadoop-home")
         val res      = os.proc(
           TestUtil.cli,
-          "--power",
+          TestUtil.powerOptions,
           "run",
+          TestUtil.offlineOptions,
           extraOptions,
           "--spark-standalone",
           ".",

--- a/modules/integration/src/test/scala/scala/cli/integration/SparkTests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SparkTests212.scala
@@ -33,8 +33,9 @@ class SparkTests212 extends SparkTestDefinitions with Test212 {
       val dest = os.rel / "SparkJob.jar"
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         extraOptions,
         "--spark",
         "--jvm",
@@ -92,8 +93,9 @@ class SparkTests212 extends SparkTestDefinitions with Test212 {
       val scopeOptions = if (withTestScope) Seq("--test") else Nil
       val res          = os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "run",
+        TestUtil.offlineOptions,
         extraOptions,
         "--spark",
         "--jvm",

--- a/modules/integration/src/test/scala/scala/cli/integration/TestNativeImageOnScala3.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestNativeImageOnScala3.scala
@@ -16,8 +16,9 @@ class TestNativeImageOnScala3 extends ScalaCliSuite {
     inputs.fromRoot { root =>
       os.proc(
         TestUtil.cli,
-        "--power",
+        TestUtil.powerOptions,
         "package",
+        TestUtil.offlineOptions,
         ".",
         "--native-image",
         "-o",

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -10,9 +10,10 @@ import scala.util.Properties
 
 abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionArgs {
   this: TestScalaVersion =>
-  protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
-  private val utestVersion                     = "0.8.3"
-  private val zioTestVersion                   = "2.1.17"
+  protected lazy val extraOptions: Seq[String] =
+    scalaVersionArgs ++ TestUtil.extraOptionsWithOffline
+  private val utestVersion   = "0.8.3"
+  private val zioTestVersion = "2.1.17"
 
   def successfulTestInputs(directivesString: String =
     s"//> using dep org.scalameta::munit::$munitVersion"): TestInputs = TestInputs(
@@ -331,8 +332,9 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
         TestUtil.withProcessWatching(
           proc = os.proc(
             TestUtil.cli,
-            "--power",
+            TestUtil.powerOptions,
             "test",
+            TestUtil.offlineOptions,
             ".",
             "--watch",
             "--watching",
@@ -359,7 +361,16 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
     test("successful test JVM 8") {
       successfulTestInputs().fromRoot { root =>
         val output =
-          os.proc(TestUtil.cli, "test", "--jvm", "8", extraOptions, ".").call(cwd = root).out.text()
+          os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "test",
+            TestUtil.offlineOptions,
+            "--jvm",
+            "8",
+            extraOptions,
+            "."
+          ).call(cwd = root).out.text()
         expect(output.contains("Hello from tests"))
       }
     }
@@ -403,7 +414,9 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
       val res =
         os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "test",
+          TestUtil.offlineOptions,
           ".",
           extraOptions,
           "--test-only",
@@ -450,7 +463,9 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
       val res =
         os.proc(
           TestUtil.cli,
+          TestUtil.powerOptions,
           "test",
+          TestUtil.offlineOptions,
           ".",
           extraOptions,
           "--test-only",
@@ -716,7 +731,16 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
                |""".stripMargin
         ).fromRoot { root =>
           val res =
-            os.proc(TestUtil.cli, "test", TestUtil.extraOptions, ".", "--jvm", javaVersion)
+            os.proc(
+              TestUtil.cli,
+              TestUtil.powerOptions,
+              "test",
+              TestUtil.offlineOptions,
+              TestUtil.extraOptionsWithOffline,
+              ".",
+              "--jvm",
+              javaVersion
+            )
               .call(cwd = root)
           expect(res.out.text().contains("Hello from pure Java Jupiter"))
         }
@@ -957,7 +981,15 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
       }
       inputs.fromRoot { root =>
         val res =
-          os.proc(TestUtil.cli, "--power", "test", extraOptions, ".", "--cross").call(cwd = root)
+          os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "test",
+            TestUtil.offlineOptions,
+            extraOptions,
+            ".",
+            "--cross"
+          ).call(cwd = root)
         val output        = res.out.text()
         val expectedCount = 2 + (if (supportsNative) 1 else 0)
         expect(countSubStrings(output, "Hello from shared") == expectedCount)
@@ -1107,7 +1139,14 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
            |    )
            |}
            |""".stripMargin).fromRoot { root =>
-        val r = os.proc(TestUtil.cli, "test", ".", extraOptions)
+        val r = os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "test",
+          TestUtil.offlineOptions,
+          ".",
+          extraOptions
+        )
           .call(cwd = root, check = false, stderr = os.Pipe)
         expect(r.exitCode == 1)
         val expectedWarning =
@@ -1145,7 +1184,15 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
              |    )
              |}
              |""".stripMargin).fromRoot { root =>
-          val r = os.proc(TestUtil.cli, "test", ".", extraOptions, platformOptions).call(cwd = root)
+          val r = os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "test",
+            TestUtil.offlineOptions,
+            ".",
+            extraOptions,
+            platformOptions
+          ).call(cwd = root)
           val output = r.out.trim()
           expect(output.contains(expectedMessage))
           expect(countSubStrings(output, expectedMessage) == 1)
@@ -1306,7 +1353,16 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
            |}
            |""".stripMargin).fromRoot { root =>
         val res =
-          os.proc(TestUtil.cli, "test", ".", extraOptions, "--jvm", javaVersion)
+          os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "test",
+            TestUtil.offlineOptions,
+            ".",
+            extraOptions,
+            "--jvm",
+            javaVersion
+          )
             .call(cwd = root, stderr = os.Pipe)
         val out = res.out.trim()
         expect(out.contains(expectedMessage))

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTests212.scala
@@ -22,7 +22,14 @@ class TestTests212 extends TestTestDefinitions with Test212 {
       val expectedWarning =
         s"Defaulting to a legacy test-runner module version: ${Constants.runnerScala2LegacyVersion}"
       val res =
-        os.proc(TestUtil.cli, "test", ".", extraOptions)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "test",
+          TestUtil.offlineOptions,
+          ".",
+          extraOptions
+        )
           .call(cwd = root, stderr = os.Pipe)
       val out = res.out.trim()
       expect(out.contains(expectedMessage))

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTests213.scala
@@ -22,7 +22,14 @@ class TestTests213 extends TestTestDefinitions with Test213 {
       val expectedWarning =
         s"Defaulting to a legacy test-runner module version: ${Constants.runnerScala2LegacyVersion}"
       val res =
-        os.proc(TestUtil.cli, "test", ".", extraOptions)
+        os.proc(
+          TestUtil.cli,
+          TestUtil.powerOptions,
+          "test",
+          TestUtil.offlineOptions,
+          ".",
+          extraOptions
+        )
           .call(cwd = root, stderr = os.Pipe)
       val out = res.out.trim()
       expect(out.contains(expectedMessage))

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
@@ -35,7 +35,15 @@ class TestTestsDefault extends TestTestDefinitions with TestDefault {
     )
 
     inputs.fromRoot { root =>
-      val compileRes = os.proc(TestUtil.cli, "compile", "--print-class-path", extraOptions, ".")
+      val compileRes = os.proc(
+        TestUtil.cli,
+        TestUtil.powerOptions,
+        "compile",
+        TestUtil.offlineOptions,
+        "--print-class-path",
+        extraOptions,
+        "."
+      )
         .call(cwd = root)
       val cp = compileRes.out.trim().split(File.pathSeparator)
       expect(cp.length == 1) // only class dir, no scala JARs
@@ -89,7 +97,16 @@ class TestTestsDefault extends TestTestDefinitions with TestDefault {
            |}
            |""".stripMargin).fromRoot { root =>
         val res =
-          os.proc(TestUtil.cli, "test", ".", "-S", scalaVersion, TestUtil.extraOptions)
+          os.proc(
+            TestUtil.cli,
+            TestUtil.powerOptions,
+            "test",
+            TestUtil.offlineOptions,
+            ".",
+            "-S",
+            scalaVersion,
+            TestUtil.extraOptionsWithOffline
+          )
             .call(cwd = root, stderr = os.Pipe)
         val out = res.out.trim()
         expect(out.contains(expectedMessage))

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -50,12 +50,18 @@ object TestUtil {
         case _ => Seq("java", "-Xmx512m", "-Xms128m", "-jar", cliPath)
       }
 
-  val extraOptions: List[String] = List(
+  val bloopTimeoutOptions: List[String] = List(
     "--bloop-startup-timeout",
     "2min",
     "--bloop-bsp-timeout",
     "1min"
   )
+
+  val powerOptions: List[String]   = List("--power")
+  val offlineOptions: List[String] = List("--offline")
+
+  val extraOptionsWithOffline: List[String] =
+    bloopTimeoutOptions ++ powerOptions ++ offlineOptions
 
   def fromPath(app: String): Option[String] = {
 

--- a/modules/integration/src/test/scala/scala/cli/integration/VersionTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/VersionTests.scala
@@ -11,7 +11,7 @@ class VersionTests extends ScalaCliSuite {
       // tests if the format is correct instead of comparing to a version passed via Constants
       // in order to catch errors in Mill configuration, too
       val versionRegex = ".*\\d+[.]\\d+[.]\\d+.*".r
-      val version      = os.proc(TestUtil.cli, versionOption).call(check = false)
+      val version      = os.proc(TestUtil.cli, versionOption, "--offline").call(check = false)
       assert(
         versionRegex.findFirstMatchIn(version.out.text()).isDefined,
         clues(version.exitCode, version.out.text(), version.err.text())
@@ -22,7 +22,7 @@ class VersionTests extends ScalaCliSuite {
     test(s"$versionOption --offline") {
       TestInputs.empty.fromRoot { root =>
         // TODO: --power should not be necessary here
-        os.proc(TestUtil.cli, versionOption, "--offline", "--power").call(cwd = root)
+        os.proc(TestUtil.cli, versionOption, "--offline").call(cwd = root)
       }
     }
   }


### PR DESCRIPTION
- a subtask of https://github.com/VirtusLab/scala-cli/issues/2937

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Cursor + Claude

## How was the solution tested?
existing/refactored tests