### PR TITLE
Bump Scala.js to 1.22.0 (was 1.21.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1212,6 +1212,10 @@ jobs:
       if: env.SHOULD_RUN == 'true'
       with:
         jvm: "temurin:17"
+    - uses: actions/setup-node@v6
+      if: env.SHOULD_RUN == 'true'
+      with:
+        node-version: 24
     - name: Get latest coursier launcher
       if: env.SHOULD_RUN == 'true'
       run: .github/scripts/get-latest-cs.sh
@@ -1273,6 +1277,10 @@ jobs:
         if: env.SHOULD_RUN == 'true'
         with:
           jvm: "temurin:17"
+      - uses: actions/setup-node@v6
+        if: env.SHOULD_RUN == 'true'
+        with:
+          node-version: 24
       - name: Get latest coursier launcher
         if: env.SHOULD_RUN == 'true'
         run: .github/scripts/get-latest-cs.sh
@@ -1334,6 +1342,10 @@ jobs:
         if: env.SHOULD_RUN == 'true'
         with:
           jvm: "temurin:17"
+      - uses: actions/setup-node@v6
+        if: env.SHOULD_RUN == 'true'
+        with:
+          node-version: 24
       - name: Get latest coursier launcher
         if: env.SHOULD_RUN == 'true'
         run: .github/scripts/get-latest-cs.sh

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -45,7 +45,7 @@ object Scala {
   val scala3MainVersions  = (defaults ++ allScala3).distinct
   val runnerScalaVersions = (Seq(runnerScala3) ++ scala3MainVersions).distinct
 
-  def scalaJs    = "1.21.0"
+  def scalaJs    = "1.22.0"
   def scalaJsCli = scalaJs // this must be compatible with the Scala.js version
 
   private def patchVer(sv: String): Int =

--- a/website/docs/guides/advanced/scala-js.md
+++ b/website/docs/guides/advanced/scala-js.md
@@ -199,5 +199,6 @@ The table below lists the last supported version of Scala.js in Scala CLI. If yo
 | 1.8.0 - 1.9.0      |  1.19.0  |
 | 1.9.1 - 1.11.0     |  1.20.1  |
 | 1.12.0 - 1.12.5    |  1.20.2  |
-| 1.13.0 - current   |  1.21.0  |
+| 1.13.0 - 1.14.0    |  1.21.0  |
+| 1.15.0 - current   |  1.22.0  |
 

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1344,7 +1344,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 ### `--js-version`
 
-The Scala.js version (1.21.0 by default).
+The Scala.js version (1.22.0 by default).
 
 ### `--js-mode`
 
@@ -1421,7 +1421,7 @@ Path to the Scala.js linker
 ### `--js-cli-version`
 
 [Internal]
-Scala.js CLI version to use for linking (1.21.0 by default).
+Scala.js CLI version to use for linking (1.22.0 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -647,7 +647,7 @@ Add Scala.js options
 
 
 #### Examples
-`//> using jsVersion 1.21.0`
+`//> using jsVersion 1.22.0`
 
 `//> using jsMode mode`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -808,7 +808,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 `SHOULD have` per Scala Runner specification
 
-The Scala.js version (1.21.0 by default).
+The Scala.js version (1.22.0 by default).
 
 ### `--js-mode`
 
@@ -908,7 +908,7 @@ Path to the Scala.js linker
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Scala.js CLI version to use for linking (1.21.0 by default).
+Scala.js CLI version to use for linking (1.22.0 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -429,7 +429,7 @@ Add Scala.js options
 
 
 #### Examples
-`//> using jsVersion 1.21.0`
+`//> using jsVersion 1.22.0`
 
 `//> using jsMode mode`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -134,7 +134,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.21.0 by default).
+The Scala.js version (1.22.0 by default).
 
 **--js-mode**
 
@@ -432,7 +432,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.21.0 by default).
+Scala.js CLI version to use for linking (1.22.0 by default).
 
 **--js-cli-java-arg**
 
@@ -961,7 +961,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.21.0 by default).
+The Scala.js version (1.22.0 by default).
 
 **--js-mode**
 
@@ -1247,7 +1247,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.21.0 by default).
+Scala.js CLI version to use for linking (1.22.0 by default).
 
 **--js-cli-java-arg**
 
@@ -1586,7 +1586,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.21.0 by default).
+The Scala.js version (1.22.0 by default).
 
 **--js-mode**
 
@@ -1878,7 +1878,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.21.0 by default).
+Scala.js CLI version to use for linking (1.22.0 by default).
 
 **--js-cli-java-arg**
 
@@ -2247,7 +2247,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.21.0 by default).
+The Scala.js version (1.22.0 by default).
 
 **--js-mode**
 
@@ -2549,7 +2549,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.21.0 by default).
+Scala.js CLI version to use for linking (1.22.0 by default).
 
 **--js-cli-java-arg**
 
@@ -2917,7 +2917,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.21.0 by default).
+The Scala.js version (1.22.0 by default).
 
 **--js-mode**
 
@@ -3219,7 +3219,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.21.0 by default).
+Scala.js CLI version to use for linking (1.22.0 by default).
 
 **--js-cli-java-arg**
 
@@ -3563,7 +3563,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.21.0 by default).
+The Scala.js version (1.22.0 by default).
 
 **--js-mode**
 
@@ -3847,7 +3847,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.21.0 by default).
+Scala.js CLI version to use for linking (1.22.0 by default).
 
 **--js-cli-java-arg**
 
@@ -4246,7 +4246,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.21.0 by default).
+The Scala.js version (1.22.0 by default).
 
 **--js-mode**
 
@@ -4553,7 +4553,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.21.0 by default).
+Scala.js CLI version to use for linking (1.22.0 by default).
 
 **--js-cli-java-arg**
 
@@ -4989,7 +4989,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.21.0 by default).
+The Scala.js version (1.22.0 by default).
 
 **--js-mode**
 
@@ -5269,7 +5269,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.21.0 by default).
+Scala.js CLI version to use for linking (1.22.0 by default).
 
 **--js-cli-java-arg**
 
@@ -5988,7 +5988,7 @@ Enable Scala.js. To show more options for Scala.js pass `--help-js`
 
 **--js-version**
 
-The Scala.js version (1.21.0 by default).
+The Scala.js version (1.22.0 by default).
 
 **--js-mode**
 
@@ -6268,7 +6268,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.21.0 by default).
+Scala.js CLI version to use for linking (1.22.0 by default).
 
 **--js-cli-java-arg**
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-js-cli/releases/tag/v1.22.0
https://github.com/scala-js/scala-js/releases/tag/v1.22.0

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)
- ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
not at all

## How was the solution tested?
existing tests