### PR TITLE
Add support for VS 2026 in `vcredist`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1923,7 +1923,6 @@ jobs:
     needs: [changes]
     timeout-minutes: 15
     runs-on: "windows-2025"
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'Virtuslab/scala-cli'
     env:
       SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.test_all == 'true' }}
     steps:

--- a/build.mill
+++ b/build.mill
@@ -2025,7 +2025,7 @@ object ci extends Module {
     distName: String = "vc_redist.x64.exe"
   ): Command[Unit] =
     Task.Command {
-      def vcVersions        = Seq("2022", "2019", "2017")
+      def vcVersions        = Seq("18", "2026", "2022", "2019", "2017")
       def vcEditions        = Seq("Enterprise", "Community", "BuildTools")
       def candidateBaseDirs =
         for {


### PR DESCRIPTION
This should fix the `vcredist` job on `main`. 
It also enables running the job on PRs, as it was previously gated to `main` only.

## Checklist
- ran the code formatter (`scala-cli fmt .`)

## How much have your relied on LLM-based tools in this contribution?
moderately

## How was the solution tested?
existing tests