### PR TITLE
Bump `scala-cli-signing` to 0.3.0 (was 0.2.13)

### DIFF
--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -134,7 +134,7 @@ object Deps {
     def maxScalaNativeForScalaPy          = scalaNative04
     def maxScalaNativeForMillExport       = scalaNative05
     def scalaPackager                     = "0.2.2"
-    def signingCli                        = "0.2.13"
+    def signingCli                        = "0.3.0"
     def signingCliJvmVersion              = Java.defaultJava
     def javaSemanticdb                    = "0.12.3"
     def javaClassName                     = "0.1.9"

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -2253,7 +2253,7 @@ Available in commands:
 ### `--signing-cli-version`
 
 [Internal]
-scala-cli-signing version when running externally (0.2.13 by default)
+scala-cli-signing version when running externally (0.3.0 by default)
 
 ### `--signing-cli-java-arg`
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-cli-signing/releases/tag/v0.3.0