### PR TITLE
Exclude `*.asc` signature files from checksums

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -3,8 +3,8 @@ package scala.cli.commands.publish
 import caseapp.core.RemainingArgs
 import caseapp.core.help.HelpFormat
 import coursier.core.{Authentication, Configuration}
+import coursier.publish.checksum.ChecksumType
 import coursier.publish.checksum.logger.InteractiveChecksumLogger
-import coursier.publish.checksum.{ChecksumType, Checksums}
 import coursier.publish.fileset.{FileSet, Path}
 import coursier.publish.signing.logger.InteractiveSignerLogger
 import coursier.publish.signing.{NopSigner, Signer}
@@ -911,13 +911,13 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
             .left.map(errors => new MalformedChecksumsError(inputs, errors))
         }
     }
-    val checksums = Checksums(
-      types = checksumTypes,
+    val checksums = PublishUtils.computeChecksums(
       fileSet = fileSet1,
+      types = checksumTypes,
       now = now,
       pool = ec,
       logger = checksumLogger
-    ).unsafeRun()(using ec)
+    )
     val fileSet2 = fileSet1 ++ checksums
 
     val finalFileSet =

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishUtils.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishUtils.scala
@@ -1,9 +1,13 @@
 package scala.cli.commands.publish
 
 import coursier.cache.{ArchiveCache, FileCache}
+import coursier.publish.checksum.logger.ChecksumLogger
+import coursier.publish.checksum.{ChecksumType, Checksums}
+import coursier.publish.fileset.FileSet
 import coursier.publish.signing.{GpgSigner, Signer}
 
 import java.net.URI
+import java.time.Instant
 import java.util.function.Supplier
 
 import scala.build.Ops.*
@@ -16,8 +20,35 @@ import scala.cli.config.{ConfigDb, Keys, PasswordOption, PublishCredentials}
 import scala.cli.errors.MissingPublishOptionError
 import scala.cli.publish.BouncycastleSignerMaker
 import scala.cli.util.ConfigPasswordOptionHelpers.*
+import scala.concurrent.ExecutionContextExecutorService
 
 object PublishUtils {
+
+  /** Compute checksum files for the given [[FileSet]].
+    *
+    * Signature files (`.asc`) are excluded — only raw artifacts should carry checksums.
+    */
+  def computeChecksums(
+    fileSet: FileSet,
+    types: Seq[ChecksumType],
+    now: Instant,
+    pool: ExecutionContextExecutorService,
+    logger: => ChecksumLogger
+  ): FileSet = {
+    val withoutSignatures = FileSet(
+      fileSet.elements.filterNot((path, _) =>
+        path.elements.lastOption.exists(_.endsWith(".asc"))
+      )
+    )
+    Checksums(
+      types = types,
+      fileSet = withoutSignatures,
+      now = now,
+      pool = pool,
+      logger = logger
+    ).unsafeRun()(using pool)
+  }
+
   def getBouncyCastleSigner(
     secretKey: PasswordOption,
     secretKeyPasswordOpt: Option[PasswordOption],

--- a/modules/cli/src/test/scala/scala/cli/commands/publish/PublishChecksumTests.scala
+++ b/modules/cli/src/test/scala/scala/cli/commands/publish/PublishChecksumTests.scala
@@ -1,0 +1,59 @@
+package scala.cli.commands.publish
+
+import coursier.publish.Content
+import coursier.publish.checksum.ChecksumType
+import coursier.publish.checksum.logger.ChecksumLogger
+import coursier.publish.fileset.{FileSet, Path}
+
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.util.concurrent.Executors
+
+import scala.concurrent.ExecutionContext
+
+class PublishChecksumTests extends munit.FunSuite {
+
+  test("checksums are not generated for .asc signature files") {
+    val now     = Instant.parse("2024-01-02T03:04:05Z")
+    val jarPath = Path(Seq("org", "example", "demo", "1.0", "demo-1.0.jar"))
+    val pomPath = Path(Seq("org", "example", "demo", "1.0", "demo-1.0.pom"))
+    val fileSet = FileSet(
+      Seq(
+        (jarPath, Content.InMemory(now, "jar-bytes".getBytes(StandardCharsets.UTF_8))),
+        (
+          jarPath.mapLast(_ + ".asc"),
+          Content.InMemory(now, "jar-sig".getBytes(StandardCharsets.UTF_8))
+        ),
+        (pomPath, Content.InMemory(now, "pom-bytes".getBytes(StandardCharsets.UTF_8))),
+        (
+          pomPath.mapLast(_ + ".asc"),
+          Content.InMemory(now, "pom-sig".getBytes(StandardCharsets.UTF_8))
+        )
+      )
+    )
+
+    val pool = Executors.newFixedThreadPool(1)
+    try {
+      val checksums = PublishUtils.computeChecksums(
+        fileSet = fileSet,
+        types = Seq(ChecksumType.MD5, ChecksumType.SHA1),
+        now = now,
+        pool = ExecutionContext.fromExecutorService(pool),
+        logger = new ChecksumLogger {}
+      )
+
+      val names = checksums.elements.map(_._1.elements.last).toSet
+
+      assert(names.contains("demo-1.0.jar.md5"))
+      assert(names.contains("demo-1.0.jar.sha1"))
+      assert(names.contains("demo-1.0.pom.md5"))
+      assert(names.contains("demo-1.0.pom.sha1"))
+      assert(
+        names.forall(!_.contains(".asc.")),
+        s"checksums must not be generated for .asc files, got: $names"
+      )
+    }
+    finally
+      pool.shutdown()
+  }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishTestDefinitions.scala
@@ -75,12 +75,7 @@ abstract class PublishTestDefinitions extends ScalaCliSuite with TestScalaVersio
   )
 
   val expectedArtifacts: Set[os.RelPath] = baseExpectedArtifacts
-    .flatMap { n =>
-      Seq(n, n + ".asc")
-    }
-    .flatMap { n =>
-      Seq("", ".md5", ".sha1").map(n + _)
-    }
+    .flatMap(n => Seq("", ".md5", ".sha1").map(n + _) :+ (n + ".asc"))
     .map(os.rel / _)
 
   def expectedSourceEntries(withTestScope: Boolean = false): Set[String] = Set(


### PR DESCRIPTION
Publishing was calculating checksums including `*.asc` signature files, while only raw artifacts should be taken into account.

Thanks to @SethTisue for raising this at https://github.com/sbt/sbt/issues/8134#issuecomment-5075580174, we indeed have had the same problem as SBT.

## Checklist
- tested the solution locally and it works 
- ran the code formatter (`scala-cli fmt .`)
- ran `scalafix` (`./mill -i __.fix`)

## How much have your relied on LLM-based tools in this contribution?
extensively

## How was the solution tested?
included new automated tests