### PR TITLE
Wrap all names containing `$` reserved character in backticks for all script wrappers

### DIFF
--- a/modules/build/src/main/scala/scala/build/internal/ClassCodeWrapper.scala
+++ b/modules/build/src/main/scala/scala/build/internal/ClassCodeWrapper.scala
@@ -24,23 +24,25 @@ case class ClassCodeWrapper(scalaVersion: String, log: String => Unit) extends C
         otherwise.warningMessage.foreach(log)
         s"val _ = script.hashCode()"
 
-    val name             = mainClassObject(indexedWrapperName).backticked
-    val wrapperClassName = scala.build.internal.Name(indexedWrapperName.raw ++ "$_").backticked
-    val mainObjectCode   =
+    val name = mainClassObject(indexedWrapperName).backticked
+    // Force backticks so Scala 3.9+ does not warn about `$` in the wrapper class name
+    val wrapperClassName =
+      s"`${scala.build.internal.Name(indexedWrapperName.raw ++ "$_").encoded}`"
+    val mainObjectCode =
       AmmUtil.normalizeNewlines(s"""|object $name {
-                                    |  private var args$$opt0 = Option.empty[Array[String]]
-                                    |  def args$$set(args: Array[String]): Unit = {
-                                    |    args$$opt0 = Some(args)
+                                    |  private var `args$$opt0` = Option.empty[Array[String]]
+                                    |  def `args$$set`(args: Array[String]): Unit = {
+                                    |    `args$$opt0` = Some(args)
                                     |  }
-                                    |  def args$$opt: Option[Array[String]] = args$$opt0
-                                    |  def args$$: Array[String] = args$$opt.getOrElse {
+                                    |  def `args$$opt`: Option[Array[String]] = `args$$opt0`
+                                    |  def `args$$`: Array[String] = `args$$opt`.getOrElse {
                                     |    sys.error("No arguments passed to this script")
                                     |  }
                                     |
                                     |  lazy val script = new $wrapperClassName
                                     |
                                     |  def main(args: Array[String]): Unit = {
-                                    |    args$$set(args)
+                                    |    `args$$set`(args)
                                     |    $mainInvocation // hashCode to clear scalac warning about pure expression in statement position
                                     |  }
                                     |}
@@ -55,7 +57,7 @@ case class ClassCodeWrapper(scalaVersion: String, log: String => Unit) extends C
       s"""$packageDirective
          |
          |final class $wrapperClassName {
-         |def args = $name.args$$
+         |def args = $name.`args$$`
          |def scriptPath = \"\"\"$scriptPath\"\"\"
          |""".stripMargin
     )

--- a/modules/build/src/main/scala/scala/build/internal/ObjectCodeWrapper.scala
+++ b/modules/build/src/main/scala/scala/build/internal/ObjectCodeWrapper.scala
@@ -15,9 +15,10 @@ case class ObjectCodeWrapper(scalaVersion: String, log: String => Unit) extends 
     extraCode: String,
     scriptPath: String
   ) = {
-    val mainObject         = WrapperUtils.mainObjectInScript(scalaVersion, code)
-    val name               = mainClassObject(indexedWrapperName).backticked
-    val aliasedWrapperName = name + "$$alias"
+    val mainObject = WrapperUtils.mainObjectInScript(scalaVersion, code)
+    val name       = mainClassObject(indexedWrapperName).backticked
+    // Force backticks so Scala 3.9+ does not warn about `$` in the alias object name
+    val aliasedWrapperName = s"`$name$$$$alias`"
     val realScript         =
       if (name == "main_sc")
         s"$aliasedWrapperName.alias" // https://github.com/VirtusLab/scala-cli/issues/314
@@ -31,16 +32,16 @@ case class ObjectCodeWrapper(scalaVersion: String, log: String => Unit) extends 
     // We need to call hashCode (or any other method so compiler does not report a warning)
     val mainObjectCode =
       AmmUtil.normalizeNewlines(s"""|object $name {
-                                    |  private var args$$opt0 = Option.empty[Array[String]]
-                                    |  def args$$set(args: Array[String]): Unit = {
-                                    |    args$$opt0 = Some(args)
+                                    |  private var `args$$opt0` = Option.empty[Array[String]]
+                                    |  def `args$$set`(args: Array[String]): Unit = {
+                                    |    `args$$opt0` = Some(args)
                                     |  }
-                                    |  def args$$opt: Option[Array[String]] = args$$opt0
-                                    |  def args$$: Array[String] = args$$opt.getOrElse {
+                                    |  def `args$$opt`: Option[Array[String]] = `args$$opt0`
+                                    |  def `args$$`: Array[String] = `args$$opt`.getOrElse {
                                     |    sys.error("No arguments passed to this script")
                                     |  }
                                     |  def main(args: Array[String]): Unit = {
-                                    |    args$$set(args)
+                                    |    `args$$set`(args)
                                     |    $funHashCodeMethod // hashCode to clear scalac warning about pure expression in statement position
                                     |  }
                                     |}
@@ -60,7 +61,7 @@ case class ObjectCodeWrapper(scalaVersion: String, log: String => Unit) extends 
       s"""$packageDirective
          |
          |object ${indexedWrapperName.backticked} {
-         |def args = $name.args$$
+         |def args = $name.`args$$`
          |def scriptPath = \"\"\"$scriptPath\"\"\"
          |""".stripMargin
     )

--- a/modules/build/src/test/scala/scala/build/tests/ScriptWrapperTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ScriptWrapperTests.scala
@@ -24,7 +24,7 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
       clue(s"Generated file content: $generatedFileContent")
     )
     assert(
-      !generatedFileContent.contains(s"final class $wrapperName$$_") &&
+      !generatedFileContent.contains(s"final class `$wrapperName$$_`") &&
       !generatedFileContent.contains(s"object $wrapperName {"),
       clue(s"Generated file content: $generatedFileContent")
     )
@@ -37,7 +37,7 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
       clue(s"Generated file content: $generatedFileContent")
     )
     assert(
-      !generatedFileContent.contains(s"final class $wrapperName$$_") &&
+      !generatedFileContent.contains(s"final class `$wrapperName$$_`") &&
       !generatedFileContent.contains(s"object $wrapperName extends App {"),
       clue(s"Generated file content: $generatedFileContent")
     )
@@ -46,7 +46,7 @@ class ScriptWrapperTests extends TestUtil.ScalaCliBuildSuite {
   def expectClassWrapper(wrapperName: String, path: os.Path): Unit = {
     val generatedFileContent = os.read(path)
     assert(
-      generatedFileContent.contains(s"final class $wrapperName$$_"),
+      generatedFileContent.contains(s"final class `$wrapperName$$_`"),
       clue(s"Generated file content: $generatedFileContent")
     )
     assert(

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -909,7 +909,7 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
       if (actualScalaVersion.startsWith("2."))
         expect(genContentStr.contains("object simple"))
       else
-        expect(genContentStr.contains("class simple$_"))
+        expect(genContentStr.contains("class `simple$_`"))
     }
   }
 

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -1338,6 +1338,17 @@ abstract class RunTestDefinitions
       }
     }
 
+  if isScala39OrNewer then
+    test("scripts should not warn about dollar-sign identifiers in wrapper (Scala 3.9+)") {
+      TestInputs(os.rel / "snippet.sc" -> """println("hello")""").fromRoot { root =>
+        val defaultRes = os.proc(TestUtil.cli, "run", extraOptions, "snippet.sc")
+          .call(cwd = root, mergeErrIntoOut = true)
+        val defaultOutput = defaultRes.out.trim()
+        expect(!defaultOutput.contains("reserved for internal compiler use"))
+        expect(!defaultOutput.contains("should not contain `$`"))
+      }
+    }
+
   test("should add toolkit to classpath") {
     val inputs = TestInputs(
       os.rel / "Hello.scala" ->
@@ -1685,7 +1696,7 @@ abstract class RunTestDefinitions
            |  assert(BuildInfo.Main.resolvers.size == 3)
            |  assert(BuildInfo.Main.resourceDirs.size == 1)
            |  assert(BuildInfo.Main.customJarsDecls.size == 2)
-           |   
+           |
            |  assert(BuildInfo.Test.sources.head.endsWith("Test.scala"))
            |  assert(BuildInfo.Test.scalacOptions == Seq("-Xasync"))
            |  assert(BuildInfo.Test.scalaCompilerPlugins.size == 0)

--- a/modules/integration/src/test/scala/scala/cli/integration/ScriptWrapperTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ScriptWrapperTestDefinitions.scala
@@ -9,7 +9,7 @@ import scala.jdk.CollectionConverters.*
 
 trait ScriptWrapperTestDefinitions extends ScalaCliSuite { this: BspTestDefinitions =>
   private def appWrapperSnippet(wrapperName: String)    = s"object $wrapperName extends App {"
-  private def classWrapperSnippet(wrapperName: String)  = s"final class $wrapperName$$_"
+  private def classWrapperSnippet(wrapperName: String)  = s"final class `$wrapperName$$_`"
   private def objectWrapperSnippet(wrapperName: String) = s"object $wrapperName {"
   def expectScriptWrapper(
     path: os.Path,


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/4374
This is an alternative to https://github.com/VirtusLab/scala-cli/pull/4375, as per https://github.com/VirtusLab/scala-cli/pull/4375#issuecomment-4981636297

### What's  this about

We no longer can just use `$` in field names in the `*.sc` script wrapper, as otherwise on Scala 3.9+ (currently `rc`/`nightly`) we get:

```scala
[warn] .../snippet.scala:12:15
[warn] The identifier `args$opt0` should not contain `$`, which is reserved for internal compiler use.
[warn]   private var args$opt0 = Option.empty[Array[String]]
[warn]               ^^^^^^^^^
[warn] .../snippet.scala:3:13
[warn] The identifier `snippet$_` should not contain `$`, which is reserved for internal compiler use.
[warn] final class snippet$_ {
[warn]             ^^^^^^^^^
[warn] .../snippet.scala:13:7
[warn] The identifier `args$set` should not contain `$`, which is reserved for internal compiler use.
[warn]   def args$set(args: Array[String]): Unit = {
[warn]       ^^^^^^^^
[warn] .../snippet.scala:16:7
[warn] The identifier `args$opt` should not contain `$`, which is reserved for internal compiler use.
[warn]   def args$opt: Option[Array[String]] = args$opt0
[warn]       ^^^^^^^^
[warn] .../snippet.scala:17:7
[warn] The identifier `args` should not contain `$`, which is reserved for internal compiler use.
[warn]   def args$: Array[String] = args$opt.getOrElse {
[warn]       ^^^^^
```

### What changes

Rather than migrating the wrapper off-`$`, this approach wraps everything in backticks.

For a given script:

```scala
// hello.sc
println("Hello")
println(args.head)
```

The under-the-hood generated code wrapper looked roughly like this:

```scala
final class hello$_ {
  def args = hello_sc.args$
  def scriptPath = """hello.sc"""
  // ... your script code here ...
}
object hello_sc {
  private var args$opt0 = Option.empty[Array[String]]
  def args$set(args: Array[String]): Unit = { args$opt0 = Some(args) }
  def args$opt: Option[Array[String]] = args$opt0
  def args$: Array[String] = args$opt.getOrElse {
    sys.error("No arguments passed to this script")
  }
  lazy val script = new hello$_
  def main(args: Array[String]): Unit = {
    args$set(args)
    val _ = script.hashCode()
  }
}
export hello_sc.script as `hello`
```

After this change, this migrates to:

```scala
final class `hello$_` {
  def args = `hello_sc.args$`
  def scriptPath = """hello.sc"""
  // ... your script code here ...
}
object hello_sc {
  private var `args$opt0` = Option.empty[Array[String]]
  def `args$set`(args: Array[String]): Unit = { `args$opt0` = Some(args) }
  def `args$opt`: Option[Array[String]] = `args$opt0`
  def `args$`: Array[String] = `args$opt`.getOrElse {
    sys.error("No arguments passed to this script")
  }
  lazy val script = new `hello$_`
  def main(args: Array[String]): Unit = {
    `args$set`(args)
    val _ = script.hashCode()
  }
}
export hello_sc.script as `hello`
```

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Cursor + Claude

## How was the solution tested?
Included new automated test ensuring the warning is not there