### PR TITLE
Bump `scala-cli-signing` to 0.2.14 (was 0.2.13)

### DIFF
--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -133,7 +133,7 @@ object Deps {
     def maxScalaNativeForScalaPy          = scalaNative04
     def maxScalaNativeForMillExport       = scalaNative05
     def scalaPackager                     = "0.2.2"
-    def signingCli                        = "0.2.13"
+    def signingCli                        = "0.2.14"
     def signingCliJvmVersion              = Java.defaultJava
     def javaSemanticdb                    = "0.12.3"
     def javaClassName                     = "0.1.9"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -388,7 +388,7 @@ Version of SBT to be used for the export (2.0.0 by default)
 
 ### `--mill-version`
 
-Version of Mill to be used for the export (1.1.6 by default)
+Version of Mill to be used for the export (1.1.7 by default)
 
 ### `--mvn-version`
 
@@ -2253,7 +2253,7 @@ Available in commands:
 ### `--signing-cli-version`
 
 [Internal]
-scala-cli-signing version when running externally (0.2.13 by default)
+scala-cli-signing version when running externally (0.2.14 by default)
 
 ### `--signing-cli-java-arg`
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-cli-signing/releases/tag/v0.2.14

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
none

## How was the solution tested?
existing tests