### PR TITLE
Add anti-regression tests for #4329

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestDefinitions.scala
@@ -147,6 +147,48 @@ abstract class ReplTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
       )
     }
 
+    if !Properties.isWin then {
+      test(s"$runInReplPrefix pure Java sources available with --jshell=false (#4329)") {
+        val expectedMessage = "1337"
+        runInRepl(
+          codeToRunInRepl = """println(new JavaClass().hi())""",
+          testInputs = TestInputs(
+            os.rel / "JavaClass.java" ->
+              s"""public class JavaClass {
+                 |  public String hi() { return "$expectedMessage"; }
+                 |}
+                 |""".stripMargin
+          ),
+          cliOptions = Seq("--jshell=false"),
+          skipScalaVersionArgs = true,
+          shouldPipeStdErr = true
+        ) { res =>
+          val combined = res.out.text() + res.err.text()
+          expect(combined.contains(expectedMessage))
+        }
+      }
+
+      test(s"$runInReplPrefix Java sources available next to an empty Scala source (#4329)") {
+        val expectedMessage = "1337"
+        runInRepl(
+          codeToRunInRepl = """println(new JavaClass().hi())""",
+          testInputs = TestInputs(
+            os.rel / "JavaClass.java" ->
+              s"""public class JavaClass {
+                 |  public String hi() { return "$expectedMessage"; }
+                 |}
+                 |""".stripMargin,
+            os.rel / "Empty.scala" -> ""
+          ),
+          skipScalaVersionArgs = true,
+          shouldPipeStdErr = true
+        ) { res =>
+          val combined = res.out.text() + res.err.text()
+          expect(combined.contains(expectedMessage))
+        }
+      }
+    }
+
     test(s"$runInReplPrefix init script file with quotes and newlines") {
       runInRepl(
         codeToRunInRepl =


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/4329
- this actually already got fixed way back in #4262
- this just adds tests so that we have guards against the issue

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)

## How much have your relied on LLM-based tools in this contribution?
moderately

## How was the solution tested?
added new tests