### PR TITLE
Add anti-regression tests for #4339

### DIFF
--- a/modules/build/src/test/scala/scala/build/tests/WrapperUtilsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/WrapperUtilsTests.scala
@@ -1,0 +1,53 @@
+package scala.build.tests
+
+import com.eed3si9n.expecty.Expecty.expect
+
+import scala.build.internal.WrapperUtils
+import scala.build.internal.WrapperUtils.ScriptMainMethod
+import scala.meta.*
+
+class WrapperUtilsTests extends TestUtil.ScalaCliBuildSuite {
+
+  private val scriptWithTupleComparison =
+    """|object MainNeverCalled {
+       |  def main(args: Array[String]): Unit = {
+       |    printf("yo!\n")
+       |    val pair = ("", "")
+       |    val (a, b) = pair
+       |    if (a, b) == pair then println("yo")
+       |  }
+       |}
+       |""".stripMargin
+
+  test("detect main method in script with tuple comparison in if condition") {
+    WrapperUtils.mainObjectInScript("3.8.3", scriptWithTupleComparison) match
+      case ScriptMainMethod.Exists(name) => expect(name == "MainNeverCalled")
+      case other                         => fail(s"Expected main method to be detected, got $other")
+  }
+
+  test("parse tuple comparison in if condition") {
+    val scriptDialect =
+      dialects.Scala3Future.withAllowToplevelStatements(true).withAllowToplevelTerms(true)
+    given Dialect = scriptDialect
+    val code      = "if (a, b) == pair then ???"
+    code.parse[Stat] match
+      case Parsed.Success(_) => ()
+      case other             => fail(s"Expected successful parse, got: $other")
+  }
+
+  test("parse script with tuple comparison without spurious toplevel terms") {
+    val scriptDialect =
+      dialects.Scala3Future.withAllowToplevelStatements(true).withAllowToplevelTerms(true)
+    given Dialect = scriptDialect
+    val stats     = scriptWithTupleComparison.parse[Source] match
+      case Parsed.Success(Source(parsedStats)) => parsedStats
+      case other                               => fail(s"Failed to parse script: $other")
+
+    val toplevelTerms = stats.collect { case t: Term => t }
+    assert(
+      toplevelTerms.isEmpty,
+      clue(s"Expected no spurious toplevel terms, got: ${toplevelTerms.mkString(", ")}")
+    )
+  }
+
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScriptTestDefinitions.scala
@@ -86,6 +86,29 @@ trait RunScriptTestDefinitions { this: RunTestDefinitions =>
       expect(output == message)
     }
   }
+
+  if actualScalaVersion.startsWith("3") then
+    test("script with main method and tuple comparison in if condition") {
+      val message = "Hello"
+      val inputs  = TestInputs(
+        os.rel / "testScript.sc" ->
+          s"""|object MainNeverCalled {
+              |  def main(args: Array[String]): Unit = {
+              |    printf("$message\\n")
+              |    val pair = ("", "")
+              |    val (a, b) = pair
+              |    if (a, b) == pair then println("yo")
+              |  }
+              |}
+              |""".stripMargin
+      )
+      inputs.fromRoot { root =>
+        val output = os.proc(TestUtil.cli, extraOptions, "testScript.sc")
+          .call(cwd = root).out.trim()
+        expect(output.contains(message))
+      }
+    }
+
   test("main.sc has an object that extends App") {
     val message = "Hello"
     val inputs  = TestInputs(


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/4339

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Claude

## How was the solution tested?
ran the included tests locally, the issue does not reproduce

## Additional notes
Was originally fixed in https://github.com/VirtusLab/scala-cli/pull/4359, this just adds tests.