### PR TITLE
Mark Scala 2 nightly tests as flaky

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTests213.scala
@@ -18,7 +18,7 @@ class ReplTests213
         Seq.empty
     repoString = if withExplicitScala2SnapshotRepo then " with Scala 2 snapshot repo" else ""
   }
-    test(s"$dryRunPrefix repl Scala 2 snapshots: $nightlyVersion$repoString") {
+    test(s"$dryRunPrefix repl Scala 2 snapshots: $nightlyVersion$repoString".flaky) {
       dryRun(
         cliOptions = scalaVersionOptions ++ repoOptions,
         useExtraOptions = false

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTests212.scala
@@ -26,7 +26,7 @@ class RunTests212 extends RunTestDefinitions with Test212 {
       )
     }
   }
-  test("2.12.nightly") {
+  test("2.12.nightly".flaky) {
     TestInputs(os.rel / "sample.sc" -> "println(util.Properties.versionNumberString)").fromRoot {
       root =>
         val res =


### PR DESCRIPTION
https://scala-ci.typesafe.com/artifactory/scala-integration/ seems to be timing out/be unavailable, intermittently.

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)

## How much have your relied on LLM-based tools in this contribution?
not at all

## How was the solution tested?
existing tests