### PR TITLE
Migrate script wrapper to `$`-less syntax, keep old syntax behind `--dollar-wrapper`

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/ClassCodeWrapper.scala
+++ b/modules/build/src/main/scala/scala/build/internal/ClassCodeWrapper.scala
@@ -5,7 +5,11 @@ package scala.build.internal
   * running interconnected scripts using Scala CLI <br> <br> Incompatible with Scala 2 - it uses
   * Scala 3 feature 'export'<br> Incompatible with native JS members - the wrapper is a class
   */
-case class ClassCodeWrapper(scalaVersion: String, log: String => Unit) extends CodeWrapper {
+case class ClassCodeWrapper(
+  scalaVersion: String,
+  log: String => Unit,
+  useDollarNames: Boolean = false
+) extends CodeWrapper {
 
   override def mainClassObject(className: Name): Name =
     Name(className.raw ++ "_sc")
@@ -24,29 +28,17 @@ case class ClassCodeWrapper(scalaVersion: String, log: String => Unit) extends C
         otherwise.warningMessage.foreach(log)
         s"val _ = script.hashCode()"
 
+    val names            = WrapperUtils.ScriptWrapperNames(useDollarNames)
     val name             = mainClassObject(indexedWrapperName).backticked
-    val wrapperClassName = scala.build.internal.Name(indexedWrapperName.raw ++ "$_").backticked
-    val mainObjectCode   =
-      AmmUtil.normalizeNewlines(s"""|object $name {
-                                    |  private var args$$opt0 = Option.empty[Array[String]]
-                                    |  def args$$set(args: Array[String]): Unit = {
-                                    |    args$$opt0 = Some(args)
-                                    |  }
-                                    |  def args$$opt: Option[Array[String]] = args$$opt0
-                                    |  def args$$: Array[String] = args$$opt.getOrElse {
-                                    |    sys.error("No arguments passed to this script")
-                                    |  }
-                                    |
-                                    |  lazy val script = new $wrapperClassName
-                                    |
-                                    |  def main(args: Array[String]): Unit = {
-                                    |    args$$set(args)
-                                    |    $mainInvocation // hashCode to clear scalac warning about pure expression in statement position
-                                    |  }
-                                    |}
-                                    |
-                                    |export $name.script as `${indexedWrapperName.raw}`
-                                    |""".stripMargin)
+    val wrapperClassName =
+      scala.build.internal.Name(indexedWrapperName.raw ++ names.classSuffix).backticked
+    val mainObjectCode = WrapperUtils.scriptMainObjectCode(
+      names = names,
+      objectName = name,
+      mainInvocation = mainInvocation,
+      extraBody = s"lazy val script = new $wrapperClassName",
+      exportLine = Some(s"export $name.script as `${indexedWrapperName.raw}`")
+    )
 
     val packageDirective =
       if (pkgName.isEmpty) "" else s"package ${AmmUtil.encodeScalaSourcePath(pkgName)}" + "\n"
@@ -55,7 +47,7 @@ case class ClassCodeWrapper(scalaVersion: String, log: String => Unit) extends C
       s"""$packageDirective
          |
          |final class $wrapperClassName {
-         |def args = $name.args$$
+         |def args = $name.${names.argsAccessor}
          |def scriptPath = \"\"\"$scriptPath\"\"\"
          |""".stripMargin
     )

--- a/modules/build/src/main/scala/scala/build/internal/ObjectCodeWrapper.scala
+++ b/modules/build/src/main/scala/scala/build/internal/ObjectCodeWrapper.scala
@@ -4,7 +4,11 @@ package scala.build.internal
   * or/and not using JS native prefer [[ClassCodeWrapper]], since it prevents deadlocks when running
   * threads from script
   */
-case class ObjectCodeWrapper(scalaVersion: String, log: String => Unit) extends CodeWrapper {
+case class ObjectCodeWrapper(
+  scalaVersion: String,
+  log: String => Unit,
+  useDollarNames: Boolean = false
+) extends CodeWrapper {
 
   override def mainClassObject(className: Name): Name =
     Name(className.raw ++ "_sc")
@@ -16,8 +20,9 @@ case class ObjectCodeWrapper(scalaVersion: String, log: String => Unit) extends 
     scriptPath: String
   ) = {
     val mainObject         = WrapperUtils.mainObjectInScript(scalaVersion, code)
+    val names              = WrapperUtils.ScriptWrapperNames(useDollarNames)
     val name               = mainClassObject(indexedWrapperName).backticked
-    val aliasedWrapperName = name + "$$alias"
+    val aliasedWrapperName = name + names.aliasSuffix
     val realScript         =
       if (name == "main_sc")
         s"$aliasedWrapperName.alias" // https://github.com/VirtusLab/scala-cli/issues/314
@@ -28,23 +33,11 @@ case class ObjectCodeWrapper(scalaVersion: String, log: String => Unit) extends 
       case otherwise                                  =>
         otherwise.warningMessage.foreach(log)
         s"val _ = $realScript.hashCode()"
-    // We need to call hashCode (or any other method so compiler does not report a warning)
-    val mainObjectCode =
-      AmmUtil.normalizeNewlines(s"""|object $name {
-                                    |  private var args$$opt0 = Option.empty[Array[String]]
-                                    |  def args$$set(args: Array[String]): Unit = {
-                                    |    args$$opt0 = Some(args)
-                                    |  }
-                                    |  def args$$opt: Option[Array[String]] = args$$opt0
-                                    |  def args$$: Array[String] = args$$opt.getOrElse {
-                                    |    sys.error("No arguments passed to this script")
-                                    |  }
-                                    |  def main(args: Array[String]): Unit = {
-                                    |    args$$set(args)
-                                    |    $funHashCodeMethod // hashCode to clear scalac warning about pure expression in statement position
-                                    |  }
-                                    |}
-                                    |""".stripMargin)
+    val mainObjectCode = WrapperUtils.scriptMainObjectCode(
+      names = names,
+      objectName = name,
+      mainInvocation = funHashCodeMethod
+    )
 
     val packageDirective =
       if (pkgName.isEmpty) "" else s"package ${AmmUtil.encodeScalaSourcePath(pkgName)}" + "\n"
@@ -60,7 +53,7 @@ case class ObjectCodeWrapper(scalaVersion: String, log: String => Unit) extends 
       s"""$packageDirective
          |
          |object ${indexedWrapperName.backticked} {
-         |def args = $name.args$$
+         |def args = $name.${names.argsAccessor}
          |def scriptPath = \"\"\"$scriptPath\"\"\"
          |""".stripMargin
     )

--- a/modules/build/src/main/scala/scala/build/internal/WrapperUtils.scala
+++ b/modules/build/src/main/scala/scala/build/internal/WrapperUtils.scala
@@ -4,6 +4,69 @@ import scala.build.internal.util.WarningMessages
 
 object WrapperUtils {
 
+  /** Internal names used by script wrappers for args handling and wrapper class/alias suffixes. */
+  final case class ScriptWrapperNames(
+    argsOpt0: String,
+    argsSet: String,
+    argsOpt: String,
+    argsArray: String,
+    classSuffix: String,
+    aliasSuffix: String
+  ) {
+    def argsAccessor: String = argsArray
+  }
+
+  object ScriptWrapperNames {
+    def apply(useDollarNames: Boolean): ScriptWrapperNames =
+      if useDollarNames then
+        ScriptWrapperNames(
+          argsOpt0 = "args$opt0",
+          argsSet = "args$set",
+          argsOpt = "args$opt",
+          argsArray = "args$",
+          classSuffix = "$_",
+          aliasSuffix = "$$alias"
+        )
+      else
+        ScriptWrapperNames(
+          argsOpt0 = "scalaCliArgsOpt0",
+          argsSet = "scalaCliArgsSet",
+          argsOpt = "scalaCliArgsOpt",
+          argsArray = "scalaCliArgs",
+          classSuffix = "_class",
+          aliasSuffix = "_alias"
+        )
+  }
+
+  def scriptMainObjectCode(
+    names: ScriptWrapperNames,
+    objectName: String,
+    mainInvocation: String,
+    extraBody: String = "",
+    exportLine: Option[String] = None
+  ): String = {
+    val extraBody0   = if extraBody.isEmpty then "" else extraBody + "\n  "
+    val exportSuffix = exportLine.map(e => s"\n\n$e").getOrElse("")
+    AmmUtil.normalizeNewlines(
+      s"""|object $objectName {
+          |  private var ${names.argsOpt0} = Option.empty[Array[String]]
+          |  def ${names.argsSet}(args: Array[String]): Unit = {
+          |    ${names.argsOpt0} = Some(args)
+          |  }
+          |  def ${names.argsOpt}: Option[Array[String]] = ${names.argsOpt0}
+          |  def ${names.argsArray}: Array[String] = ${names.argsOpt}.getOrElse {
+          |    sys.error("No arguments passed to this script")
+          |  }
+          |
+          |  ${extraBody0}def main(args: Array[String]): Unit = {
+          |    ${names.argsSet}(args)
+          |    $mainInvocation // hashCode to clear scalac warning about pure expression in statement position
+          |  }
+          |}$exportSuffix
+          |""".stripMargin
+    )
+  }
+
   enum ScriptMainMethod:
     case Exists(name: String)
     case Multiple(names: Seq[String])

--- a/modules/build/src/main/scala/scala/build/preprocessing/DeprecatedDirectives.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/DeprecatedDirectives.scala
@@ -74,7 +74,11 @@ object DeprecatedDirectives {
     ),
     DirectiveTemplate(Seq("deprecatedForRemovalTestDirective"), None) -> noReplacement(
       deprecatedWarningForRemoval("deprecatedForRemovalTestDirective")
-    )
+    ),
+    DirectiveTemplate(
+      allKeysFrom(directives.DollarWrapper.handler),
+      None
+    ) -> noReplacement(deprecatedWarningForRemoval("dollarWrapper"))
   )
 
   private def warningAndReplacement(directive: StrictDirective): Option[WarningAndReplacement] =

--- a/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/ScriptPreprocessor.scala
@@ -162,12 +162,14 @@ case object ScriptPreprocessor extends Preprocessor {
         .orElse(buildOptions.scalaOptions.defaultScalaVersion)
         .getOrElse(Constants.defaultScalaVersion)
     def logWarning(msg: String) = logger.diagnostic(msg)
+    val useDollarNames          =
+      buildOptions.scriptOptions.useDollarScriptWrapper.getOrElse(false)
 
     def objectCodeWrapperForScalaVersion =
       // AppObjectWrapper only introduces the 'main.sc' restriction when used in Scala 3, there's no gain in using it with Scala 3
       if effectiveScalaVersion.startsWith("2") then
         AppCodeWrapper(effectiveScalaVersion, logWarning)
-      else ObjectCodeWrapper(effectiveScalaVersion, logWarning)
+      else ObjectCodeWrapper(effectiveScalaVersion, logWarning, useDollarNames)
 
     buildOptions.scriptOptions.forceObjectWrapper match {
       case Some(true) => objectCodeWrapperForScalaVersion
@@ -176,7 +178,7 @@ case object ScriptPreprocessor extends Preprocessor {
           case Some(_: Platform.JS.type)                  => objectCodeWrapperForScalaVersion
           case _ if effectiveScalaVersion.startsWith("2") =>
             AppCodeWrapper(effectiveScalaVersion, logWarning)
-          case _ => ClassCodeWrapper(effectiveScalaVersion, logWarning)
+          case _ => ClassCodeWrapper(effectiveScalaVersion, logWarning, useDollarNames)
         }
     }
   }

--- a/modules/build/src/main/scala/scala/build/preprocessing/directives/DirectivesPreprocessingUtils.scala
+++ b/modules/build/src/main/scala/scala/build/preprocessing/directives/DirectivesPreprocessingUtils.scala
@@ -19,6 +19,7 @@ object DirectivesPreprocessingUtils {
       directives.Jvm.handler,
       directives.MainClass.handler,
       directives.ObjectWrapper.handler,
+      directives.DollarWrapper.handler,
       directives.Packaging.handler,
       directives.Platform.handler,
       directives.Plugin.handler,

--- a/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildTests.scala
@@ -100,10 +100,10 @@ abstract class BuildTests(server: Boolean) extends TestUtil.ScalaCliBuildSuite {
     testInputs.withBuild(defaultScala3Options, buildThreads, bloopConfigOpt) {
       (_, _, maybeBuild) =>
         maybeBuild.orThrow.assertGeneratedEquals(
-          "simple$_.class",
+          "simple_class.class",
           "simple_sc.class",
           "simple_sc.tasty",
-          "simple$_.tasty",
+          "simple_class.tasty",
           "simple_sc$.class",
           "simple$package$.class",
           "simple$package.class",
@@ -123,9 +123,9 @@ abstract class BuildTests(server: Boolean) extends TestUtil.ScalaCliBuildSuite {
       (_, _, maybeBuild) =>
         val build = maybeBuild.orThrow
         build.assertGeneratedEquals(
-          "other$_$A.class",
-          "other$_.tasty",
-          "other$_.class",
+          "other_class$A.class",
+          "other_class.tasty",
+          "other_class.class",
           "other_sc$.class",
           "other_sc.class",
           "other_sc.tasty",
@@ -228,10 +228,10 @@ abstract class BuildTests(server: Boolean) extends TestUtil.ScalaCliBuildSuite {
     testInputs.withBuild(buildOptions, buildThreads, bloopConfigOpt) { (_, _, maybeBuild) =>
       val build = maybeBuild.orThrow
       build.assertGeneratedEquals(
-        "simple$_.class",
+        "simple_class.class",
         "simple_sc.class",
         "simple_sc.tasty",
-        "simple$_.tasty",
+        "simple_class.tasty",
         "simple_sc$.class",
         "simple$package$.class",
         "simple$package.class",
@@ -240,7 +240,7 @@ abstract class BuildTests(server: Boolean) extends TestUtil.ScalaCliBuildSuite {
       )
       maybeBuild.orThrow.assertNoDiagnostics()
       val outputDir = build.outputOpt.getOrElse(sys.error("no build output???"))
-      val tastyData = TastyData.read(os.read.bytes(outputDir / "simple$_.tasty")).orThrow
+      val tastyData = TastyData.read(os.read.bytes(outputDir / "simple_class.tasty")).orThrow
       val names     = tastyData.names.simpleNames
       expect(names.contains("simple.sc"))
     }

--- a/modules/build/src/test/scala/scala/build/tests/DeprecationTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DeprecationTests.scala
@@ -85,6 +85,21 @@ class DeprecationTests extends TestUtil.ScalaCliBuildSuite {
     expect(diag.get.textEdit.isEmpty)
   }
 
+  test("DeprecatedDirectives dollarWrapper emits warning for removal without TextEdit") {
+    val directive = StrictDirective("dollarWrapper", Seq.empty)
+    val logger    = new DiagnosticCapturingLogger()
+    DeprecatedDirectives.issueWarnings(
+      Left("test.scala"),
+      Seq(directive),
+      SuppressWarningOptions(),
+      logger
+    )
+    val diag = logger.diagnostics.find(_.message.contains("dollarWrapper"))
+    expect(diag.isDefined)
+    expect(diag.get.message.contains("removed in a future version"))
+    expect(diag.get.textEdit.isEmpty)
+  }
+
   test("DeprecatedDirectives key replacement emits warning with TextEdit") {
     val directive = StrictDirective("deprecatedTestDirective", Seq.empty)
     val logger    = new DiagnosticCapturingLogger()

--- a/modules/build/src/test/scala/scala/build/tests/ScriptWrapperTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ScriptWrapperTests.scala
@@ -46,12 +46,20 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
   def expectClassWrapper(wrapperName: String, path: os.Path): Unit = {
     val generatedFileContent = os.read(path)
     assert(
-      generatedFileContent.contains(s"final class $wrapperName$$_"),
+      generatedFileContent.contains(s"final class ${wrapperName}_class"),
       clue(s"Generated file content: $generatedFileContent")
     )
     assert(
       !generatedFileContent.contains(s"object $wrapperName extends App {") &&
       !generatedFileContent.contains(s"object $wrapperName {"),
+      clue(s"Generated file content: $generatedFileContent")
+    )
+  }
+
+  def expectLegacyClassWrapper(wrapperName: String, path: os.Path): Unit = {
+    val generatedFileContent = os.read(path)
+    assert(
+      generatedFileContent.contains(s"final class $wrapperName$$_"),
       clue(s"Generated file content: $generatedFileContent")
     )
   }
@@ -89,6 +97,11 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
       platform = Some(Positioned(List(Position.CommandLine()), Platform.JS))
     )
   )
+  val dollarWrapperOptions = BuildOptions(
+    scriptOptions = ScriptOptions(
+      useDollarScriptWrapper = Some(true)
+    )
+  )
 
   test(s"class wrapper for scala 3") {
     val inputs = TestInputs(
@@ -119,6 +132,25 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
         expectClassWrapper(
           "script2",
           projectDir.head / "src_generated" / "main" / "script2.scala"
+        )
+    }
+  }
+
+  test(s"legacy dollar class wrapper for scala 3") {
+    val inputs = TestInputs(
+      os.rel / "script1.sc" -> """println("Hello")"""
+    )
+
+    inputs.withBuild(baseOptions.orElse(dollarWrapperOptions), buildThreads, bloopConfigOpt) {
+      (root, _, maybeBuild) =>
+        expect(maybeBuild.orThrow.success)
+        val projectDir = os.list(root / ".scala-build").filter(
+          _.baseName.startsWith(root.baseName + "_")
+        )
+        expect(projectDir.size == 1)
+        expectLegacyClassWrapper(
+          "script1",
+          projectDir.head / "src_generated" / "main" / "script1.scala"
         )
     }
   }

--- a/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/RestrictedCommandsParser.scala
@@ -55,6 +55,12 @@ object RestrictedCommandsParser {
           case (r @ Right(Some(_, arg: Arg, _)), passedOption :: _)
               if arg.isExperimental && !shouldSuppressExperimentalWarnings =>
             logger.experimentalWarning(passedOption, FeatureType.Option)
+            if arg.isDeprecatedOption && !shouldSuppressDeprecatedWarnings then
+              logger.deprecationWarning(
+                passedOption,
+                arg.deprecationMessage.getOrElse(""),
+                FeatureType.Option
+              )
             r
           case (r @ Right(Some(_, arg: Arg, _)), passedOption :: _)
               if arg.isDeprecatedOption && !shouldSuppressDeprecatedWarnings =>

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -210,6 +210,15 @@ final case class SharedOptions(
   @HelpMessage("Force object wrapper for scripts")
   @Tag(tags.experimental)
     objectWrapper: Option[Boolean] = None,
+  @HelpMessage(
+    "[deprecated] Use the legacy dollar-sign ($) based script wrapper naming"
+  )
+  @Tag(tags.implementation)
+  @Name("dollarWrapper")
+  @Tag(tags.deprecatedOption(
+    "The dollar-sign script wrapper is a backwards-compat shim and will be removed in a future version."
+  ))
+    dollarScriptWrapper: Option[Boolean] = None,
   @Group(HelpGroup.Scala.toString)
   @HelpMessage(
     "Automatically generate BSP configuration in `.bsp/` when running build commands. Enabled by default."
@@ -453,7 +462,8 @@ final case class SharedOptions(
           platform = platformOpt.map(o => Positioned(List(Position.CommandLine()), o))
         ),
         scriptOptions = scala.build.options.ScriptOptions(
-          forceObjectWrapper = objectWrapper
+          forceObjectWrapper = objectWrapper,
+          useDollarScriptWrapper = dollarScriptWrapper
         ),
         scalaJsOptions = value(scalaJsOptions(js)),
         scalaNativeOptions = snOpts,

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/DollarWrapper.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/DollarWrapper.scala
@@ -1,0 +1,28 @@
+package scala.build.preprocessing.directives
+
+import scala.build.directives.*
+import scala.build.errors.BuildException
+import scala.build.options.{BuildOptions, ScriptOptions}
+import scala.cli.commands.SpecificationLevel
+
+@DirectiveExamples("//> using dollarWrapper")
+@DirectiveUsage("//> using dollarWrapper", "`//> using dollarWrapper`")
+@DirectiveDescription(
+  "Use the legacy dollar-sign ($) based script wrapper naming"
+)
+@DirectiveLevel(SpecificationLevel.IMPLEMENTATION)
+final case class DollarWrapper(
+  @DirectiveName("dollar.wrapper")
+  @DirectiveName("wrapper.dollar")
+  dollarWrapper: Boolean = false
+) extends HasBuildOptions {
+  def buildOptions: Either[BuildException, BuildOptions] =
+    val options = BuildOptions(scriptOptions =
+      ScriptOptions(useDollarScriptWrapper = Some(true))
+    )
+    Right(options)
+}
+
+object DollarWrapper {
+  val handler: DirectiveHandler[DollarWrapper] = DirectiveHandler.derive
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/BspTestDefinitions.scala
@@ -259,7 +259,7 @@ abstract class BspTestDefinitions extends ScalaCliSuite
 
         val classFilePath = os.rel / {
           if actualScalaVersion.startsWith("3.")
-          then "simple$_.class"
+          then "simple_class.class"
           else "simple$.class"
         }
         expect(compileProducts.contains(classFilePath))

--- a/modules/integration/src/test/scala/scala/cli/integration/DeprecationTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DeprecationTests.scala
@@ -107,4 +107,41 @@ class DeprecationTests extends ScalaCliSuite {
       expect(deprecatedWarningLines == 1)
     }
   }
+
+  Seq("--dollar-script-wrapper", "--dollar-wrapper").foreach { optionName =>
+    test(s"$optionName is deprecated") {
+      val inputPath = os.rel / "example.sc"
+      TestInputs(inputPath -> """println("hello")""").fromRoot { root =>
+        val res = os.proc(
+          TestUtil.cli,
+          "run",
+          TestUtil.extraOptions,
+          optionName,
+          inputPath
+        ).call(cwd = root, stderr = os.Pipe)
+        val err = res.err.trim()
+        expect(err.contains(optionName))
+        expect(err.contains("is deprecated."))
+        expect(err.contains("backwards-compat shim"))
+      }
+    }
+  }
+
+  test("dollarWrapper using directive is deprecated for removal") {
+    val inputPath = os.rel / "example.sc"
+    TestInputs(inputPath ->
+      """//> using dollarWrapper
+        |println("hello")
+        |""".stripMargin).fromRoot { root =>
+      val res = os.proc(
+        TestUtil.cli,
+        "run",
+        TestUtil.extraOptions,
+        inputPath
+      ).call(cwd = root, stderr = os.Pipe)
+      val err = res.err.trim()
+      expect(err.contains("dollarWrapper"))
+      expect(err.contains("removed in a future version"))
+    }
+  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
@@ -57,14 +57,14 @@ abstract class DocTestDefinitions extends ScalaCliSuite with TestScalaVersionArg
             Seq(
               "index.html",
               "inkuire-db.json",
-              "$lessempty$greater$/simple$_.html",
+              "$lessempty$greater$/simple_class.html",
               "lib/Messages$.html"
             )
           else
             Seq(
               "index.html",
               "inkuire-db.json",
-              "_empty_/simple$_.html",
+              "_empty_/simple_class.html",
               "lib/Messages$.html"
             )
         val entries =

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -909,7 +909,7 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
       if (actualScalaVersion.startsWith("2."))
         expect(genContentStr.contains("object simple"))
       else
-        expect(genContentStr.contains("class simple$_"))
+        expect(genContentStr.contains("class simple_class"))
     }
   }
 
@@ -941,14 +941,14 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
           Seq(
             "index.html",
             "inkuire-db.json",
-            "$lessempty$greater$/simple$_.html",
+            "$lessempty$greater$/simple_class.html",
             "lib/Messages$.html"
           )
         else
           Seq(
             "index.html",
             "inkuire-db.json",
-            "_empty_/simple$_.html",
+            "_empty_/simple_class.html",
             "lib/Messages$.html"
           )
       val entries = zf.entries().asScala.iterator.map(_.getName).toSet

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
@@ -294,8 +294,8 @@ trait RunScriptTestDefinitions { this: RunTestDefinitions =>
   test("sub-directory") {
     val fileName          = "script.sc"
     val expectedClassName =
-      if (actualScalaVersion.startsWith("3."))
-        fileName.stripSuffix(".sc") + "$_"
+      if actualScalaVersion.startsWith("3.") then
+        fileName.stripSuffix(".sc") + "_class"
       else
         fileName.stripSuffix(".sc") + "$"
     val scriptPath = os.rel / "something" / fileName
@@ -316,8 +316,8 @@ trait RunScriptTestDefinitions { this: RunTestDefinitions =>
   test("sub-directory and script") {
     val fileName          = "script.sc"
     val expectedClassName =
-      if (actualScalaVersion.startsWith("3."))
-        fileName.stripSuffix(".sc") + "$_"
+      if actualScalaVersion.startsWith("3.") then
+        fileName.stripSuffix(".sc") + "_class"
       else
         fileName.stripSuffix(".sc") + "$"
     val scriptPath = os.rel / "something" / fileName
@@ -511,13 +511,13 @@ trait RunScriptTestDefinitions { this: RunTestDefinitions =>
       val (caughtLines, causedLines) = exceptionLines.span(!_.startsWith("Caused by:"))
 
       assert(caughtLines.length > 1)
-      assert(caughtLines.contains(s"${tab}at throws$$_.<init>(throws.sc:8)"), clues(caughtLines))
+      assert(caughtLines.contains(s"${tab}at throws_class.<init>(throws.sc:8)"), clues(caughtLines))
 
       assert(causedLines.length > 1)
       assert(
         causedLines.contains(s"Caused by: java.lang.RuntimeException: nope") &&
-        causedLines.contains(s"${tab}at throws$$_.something(throws.sc:3)") &&
-        causedLines.contains(s"${tab}at throws$$_.<init>(throws.sc:5)"),
+        causedLines.contains(s"${tab}at throws_class.something(throws.sc:3)") &&
+        causedLines.contains(s"${tab}at throws_class.<init>(throws.sc:5)"),
         clues(causedLines)
       )
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -1338,6 +1338,40 @@ abstract class RunTestDefinitions
       }
     }
 
+  if isScala39OrNewer then
+    test("scripts should not warn about dollar-sign identifiers in wrapper (Scala 3.9+)") {
+      val inputs = TestInputs(
+        os.rel / "snippet.sc" -> """println("hello")""",
+        os.rel / "legacy.sc"  ->
+          """//> using dollarWrapper
+            |println("legacy")""".stripMargin
+      )
+      inputs.fromRoot { root =>
+        val defaultRes = os.proc(TestUtil.cli, "run", extraOptions, "snippet.sc")
+          .call(cwd = root, mergeErrIntoOut = true)
+        val defaultOutput = defaultRes.out.trim()
+        expect(!defaultOutput.contains("reserved for internal compiler use"))
+        expect(!defaultOutput.contains("should not contain `$`"))
+
+        val legacyFlagRes = os.proc(
+          TestUtil.cli,
+          "run",
+          extraOptions,
+          "--dollar-script-wrapper",
+          "snippet.sc"
+        ).call(cwd = root, mergeErrIntoOut = true)
+        expect(legacyFlagRes.out.trim().contains("reserved for internal compiler use"))
+
+        val legacyDirectiveRes = os.proc(
+          TestUtil.cli,
+          "run",
+          extraOptions,
+          "legacy.sc"
+        ).call(cwd = root, mergeErrIntoOut = true)
+        expect(legacyDirectiveRes.out.trim().contains("reserved for internal compiler use"))
+      }
+    }
+
   test("should add toolkit to classpath") {
     val inputs = TestInputs(
       os.rel / "Hello.scala" ->

--- a/modules/integration/src/test/scala/scala/cli/integration/ScriptWrapperTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ScriptWrapperTestDefinitions.scala
@@ -9,7 +9,7 @@ import scala.jdk.CollectionConverters.*
 
 trait ScriptWrapperTestDefinitions extends ScalaCliSuite { this: BspTestDefinitions =>
   private def appWrapperSnippet(wrapperName: String)    = s"object $wrapperName extends App {"
-  private def classWrapperSnippet(wrapperName: String)  = s"final class $wrapperName$$_"
+  private def classWrapperSnippet(wrapperName: String)  = s"final class ${wrapperName}_class"
   private def objectWrapperSnippet(wrapperName: String) = s"object $wrapperName {"
   def expectScriptWrapper(
     path: os.Path,

--- a/modules/options/src/main/scala/scala/build/options/ScriptOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScriptOptions.scala
@@ -1,7 +1,8 @@
 package scala.build.options
 
 final case class ScriptOptions(
-  forceObjectWrapper: Option[Boolean] = None
+  forceObjectWrapper: Option[Boolean] = None,
+  useDollarScriptWrapper: Option[Boolean] = None
 )
 
 object ScriptOptions {

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1708,6 +1708,14 @@ Exclude sources
 
 Force object wrapper for scripts
 
+### [deprecated] `--dollar-script-wrapper`
+
+Aliases: `--dollar-wrapper`
+
+**Deprecated**: The dollar-sign script wrapper is a backwards-compat shim and will be removed in a future version.
+
+[deprecated] Use the legacy dollar-sign ($) based script wrapper naming
+
 ### `--auto-setup-ide`
 
 Aliases: `--auto-setup-bsp`

--- a/website/docs/reference/directives.md
+++ b/website/docs/reference/directives.md
@@ -170,6 +170,15 @@ Add dependencies
 
 `//> using scalafix.dep com.github.xuwei-k::scalafix-rules:0.5.1`
 
+### DollarWrapper
+
+Use the legacy dollar-sign ($) based script wrapper naming
+
+`//> using dollarWrapper`
+
+#### Examples
+`//> using dollarWrapper`
+
 ### Exclude sources
 
 Exclude sources from the project

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -1200,6 +1200,16 @@ Add toolkit to classPath (not supported in Scala 2.12), 'default' version for Sc
 
 Exclude sources
 
+### [deprecated] `--dollar-script-wrapper`
+
+Aliases: `--dollar-wrapper`
+
+**Deprecated**: The dollar-sign script wrapper is a backwards-compat shim and will be removed in a future version.
+
+`IMPLEMENTATION specific` per Scala Runner specification
+
+[deprecated] Use the legacy dollar-sign ($) based script wrapper naming
+
 ### `--auto-setup-ide`
 
 Aliases: `--auto-setup-bsp`

--- a/website/docs/reference/scala-command/directives.md
+++ b/website/docs/reference/scala-command/directives.md
@@ -489,3 +489,16 @@ Use a toolkit as dependency (not supported in Scala 2.12), 'default' version for
 
 `//> using test.toolkit default`
 
+## Implementation-specific directices
+
+Directives which are used within Scala CLI and should be a part of the `scala` command but aren't a part of the specification.
+
+### DollarWrapper
+
+Use the legacy dollar-sign ($) based script wrapper naming
+
+`//> using dollarWrapper`
+
+#### Examples
+`//> using dollarWrapper`
+

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -656,6 +656,12 @@ Aliases: `--toolkit`
 
 Exclude sources
 
+**--dollar-script-wrapper**
+
+[deprecated] Use the legacy dollar-sign ($) based script wrapper naming
+
+Aliases: `--dollar-wrapper`
+
 **--auto-setup-ide**
 
 Automatically generate BSP configuration in `.bsp/` when running build commands. Enabled by default.
@@ -1471,6 +1477,12 @@ Aliases: `--toolkit`
 
 Exclude sources
 
+**--dollar-script-wrapper**
+
+[deprecated] Use the legacy dollar-sign ($) based script wrapper naming
+
+Aliases: `--dollar-wrapper`
+
 **--auto-setup-ide**
 
 Automatically generate BSP configuration in `.bsp/` when running build commands. Enabled by default.
@@ -2101,6 +2113,12 @@ Aliases: `--toolkit`
 **--exclude**
 
 Exclude sources
+
+**--dollar-script-wrapper**
+
+[deprecated] Use the legacy dollar-sign ($) based script wrapper naming
+
+Aliases: `--dollar-wrapper`
 
 **--auto-setup-ide**
 
@@ -2773,6 +2791,12 @@ Aliases: `--toolkit`
 
 Exclude sources
 
+**--dollar-script-wrapper**
+
+[deprecated] Use the legacy dollar-sign ($) based script wrapper naming
+
+Aliases: `--dollar-wrapper`
+
 **--auto-setup-ide**
 
 Automatically generate BSP configuration in `.bsp/` when running build commands. Enabled by default.
@@ -3443,6 +3467,12 @@ Aliases: `--toolkit`
 
 Exclude sources
 
+**--dollar-script-wrapper**
+
+[deprecated] Use the legacy dollar-sign ($) based script wrapper naming
+
+Aliases: `--dollar-wrapper`
+
 **--auto-setup-ide**
 
 Automatically generate BSP configuration in `.bsp/` when running build commands. Enabled by default.
@@ -4070,6 +4100,12 @@ Aliases: `--toolkit`
 **--exclude**
 
 Exclude sources
+
+**--dollar-script-wrapper**
+
+[deprecated] Use the legacy dollar-sign ($) based script wrapper naming
+
+Aliases: `--dollar-wrapper`
 
 **--auto-setup-ide**
 
@@ -4776,6 +4812,12 @@ Aliases: `--toolkit`
 **--exclude**
 
 Exclude sources
+
+**--dollar-script-wrapper**
+
+[deprecated] Use the legacy dollar-sign ($) based script wrapper naming
+
+Aliases: `--dollar-wrapper`
 
 **--auto-setup-ide**
 
@@ -5492,6 +5534,12 @@ Aliases: `--toolkit`
 **--exclude**
 
 Exclude sources
+
+**--dollar-script-wrapper**
+
+[deprecated] Use the legacy dollar-sign ($) based script wrapper naming
+
+Aliases: `--dollar-wrapper`
 
 **--auto-setup-ide**
 
@@ -6491,6 +6539,12 @@ Aliases: `--toolkit`
 **--exclude**
 
 Exclude sources
+
+**--dollar-script-wrapper**
+
+[deprecated] Use the legacy dollar-sign ($) based script wrapper naming
+
+Aliases: `--dollar-wrapper`
 
 **--auto-setup-ide**
 


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/4374

### What's  this about

We no longer can use `$` in field names in the `*.sc` script wrapper, as otherwise on Scala 3.9+ (currently `rc`/`nightly`) we get:

```scala
[warn] .../snippet.scala:12:15
[warn] The identifier `args$opt0` should not contain `$`, which is reserved for internal compiler use.
[warn]   private var args$opt0 = Option.empty[Array[String]]
[warn]               ^^^^^^^^^
[warn] .../snippet.scala:3:13
[warn] The identifier `snippet$_` should not contain `$`, which is reserved for internal compiler use.
[warn] final class snippet$_ {
[warn]             ^^^^^^^^^
[warn] .../snippet.scala:13:7
[warn] The identifier `args$set` should not contain `$`, which is reserved for internal compiler use.
[warn]   def args$set(args: Array[String]): Unit = {
[warn]       ^^^^^^^^
[warn] .../snippet.scala:16:7
[warn] The identifier `args$opt` should not contain `$`, which is reserved for internal compiler use.
[warn]   def args$opt: Option[Array[String]] = args$opt0
[warn]       ^^^^^^^^
[warn] .../snippet.scala:17:7
[warn] The identifier `args` should not contain `$`, which is reserved for internal compiler use.
[warn]   def args$: Array[String] = args$opt.getOrElse {
[warn]       ^^^^^
```

### What changes

For a given script:

```scala
// hello.sc
println("Hello")
println(args.head)
```

The under-the-hood generated code wrapper looked roughly like this:

```scala
final class hello$_ {
  def args = hello_sc.args$
  def scriptPath = """hello.sc"""
  // ... your script code here ...
}
object hello_sc {
  private var args$opt0 = Option.empty[Array[String]]
  def args$set(args: Array[String]): Unit = { args$opt0 = Some(args) }
  def args$opt: Option[Array[String]] = args$opt0
  def args$: Array[String] = args$opt.getOrElse {
    sys.error("No arguments passed to this script")
  }
  lazy val script = new hello$_
  def main(args: Array[String]): Unit = {
    args$set(args)
    val _ = script.hashCode()
  }
}
export hello_sc.script as `hello`
```

After this change, this migrates to:

```scala
final class hello_class {
  def args = hello_sc.scalaCliArgs
  def scriptPath = """hello.sc"""
  // ... your script code here ...
}
object hello_sc {
  private var scalaCliArgsOpt0 = Option.empty[Array[String]]
  def scalaCliArgsSet(args: Array[String]): Unit = { scalaCliArgsOpt0 = Some(args) }
  def scalaCliArgsOpt: Option[Array[String]] = scalaCliArgsOpt0
  def scalaCliArgs: Array[String] = scalaCliArgsOpt.getOrElse {
    sys.error("No arguments passed to this script")
  }
  lazy val script = new hello_class
  def main(args: Array[String]): Unit = {
    scalaCliArgsSet(args)
    val _ = script.hashCode()
  }
}
export hello_sc.script as `hello`
```

The old wrapper remains available just in case this causes any migration issues, behind a flag `--dollar-wrapper`/`--dollar-script-wrapper` or directive `//> using dollarWrapper`. These come immediately deprecated, to be removed in a future version (likely sometime alongside Scala 3.10+).

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)
- ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Claude

## How was the solution tested?
included automated tests

## Additional notes
We have been using `$` as that made the names unlikely to cause a collision. The new approach is perhaps more prone to problems. I am open to suggestions here.