### PR TITLE
Temporarily label all Scala 3 nightly tests as flaky

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/CompileScalacCompatTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileScalacCompatTestDefinitions.scala
@@ -235,8 +235,12 @@ trait CompileScalacCompatTestDefinitions { this: CompileTestDefinitions =>
     withBloopString = if (withBloop) "with Bloop" else "scalac"
     buildServerOpts = if (withBloop) Nil else Seq("--server=false")
     if (!Properties.isWin || withBloop) && actualScalaVersion == Constants.scala3Next
-  }
-    test(s"sanity check for Scala $scalaVersion standard library with cc ($withBloopString)") {
+  } {
+    val testName =
+      s"sanity check for Scala $scalaVersion standard library with cc ($withBloopString)"
+    val testOpts =
+      if scalaVersion == "3.nightly" then testName.flaky else munit.TestOptions(testName)
+    test(testOpts) {
       TestUtil.retryOnCi() {
         val input = "example.scala"
         TestInputs(os.rel / input ->
@@ -254,4 +258,5 @@ trait CompileScalacCompatTestDefinitions { this: CompileTestDefinitions =>
         }
       }
     }
+  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTests3Lts.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTests3Lts.scala
@@ -8,7 +8,7 @@ class ReplTests3Lts extends ReplTestDefinitions with Test3Lts
   if canRunInRepl then
     for { ltsNightlyTag <- List("3.lts.nightly", "lts.nightly") }
       test(
-        s"$runInReplPrefix $ltsNightlyTag returns the same Scala version as $scala3LtsPrefix.nightly"
+        s"$runInReplPrefix $ltsNightlyTag returns the same Scala version as $scala3LtsPrefix.nightly".flaky
       ) {
         val code = s"""println($retrieveScalaVersionCode)"""
         runInRepl(

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestsDefault.scala
@@ -8,7 +8,7 @@ class ReplTestsDefault extends ReplTestDefinitions
   if canRunInRepl then
     for { nightlyTag <- List("3.nightly", "nightly") }
       test(
-        s"$runInReplPrefix $nightlyTag returns the same Scala version as <latest-minor>.nightly"
+        s"$runInReplPrefix $nightlyTag returns the same Scala version as <latest-minor>.nightly".flaky
       ) {
         val code = """println(scala.util.Properties.versionNumberString)"""
         runInRepl(code, cliOptions = Seq("-S", nightlyTag)) { r1 =>

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTests3Lts.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTests3Lts.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 class RunTests3Lts extends RunTestDefinitions with Test3Lts {
   import Constants.scala3LtsPrefix
   for (ltsNightlyAlias <- List("lts.nightly", "3.lts.nightly"))
-    test(s"Scala $ltsNightlyAlias & $scala3LtsPrefix.nightly point to the same version") {
+    test(s"Scala $ltsNightlyAlias & $scala3LtsPrefix.nightly point to the same version".flaky) {
       TestInputs.empty.fromRoot { root =>
         val version1      = getScalaVersion(ltsNightlyAlias, root)
         val nightlyPrefix = version1.split('.').take(2).mkString(".")

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTests3NextRc.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTests3NextRc.scala
@@ -4,7 +4,7 @@ import com.eed3si9n.expecty.Expecty.expect
 
 class RunTests3NextRc extends RunTestDefinitions with Test3NextRc {
   for { nightlyTag <- List("3.nightly", "nightly") }
-    test(s"Scala $nightlyTag & 3.<latest-minor>.nightly point to the same version") {
+    test(s"Scala $nightlyTag & 3.<latest-minor>.nightly point to the same version".flaky) {
       TestInputs.empty.fromRoot { root =>
         val version1     = getScalaVersion(nightlyTag, root)
         val nightlyMinor = version1.split('.').take(2).last
@@ -14,7 +14,8 @@ class RunTests3NextRc extends RunTestDefinitions with Test3NextRc {
     }
 
   for {
-    label <- List("rc", "3.rc", "3.lts.rc", "lts.rc", s"${Constants.scala3LtsPrefix}.rc", "3.7.rc")
+    label <-
+      List("rc", "3.lts.rc", "lts.rc", s"${Constants.scala3LtsPrefix}.rc", "3.7.rc") // TODO "3.rc"
   }
     test(s"$label is valid and works as expected") {
       TestInputs.empty.fromRoot { root =>

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
@@ -53,7 +53,7 @@ class RunTestsDefault extends RunTestDefinitions
       archLinuxTest()
     }
 
-  test("3.nightly") { // should run code using scala 3 nightly version
+  test("3.nightly".flaky) { // should run code using scala 3 nightly version
     TestInputs(os.rel / "sample.sc" -> """println("Hello World")""").fromRoot {
       root =>
         val res =

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -798,7 +798,7 @@ class SipScalaTests extends ScalaCliSuite
     }
   }
 
-  test("no warnings about TASTY when using the latest nightly with scripts") {
+  test("no warnings about TASTY when using the latest nightly with scripts".flaky) {
     val scriptName = "script.sc"
     TestInputs(os.rel / "script.sc" -> "println(1)").fromRoot { root =>
       val scala3Nightly =

--- a/website/docs/commands/compile.md
+++ b/website/docs/commands/compile.md
@@ -121,7 +121,7 @@ scala-cli Hello.scala -S 2.nightly
 
 For compiling with the latest Scala 3 nightly build:
 
-```bash
+```bash ignore
 scala-cli Hello.scala -S 3.nightly
 ```
 
@@ -137,7 +137,7 @@ For setting this inside scala files, use [`using` directives](../guides/introduc
 //> using scala 2.nightly
 ```
 
-```scala compile
+```scala
 //> using scala 3.nightly
 ```
 

--- a/website/docs/release_notes.md
+++ b/website/docs/release_notes.md
@@ -808,7 +808,7 @@ scala-cli -e 'println(dotty.tools.dotc.config.Properties.simpleVersionString)' -
 
 Dedicated default and LTS nightly aliases are also provided.
 
-```bash
+```bash ignore
 scala-cli -e 'println(scala.util.Properties.versionNumberString)' -S nightly
 # 3.8.2-RC1-bin-20260115-6151803-NIGHTLY
 scala-cli -e 'println(dotty.tools.dotc.config.Properties.simpleVersionString)' -S lts.nightly --with-compiler


### PR DESCRIPTION
It seems Scala 3 nightlies are broken (both Next and 3.3 LTS), so I'm labelling them as flaky to unblock the CI.

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)

## How much have your relied on LLM-based tools in this contribution?
moderately

## How was the solution tested?
existing tests