### PR TITLE
Bump `mill-native-image` and `mill-native-image-upload` to 0.2.6 (was 0.2.4) and add support for VS 2026

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,7 +1,7 @@
 //| mill-jvm-version: system|17
 //| mvnDeps:
-//| - io.github.alexarchambault.mill::mill-native-image::0.2.4
-//| - io.github.alexarchambault.mill::mill-native-image-upload:0.2.4
+//| - io.github.alexarchambault.mill::mill-native-image::0.2.6
+//| - io.github.alexarchambault.mill::mill-native-image-upload:0.2.6
 //| - com.goyeau::mill-scalafix::0.6.0
 //| - com.lumidion::sonatype-central-client-requests:0.6.0
 //| - io.get-coursier:coursier-launcher_2.13:2.1.25-M25
@@ -594,6 +594,8 @@ trait Core extends ScalaCliCrossSbtModule
     PathRef(dir)
   }
   override def generatedSources: T[Seq[PathRef]] = super.generatedSources() ++ Seq(constantsFile())
+
+  object test extends ScalaCliTests
 }
 
 trait Directives extends ScalaCliCrossSbtModule
@@ -1507,6 +1509,7 @@ def unitTests(): Command[(msg: String, results: Seq[TestResult])] = Task.Command
   `build-module`(Scala.defaultInternal).test.testForked()()
   `build-macros`(Scala.defaultInternal).test.testForked()()
   cli(Scala.defaultInternal).test.testForked()()
+  core(Scala.defaultInternal).test.testForked()()
   directives(Scala.defaultInternal).test.testForked()()
   options(Scala.defaultInternal).test.testForked()()
 }
@@ -2062,7 +2065,7 @@ object ci extends Module {
     Task.Command {
       val msmPath = {
 
-        val vcVersions = Seq("2022", "2019", "2017")
+        val vcVersions = Seq("18", "2026", "2022", "2019", "2017")
         val vcEditions = Seq("Enterprise", "Community", "BuildTools")
         val vsDirs     = Seq(
           os.Path("""C:\Program Files\Microsoft Visual Studio"""),

--- a/modules/core/src/main/scala/scala/build/internals/NativeWrapper.scala
+++ b/modules/core/src/main/scala/scala/build/internals/NativeWrapper.scala
@@ -298,10 +298,11 @@ object MsvcEnvironment {
   }
 
   // newest VS first, Enterprise > Community > BuildTools
-  private def vcVersions                              = Seq("2022", "2019", "2017")
-  private def vcEditions                              = Seq("Enterprise", "Community", "BuildTools")
-  private lazy val vcVarsCandidates: Iterable[String] =
-    EnvVar.Misc.vcVarsAll.valueOpt ++ {
+  private def vcVersions = Seq("18", "2026", "2022", "2019", "2017")
+  private def vcEditions = Seq("Enterprise", "Community", "BuildTools")
+
+  def vcVarsCandidatePaths(vcVarsAllOverride: Option[String] = None): Seq[String] =
+    vcVarsAllOverride.toSeq ++ {
       for {
         isX86   <- Seq(false, true)
         version <- vcVersions
@@ -312,6 +313,9 @@ object MsvcEnvironment {
           """\VC\Auxiliary\Build\vcvars64.bat"""
       }
     }
+
+  private lazy val vcVarsCandidates: Iterable[String] =
+    vcVarsCandidatePaths(EnvVar.Misc.vcVarsAll.valueOpt)
 
   lazy val mountedDrives: String = {
     val str         = "HKEY_LOCAL_MACHINE/SYSTEM/MountedDevices".replace('/', '\\')

--- a/modules/core/src/test/scala/scala/build/internals/MsvcEnvironmentTests.scala
+++ b/modules/core/src/test/scala/scala/build/internals/MsvcEnvironmentTests.scala
@@ -1,0 +1,14 @@
+package scala.build.internals
+
+import com.eed3si9n.expecty.Expecty.expect
+
+class MsvcEnvironmentTests extends munit.FunSuite {
+  test("vcVarsCandidatePaths includes VS 2026 Enterprise path") {
+    val paths = MsvcEnvironment.vcVarsCandidatePaths(vcVarsAllOverride = None)
+    expect(
+      paths.contains(
+        """C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvars64.bat"""
+      )
+    )
+  }
+}

--- a/project/settings/package.mill
+++ b/project/settings/package.mill
@@ -162,7 +162,6 @@ trait CliLaunchers extends SbtModule { self =>
       Task.Command(super.writeNativeImageScript(scriptDest, "")())
 
     def launcherKind: String
-    override def nativeImageCsCommand: T[Seq[String]] = Seq(cs())
     override def nativeImagePersist: Boolean          = System.getenv("CI") != null
     override def nativeImageGraalVmJvmId: T[String]   = deps.graalVmJvmId
     override def nativeImageOptions: T[Seq[String]]   = Task {


### PR DESCRIPTION
https://github.com/alexarchambault/mill-native-image/releases/tag/v0.2.6
https://github.com/actions/runner-images/blob/win25-vs2026/20260428.85/images/windows/Windows2025-VS2026-Readme.md#visual-studio-enterprise-2026

This ought to fix our Windows CI, which now fails with:
```
Error: Failed to find 'vcvarsall.bat' in a Visual Studio installation.
Please make sure that Visual Studio 2022 version 17.1.0 or later is installed on your system. You can download it at [https://visualstudio.microsoft.com/downloads/.](https://visualstudio.microsoft.com/downloads/) If this error persists, please try and run GraalVM Native Image in an x64 Native Tools Command Prompt or file a ticket.
```

## Checklist
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)

## How much have your relied on LLM-based tools in this contribution?
moderately, Cursor + Claude

## How was the solution tested?
existing Windows test suites