### PR TITLE
Disable test parallelism for unit tests on the CI

### DIFF
--- a/project/settings/package.mill
+++ b/project/settings/package.mill
@@ -540,6 +540,9 @@ trait HasTests extends SbtModule {
     super.scalacOptions() ++ extraOptions
   }
   trait ScalaCliTests extends ScalaCliModule with super.SbtTests with TestModule.Munit {
+    override def testParallelism: T[Boolean]           = !isCI
+    override def testForkGrouping: T[Seq[Seq[String]]] =
+      if isCI then discoveredTestClasses().grouped(1).toSeq else super.testForkGrouping()
     override def mvnDeps: T[Seq[Dep]] = super.mvnDeps() ++ Seq(
       Deps.expecty,
       Deps.munit


### PR DESCRIPTION
This makes unit tests not run in parallel on the CI, similar to how we already configured our integration tests.

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)

## How much have your relied on LLM-based tools in this contribution?
not at all

## How was the solution tested?
ran example unit test suite