### PR TITLE
Cut MacOS integration tests down to just sanity tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -883,14 +883,14 @@ jobs:
 
   native-macos-tests-default:
     needs: [changes, generate-macos-launcher]
-    timeout-minutes: 240
+    timeout-minutes: 45
     runs-on: "macOS-15-intel"
     env:
       SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
-      run: echo "Skipping native macOS integration tests (default) -- changes do not affect compiled code or CI."
+      run: echo "Skipping native macOS integration tests (sanity) -- changes do not affect compiled code or CI."
     - uses: actions/checkout@v6
       if: env.SHOULD_RUN == 'true'
       with:
@@ -919,10 +919,11 @@ jobs:
         UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
         SCALA_CLI_IT_GROUP: 1
+        SCALA_CLI_IT_SANITY: true
         SCALA_CLI_SODIUM_JNI_ALLOW: false
     - name: Convert Mill test reports to JUnit XML format
       if: (success() || failure()) && env.SHOULD_RUN == 'true'
-      run: .github/scripts/generate-junit-reports.sc macos-tests-default 'Scala CLI MacOS Tests (default)' test-report.xml out/
+      run: .github/scripts/generate-junit-reports.sc macos-tests-default 'Scala CLI MacOS Tests (sanity)' test-report.xml out/
     - name: Upload test report
       uses: actions/upload-artifact@v7
       if: (success() || failure()) && env.SHOULD_RUN == 'true'
@@ -932,14 +933,14 @@ jobs:
 
   native-macos-tests-rc:
     needs: [changes, generate-macos-launcher]
-    timeout-minutes: 240
+    timeout-minutes: 45
     runs-on: "macOS-15-intel"
     env:
       SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
-        run: echo "Skipping native macOS integration tests (RC) -- changes do not affect compiled code or CI."
+        run: echo "Skipping native macOS integration tests (sanity) -- changes do not affect compiled code or CI."
       - uses: actions/checkout@v6
         if: env.SHOULD_RUN == 'true'
         with:
@@ -968,10 +969,11 @@ jobs:
           UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
           SCALA_CLI_IT_GROUP: 5
+          SCALA_CLI_IT_SANITY: true
           SCALA_CLI_SODIUM_JNI_ALLOW: false
       - name: Convert Mill test reports to JUnit XML format
         if: (success() || failure()) && env.SHOULD_RUN == 'true'
-        run: .github/scripts/generate-junit-reports.sc macos-tests-rc 'Scala CLI MacOS Tests (5)' test-report.xml out/
+        run: .github/scripts/generate-junit-reports.sc macos-tests-rc 'Scala CLI MacOS Tests (sanity)' test-report.xml out/
       - name: Upload test report
         uses: actions/upload-artifact@v7
         if: (success() || failure()) && env.SHOULD_RUN == 'true'
@@ -1026,14 +1028,14 @@ jobs:
 
   native-macos-arm64-tests-default:
     needs: [changes, generate-macos-arm64-launcher]
-    timeout-minutes: 240
+    timeout-minutes: 45
     runs-on: "macOS-15"
     env:
       SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
-        run: echo "Skipping native macOS ARM64 integration tests (default) -- changes do not affect compiled code or CI."
+        run: echo "Skipping native macOS ARM64 integration tests (sanity) -- changes do not affect compiled code or CI."
       - uses: actions/checkout@v6
         if: env.SHOULD_RUN == 'true'
         with:
@@ -1062,10 +1064,11 @@ jobs:
           UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
           SCALA_CLI_IT_GROUP: 1
+          SCALA_CLI_IT_SANITY: true
           SCALA_CLI_SODIUM_JNI_ALLOW: false
       - name: Convert Mill test reports to JUnit XML format
         if: (success() || failure()) && env.SHOULD_RUN == 'true'
-        run: .github/scripts/generate-junit-reports.sc macos-arm64-tests-default 'Scala CLI MacOS ARM64 Tests (default)' test-report.xml out/
+        run: .github/scripts/generate-junit-reports.sc macos-arm64-tests-default 'Scala CLI MacOS ARM64 Tests (sanity)' test-report.xml out/
       - name: Upload test report
         uses: actions/upload-artifact@v7
         if: (success() || failure()) && env.SHOULD_RUN == 'true'
@@ -1073,65 +1076,16 @@ jobs:
           name: test-results-macos-arm64-tests-default
           path: test-report.xml
 
-  native-macos-arm64-tests-lts:
-    needs: [changes, generate-macos-arm64-launcher]
-    timeout-minutes: 240
-    runs-on: "macOS-15"
-    env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
-    steps:
-      - name: Log skip reason
-        if: env.SHOULD_RUN != 'true'
-        run: echo "Skipping native macOS ARM64 integration tests (Scala 3 LTS) -- changes do not affect compiled code or CI."
-      - uses: actions/checkout@v6
-        if: env.SHOULD_RUN == 'true'
-        with:
-          fetch-depth: 0
-          submodules: true
-      - uses: coursier/cache-action@v8
-        if: env.SHOULD_RUN == 'true'
-        with:
-          ignoreJob: true
-      - uses: VirtusLab/scala-cli-setup@v1
-        if: env.SHOULD_RUN == 'true'
-        with:
-          jvm: "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.2.0/graalvm-ce-java17-darwin-aarch64-22.2.0.tar.gz"
-      - name: Ensure it's running on aarch64
-        if: env.SHOULD_RUN == 'true'
-        run: scala-cli -e 'assert(System.getProperty("os.arch") == "aarch64")'
-      - uses: actions/download-artifact@v8
-        if: env.SHOULD_RUN == 'true'
-        with:
-          name: macos-arm64-launchers
-          path: artifacts/
-      - name: Native integration tests
-        if: env.SHOULD_RUN == 'true'
-        run: ./mill -i nativeIntegrationTests
-        env:
-          UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
-          SCALA_CLI_IT_GROUP: 4
-          SCALA_CLI_SODIUM_JNI_ALLOW: false
-      - name: Convert Mill test reports to JUnit XML format
-        if: (success() || failure()) && env.SHOULD_RUN == 'true'
-        run: .github/scripts/generate-junit-reports.sc macos-arm64-tests-lts 'Scala CLI MacOS ARM64 Tests (Scala 3 LTS)' test-report.xml out/
-      - name: Upload test report
-        uses: actions/upload-artifact@v7
-        if: (success() || failure()) && env.SHOULD_RUN == 'true'
-        with:
-          name: test-results-macos-arm64-tests-lts
-          path: test-report.xml
-
   native-macos-arm64-tests-rc:
     needs: [changes, generate-macos-arm64-launcher]
-    timeout-minutes: 240
+    timeout-minutes: 45
     runs-on: "macOS-15"
     env:
       SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
-        run: echo "Skipping native macOS ARM64 integration tests (RC) -- changes do not affect compiled code or CI."
+        run: echo "Skipping native macOS ARM64 integration tests (sanity) -- changes do not affect compiled code or CI."
       - uses: actions/checkout@v6
         if: env.SHOULD_RUN == 'true'
         with:
@@ -1160,10 +1114,11 @@ jobs:
           UPDATE_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SCALA_CLI_IT_FORCED_LAUNCHER_DIRECTORY: artifacts/
           SCALA_CLI_IT_GROUP: 5
+          SCALA_CLI_IT_SANITY: true
           SCALA_CLI_SODIUM_JNI_ALLOW: false
       - name: Convert Mill test reports to JUnit XML format
         if: (success() || failure()) && env.SHOULD_RUN == 'true'
-        run: .github/scripts/generate-junit-reports.sc macos-arm64-tests-rc 'Scala CLI MacOS ARM64 Tests (5)' test-report.xml out/
+        run: .github/scripts/generate-junit-reports.sc macos-arm64-tests-rc 'Scala CLI MacOS ARM64 Tests (sanity)' test-report.xml out/
       - name: Upload test report
         uses: actions/upload-artifact@v7
         if: (success() || failure()) && env.SHOULD_RUN == 'true'
@@ -1978,7 +1933,6 @@ jobs:
       - native-macos-tests-default
       - native-macos-tests-rc
       - native-macos-arm64-tests-default
-      - native-macos-arm64-tests-lts
       - native-macos-arm64-tests-rc
       - native-windows-tests-default
       - native-windows-tests-lts
@@ -2059,7 +2013,6 @@ jobs:
       - native-macos-tests-default
       - native-macos-tests-rc
       - native-macos-arm64-tests-default
-      - native-macos-arm64-tests-lts
       - native-macos-arm64-tests-rc
       - native-windows-tests-default
       - native-windows-tests-lts

--- a/build.mill
+++ b/build.mill
@@ -130,7 +130,9 @@ object integration extends CliIntegration {
   object test extends IntegrationScalaTests {
     override def testParallelism: T[Boolean]           = !isCI
     override def testForkGrouping: T[Seq[Seq[String]]] =
-      if isCI then discoveredTestClasses().grouped(1).toSeq else super.testForkGrouping()
+      if isCI && System.getenv("SCALA_CLI_IT_SANITY") == null then
+        discoveredTestClasses().grouped(1).toSeq
+      else super.testForkGrouping()
     override def mvnDeps: T[Seq[Dep]] = super.mvnDeps() ++ Seq(
       Deps.coursierArchiveCache,
       Deps.jgit,

--- a/modules/integration/src/test/scala/scala/cli/integration/HadoopTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/HadoopTests.scala
@@ -2,7 +2,7 @@ package scala.cli.integration
 
 import com.eed3si9n.expecty.Expecty.expect
 
-class HadoopTests extends munit.FunSuite {
+class HadoopTests extends ScalaCliSuite {
   protected lazy val extraOptions: Seq[String] = TestUtil.extraOptions
 
   for {

--- a/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/NativePackagerTests.scala
@@ -24,7 +24,7 @@ class NativePackagerTests extends ScalaCliSuite {
   private val ciOpt = Option(System.getenv("CI")).map(v => Seq("-e", s"CI=$v")).getOrElse(Nil)
 
   if (Properties.isMac) {
-    test("building pkg package") {
+    test("building pkg package".tag(ScalaCliSuite.sanity)) {
 
       testInputs.fromRoot { root =>
 

--- a/modules/integration/src/test/scala/scala/cli/integration/ResourceTrackerTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ResourceTrackerTests.scala
@@ -8,7 +8,7 @@ import scala.concurrent.{Future, Promise}
 import scala.jdk.CollectionConverters.*
 import scala.util.Properties
 
-class ResourceTrackerTests extends munit.FunSuite {
+class ResourceTrackerTests extends ScalaCliSuite {
 
   private final class RecordingResourceTracker(events: ConcurrentLinkedQueue[String])
       extends ResourceTracker {

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaJsTestDefinitions.scala
@@ -26,7 +26,7 @@ trait RunScalaJsTestDefinitions { this: RunTestDefinitions =>
     }
   }
 
-  test("simple script JS") {
+  test("simple script JS".tag(ScalaCliSuite.sanity)) {
     simpleJsTestOutput()
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
@@ -44,7 +44,7 @@ trait RunScalaNativeTestDefinitions { this: RunTestDefinitions =>
       }
   }
 
-  test("simple script native") {
+  test("simple script native".tag(ScalaCliSuite.sanity)) {
     TestUtil.retryOnCi() {
       simpleNativeTests()
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -52,7 +52,7 @@ abstract class RunTestDefinitions
       .out
       .trim()
 
-  test("print command") {
+  test("print command".tag(ScalaCliSuite.sanity)) {
     val fileName = "simple.sc"
     val message  = "Hello"
     val inputs   = TestInputs(

--- a/modules/integration/src/test/scala/scala/cli/integration/ScalaCliSuite.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ScalaCliSuite.scala
@@ -66,10 +66,19 @@ abstract class ScalaCliSuite extends munit.FunSuite {
       .flatMap(_.toIntOption)
       .exists(_ != group.idx)
 
+  private def sanityOnly: Boolean =
+    Option(System.getenv("SCALA_CLI_IT_SANITY")).exists(_.equalsIgnoreCase("true"))
+
+  override def munitTests(): Seq[Test] =
+    val all = super.munitTests()
+    if sanityOnly then all.filter(_.tags.contains(ScalaCliSuite.sanity)) else all
+
   override def munitFlakyOK: Boolean = TestUtil.isCI
 }
 
 object ScalaCliSuite {
+  val sanity: munit.Tag = new munit.Tag("sanity")
+
   sealed abstract class TestGroup(val idx: Int) extends Product with Serializable
   object TestGroup {
     case object First  extends TestGroup(1) // Scala 3 Next / default


### PR DESCRIPTION
As MacOS runners have become very unstable, we are cutting on running integration tests on MacOS to the absolute bare minimum.

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)

## How much have your relied on LLM-based tools in this contribution?
Extensively

## How was the solution tested?
ran the entire suite, only the tagged tests ran.