### PR TITLE
Migrate integration tests off the stale `com.spotify:docker-client` to `com.github.docker-java:docker-java*`

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1031,7 +1031,8 @@ trait CliIntegration extends SbtModule
       Deps.bsp4j,
       Deps.coursier
         .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-macros")),
-      Deps.dockerClient,
+      Deps.dockerJavaCore,
+      Deps.dockerJavaTransport,
       Deps.jsoniterCore,
       Deps.libsodiumjni,
       Deps.pprint,

--- a/build.mill
+++ b/build.mill
@@ -1033,6 +1033,7 @@ trait CliIntegration extends SbtModule
         .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-macros")),
       Deps.dockerJavaCore,
       Deps.dockerJavaTransport,
+      Deps.bcpkixJdk18on,
       Deps.jsoniterCore,
       Deps.libsodiumjni,
       Deps.pprint,

--- a/modules/integration/src/test/scala/scala/cli/integration/util/DockerServer.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/util/DockerServer.scala
@@ -2,10 +2,11 @@ package scala.cli.integration.util
 
 // adapted from https://github.com/coursier/coursier/blob/2cb552ea934a100f52ce79f94278304c90d808a4/modules/proxy-tests/src/it/scala/coursier/test/DockerServer.scala
 
-import com.spotify.docker.client.DefaultDockerClient
-import com.spotify.docker.client.messages.{ContainerConfig, HostConfig, PortBinding}
+import com.github.dockerjava.api.command.PullImageResultCallback
+import com.github.dockerjava.api.model.{ExposedPort, HostConfig, Ports}
+import com.github.dockerjava.core.{DefaultDockerClientConfig, DockerClientImpl}
+import com.github.dockerjava.zerodep.ZerodepDockerHttpClient
 
-import scala.jdk.CollectionConverters.*
 import scala.util.Try
 
 final case class DockerServer(
@@ -29,36 +30,40 @@ object DockerServer {
     def log(s: String): Unit =
       Console.err.println(s"[$image @ $addr] $s")
 
-    val docker = DefaultDockerClient.fromEnv().build()
-    docker.pull(image)
-
-    val portBindings = Map(imagePort.toString -> Seq(PortBinding.of("0.0.0.0", hostPort)).asJava)
-
-    val hostConfig = HostConfig.builder().portBindings(portBindings.asJava).build()
-
-    val containerConfig = ContainerConfig.builder()
-      .hostConfig(hostConfig)
-      .image(image)
-      .exposedPorts(portBindings.keys.toSeq*)
+    val config     = DefaultDockerClientConfig.createDefaultConfigBuilder().build()
+    val httpClient = new ZerodepDockerHttpClient.Builder()
+      .dockerHost(config.getDockerHost)
+      .sslConfig(config.getSSLConfig)
       .build()
+    val docker = DockerClientImpl.getInstance(config, httpClient)
+
+    docker.pullImageCmd(image).exec(new PullImageResultCallback()).awaitCompletion()
+
+    val exposedPort = ExposedPort.tcp(imagePort)
+    val ports       = new Ports()
+    ports.bind(exposedPort, Ports.Binding.bindPort(hostPort))
+
+    val hostConfig = HostConfig.newHostConfig().withPortBindings(ports)
 
     var idOpt = Option.empty[String]
 
     def shutdown(): Unit =
       for (id <- idOpt) {
-        Try(docker.killContainer(id))
-        docker.removeContainer(id)
+        Try(docker.killContainerCmd(id).exec())
+        docker.removeContainerCmd(id).exec()
         docker.close()
       }
 
     try {
-      val creation = docker.createContainer(containerConfig)
-
-      val id = creation.id()
+      val id = docker.createContainerCmd(image)
+        .withExposedPorts(exposedPort)
+        .withHostConfig(hostConfig)
+        .exec()
+        .getId
       idOpt = Some(id)
 
       log(s"starting container $id")
-      docker.startContainer(id)
+      docker.startContainerCmd(id).exec()
 
       val base = s"http://localhost:$hostPort/$basePath"
 

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -121,6 +121,7 @@ object Deps {
     def coursier                          = coursierDefault
     def coursierCli                       = coursierDefault
     def coursierPublish                   = "0.4.4"
+    def dockerJava                        = "3.7.1"
     def jmh                               = "1.37"
     def jsoniterScala                     = "2.38.17"
     def jsoup                             = "1.22.2"
@@ -178,8 +179,11 @@ object Deps {
   def coursierPublish    = mvn"io.get-coursier.publish::publish:${Versions.coursierPublish}"
     .exclude(("org.scala-lang.modules", "scala-collection-compat_2.13"))
     .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-core_2.13"))
-  def dependency    = mvn"io.get-coursier::dependency:0.3.2"
-  def dockerClient  = mvn"com.spotify:docker-client:8.16.0"
+    def dependency    = mvn"io.get-coursier::dependency:0.3.2"
+  def dockerJavaCore =
+    mvn"com.github.docker-java:docker-java-core:${Versions.dockerJava}"
+  def dockerJavaTransport =
+    mvn"com.github.docker-java:docker-java-transport-zerodep:${Versions.dockerJava}"
   def expecty       = mvn"com.eed3si9n.expecty::expecty:0.17.1"
   def fansi         = mvn"com.lihaoyi::fansi:0.5.1"
   def giter8        = mvn"org.foundweekends.giter8:giter8:0.18.0"

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -140,6 +140,7 @@ object Deps {
     def javaSemanticdb                    = "0.12.3"
     def javaClassName                     = "0.1.9"
     def bloop                             = "2.1.0"
+    def bouncycastle                      = "1.84"
     def sbt1Version                       = "1.12.5"
     def sbt2Version                       = "2.0.1"
     def sbtVersion                        = sbt2Version
@@ -179,9 +180,11 @@ object Deps {
   def coursierPublish    = mvn"io.get-coursier.publish::publish:${Versions.coursierPublish}"
     .exclude(("org.scala-lang.modules", "scala-collection-compat_2.13"))
     .exclude(("com.github.plokhotnyuk.jsoniter-scala", "jsoniter-scala-core_2.13"))
-    def dependency    = mvn"io.get-coursier::dependency:0.3.2"
+  def dependency    = mvn"io.get-coursier::dependency:0.3.2"
+  def bcpkixJdk18on = mvn"org.bouncycastle:bcpkix-jdk18on:${Versions.bouncycastle}"
   def dockerJavaCore =
     mvn"com.github.docker-java:docker-java-core:${Versions.dockerJava}"
+      .exclude("org.bouncycastle" -> "bcpkix-jdk18on")
   def dockerJavaTransport =
     mvn"com.github.docker-java:docker-java-transport-zerodep:${Versions.dockerJava}"
   def expecty       = mvn"com.eed3si9n.expecty::expecty:0.17.1"


### PR DESCRIPTION
Requires https://github.com/VirtusLab/scala-cli/pull/4363

`com.spotify:docker-client` is quite old, unmaintained and brings in old BouncyCastle, so we're migrating to `com.github.docker-java`

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)
- ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Cursor

## How was the solution tested?
existing tests