### PR TITLE
Maintenance/agents tests

### DIFF
--- a/agentskills/integration-tests/SKILL.md
+++ b/agentskills/integration-tests/SKILL.md
@@ -9,6 +9,14 @@ description: Add or run Scala CLI integration tests. Use when adding integration
 
 **Run**: `./mill -i integration.test.jvm` (all). Filter: `./mill -i integration.test.jvm 'scala.cli.integration.RunTestsDefault.*'` or by test name. Native: `./mill -i integration.test.native`.
 
+**Always set `CI=true` when running integration tests**, unless the user explicitly asks otherwise:
+
+```bash
+CI=true ./mill -i integration.test.jvm 'scala.cli.integration.RunTestsDefault.*'
+```
+
+This disables test parallelism, so the run mirrors how the tests behave on CI. It is slower, but the extra time is an acceptable trade-off for reproducible results.
+
 **Structure**: `*TestDefinitions.scala` (abstract, holds test logic) → `*TestsDefault`, `*Tests213`, etc. (concrete, Scala version trait). Traits: `TestDefault`, `Test212`, `Test213`, `Test3Lts`, `Test3NextRc`.
 
 **Adding a test**:

--- a/build.mill
+++ b/build.mill
@@ -128,7 +128,6 @@ object `scala-cli-bsp` extends JavaModule
 }
 object integration extends CliIntegration {
   object test extends IntegrationScalaTests {
-    override def testParallelism: T[Boolean]           = !isCI
     override def testForkGrouping: T[Seq[Seq[String]]] =
       if isCI && System.getenv("SCALA_CLI_IT_SANITY") == null then
         discoveredTestClasses().grouped(1).toSeq
@@ -433,8 +432,7 @@ trait Core extends ScalaCliCrossSbtModule
   private def vcsState: T[String] = Task(persistent = true) {
     val isCI  = System.getenv("CI") != null
     val state = VcsVersion.vcsState().format()
-    if (isCI) state
-    else state + "-maybe-stale"
+    if isCI then state else state + "-maybe-stale"
   }
 
   def constantsFile: T[PathRef] = Task(persistent = true) {


### PR DESCRIPTION
Integration tests get flaky when run in parallel, which in turn gives false positives when agents are running.


## How much have your relied on LLM-based tools in this contribution?
moderately

## How was the solution tested?
ran some agent tasks with this