### PR TITLE
Bump `coursier` to 2.1.25-M26 (was 2.1.25-M25)

### DIFF
--- a/.github/scripts/get-latest-cs.sh
+++ b/.github/scripts/get-latest-cs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-CS_VERSION="2.1.25-M25"
+CS_VERSION="2.1.25-M26"
 
 DIR="$(cs get --archive "https://github.com/coursier/coursier/releases/download/v$CS_VERSION/cs-x86_64-pc-win32.zip")"
 

--- a/build.mill
+++ b/build.mill
@@ -4,7 +4,7 @@
 //| - io.github.alexarchambault.mill::mill-native-image-upload:0.2.6
 //| - com.goyeau::mill-scalafix::0.6.0
 //| - com.lumidion::sonatype-central-client-requests:0.6.0
-//| - io.get-coursier:coursier-launcher_2.13:2.1.25-M25
+//| - io.get-coursier:coursier-launcher_2.13:2.1.25-M26
 //| - org.eclipse.jgit:org.eclipse.jgit:7.5.0.202512021534-r
 package build
 

--- a/mill
+++ b/mill
@@ -2,7 +2,7 @@
 
 # Adapted from
 
-coursier_version="2.1.25-M25"
+coursier_version="2.1.25-M26"
 COMMAND=$@
 
 # necessary for Windows various shell environments

--- a/modules/build/src/main/scala/scala/build/internal/ManifestJar.scala
+++ b/modules/build/src/main/scala/scala/build/internal/ManifestJar.scala
@@ -13,11 +13,14 @@ object ManifestJar {
     *   (but the manifest JAR can't be passed to 'java -cp' any more on Windows)
     * @param scratchDirOpt
     *   an optional scratch directory to write the manifest JAR under
+    * @param manifestDeleteOnExit
+    *   whether the temporary manifest JAR should be deleted on JVM exit
     */
   def create(
     classPath: Seq[os.Path],
     wrongSimplePaths: Boolean = false,
-    scratchDirOpt: Option[os.Path] = None
+    scratchDirOpt: Option[os.Path] = None,
+    manifestDeleteOnExit: Boolean = true
   ): os.Path = {
     import java.util.jar._
     val manifest   = new Manifest
@@ -38,7 +41,7 @@ object ManifestJar {
         os.makeDir.all(scratchDir)
         os.temp(dir = scratchDir, prefix = "classpathJar", suffix = ".jar", deleteOnExit = false)
       case None =>
-        os.temp(prefix = "classpathJar", suffix = ".jar")
+        os.temp(prefix = "classpathJar", suffix = ".jar", deleteOnExit = manifestDeleteOnExit)
     }
     var os0: OutputStream    = null
     var jos: JarOutputStream = null

--- a/modules/build/src/main/scala/scala/build/internal/Runner.scala
+++ b/modules/build/src/main/scala/scala/build/internal/Runner.scala
@@ -1,6 +1,6 @@
 package scala.build.internal
 
-import coursier.jvm.Execve
+import coursier.exec.Execve
 import org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
 import org.scalajs.jsenv.nodejs.NodeJSEnv
 import org.scalajs.jsenv.{Input, JSEnv, RunConfig}
@@ -23,6 +23,8 @@ object Runner {
 
   private def toTestRunnerLogger(logger: Logger): TestRunnerLogger =
     TestRunnerLogger(logger.verbosity)
+
+  def execveAvailable: Boolean = Execve.available()
 
   def maybeExec(
     commandName: String,
@@ -124,7 +126,8 @@ object Runner {
     args: Seq[String],
     extraEnv: Map[String, String] = Map.empty,
     useManifest: Option[Boolean] = None,
-    scratchDirOpt: Option[os.Path] = None
+    scratchDirOpt: Option[os.Path] = None,
+    allowExecve: Boolean = false
   ): Seq[String] = {
 
     def command(cp: Seq[os.Path]) =
@@ -152,7 +155,12 @@ object Runner {
     }
 
     if (useManifest0) {
-      val manifestJar = ManifestJar.create(classPath, scratchDirOpt = scratchDirOpt)
+      val manifestJar =
+        ManifestJar.create(
+          classPath,
+          scratchDirOpt = scratchDirOpt,
+          manifestDeleteOnExit = !(allowExecve && execveAvailable)
+        )
       command(Seq(manifestJar))
     }
     else initialCommand
@@ -180,7 +188,8 @@ object Runner {
       args,
       Map.empty,
       useManifest,
-      scratchDirOpt
+      scratchDirOpt,
+      allowExecve = allowExecve
     )
 
     if (allowExecve)

--- a/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
@@ -463,8 +463,10 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
   ): Either[BuildException, Either[Seq[Seq[String]], Seq[(Process, Option[() => Unit])]]] = {
     val crossBuilds        = allBuilds.groupedByCrossParams.toSeq
     val shouldLogCrossInfo = crossBuilds.size > 1
-    // execve replaces the current process, so we must not use it when spawning multiple cross-builds
-    val effectiveAllowExecve = allowExecve && !shouldLogCrossInfo
+    // execve replaces the current process, so we must not use it when spawning multiple cross-builds;
+    // coursier also runs JVM shutdown hooks right before execve (deleting deleteOnExit temp files),
+    // and our own onExit cleanup never runs in that case, so execve-bound temp files must persist
+    val effectiveAllowExecve = allowExecve && !shouldLogCrossInfo && Runner.execveAvailable
     if shouldLogCrossInfo then
       logger.log(
         s"Running ${crossBuilds.size} cross builds, one for each Scala version and platform combination."
@@ -487,7 +489,7 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
               dir = scratchDirOpt.orNull,
               prefix = "main",
               suffix = ".mjs",
-              deleteOnExit = scratchDirOpt.isEmpty
+              deleteOnExit = scratchDirOpt.isEmpty && !effectiveAllowExecve
             )
 
             val linkerConfig = jsOpts.linkerConfig(logger)
@@ -557,7 +559,7 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
 
                 val linkerConfig = build.options.scalaJsOptions.linkerConfig(logger)
                 val jsDest       = {
-                  val delete = scratchDirOpt.isEmpty
+                  val delete = scratchDirOpt.isEmpty && !effectiveAllowExecve
                   scratchDirOpt.foreach(os.makeDir.all(_))
                   os.temp(
                     dir = scratchDirOpt.orNull,

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -116,7 +116,7 @@ object Deps {
   object Versions {
     def argonautShapeless = "1.3.1"
     // jni-utils version may need to be sync-ed when bumping the coursier version
-    def coursierDefault                   = "2.1.25-M25"
+    def coursierDefault                   = "2.1.25-M26"
     def coursier                          = coursierDefault
     def coursierCli                       = coursierDefault
     def coursierPublish                   = "0.4.4"

--- a/project/settings/package.mill
+++ b/project/settings/package.mill
@@ -352,7 +352,7 @@ trait CliLaunchers extends SbtModule { self =>
     override def nativeImageDockerParams: T[Option[NativeImage.DockerParams]] = Task {
       val baseDockerParams = NativeImage.linuxStaticParams(
         Docker.muslBuilder,
-        s"https://github.com/coursier/coursier/releases/download/v${deps.csDockerVersion}/cs-x86_64-pc-linux.gz"
+        s"https://github.com/coursier/coursier/releases/download/v${deps.csDockerVersion}/cs-x86_64-pc-linux-static.gz"
       )
       val dockerParams = setupLocaleAndOptions(baseDockerParams)
       buildHelperImage()

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -388,7 +388,7 @@ Version of SBT to be used for the export (2.0.0 by default)
 
 ### `--mill-version`
 
-Version of Mill to be used for the export (1.1.6 by default)
+Version of Mill to be used for the export (1.1.7 by default)
 
 ### `--mvn-version`
 


### PR DESCRIPTION
https://github.com/coursier/coursier/releases/tag/v2.1.25-M26

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)
- ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
extensively, to identify the API changes

## How was the solution tested?
existing test suites