### PR TITLE
Bump `scala-js-cli` to 1.22.0.1 (was 1.22.0)

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -115,7 +115,7 @@ various "mappings" are computed out of the generated sources list, and are used 
     - For instance: For release `1.13.0.2`, the launchers are uploaded to tags `1.13.0.2` and `1.13.0`.
 - ScalaCli dependency to `scalajs-cli`:
     - For Coursier to retrieve the most recent scalajs-cli for a specific Scala.js version, the version is set
-      as `org.virtuslab:scalajscli_2.13:{Scala.js version}+`. For example `org.virtuslab:scalajscli_2.13:1.13.0+`.
+      as `org.virtuslab:scalajscli_3:{Scala.js version}+`. For example `org.virtuslab:scalajscli_3:1.22.0.1`.
     - Native Version Download:
         - The native version is downloaded from the Scala.js version tag. If there are updates or fixes to the
           native `scalajs-cli` launchers, the updated launchers are uploaded to the `1.13.0` tag during the `1.13.0.1`

--- a/modules/cli/src/main/scala/scala/cli/internal/ScalaJsLinker.scala
+++ b/modules/cli/src/main/scala/scala/cli/internal/ScalaJsLinker.scala
@@ -48,7 +48,7 @@ object ScalaJsLinker {
       case None =>
         val scalaJsCliVersion = options.finalScalaJsCliVersion
         val scalaJsCliDep     = {
-          val mod = mod"org.virtuslab.scala-cli:scalajscli_2.13"
+          val mod = mod"org.virtuslab.scala-cli:scalajscli_3"
           dependency.Dependency(mod, s"$scalaJsCliVersion+")
         }
 

--- a/modules/options/src/main/scala/scala/build/Artifacts.scala
+++ b/modules/options/src/main/scala/scala/build/Artifacts.scala
@@ -315,7 +315,7 @@ object Artifacts {
           scalaArtifactsParams.scalaJsCliVersion.map { scalaJsCliVersion =>
             val mod = Module(
               Organization("org.virtuslab.scala-cli"),
-              ModuleName(s"scalajscli_2.13"),
+              ModuleName("scalajscli_3"),
               Map.empty
             )
             Seq(coursier.Dependency(mod, VersionConstraint(s"$scalaJsCliVersion+")))

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -13,15 +13,16 @@ object Cli {
 }
 
 object Scala {
-  def scala212         = "2.12.21"
-  def scala213         = "2.13.18"
-  def scala3LtsPrefix  = "3.3"                  // used for the LTS version tags
-  def scala3Lts        = s"$scala3LtsPrefix.8"  // the LTS version currently used in the build
-  def runnerScala3     = scala3Lts
-  def scala3NextPrefix = "3.8"
-  def scala3Next       = s"$scala3NextPrefix.4" // the newest/next version of Scala
-  def scala3NextAnnounced   = s"$scala3NextPrefix.4"  // the newest/next version of Scala that's been announced
-  def scala3NextRc          = "3.9.0-RC1" // the latest RC version of Scala Next
+  def scala212            = "2.12.21"
+  def scala213            = "2.13.18"
+  def scala3LtsPrefix     = "3.3"                  // used for the LTS version tags
+  def scala3Lts           = s"$scala3LtsPrefix.8"  // the LTS version currently used in the build
+  def runnerScala3        = scala3Lts
+  def scala3NextPrefix    = "3.8"
+  def scala3Next          = s"$scala3NextPrefix.4" // the newest/next version of Scala
+  def scala3NextAnnounced =
+    s"$scala3NextPrefix.4" // the newest/next version of Scala that's been announced
+  def scala3NextRc        = "3.9.0-RC1"            // the latest RC version of Scala Next
   def scala3NextRcAnnounced = "3.8.4-RC3" // the latest announced RC version of Scala Next
 
   // The Scala version used to build the CLI itself.
@@ -46,7 +47,7 @@ object Scala {
   val runnerScalaVersions = (Seq(runnerScala3) ++ scala3MainVersions).distinct
 
   def scalaJs    = "1.22.0"
-  def scalaJsCli = scalaJs // this must be compatible with the Scala.js version
+  def scalaJsCli = "1.22.0.1" // this must be compatible with the Scala.js version
 
   private def patchVer(sv: String): Int =
     sv.split('.').drop(2).head.takeWhile(_.isDigit).toInt

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -388,7 +388,7 @@ Version of SBT to be used for the export (2.0.0 by default)
 
 ### `--mill-version`
 
-Version of Mill to be used for the export (1.1.6 by default)
+Version of Mill to be used for the export (1.1.7 by default)
 
 ### `--mvn-version`
 
@@ -1421,7 +1421,7 @@ Path to the Scala.js linker
 ### `--js-cli-version`
 
 [Internal]
-Scala.js CLI version to use for linking (1.22.0 by default).
+Scala.js CLI version to use for linking (1.22.0.1 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -908,7 +908,7 @@ Path to the Scala.js linker
 
 `IMPLEMENTATION specific` per Scala Runner specification
 
-Scala.js CLI version to use for linking (1.22.0 by default).
+Scala.js CLI version to use for linking (1.22.0.1 by default).
 
 ### `--js-cli-java-arg`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -432,7 +432,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.22.0 by default).
+Scala.js CLI version to use for linking (1.22.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -1247,7 +1247,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.22.0 by default).
+Scala.js CLI version to use for linking (1.22.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -1878,7 +1878,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.22.0 by default).
+Scala.js CLI version to use for linking (1.22.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -2549,7 +2549,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.22.0 by default).
+Scala.js CLI version to use for linking (1.22.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -3219,7 +3219,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.22.0 by default).
+Scala.js CLI version to use for linking (1.22.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -3847,7 +3847,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.22.0 by default).
+Scala.js CLI version to use for linking (1.22.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -4553,7 +4553,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.22.0 by default).
+Scala.js CLI version to use for linking (1.22.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -5269,7 +5269,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.22.0 by default).
+Scala.js CLI version to use for linking (1.22.0.1 by default).
 
 **--js-cli-java-arg**
 
@@ -6268,7 +6268,7 @@ Path to the Scala.js linker
 
 **--js-cli-version**
 
-Scala.js CLI version to use for linking (1.22.0 by default).
+Scala.js CLI version to use for linking (1.22.0.1 by default).
 
 **--js-cli-java-arg**
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-js-cli/releases/tag/v1.22.0.1

This is literally just to test the Scala 3 implementation.

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)
- ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
none

## How was the solution tested?
existing tests