### PR TITLE
Add a `[test_skip]` override for the CI

### DIFF
--- a/.github/scripts/check-override-keywords.sh
+++ b/.github/scripts/check-override-keywords.sh
@@ -6,14 +6,15 @@ set -euo pipefail
 # Outputs: writes override=true/false pairs to $GITHUB_OUTPUT and a summary table to $GITHUB_STEP_SUMMARY
 
 if [[ "$EVENT_NAME" != "pull_request" ]]; then
-  echo "Non-PR event, setting all overrides to true"
+  echo "Non-PR event, setting all overrides to true (except test_skip)"
   for override in test_all test_native test_integration test_docs test_format; do
     echo "$override=true" >> "$GITHUB_OUTPUT"
   done
+  echo "test_skip=false" >> "$GITHUB_OUTPUT"
   exit 0
 fi
 
-TEST_ALL=false; TEST_NATIVE=false; TEST_INTEGRATION=false; TEST_DOCS=false; TEST_FORMAT=false
+TEST_ALL=false; TEST_NATIVE=false; TEST_INTEGRATION=false; TEST_DOCS=false; TEST_FORMAT=false; TEST_SKIP=false
 
 check_override() {
   local keyword="$1"
@@ -29,6 +30,7 @@ check_override "[test_native]" "TEST_NATIVE"
 check_override "[test_integration]" "TEST_INTEGRATION"
 check_override "[test_docs]" "TEST_DOCS"
 check_override "[test_format]" "TEST_FORMAT"
+check_override "[test_skip]" "TEST_SKIP"
 
 echo "Override keywords:"
 echo "  test_all=$TEST_ALL"
@@ -36,12 +38,14 @@ echo "  test_native=$TEST_NATIVE"
 echo "  test_integration=$TEST_INTEGRATION"
 echo "  test_docs=$TEST_DOCS"
 echo "  test_format=$TEST_FORMAT"
+echo "  test_skip=$TEST_SKIP"
 
 echo "test_all=$TEST_ALL" >> "$GITHUB_OUTPUT"
 echo "test_native=$TEST_NATIVE" >> "$GITHUB_OUTPUT"
 echo "test_integration=$TEST_INTEGRATION" >> "$GITHUB_OUTPUT"
 echo "test_docs=$TEST_DOCS" >> "$GITHUB_OUTPUT"
 echo "test_format=$TEST_FORMAT" >> "$GITHUB_OUTPUT"
+echo "test_skip=$TEST_SKIP" >> "$GITHUB_OUTPUT"
 
 echo "## Override keywords" >> "$GITHUB_STEP_SUMMARY"
 echo "| Keyword | Active |" >> "$GITHUB_STEP_SUMMARY"
@@ -51,3 +55,4 @@ echo "| [test_native] | $TEST_NATIVE |" >> "$GITHUB_STEP_SUMMARY"
 echo "| [test_integration] | $TEST_INTEGRATION |" >> "$GITHUB_STEP_SUMMARY"
 echo "| [test_docs] | $TEST_DOCS |" >> "$GITHUB_STEP_SUMMARY"
 echo "| [test_format] | $TEST_FORMAT |" >> "$GITHUB_STEP_SUMMARY"
+echo "| [test_skip] | $TEST_SKIP |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       test_integration: ${{ steps.overrides.outputs.test_integration }}
       test_docs: ${{ steps.overrides.outputs.test_docs }}
       test_format: ${{ steps.overrides.outputs.test_format }}
+      test_skip: ${{ steps.overrides.outputs.test_skip }}
     steps:
     - uses: actions/checkout@v7
       with:
@@ -51,7 +52,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -106,7 +107,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -140,7 +141,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_integration == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_integration == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
@@ -181,7 +182,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_integration == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_integration == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -226,7 +227,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_integration == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_integration == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -271,7 +272,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_integration == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_integration == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -316,7 +317,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_integration == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_integration == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
@@ -361,7 +362,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_integration == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_integration == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
@@ -406,7 +407,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -451,7 +452,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -500,7 +501,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -549,7 +550,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -598,7 +599,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
@@ -647,7 +648,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
@@ -696,7 +697,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-24.04-arm
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
@@ -743,7 +744,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04-arm
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
@@ -792,7 +793,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04-arm
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
@@ -841,7 +842,7 @@ jobs:
     timeout-minutes: 120
     runs-on: "macOS-15-intel"
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -886,7 +887,7 @@ jobs:
     timeout-minutes: 45
     runs-on: "macOS-15-intel"
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -936,7 +937,7 @@ jobs:
     timeout-minutes: 45
     runs-on: "macOS-15-intel"
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
@@ -986,7 +987,7 @@ jobs:
     timeout-minutes: 120
     runs-on: "macOS-15"
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
@@ -1031,7 +1032,7 @@ jobs:
     timeout-minutes: 45
     runs-on: "macOS-15"
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
@@ -1081,7 +1082,7 @@ jobs:
     timeout-minutes: 45
     runs-on: "macOS-15"
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
@@ -1131,7 +1132,7 @@ jobs:
     timeout-minutes: 120
     runs-on: "windows-2025"
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -1184,7 +1185,7 @@ jobs:
     timeout-minutes: 150
     runs-on: "windows-2025"
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -1249,7 +1250,7 @@ jobs:
     timeout-minutes: 150
     runs-on: "windows-2025"
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
@@ -1314,7 +1315,7 @@ jobs:
     timeout-minutes: 150
     runs-on: "windows-2025"
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
@@ -1379,7 +1380,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -1417,7 +1418,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -1481,7 +1482,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
@@ -1531,7 +1532,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -1569,7 +1570,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -1633,7 +1634,7 @@ jobs:
     timeout-minutes: 150
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_native == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
       - name: Log skip reason
         if: env.SHOULD_RUN != 'true'
@@ -1685,7 +1686,7 @@ jobs:
     # for now, let's run those tests only on ubuntu
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.gifs == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_docs == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.gifs == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' || needs.changes.outputs.test_docs == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -1802,7 +1803,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.docs == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -1831,7 +1832,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.benchmark == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.benchmark == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -1870,7 +1871,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ubuntu-24.04
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'
@@ -1897,7 +1898,7 @@ jobs:
     timeout-minutes: 15
     runs-on: "windows-2025"
     env:
-      SHOULD_RUN: ${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true' }}
+      SHOULD_RUN: ${{ (needs.changes.outputs.code == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.mill_wrapper == 'true' || needs.changes.outputs.test_all == 'true') && needs.changes.outputs.test_skip != 'true' }}
     steps:
     - name: Log skip reason
       if: env.SHOULD_RUN != 'true'


### PR DESCRIPTION
For when a change can only be checked on `main`, anyway.
The override limits the CI jobs to be run to just `checks` and `format`, which we treat as the absolute minimum sanity check.

## How much have your relied on LLM-based tools in this contribution?
Extensively, Claude

## How was the solution tested?
on the CI

## Additional notes
[test_skip]