### PR TITLE
Add support for SBT 2.* export

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1135,6 +1135,8 @@ trait CliIntegration extends SbtModule
            |  def defaultMillVersion = "${BuildInfo.millVersion}"
            |  def mill012Version = "${Deps.Versions.mill012Version}"
            |  def mill1Version = "${Deps.Versions.mill1Version}"
+           |  def sbt1Version = "${Deps.Versions.sbt1Version}"
+           |  def sbt2Version = "${Deps.Versions.sbt2Version}"
            |}
            |""".stripMargin
       if (!os.isFile(dest) || os.read(dest) != code)

--- a/modules/cli/src/main/scala/scala/cli/exportCmd/SbtProjectDescriptor.scala
+++ b/modules/cli/src/main/scala/scala/cli/exportCmd/SbtProjectDescriptor.scala
@@ -170,24 +170,35 @@ final case class SbtProjectDescriptor(
     )
   }
 
+  private def isSbt2: Boolean = sbtVersion.startsWith("2.")
+
+  private def unmanagedClasspathSettings(config: String, paths: Seq[os.Path]): Seq[String] =
+    if paths.isEmpty then Nil
+    else
+      val fileExprs = paths.map(p => s"""file("$p")""")
+      if isSbt2 then
+        val classpathExpr =
+          if fileExprs.lengthCompare(1) == 0 then
+            s"PathFinder(${fileExprs.head}).classpath"
+          else
+            s"List(${fileExprs.mkString(", ")}).flatMap(f => PathFinder(f).classpath)"
+        Seq(
+          s"""$config / unmanagedClasspath ++= {
+             |  implicit val conv: xsbti.FileConverter = fileConverter.value
+             |  $classpathExpr
+             |}""".stripMargin
+        )
+      else
+        Seq(s"""$config / unmanagedClasspath ++= Seq(${fileExprs.mkString(", ")})""")
+
   private def customJarsSettings(options: BuildOptions): SbtProject = {
 
     val customCompileOnlyJarsSettings =
-      if (options.classPathOptions.extraCompileOnlyJars.isEmpty) Nil
-      else {
-        val jars = options.classPathOptions.extraCompileOnlyJars.map(p => s"""file("$p")""")
-        Seq(s"""Compile / unmanagedClasspath ++= Seq(${jars.mkString(", ")})""")
-      }
+      unmanagedClasspathSettings("Compile", options.classPathOptions.extraCompileOnlyJars)
 
     val customJarsSettings =
-      if (options.classPathOptions.extraClassPath.isEmpty) Nil
-      else {
-        val jars = options.classPathOptions.extraClassPath.map(p => s"""file("$p")""")
-        Seq(
-          s"""Compile / unmanagedClasspath ++= Seq(${jars.mkString(", ")})""",
-          s"""Runtime / unmanagedClasspath ++= Seq(${jars.mkString(", ")})"""
-        )
-      }
+      unmanagedClasspathSettings("Compile", options.classPathOptions.extraClassPath) ++
+        unmanagedClasspathSettings("Runtime", options.classPathOptions.extraClassPath)
 
     SbtProject(
       settings = Seq(customCompileOnlyJarsSettings, customJarsSettings)

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportCommonTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportCommonTestDefinitions.scala
@@ -12,7 +12,9 @@ trait ExportCommonTestDefinitions { this: ScalaCliSuite & TestScalaVersionArgs =
 
   protected def commonTestDescriptionSuffix: String = ""
 
-  protected def runExportTests: Boolean = Properties.isMac
+  protected def runExportTests: Boolean           = Properties.isMac
+  protected def runScalaJsExportTest: Boolean     = runExportTests
+  protected def runScalaNativeExportTest: Boolean = runExportTests
   protected def exportCommand(args: String*): os.proc
   protected def defaultExportCommandArgs: Seq[String] = Nil
 

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbt1Tests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbt1Tests212.scala
@@ -1,0 +1,3 @@
+package scala.cli.integration
+
+class ExportSbt1Tests212 extends ExportSbtTestDefinitions with Test212 with TestSbt1

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbt1Tests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbt1Tests213.scala
@@ -1,0 +1,4 @@
+package scala.cli.integration
+
+class ExportSbt1Tests213 extends ExportSbtTestDefinitions with Test213 with TestSbt1
+    with ExportSbtTests213

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbt1Tests3Lts.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbt1Tests3Lts.scala
@@ -1,0 +1,3 @@
+package scala.cli.integration
+
+class ExportSbt1Tests3Lts extends ExportSbtTestDefinitions with Test3Lts with TestSbt1

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbt1Tests3NextRc.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbt1Tests3NextRc.scala
@@ -1,0 +1,3 @@
+package scala.cli.integration
+
+class ExportSbt1Tests3NextRc extends ExportSbtTestDefinitions with Test3NextRc with TestSbt1

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbt1TestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbt1TestsDefault.scala
@@ -1,0 +1,3 @@
+package scala.cli.integration
+
+class ExportSbt1TestsDefault extends ExportSbtTestDefinitions with TestDefault with TestSbt1

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbt2Tests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbt2Tests212.scala
@@ -1,0 +1,3 @@
+package scala.cli.integration
+
+class ExportSbt2Tests212 extends ExportSbtTestDefinitions with Test212 with TestSbt2

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbt2Tests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbt2Tests213.scala
@@ -1,0 +1,4 @@
+package scala.cli.integration
+
+class ExportSbt2Tests213 extends ExportSbtTestDefinitions with Test213 with TestSbt2
+    with ExportSbtTests213

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbt2Tests3Lts.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbt2Tests3Lts.scala
@@ -1,0 +1,3 @@
+package scala.cli.integration
+
+class ExportSbt2Tests3Lts extends ExportSbtTestDefinitions with Test3Lts with TestSbt2

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbt2Tests3NextRc.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbt2Tests3NextRc.scala
@@ -1,0 +1,3 @@
+package scala.cli.integration
+
+class ExportSbt2Tests3NextRc extends ExportSbtTestDefinitions with Test3NextRc with TestSbt2

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbt2TestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbt2TestsDefault.scala
@@ -1,0 +1,3 @@
+package scala.cli.integration
+
+class ExportSbt2TestsDefault extends ExportSbtTestDefinitions with TestDefault with TestSbt2

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestDefinitions.scala
@@ -1,9 +1,10 @@
 package scala.cli.integration
 
 abstract class ExportSbtTestDefinitions extends ScalaCliSuite
-    with TestScalaVersionArgs with ExportCommonTestDefinitions
-    with ExportScalaOrientedBuildToolsTestDefinitions with SbtTestHelper {
-  this: TestScalaVersion =>
+    with TestScalaVersionArgs
+    with ExportCommonTestDefinitions
+    with ExportScalaOrientedBuildToolsTestDefinitions
+    with SbtTestHelper { this: TestScalaVersion & TestSbtVersion =>
   override def exportCommand(args: String*): os.proc =
     os.proc(
       TestUtil.cli,
@@ -17,14 +18,39 @@ abstract class ExportSbtTestDefinitions extends ScalaCliSuite
     )
 
   override def buildToolCommand(root: os.Path, mainClass: Option[String], args: String*): os.proc =
-    sbtCommand(args*)
+    sbtCommand(sbtVersion, args*)
 
   override def runMainArgs(mainClass: Option[String]): Seq[String]  = Seq("run")
-  override def runTestsArgs(mainClass: Option[String]): Seq[String] = Seq("test")
+  override def runTestsArgs(mainClass: Option[String]): Seq[String] =
+    if sbtVersion.startsWith("2.") then Seq("testFull") else Seq("test")
 
-  test("Scala Native") {
-    TestUtil.retryOnCi() {
-      simpleTest(ExportTestProjects.nativeTest(actualScalaVersion), mainClass = None)
+  override def commonTestDescriptionSuffix: String =
+    s" (Sbt $sbtVersion & Scala $actualScalaVersion)"
+
+  override protected def defaultExportCommandArgs: Seq[String] = Seq("--sbt-version", sbtVersion)
+
+  if runScalaNativeExportTest then
+    test(s"Scala Native$commonTestDescriptionSuffix") {
+      TestUtil.retryOnCi() {
+        simpleTest(
+          ExportTestProjects.nativeTest(actualScalaVersion),
+          mainClass = None,
+          extraExportArgs = defaultExportCommandArgs
+        )
+      }
     }
-  }
+
 }
+
+sealed trait TestSbtVersion:
+  def sbtVersion: String
+
+trait TestSbt1 extends TestSbtVersion:
+  self: ExportSbtTestDefinitions =>
+  override def sbtVersion: String = Constants.sbt1Version
+
+trait TestSbt2 extends TestSbtVersion:
+  self: ExportSbtTestDefinitions =>
+  override def sbtVersion: String                          = Constants.sbt2Version
+  override protected def runScalaJsExportTest: Boolean     = false // TODO: enable when available
+  override protected def runScalaNativeExportTest: Boolean = false // TODO: enable when available

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTests212.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTests212.scala
@@ -1,3 +1,0 @@
-package scala.cli.integration
-
-class ExportSbtTests212 extends ExportSbtTestDefinitions with Test212

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTests213.scala
@@ -1,19 +1,32 @@
 package scala.cli.integration
 
-class ExportSbtTests213 extends ExportSbtTestDefinitions with Test213 {
-  if (runExportTests) {
-    test("scalac options") {
-      simpleTest(ExportTestProjects.scalacOptionsScala2Test(actualScalaVersion), mainClass = None)
+trait ExportSbtTests213 { this: ExportSbtTestDefinitions & TestScalaVersion & TestSbtVersion =>
+  if runExportTests then
+    test(s"scalac options$commonTestDescriptionSuffix") {
+      TestUtil.retryOnCi() {
+        simpleTest(
+          inputs = ExportTestProjects.scalacOptionsScala2Test(actualScalaVersion),
+          mainClass = None,
+          extraExportArgs = defaultExportCommandArgs
+        )
+      }
     }
-    test("pure java") {
-      simpleTest(
-        ExportTestProjects.pureJavaTest("ScalaCliJavaTest"),
-        mainClass = None,
-        extraExportArgs = Seq("--sbt-setting=fork := true")
-      )
+    test(s"pure java$commonTestDescriptionSuffix") {
+      TestUtil.retryOnCi() {
+        simpleTest(
+          inputs = ExportTestProjects.pureJavaTest("ScalaCliJavaTest"),
+          mainClass = None,
+          extraExportArgs = defaultExportCommandArgs ++ Seq("--sbt-setting=fork := true")
+        )
+      }
     }
-    test("custom JAR") {
-      simpleTest(ExportTestProjects.customJarTest(actualScalaVersion), mainClass = None)
+    test(s"custom JAR$commonTestDescriptionSuffix") {
+      TestUtil.retryOnCi() {
+        simpleTest(
+          inputs = ExportTestProjects.customJarTest(actualScalaVersion),
+          mainClass = None,
+          extraExportArgs = defaultExportCommandArgs
+        )
+      }
     }
-  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTests3Lts.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTests3Lts.scala
@@ -1,3 +1,0 @@
-package scala.cli.integration
-
-class ExportSbtTests3Lts extends ExportSbtTestDefinitions with Test3Lts

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTests3NextRc.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTests3NextRc.scala
@@ -1,3 +1,0 @@
-package scala.cli.integration
-
-class ExportSbtTests3NextRc extends ExportSbtTestDefinitions with Test3NextRc

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportSbtTestsDefault.scala
@@ -1,3 +1,0 @@
-package scala.cli.integration
-
-class ExportSbtTestsDefault extends ExportSbtTestDefinitions with TestDefault

--- a/modules/integration/src/test/scala/scala/cli/integration/ExportScalaOrientedBuildToolsTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ExportScalaOrientedBuildToolsTestDefinitions.scala
@@ -76,15 +76,16 @@ trait ExportScalaOrientedBuildToolsTestDefinitions {
         compileOnlyTest(mainClass = "main", extraExportArgs = defaultExportCommandArgs)
       }
     }
-    test(s"Scala.js$commonTestDescriptionSuffix") {
-      TestUtil.retryOnCi() {
-        simpleTest(
-          inputs = ExportTestProjects.jsTest(actualScalaVersion),
-          mainClass = None,
-          extraExportArgs = defaultExportCommandArgs
-        )
+    if runScalaJsExportTest then
+      test(s"Scala.js$commonTestDescriptionSuffix") {
+        TestUtil.retryOnCi() {
+          simpleTest(
+            inputs = ExportTestProjects.jsTest(actualScalaVersion),
+            mainClass = None,
+            extraExportArgs = defaultExportCommandArgs
+          )
+        }
       }
-    }
     test(s"zio test$commonTestDescriptionSuffix") {
       TestUtil.retryOnCi() {
         testZioTest(testClassName = "ZioSpec", extraExportArgs = defaultExportCommandArgs)

--- a/modules/integration/src/test/scala/scala/cli/integration/SbtTestHelper.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SbtTestHelper.scala
@@ -1,16 +1,28 @@
 package scala.cli.integration
 
 trait SbtTestHelper {
-  protected lazy val sbtLaunchJar: os.Path = {
+  private def fetchSbtLaunchJar(sbtVersion: String): os.Path =
     val res =
-      os.proc(TestUtil.cs, "fetch", "--intransitive", "org.scala-sbt:sbt-launch:1.5.5").call()
+      os.proc(
+        TestUtil.cs,
+        "fetch",
+        "--intransitive",
+        s"org.scala-sbt:sbt-launch:$sbtVersion"
+      ).call()
     val rawPath = res.out.trim()
     val path    = os.Path(rawPath, os.pwd)
-    if (os.isFile(path)) path
+    if os.isFile(path) then path
     else sys.error(s"Something went wrong (invalid sbt launch JAR path '$rawPath')")
-  }
 
-  protected lazy val sbt: os.Shellable =
+  private lazy val sbt1LaunchJar: os.Path = fetchSbtLaunchJar(Constants.sbt1Version)
+  private lazy val sbt2LaunchJar: os.Path = fetchSbtLaunchJar(Constants.sbt2Version)
+
+  protected def sbtLaunchJar(sbtVersion: String): os.Path =
+    if sbtVersion == Constants.sbt1Version then sbt1LaunchJar
+    else if sbtVersion == Constants.sbt2Version then sbt2LaunchJar
+    else fetchSbtLaunchJar(sbtVersion)
+
+  protected def sbtShellable(sbtVersion: String): os.Shellable =
     Seq[os.Shellable](
       "java",
       "-Xmx512m",
@@ -18,8 +30,9 @@ trait SbtTestHelper {
       "-Djline.terminal=jline.UnsupportedTerminal",
       "-Dsbt.log.noformat=true",
       "-jar",
-      sbtLaunchJar
+      sbtLaunchJar(sbtVersion)
     )
 
-  protected def sbtCommand(args: String*): os.proc = os.proc(sbt, args)
+  protected def sbtCommand(sbtVersion: String, args: String*): os.proc =
+    os.proc(sbtShellable(sbtVersion), args)
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -719,7 +719,7 @@ class SipScalaTests extends ScalaCliSuite
         outputDir
       ).call(cwd = root)
       expect(exportRes.exitCode == 0)
-      val sbtRes = sbtCommand("run").call(cwd = root / outputDir)
+      val sbtRes = sbtCommand(Constants.sbt2Version, "run").call(cwd = root / outputDir)
       val output = sbtRes.out.trim()
       expect(output.contains(expectedMessage))
     }

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -138,7 +138,9 @@ object Deps {
     def javaSemanticdb                    = "0.12.3"
     def javaClassName                     = "0.1.9"
     def bloop                             = "2.1.0"
-    def sbtVersion                        = "1.12.5"
+    def sbt1Version                       = "1.12.5"
+    def sbt2Version                       = "2.0.0"
+    def sbtVersion                        = sbt2Version
     def mill012Version                    = "0.12.17"
     def mill1Version                      = BuildInfo.millVersion
     def mavenVersion                      = "3.8.1"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -384,7 +384,7 @@ Project name to be used on Mill build file
 
 ### `--sbt-version`
 
-Version of SBT to be used for the export (1.12.5 by default)
+Version of SBT to be used for the export (2.0.0 by default)
 
 ### `--mill-version`
 


### PR DESCRIPTION
https://www.scala-sbt.org/2.x/docs/en/changes/sbt-2.0-change-summary.html
https://github.com/sbt/sbt/releases/tag/v2.0.0

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)
- ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
Extensively, Cursor + Claude

## How was the solution tested?
added dedicated test suites for SBT 2.* and 1.*