### PR TITLE
Only prepend snapshot repos for `*-SNAPSHOT` Bloop versions

### DIFF
--- a/modules/build/src/main/scala/scala/build/Bloop.scala
+++ b/modules/build/src/main/scala/scala/build/Bloop.scala
@@ -78,11 +78,13 @@ object Bloop {
       val res = value {
         Artifacts.artifacts(
           Seq(Positioned.none(dep)),
-          Seq(
-            coursier.Repositories.centralMavenSnapshots,
-            RepositoryUtils.snapshotsRepository,
-            RepositoryUtils.scala3NightlyRepository
-          ),
+          if dep.version.endsWith("SNAPSHOT") then
+            Seq(
+              coursier.Repositories.centralMavenSnapshots,
+              RepositoryUtils.snapshotsRepository,
+              RepositoryUtils.scala3NightlyRepository
+            )
+          else Nil,
           Some(params),
           logger,
           cache.withMessage(s"Downloading compilation server ${dep.version}")

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -2579,4 +2579,74 @@ abstract class RunTestDefinitions
       expect(output == message)
     }
   }
+
+  if actualScalaVersion.startsWith("3") then
+    cleanBloopFixture
+      .test("compilation server download respects COURSIER_REPOSITORIES for Bloop download") {
+        cleanBloopResult =>
+          expect(cleanBloopResult.exitCode == 0)
+          val inputs = TestInputs(os.rel / "simple.sc" -> """println("hello")""")
+          inputs.fromRoot { root =>
+            // Pre-download bloop (and Scala compiler) via coursier into a cache, then mirror
+            // that cache into a proper local maven repo. Coursier cache paths URL-encode '+'
+            // as '%2B', which is not valid maven layout, so we decode while copying.
+            val prefilledCache = root / "prefilled-cache"
+            os.makeDir(prefilledCache)
+            val artifactsToPrefetch = Seq(
+              s"ch.epfl.scala:bloop-frontend_2.12:${Constants.bloopVersion}",
+              s"org.scala-lang:scala3-compiler_3:$actualScalaVersion",
+              s"org.scala-lang:scala3-sbt-bridge:$actualScalaVersion"
+            )
+            for artifact <- artifactsToPrefetch do
+              os.proc(TestUtil.cs, "fetch", "--cache", prefilledCache.toString, artifact)
+                .call(cwd = root)
+
+            val cacheMaven2 = prefilledCache / "https" / "repo1.maven.org" / "maven2"
+            val customRepo  = root / "custom-repo"
+            for path <- os.walk(cacheMaven2) if os.isFile(path) do
+              val name = path.last
+              if !name.startsWith(".") then
+                val rel        = path.relativeTo(cacheMaven2)
+                val decodedRel = os.RelPath(
+                  rel.segments.map(s => java.net.URLDecoder.decode(s, "UTF-8")),
+                  ups = 0
+                )
+                os.copy(path, customRepo / decodedRel, createFolders = true)
+
+            val customRepoUri = customRepo.toNIO.toUri.toASCIIString
+
+            // Fresh empty cache to force resolution via COURSIER_REPOSITORIES
+            val freshCache = root / "fresh-cache"
+            os.makeDir(freshCache)
+
+            // Exit any existing bloop to force a fresh compilation server resolution
+            os.proc(TestUtil.cli, "--power", "bloop", "exit")
+              .call(cwd = root, check = false)
+
+            val env = Map(
+              "COURSIER_CACHE"        -> freshCache.toString,
+              "COURSIER_REPOSITORIES" -> customRepoUri
+            )
+
+            // Run with verbose logging to capture resolution attempts
+            val res = os.proc(TestUtil.cli, "run", "simple.sc", extraOptions, "-v", "-v")
+              .call(cwd = root, env = env, mergeErrIntoOut = true)
+
+            val output = res.out.text()
+
+            val mavenCentral    = "central.sonatype.com"
+            val scalaLang       = "repo.scala-lang.org"
+            val bloopResolution = output.linesIterator
+              .filter(line =>
+                line.contains("bloop-frontend") || line.contains("compilation server")
+              )
+              .mkString("\n")
+
+            expect(!bloopResolution.contains(mavenCentral))
+            expect(!bloopResolution.contains(scalaLang))
+
+            expect(res.exitCode == 0)
+            expect(output.contains("hello"))
+          }
+      }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ScalaCliSuite.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ScalaCliSuite.scala
@@ -74,6 +74,11 @@ abstract class ScalaCliSuite extends munit.FunSuite {
     if sanityOnly then all.filter(_.tags.contains(ScalaCliSuite.sanity)) else all
 
   override def munitFlakyOK: Boolean = TestUtil.isCI
+
+  def exitBloop: os.CommandResult = os.proc(TestUtil.cli, "--power", "bloop", "exit").call()
+
+  val cleanBloopFixture =
+    FunFixture[os.CommandResult](setup = _ => exitBloop, teardown = _ => exitBloop)
 }
 
 object ScalaCliSuite {


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/4392

The TL;DR of it is that we've been prepending snapshot repositories for Bloop downloads regardless if a snapshot Bloop was used or not.
We should only prepend them for actual Bloop snapshot builds.

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)

## How much have your relied on LLM-based tools in this contribution?
extensively

## How was the solution tested?
included an automated test