### PR TITLE
Support JEP 512 flexible main methods on JDK 25+ / JDK21+ with `--enable-preview`

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -544,6 +544,8 @@ trait Core extends ScalaCliCrossSbtModule
           .map(s => s"\"$s\"")
           .mkString(", ")})
          |  def scala38MinJavaVersion = ${Java.minimumScala38Java}
+         |  def jep512MinJavaVersion = ${Java.minimumJep512Java}
+         |  def jep512PreviewMinJavaVersion = ${Java.minimumJep512PreviewJava}
          |
          |  def workspaceDirName = "$workspaceDirName"
          |  def projectFileName = "$projectFileName"
@@ -1089,6 +1091,7 @@ trait CliIntegration extends SbtModule
             .map(s => s"\"$s\"")
             .mkString(", ")})
            |  def scala38MinJavaVersion        = ${Java.minimumScala38Java}
+           |  def jep512MinJavaVersion         = ${Java.minimumJep512Java}
            |  def defaultScalafmtVersion       = "${Deps.scalafmtCli.dep.versionConstraint.asString}"
            |  def legacyScala3Versions         = Seq(${Scala.legacyScala3Versions.map(p =>
             s"\"$p\""
@@ -1313,6 +1316,7 @@ trait CliIntegrationDocker extends SbtModule with ScalaCliPublishModule with Has
 trait Runner extends CrossSbtModule
     with ScalaCliPublishModule
     with ScalaCliScalafixModule
+    with HasTests
     with LocatedInModules {
   override def scalacOptions: T[Seq[String]] = Task {
     super.scalacOptions() ++ Seq("-deprecation")
@@ -1324,6 +1328,7 @@ trait Runner extends CrossSbtModule
     val extraDirs = Seq(PathRef(moduleDir / "src" / "main" / scala3DirName))
     super.sources() ++ extraDirs
   }
+  object test extends ScalaCliTests with ScalaCliScalafixModule
 }
 
 trait TestRunner extends CrossSbtModule

--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -65,14 +65,76 @@ object Build {
       sources.resourceDirs ++ artifacts.compileClassPath
     def fullClassPath: Seq[os.Path]        = Seq(output) ++ dependencyClassPath
     def fullCompileClassPath: Seq[os.Path] = fullClassPath ++ dependencyCompileClassPath
-    private lazy val mainClassesFoundInProject: Seq[String] = MainClass.find(output, logger).sorted
-    private lazy val mainClassesFoundOnExtraClasspath: Seq[String] =
-      options.classPathOptions.extraClassPath.flatMap(MainClass.find(_, logger)).sorted
+    private lazy val mainClassCandidatesInProject: Seq[MainClass.MainClassCandidate] =
+      MainClass.find(output, logger).filterNot(isScriptWrapperUserCodeClass)
+    private lazy val mainClassCandidatesOnExtraClasspath: Seq[MainClass.MainClassCandidate] =
+      options.classPathOptions.extraClassPath.flatMap(MainClass.find(_, logger))
     private lazy val mainClassesFoundInUserExtraDependencies: Seq[String] =
       artifacts.jarsForUserExtraDependencies.flatMap(MainClass.findInDependency).sorted
+
+    private def isScriptWrapperUserCodeClass(candidate: MainClass.MainClassCandidate): Boolean =
+      // ClassCodeWrapper puts user code in a class named `{script}$_`; its instance main must not
+      // surface as a selectable entry point alongside the real `{script}_sc` wrapper main.
+      candidate.className.endsWith("$_")
+
+    private lazy val hasEnablePreview: Boolean =
+      options.javaOptions.javaOpts.toSeq.exists(_.value.value == "--enable-preview")
+
+    private lazy val isJvmPlatform: Boolean = options.platform.value == Platform.JVM
+
+    private lazy val jvmVersion: Int = options.javaHome().value.version
+
+    /** JEP 512 main method shapes are only launchable by a new enough JVM; a classic
+      * `static void main(String[])` is launchable on every platform.
+      */
+    private def isMainMethodSupportedByTargetRuntime(kind: MainClass.MainMethodKind): Boolean =
+      !kind.requiresJep512 ||
+      (isJvmPlatform && kind.isSupportedByJvm(jvmVersion, hasEnablePreview))
+
+    private lazy val allMainClassCandidates: Seq[MainClass.MainClassCandidate] =
+      mainClassCandidatesInProject ++ mainClassCandidatesOnExtraClasspath
+
+    private def supportedMainClassNames(candidates: Seq[MainClass.MainClassCandidate])
+      : Seq[String] =
+      candidates.collect {
+        case c if isMainMethodSupportedByTargetRuntime(c.kind) => c.className
+      }.sorted
+
+    private lazy val mainClassesFoundInProject: Seq[String] =
+      supportedMainClassNames(mainClassCandidatesInProject)
+    private lazy val mainClassesFoundOnExtraClasspath: Seq[String] =
+      supportedMainClassNames(mainClassCandidatesOnExtraClasspath)
+
     def foundMainClasses(): Seq[String] = {
       val found = mainClassesFoundInProject ++ mainClassesFoundOnExtraClasspath
       if inputs.isEmpty && found.isEmpty then mainClassesFoundInUserExtraDependencies else found
+    }
+
+    def mainClassKind(className: String): Option[MainClass.MainMethodKind] =
+      allMainClassCandidates.find(_.className == className).map(_.kind).orElse {
+        if mainClassesFoundInUserExtraDependencies.contains(className) then
+          Some(MainClass.MainMethodKind.StaticWithArgs)
+        else None
+      }
+
+    /** Explains why detected main methods cannot be launched by the target runtime (wrong platform
+      * for JEP 512 shapes, or JVM older than JEP 512).
+      */
+    def unsupportedMainMethodsNote: Option[String] = {
+      val rejected =
+        allMainClassCandidates.filterNot(c => isMainMethodSupportedByTargetRuntime(c.kind))
+      if rejected.isEmpty || foundMainClasses().nonEmpty then None
+      else
+        val names     = rejected.map(_.className).distinct.sorted
+        val classList =
+          if names.size == 1 then s"Class ${names.head}"
+          else s"Classes ${names.mkString(", ")}"
+        val reason =
+          if options.platform.value != Platform.JVM then
+            s"$classList declare(s) a main method that is only launchable on the JVM (JEP 512)."
+          else
+            s"$classList declare(s) a main method that requires JDK ${Constants.jep512MinJavaVersion} or newer (JEP 512); the current JVM is $jvmVersion."
+        Some(reason)
     }
     def retainedMainClass(
       mainClasses: Seq[String],
@@ -83,7 +145,7 @@ object Build {
         .filter(name => mainClasses.contains(name))
       def foundMainClass: Either[BuildException, String] =
         mainClasses match {
-          case Seq()          => Left(new NoMainClassFoundError)
+          case Seq()          => Left(new NoMainClassFoundError(unsupportedMainMethodsNote))
           case Seq(mainClass) => Right(mainClass)
           case _              =>
             inferredMainClass(mainClasses, logger)

--- a/modules/build/src/main/scala/scala/build/input/Element.scala
+++ b/modules/build/src/main/scala/scala/build/input/Element.scala
@@ -51,8 +51,20 @@ sealed abstract class VirtualSourceFile extends Virtual {
   def isSnippet: Boolean = source.startsWith("<snippet>")
 
   protected def generatedSourceFileName(fileSuffix: String): String =
-    if (isStdin) s"stdin$fileSuffix"
-    else if (isSnippet) s"${source.stripPrefix("<snippet>-")}$fileSuffix"
+    if isStdin then s"stdin$fileSuffix"
+    else if isSnippet then {
+      val rawBase = source.stripPrefix("<snippet>-")
+      // Compact Java source files (JEP 512) name the implicit class after the file base name,
+      // which must be a valid Java identifier — replace '-' and other illegal chars.
+      val safeBase = rawBase.map {
+        case c if Character.isJavaIdentifierPart(c) => c
+        case _                                      => '_'
+      }
+      val startingSafe =
+        if safeBase.isEmpty || !Character.isJavaIdentifierStart(safeBase.head) then s"_$safeBase"
+        else safeBase
+      s"$startingSafe$fileSuffix"
+    }
     else s"virtual$fileSuffix"
 }
 

--- a/modules/build/src/main/scala/scala/build/internal/MainClass.scala
+++ b/modules/build/src/main/scala/scala/build/internal/MainClass.scala
@@ -17,8 +17,11 @@ object MainClass {
     * Case declaration order is the JEP 512 resolution order: `main(String[])` before `main()`, and
     * within each signature the static form before the instance form.
     *
-    * Inherited mains are still not detected — the ASM scan is per-class and has no classpath-wide
-    * hierarchy resolution. The JVM launcher does support that.
+    * Detection is per-class: the scan only sees methods declared in the class file it reads. A
+    * `main` inherited from a superclass or a Java interface is not detected, even though the JVM
+    * launcher resolves it through the hierarchy (the same already holds for a classic inherited
+    * `static main(String[])`). Scala traits are an exception: the compiler emits a mixin forwarder
+    * into the implementing class, so that class declares `main` itself and is detected.
     */
   enum MainMethodKind(val requiresJep512: Boolean):
     case StaticWithArgs   extends MainMethodKind(false)

--- a/modules/build/src/main/scala/scala/build/internal/MainClass.scala
+++ b/modules/build/src/main/scala/scala/build/internal/MainClass.scala
@@ -12,12 +12,39 @@ import scala.build.{Logger, retry}
 
 object MainClass {
 
-  private def stringArrayDescriptor = "([Ljava/lang/String;)V"
+  /** Shape of a `main` entry point recognised in bytecode.
+    *
+    * Case declaration order is the JEP 512 resolution order: `main(String[])` before `main()`, and
+    * within each signature the static form before the instance form.
+    *
+    * Inherited mains are still not detected — the ASM scan is per-class and has no classpath-wide
+    * hierarchy resolution. The JVM launcher does support that.
+    */
+  enum MainMethodKind(val requiresJep512: Boolean):
+    case StaticWithArgs   extends MainMethodKind(false)
+    case InstanceWithArgs extends MainMethodKind(true)
+    case StaticNoArgs     extends MainMethodKind(true)
+    case InstanceNoArgs   extends MainMethodKind(true)
+
+    /** Whether a JVM of version `jvmVersion` can launch this main method shape. The JEP 512 shapes
+      * need JDK 25 or newer, or JDK 21 or newer with `--enable-preview`.
+      */
+    def isSupportedByJvm(jvmVersion: Int, previewEnabled: Boolean): Boolean =
+      !requiresJep512 ||
+      jvmVersion >= Constants.jep512MinJavaVersion ||
+      (previewEnabled && jvmVersion >= Constants.jep512PreviewMinJavaVersion)
+
+  final case class MainClassCandidate(className: String, kind: MainMethodKind)
+
+  private val stringArrayDescriptor = "([Ljava/lang/String;)V"
+  private val noArgDescriptor       = "()V"
 
   private class MainMethodChecker extends asm.ClassVisitor(asm.Opcodes.ASM9) {
-    private var foundMainClass = false
-    private var nameOpt        = Option.empty[String]
-    def found: Boolean         = foundMainClass
+    private var nameOpt: Option[String]         = None
+    private var classAccess: Int                = 0
+    private var hasNonPrivateNoArgCtor: Boolean = false
+    private var mainKinds: Set[MainMethodKind]  = Set.empty
+
     override def visit(
       version: Int,
       access: Int,
@@ -26,8 +53,10 @@ object MainClass {
       superName: String,
       interfaces: Array[String]
     ): Unit = {
+      classAccess = access
       nameOpt = Some(name.replace('/', '.').replace('\\', '.'))
     }
+
     override def visitMethod(
       access: Int,
       name: String,
@@ -35,16 +64,38 @@ object MainClass {
       signature: String,
       exceptions: Array[String]
     ): asm.MethodVisitor = {
-      def isStatic = (access & asm.Opcodes.ACC_STATIC) != 0
-      if (name == "main" && descriptor == stringArrayDescriptor && isStatic)
-        foundMainClass = true
+      val isStatic  = (access & asm.Opcodes.ACC_STATIC) != 0
+      val isPrivate = (access & asm.Opcodes.ACC_PRIVATE) != 0
+      if name == "<init>" && descriptor == noArgDescriptor && !isPrivate then
+        hasNonPrivateNoArgCtor = true
+      else if name == "main" && !isPrivate then
+        (isStatic, descriptor) match {
+          case (true, `stringArrayDescriptor`)  => mainKinds += MainMethodKind.StaticWithArgs
+          case (false, `stringArrayDescriptor`) => mainKinds += MainMethodKind.InstanceWithArgs
+          case (true, `noArgDescriptor`)        => mainKinds += MainMethodKind.StaticNoArgs
+          case (false, `noArgDescriptor`)       => mainKinds += MainMethodKind.InstanceNoArgs
+          case _                                => ()
+        }
       null
     }
-    def mainClassOpt: Option[String] =
-      if (foundMainClass) nameOpt else None
+
+    def candidateOpt: Option[MainClassCandidate] = {
+      val isAbstractOrInterface = (classAccess & asm.Opcodes.ACC_ABSTRACT) != 0 ||
+        (classAccess & asm.Opcodes.ACC_INTERFACE) != 0
+      if isAbstractOrInterface then None
+      else
+        // Instance shapes are only invocable when a non-private zero-arg constructor exists.
+        val invocableKinds = mainKinds.filter {
+          case MainMethodKind.StaticWithArgs | MainMethodKind.StaticNoArgs     => true
+          case MainMethodKind.InstanceWithArgs | MainMethodKind.InstanceNoArgs =>
+            hasNonPrivateNoArgCtor
+        }
+        MainMethodKind.values.find(invocableKinds.contains)
+          .flatMap(kind => nameOpt.map(MainClassCandidate(_, kind)))
+    }
   }
 
-  private def findInClass(path: os.Path, logger: Logger): Iterator[String] =
+  private def findInClass(path: os.Path, logger: Logger): Iterator[MainClassCandidate] =
     try {
       val is = retry()(logger)(os.read.inputStream(path))
       findInClass(is, logger)
@@ -56,12 +107,13 @@ object MainClass {
         logger.log("Are you trying to run too many builds at once? Trying to recover...")
         Iterator.empty
     }
-  private def findInClass(is: InputStream, logger: Logger): Iterator[String] =
+
+  private def findInClass(is: InputStream, logger: Logger): Iterator[MainClassCandidate] =
     try retry()(logger) {
         val reader  = new ClassReader(is)
         val checker = new MainMethodChecker
         reader.accept(checker, 0)
-        checker.mainClassOpt.iterator
+        checker.candidateOpt.iterator
       }
     catch {
       case e: ArrayIndexOutOfBoundsException =>
@@ -69,10 +121,14 @@ object MainClass {
         logger.log(s"Class input stream could not be created: $e")
         logger.log("Are you trying to run too many builds at once? Trying to recover...")
         Iterator.empty
+      case e: IllegalArgumentException =>
+        e.getStackTrace.foreach(ste => logger.debug(ste.toString))
+        logger.log(s"Class file could not be read (unsupported class file version?): $e")
+        Iterator.empty
     }
     finally is.close()
 
-  private def findInJar(path: os.Path, logger: Logger): Iterator[String] =
+  private def findInJar(path: os.Path, logger: Logger): Iterator[MainClassCandidate] =
     try retry()(logger) {
         val content        = os.read.bytes(path)
         val jarInputStream = WrappedZipInputStream.create(new ByteArrayInputStream(content))
@@ -104,7 +160,7 @@ object MainClass {
       case _ => None
     }
 
-  def find(output: os.Path, logger: Logger): Seq[String] =
+  def find(output: os.Path, logger: Logger): Seq[MainClassCandidate] =
     output match {
       case o if os.isFile(o) && o.last.endsWith(".class") =>
         findInClass(o, logger).toVector

--- a/modules/build/src/test/scala/scala/build/tests/InputsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/InputsTests.scala
@@ -202,4 +202,17 @@ class InputsTests extends TestUtil.ScalaCliBuildSuite {
       }
     }
   }
+
+  test("java snippet fallback file name is a valid Java identifier") {
+    val v = VirtualJavaFile(Array.emptyByteArray, "<snippet>-java-snippet")
+    expect(v.generatedSourceFileName == "java_snippet.java")
+    val base = v.generatedSourceFileName.stripSuffix(".java")
+    expect(Character.isJavaIdentifierStart(base.head))
+    expect(base.forall(Character.isJavaIdentifierPart))
+  }
+
+  test("stdin java fallback file name is a valid Java identifier") {
+    val v = VirtualJavaFile(Array.emptyByteArray, "<stdin>-java-file")
+    expect(v.generatedSourceFileName == "stdin.java")
+  }
 }

--- a/modules/build/src/test/scala/scala/build/tests/MainClassTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/MainClassTests.scala
@@ -1,0 +1,323 @@
+package scala.build.tests
+
+import com.eed3si9n.expecty.Expecty.expect
+
+import java.util.jar.{JarOutputStream, Manifest as JarManifest}
+import java.util.zip.ZipEntry
+
+import scala.build.Ops.*
+import scala.build.internal.MainClass
+import scala.build.internal.MainClass.MainMethodKind
+import scala.build.options.*
+import scala.build.tests.TestUtil.*
+import scala.build.{BuildThreads, Directories, LocalRepo}
+import scala.util.Using
+
+class MainClassTests extends TestUtil.ScalaCliBuildSuite {
+
+  private val jep512MinJava        = scala.build.internal.Constants.jep512MinJavaVersion
+  private val jep512PreviewMinJava = scala.build.internal.Constants.jep512PreviewMinJavaVersion
+  private val defaultJvm           = scala.build.internal.Constants.defaultJavaVersion
+
+  val buildThreads: BuildThreads = BuildThreads.create()
+  val extraRepoTmpDir: os.Path   = os.temp.dir(prefix = "scala-cli-main-class-tests-extra-repo-")
+  val directories: Directories   = Directories.under(extraRepoTmpDir)
+
+  override def afterAll(): Unit = {
+    TestInputs.tryRemoveAll(extraRepoTmpDir)
+    buildThreads.shutdown()
+  }
+
+  val baseOptions: BuildOptions = BuildOptions(
+    internal = InternalOptions(
+      localRepository = LocalRepo.localRepo(directories.localRepoDir, TestLogger()),
+      keepDiagnostics = true
+    )
+  )
+
+  val defaultOptions: BuildOptions = baseOptions.copy(
+    scalaOptions = baseOptions.scalaOptions.copy(
+      scalaVersion = Some(MaybeScalaVersion(Constants.defaultScalaVersion)),
+      scalaBinaryVersion = None
+    )
+  )
+
+  private def findKinds(dir: os.Path): Seq[(String, MainMethodKind)] =
+    MainClass.find(dir, TestLogger()).map(c => c.className -> c.kind)
+
+  test("MainMethodKind.isSupportedByJvm covers the JEP 512 version matrix") {
+    val jep512Kinds = Seq(
+      MainMethodKind.InstanceWithArgs,
+      MainMethodKind.StaticNoArgs,
+      MainMethodKind.InstanceNoArgs
+    )
+    expect(MainMethodKind.StaticWithArgs.isSupportedByJvm(defaultJvm, previewEnabled = false))
+    for kind <- jep512Kinds do {
+      expect(kind.isSupportedByJvm(jep512MinJava, previewEnabled = false))
+      expect(!kind.isSupportedByJvm(defaultJvm, previewEnabled = false))
+      expect(!kind.isSupportedByJvm(jep512PreviewMinJava, previewEnabled = false))
+      expect(kind.isSupportedByJvm(jep512PreviewMinJava, previewEnabled = true))
+    }
+  }
+
+  test("detect all launchable JEP 512 main method shapes in Java sources") {
+    TestInputs(
+      os.rel / "Classic.java" ->
+        s"""//> using jvm $jep512MinJava
+           |public class Classic {
+           |  public static void main(String[] args) {}
+           |}
+           |""".stripMargin,
+      os.rel / "ProtectedStatic.java" ->
+        """public class ProtectedStatic {
+          |  protected static void main(String[] args) {}
+          |}
+          |""".stripMargin,
+      os.rel / "StaticNoArgs.java" ->
+        """public class StaticNoArgs {
+          |  public static void main() {}
+          |}
+          |""".stripMargin,
+      os.rel / "InstanceWithArgs.java" ->
+        """public class InstanceWithArgs {
+          |  public void main(String[] args) {}
+          |}
+          |""".stripMargin,
+      os.rel / "InstanceNoArgs.java" ->
+        """public class InstanceNoArgs {
+          |  public void main() {}
+          |}
+          |""".stripMargin,
+      os.rel / "PackagePrivate.java" ->
+        """public class PackagePrivate {
+          |  void main() {}
+          |}
+          |""".stripMargin,
+      os.rel / "Both.java" ->
+        """public class Both {
+          |  public static void main() {}
+          |  public void main(String[] args) {}
+          |}
+          |""".stripMargin
+      // baseOptions (no Scala version) so this stays a pure Java project and uses javac from JDK 25
+    ).withBuild(baseOptions, buildThreads, None, buildTests = false) { (_, _, maybeBuild) =>
+      val build = maybeBuild.orThrow.successfulOpt.get
+      expect(
+        findKinds(build.output).toMap == Map(
+          "Classic"          -> MainMethodKind.StaticWithArgs,
+          "ProtectedStatic"  -> MainMethodKind.StaticWithArgs,
+          "StaticNoArgs"     -> MainMethodKind.StaticNoArgs,
+          "InstanceWithArgs" -> MainMethodKind.InstanceWithArgs,
+          "InstanceNoArgs"   -> MainMethodKind.InstanceNoArgs,
+          "PackagePrivate"   -> MainMethodKind.InstanceNoArgs,
+          "Both"             -> MainMethodKind.InstanceWithArgs
+        )
+      )
+    }
+  }
+
+  test("ignore main methods that cannot be launched, in Java sources") {
+    TestInputs(
+      os.rel / "PrivateStatic.java" ->
+        s"""//> using jvm $jep512MinJava
+           |public class PrivateStatic {
+           |  private static void main(String[] args) {}
+           |}
+           |""".stripMargin,
+      os.rel / "PrivateInstance.java" ->
+        """public class PrivateInstance {
+          |  private void main() {}
+          |}
+          |""".stripMargin,
+      os.rel / "NonVoid.java" ->
+        """public class NonVoid {
+          |  public static int main() { return 0; }
+          |}
+          |""".stripMargin,
+      os.rel / "PrivateCtor.java" ->
+        """public class PrivateCtor {
+          |  private PrivateCtor() {}
+          |  public void main() {}
+          |}
+          |""".stripMargin,
+      os.rel / "AbstractMain.java" ->
+        """public abstract class AbstractMain {
+          |  public void main() {}
+          |}
+          |""".stripMargin,
+      os.rel / "IfaceMain.java" ->
+        """public interface IfaceMain {
+          |  default void main() {}
+          |}
+          |""".stripMargin
+    ).withBuild(baseOptions, buildThreads, None, buildTests = false) { (_, _, maybeBuild) =>
+      val build = maybeBuild.orThrow.successfulOpt.get
+      expect(os.walk(build.output).exists(_.ext == "class"))
+      expect(findKinds(build.output).isEmpty)
+    }
+  }
+
+  test("detect instance mains inside a jar of compiled classes") {
+    TestInputs(
+      os.rel / "Hello.java" ->
+        s"""//> using jvm $jep512MinJava
+           |public class Hello {
+           |  public void main() {}
+           |}
+           |""".stripMargin
+    ).withBuild(baseOptions, buildThreads, None, buildTests = false) { (root, _, maybeBuild) =>
+      val build      = maybeBuild.orThrow.successfulOpt.get
+      val fromDir    = findKinds(build.output)
+      val jarPath    = root / "run.jar"
+      val classFiles = os.walk(build.output).filter(_.ext == "class")
+      Using.resource(new JarOutputStream(os.write.outputStream(jarPath), new JarManifest())) {
+        jos =>
+          for classFile <- classFiles do {
+            val entryName = classFile.relativeTo(build.output).toString
+            jos.putNextEntry(new ZipEntry(entryName))
+            jos.write(os.read.bytes(classFile))
+            jos.closeEntry()
+          }
+      }
+      expect(fromDir == Seq("Hello" -> MainMethodKind.InstanceNoArgs))
+      expect(MainClass.find(jarPath, TestLogger()).map(c => c.className -> c.kind) == fromDir)
+    }
+  }
+
+  test("detect an instance main method in a Scala class on JDK 25") {
+    TestInputs(
+      os.rel / "A.scala" ->
+        s"""//> using jvm $jep512MinJava
+           |class A { def main(): Unit = println(1) }
+           |""".stripMargin
+    ).withBuild(defaultOptions, buildThreads, None, buildTests = false) { (_, _, maybeBuild) =>
+      val build = maybeBuild.orThrow.successfulOpt.get
+      expect(build.foundMainClasses() == Seq("A"))
+    }
+  }
+
+  test("an object with a no-arg main is detected once, via its static forwarder") {
+    TestInputs(
+      os.rel / "O.scala" ->
+        s"""//> using jvm $jep512MinJava
+           |object O { def main(): Unit = println(1) }
+           |""".stripMargin
+    ).withBuild(defaultOptions, buildThreads, None, buildTests = false) { (_, _, maybeBuild) =>
+      val build = maybeBuild.orThrow.successfulOpt.get
+      expect(build.foundMainClasses() == Seq("O"))
+    }
+  }
+
+  test("do not treat an instance main as supported on JDK 17") {
+    TestInputs(
+      os.rel / "A.scala" ->
+        s"""//> using jvm $defaultJvm
+           |class A { def main(): Unit = println(1) }
+           |""".stripMargin
+    ).withBuild(defaultOptions, buildThreads, None, buildTests = false) { (_, _, maybeBuild) =>
+      val build = maybeBuild.orThrow.successfulOpt.get
+      expect(build.foundMainClasses().isEmpty)
+      expect(build.unsupportedMainMethodsNote.isDefined)
+      expect(build.unsupportedMainMethodsNote.get.contains("JEP 512"))
+      expect(build.unsupportedMainMethodsNote.get.contains("A"))
+    }
+  }
+
+  test("detect an instance main on JDK 21 with --enable-preview") {
+    TestInputs(
+      os.rel / "A.scala" ->
+        s"""//> using jvm $jep512PreviewMinJava
+           |//> using javaOpt --enable-preview
+           |class A { def main(): Unit = println(1) }
+           |""".stripMargin
+    ).withBuild(defaultOptions, buildThreads, None, buildTests = false) { (_, _, maybeBuild) =>
+      val build = maybeBuild.orThrow.successfulOpt.get
+      expect(build.foundMainClasses() == Seq("A"))
+    }
+  }
+
+  test("do not detect an instance main on Scala.js") {
+    TestInputs(
+      os.rel / "A.scala" -> "class A { def main(): Unit = println(1) }"
+    ).withBuild(defaultOptions.enableJs, buildThreads, None, buildTests = false) {
+      (_, _, maybeBuild) =>
+        val build = maybeBuild.orThrow.successfulOpt.get
+        expect(build.foundMainClasses().isEmpty)
+    }
+  }
+
+  test("do not detect an instance main on Scala Native") {
+    TestInputs(
+      os.rel / "A.scala" -> "class A { def main(): Unit = println(1) }"
+    ).withBuild(defaultOptions.enableNative, buildThreads, None, buildTests = false) {
+      (_, _, maybeBuild) =>
+        val build = maybeBuild.orThrow.successfulOpt.get
+        expect(build.foundMainClasses().isEmpty)
+    }
+  }
+
+  test("detect a classic main on Scala.js") {
+    TestInputs(
+      os.rel / "Main.scala" ->
+        """object Main {
+          |  def main(args: Array[String]): Unit = println(1)
+          |}
+          |""".stripMargin
+    ).withBuild(defaultOptions.enableJs, buildThreads, None, buildTests = false) {
+      (_, _, maybeBuild) =>
+        val build = maybeBuild.orThrow.successfulOpt.get
+        expect(build.foundMainClasses() == Seq("Main"))
+    }
+  }
+
+  test("detect a classic main on Scala Native") {
+    TestInputs(
+      os.rel / "Main.scala" ->
+        """object Main {
+          |  def main(args: Array[String]): Unit = println(1)
+          |}
+          |""".stripMargin
+    ).withBuild(defaultOptions.enableNative, buildThreads, None, buildTests = false) {
+      (_, _, maybeBuild) =>
+        val build = maybeBuild.orThrow.successfulOpt.get
+        expect(build.foundMainClasses() == Seq("Main"))
+    }
+  }
+
+  test("detect a script main on Scala.js") {
+    TestInputs(
+      os.rel / "simple.sc" -> "println(1)"
+    ).withBuild(defaultOptions.enableJs, buildThreads, None, buildTests = false) {
+      (_, _, maybeBuild) =>
+        val build = maybeBuild.orThrow.successfulOpt.get
+        expect(build.foundMainClasses().contains("simple_sc"))
+    }
+  }
+
+  test("ordinary static main(String[]) gains no extra candidates") {
+    TestInputs(
+      os.rel / "Main.scala" ->
+        """object Main {
+          |  def main(args: Array[String]): Unit = println(1)
+          |}
+          |""".stripMargin
+    ).withBuild(defaultOptions, buildThreads, None, buildTests = false) { (_, _, maybeBuild) =>
+      val build = maybeBuild.orThrow.successfulOpt.get
+      expect(build.foundMainClasses() == Seq("Main"))
+    }
+  }
+
+  test("script with a top-level no-arg main does not list the wrapper user-code class") {
+    TestInputs(
+      os.rel / "hello.sc" ->
+        s"""//> using jvm $jep512MinJava
+           |def main(): Unit = println(1)
+           |""".stripMargin
+    ).withBuild(defaultOptions, buildThreads, None, buildTests = false) { (_, _, maybeBuild) =>
+      val build = maybeBuild.orThrow.successfulOpt.get
+      val found = build.foundMainClasses()
+      expect(!found.exists(_.endsWith("$_")))
+      expect(found.contains("hello_sc"))
+    }
+  }
+}

--- a/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/package0/Package.scala
@@ -283,7 +283,9 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
         mainClassOptions
           .maybePrintMainClasses(
             builds.flatMap(_.foundMainClasses()).distinct,
-            shouldExit = allowTerminate
+            shouldExit = allowTerminate,
+            unsupportedMainMethodsNote =
+              builds.flatMap(_.unsupportedMainMethodsNote).headOption
           )
           .map(_ => None)
       }
@@ -426,6 +428,17 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
 
       def mainClassOpt: Option[String] = mainClass.toOption
 
+      def bootstrapCompatibleMainClass: Either[BuildException, String] = either {
+        val cls = value(mainClass)
+        // TODO: the coursier bootstrap launcher (Bootstrap.java in coursier-launcher)
+        // only looks up public static void main(String[]) via reflection. Once coursier
+        // implements the JEP 512 launch protocol, remove this guard and allow packaging
+        // instance / no-arg mains as bootstrap launchers.
+        if builds.view.flatMap(_.mainClassKind(cls)).exists(_.requiresJep512) then
+          value(Left(new Jep512MainUnsupportedForBootstrapError(cls)))
+        else cls
+      }
+
       val packageOptions = builds.head.options.notForBloopOptions.packageOptions
 
       def warnSlothNoOp(reason: String): Unit =
@@ -435,7 +448,13 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
 
       val outputPath = packageType match {
         case PackageType.Bootstrap =>
-          value(bootstrap(builds, destPath, value(mainClass), () => alreadyExistsCheck(), logger))
+          value(bootstrap(
+            builds,
+            destPath,
+            value(bootstrapCompatibleMainClass),
+            () => alreadyExistsCheck(),
+            logger
+          ))
           destPath
         case PackageType.LibraryJar =>
           val libraryJar0 = Library.libraryJar(builds, mainClassOpt)
@@ -557,7 +576,7 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
             bootstrap(
               builds,
               bootstrapPath,
-              value(mainClass),
+              value(bootstrapCompatibleMainClass),
               () => alreadyExistsCheck(),
               logger
             )
@@ -1110,6 +1129,11 @@ object Package extends ScalaCommand[PackageOptions] with BuildCommandHelpers {
   final class NoMainClassFoundForAssemblyError(cause: NoMainClassFoundError) extends BuildException(
         "No main class found for assembly. Either pass one with --main-class, or make the assembly non-runnable with --preamble=false",
         cause = cause
+      )
+
+  final class Jep512MainUnsupportedForBootstrapError(mainClass: String) extends BuildException(
+        s"""Main class $mainClass uses a JDK ${scala.build.internal.Constants.jep512MinJavaVersion} instance/no-arg main method (JEP 512), which the bootstrap launcher cannot invoke.
+           |Use --assembly or --library instead.""".stripMargin
       )
 
   private object LinkingDir {

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -424,7 +424,9 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
           case b if b.forall(_.success) && mainClassOptions.mainClassLs.contains(true) =>
             mainClassOptions.maybePrintMainClasses(
               mainClasses = builds0.flatMap(_.foundMainClasses()).distinct,
-              shouldExit = allowExit
+              shouldExit = allowExit,
+              unsupportedMainMethodsNote =
+                builds0.flatMap(_.unsupportedMainMethodsNote).headOption
             )
           case _ => prepareFilesAndUpload(
               builds = builds0,

--- a/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/run/Run.scala
@@ -165,7 +165,12 @@ object Run extends ScalaCommand[RunOptions] with BuildCommandHelpers {
       if options.sharedRun.mainClass.mainClassLs.contains(true) then
         value {
           options.sharedRun.mainClass
-            .maybePrintMainClasses(potentialMainClasses, shouldExit = allowTerminate)
+            .maybePrintMainClasses(
+              potentialMainClasses,
+              shouldExit = allowTerminate,
+              unsupportedMainMethodsNote =
+                builds.flatMap(_.unsupportedMainMethodsNote).headOption
+            )
             .map(_ => Seq.empty)
         }
       else {

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/MainClassOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/MainClassOptions.scala
@@ -31,14 +31,15 @@ final case class MainClassOptions(
 
   def maybePrintMainClasses(
     mainClasses: Seq[String],
-    shouldExit: Boolean = true
+    shouldExit: Boolean = true,
+    unsupportedMainMethodsNote: Option[String] = None
   ): Either[MainClassError, Unit] =
     mainClassLs match {
       case Some(true) if mainClasses.nonEmpty =>
         println(mainClasses.mkString(" "))
         if (shouldExit) sys.exit(0)
         else Right(())
-      case Some(true) => Left(new NoMainClassFoundError)
+      case Some(true) => Left(new NoMainClassFoundError(unsupportedMainMethodsNote))
       case _          => Right(())
     }
 }

--- a/modules/core/src/main/scala/scala/build/errors/NoMainClassFoundError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/NoMainClassFoundError.scala
@@ -1,3 +1,7 @@
 package scala.build.errors
 
-final class NoMainClassFoundError extends MainClassError("No main class found", Nil)
+final class NoMainClassFoundError(note: Option[String] = None)
+    extends MainClassError(
+      ("No main class found" +: note.toSeq).mkString(System.lineSeparator()),
+      Nil
+    )

--- a/modules/integration/src/test/scala/scala/cli/integration/MarkdownTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/MarkdownTests.scala
@@ -304,6 +304,23 @@ class MarkdownTests extends ScalaCliSuite {
     }
   }
 
+  for (javaVersion <- Constants.allJavaVersions.filter(_ >= Constants.jep512MinJavaVersion))
+    test(s"run a .md file with a compact java snippet on JDK $javaVersion") {
+      TestUtil.retryOnCi() {
+        TestInputs(
+          os.rel / "sample.md" ->
+            """# Sample
+              |```java
+              |void main() { System.out.println("md-compact"); }
+              |```
+              |""".stripMargin
+        ).fromRoot { root =>
+          val result = os.proc(TestUtil.cli, "sample.md", "--jvm", javaVersion).call(cwd = root)
+          expect(result.out.trim() == "md-compact")
+        }
+      }
+    }
+
   test("run a .md file with scala and java snippets") {
     val expectedOutput = "Hello world"
     TestInputs(

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageTestDefinitions.scala
@@ -1713,4 +1713,58 @@ abstract class PackageTestDefinitions extends ScalaCliSuite with TestScalaVersio
       expect(output == message)
     }
   }
+
+  for (javaVersion <- Constants.allJavaVersions.filter(_ >= Constants.jep512MinJavaVersion)) {
+    test(s"package --assembly of an instance main runs on JDK $javaVersion") {
+      TestUtil.retryOnCi() {
+        TestInputs(
+          os.rel / "A.scala" -> "class A { def main(): Unit = println(1) }"
+        ).fromRoot { root =>
+          os.proc(
+            TestUtil.cli,
+            "--power",
+            "package",
+            extraOptions,
+            ".",
+            "--assembly",
+            "--jvm",
+            javaVersion,
+            "-o",
+            "app.jar"
+          ).call(cwd = root, stdin = os.Inherit, stdout = os.Inherit)
+          val javaHome = os.Path(
+            os.proc(TestUtil.cs, "java-home", "--jvm", javaVersion).call().out.trim(),
+            os.pwd
+          )
+          val res = os.proc(javaHome / "bin" / "java", "-jar", root / "app.jar")
+            .call(cwd = root)
+          expect(res.out.trim() == "1")
+        }
+      }
+    }
+
+    test(s"package bootstrap rejects an instance main on JDK $javaVersion") {
+      TestUtil.retryOnCi() {
+        TestInputs(
+          os.rel / "A.scala" -> "class A { def main(): Unit = println(1) }"
+        ).fromRoot { root =>
+          val res = os.proc(
+            TestUtil.cli,
+            "--power",
+            "package",
+            extraOptions,
+            ".",
+            "--jvm",
+            javaVersion,
+            "-o",
+            "app"
+          ).call(cwd = root, mergeErrIntoOut = true, check = false)
+          expect(res.exitCode != 0)
+          val out = res.out.text()
+          expect(out.contains("JEP 512") || out.contains("instance/no-arg"))
+          expect(out.contains("--assembly") || out.contains("--library"))
+        }
+      }
+    }
+  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/RunPipedSourcesTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunPipedSourcesTestDefinitions.scala
@@ -70,6 +70,19 @@ trait RunPipedSourcesTestDefinitions { this: RunTestDefinitions =>
         expect(output == expectedOutput)
       }
     }
+
+    for (javaVersion <- Constants.allJavaVersions.filter(_ >= Constants.jep512MinJavaVersion))
+      test(s"piped compact Java source runs on JDK $javaVersion") {
+        TestUtil.retryOnCi() {
+          val pipedInput = """void main() { System.out.println("piped"); }"""
+          emptyInputs.fromRoot { root =>
+            val output = os.proc(TestUtil.cli, "_.java", "--jvm", javaVersion)
+              .call(cwd = root, stdin = pipedInput)
+              .out.trim()
+            expect(output == "piped")
+          }
+        }
+      }
     test("Java code with multiple classes accepted as piped input") {
       val expectedOutput = "Hello"
       val pipedInput     =

--- a/modules/integration/src/test/scala/scala/cli/integration/RunSnippetTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunSnippetTestDefinitions.scala
@@ -53,6 +53,25 @@ trait RunSnippetTestDefinitions { this: RunTestDefinitions =>
     }
   }
 
+  for (javaVersion <- Constants.allJavaVersions.filter(_ >= Constants.jep512MinJavaVersion))
+    test(s"correctly run a compact java snippet on JDK $javaVersion") {
+      TestUtil.retryOnCi() {
+        emptyInputs.fromRoot { root =>
+          val quotation = TestUtil.argQuotationMark
+          val msg       = "snippet"
+          val res       = os.proc(
+            TestUtil.cli,
+            "run",
+            "--java-snippet",
+            s"void main() { System.out.println($quotation$msg$quotation); }",
+            "--jvm",
+            javaVersion
+          ).call(cwd = root)
+          expect(res.out.trim() == msg)
+        }
+      }
+    }
+
   test("correctly run a markdown snippet") {
     emptyInputs.fromRoot { root =>
       val msg       = "Hello world"

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -1238,6 +1238,75 @@ abstract class RunTestDefinitions
     }
   }
 
+  test("instance main on an older JVM explains the JDK 25 requirement") {
+    TestUtil.retryOnCi() {
+      TestInputs(
+        os.rel / "T.scala" ->
+          s"""//> using jvm ${Constants.defaultJvmVersion}
+             |class A { def main(): Unit = println(1) }
+             |""".stripMargin
+      ).fromRoot { root =>
+        val res = os.proc(TestUtil.cli, "run", ".", extraOptions)
+          .call(cwd = root, mergeErrIntoOut = true, check = false)
+        expect(res.exitCode != 0)
+        val out = res.out.text()
+        expect(out.contains("No main class found"))
+        expect(out.contains("JEP 512"))
+        expect(out.contains(Constants.jep512MinJavaVersion.toString))
+      }
+    }
+  }
+
+  for (javaVersion <- Constants.allJavaVersions.filter(_ >= Constants.jep512MinJavaVersion)) {
+    test(s"run a Scala class with a no-arg main method on JDK $javaVersion") {
+      TestUtil.retryOnCi() {
+        TestInputs(
+          os.rel / "T.scala" -> "class A { def main(): Unit = println(1) }"
+        ).fromRoot { root =>
+          val res = os.proc(TestUtil.cli, "run", ".", extraOptions, "--jvm", javaVersion)
+            .call(cwd = root)
+          expect(res.out.trim() == "1")
+        }
+      }
+    }
+
+    test(s"run a Java compact source with an instance main on JDK $javaVersion") {
+      TestUtil.retryOnCi() {
+        TestInputs(
+          os.rel / "Hello.java" ->
+            """void main() {
+              |    System.out.println("Hello");
+              |}
+              |""".stripMargin
+        ).fromRoot { root =>
+          val res = os.proc(TestUtil.cli, "run", ".", "--jvm", javaVersion)
+            .call(cwd = root)
+          expect(res.out.trim() == "Hello")
+        }
+      }
+    }
+
+    if hasLatestRunnerModule then
+      test(s"run an instance main with --runner on JDK $javaVersion") {
+        TestUtil.retryOnCi() {
+          TestInputs(
+            os.rel / "T.scala" -> "class A { def main(): Unit = println(1) }"
+          ).fromRoot { root =>
+            val res = os.proc(
+              TestUtil.cli,
+              "run",
+              ".",
+              extraOptions,
+              "--jvm",
+              javaVersion,
+              "--runner"
+            ).call(cwd = root)
+            expect(res.out.trim() == "1")
+          }
+        }
+      }
+  }
+
   test("correctly list main classes") {
     val (scalaFile1, scalaFile2, scriptName) = ("ScalaMainClass1", "ScalaMainClass2", "ScalaScript")
     val scriptsDir                           = "scripts"

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -1270,6 +1270,21 @@ abstract class RunTestDefinitions
       }
     }
 
+    test(s"run a class inheriting a no-arg main from a Scala trait on JDK $javaVersion") {
+      TestUtil.retryOnCi() {
+        TestInputs(
+          os.rel / "T.scala" ->
+            """trait T { def main(): Unit = println("hello from a trait") }
+              |class A extends T
+              |""".stripMargin
+        ).fromRoot { root =>
+          val res = os.proc(TestUtil.cli, "run", ".", extraOptions, "--jvm", javaVersion)
+            .call(cwd = root)
+          expect(res.out.trim() == "hello from a trait")
+        }
+      }
+    }
+
     test(s"run a Java compact source with an instance main on JDK $javaVersion") {
       TestUtil.retryOnCi() {
         TestInputs(

--- a/modules/integration/src/test/scala/scala/cli/integration/TestScalaVersionArgs.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestScalaVersionArgs.scala
@@ -27,6 +27,8 @@ trait TestScalaVersionArgs extends ScalaCliSuite { this: TestScalaVersion =>
   def isScala39OrNewer: Boolean =
     actualScalaVersion.coursierVersion >= "3.9.0-RC1".coursierVersion
 
+  def hasLatestRunnerModule: Boolean = actualScalaVersion.coursierVersion > "3.3.0".coursierVersion
+
   def retrieveScalaVersionCode: String =
     if actualScalaVersion.startsWith("2.") || isScala38OrNewer then
       "scala.util.Properties.versionNumberString"

--- a/modules/runner/src/main/scala/scala/cli/runner/Runner.scala
+++ b/modules/runner/src/main/scala/scala/cli/runner/Runner.scala
@@ -1,6 +1,8 @@
 package scala.cli.runner
 
-import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.{InvocationTargetException, Method, Modifier}
+
+import scala.util.Try
 
 object Runner {
   def main(args: Array[String]): Unit = {
@@ -11,8 +13,7 @@ object Runner {
 
     val loader = Thread.currentThread().getContextClassLoader
     val cls    = loader.loadClass(mainClass)
-    val method = cls.getMethod("main", classOf[Array[String]])
-    try method.invoke(null, args0)
+    try invokeMain(cls, args0)
     catch {
       case e: InvocationTargetException if e.getCause != null =>
         val printer = StackTracePrinter(
@@ -23,5 +24,55 @@ object Runner {
         printer.printException(e.getCause, verbosity)
         System.exit(1)
     }
+  }
+
+  /** JEP 512 launch protocol: prefer `main(String[])` over `main()`; invoke static methods
+    * directly, otherwise instantiate via a non-private zero-arg constructor.
+    */
+  private[runner] def invokeMain(cls: Class[?], args: Array[String]): Unit = {
+    val withArgs = findMain(cls, hasArgs = true)
+    val noArgs   = findMain(cls, hasArgs = false)
+    val method   = withArgs.orElse(noArgs).getOrElse {
+      throw new NoSuchMethodException(
+        s"${cls.getName}.main([Ljava.lang.String;) or ${cls.getName}.main()"
+      )
+    }
+    val receiver =
+      if Modifier.isStatic(method.getModifiers) then null
+      else {
+        val ctor = cls.getDeclaredConstructors
+          .find(c => c.getParameterCount == 0 && !Modifier.isPrivate(c.getModifiers))
+          .getOrElse {
+            throw new NoSuchMethodException(
+              s"no non-private zero argument constructor found in class ${cls.getName}"
+            )
+          }
+        ctor.setAccessible(true)
+        ctor.newInstance()
+      }
+    method.setAccessible(true)
+    if method.getParameterCount == 1 then method.invoke(receiver, args)
+    else method.invoke(receiver)
+  }
+
+  private def findMain(cls: Class[?], hasArgs: Boolean): Option[Method] = {
+    val paramTypes: Seq[Class[?]] =
+      if hasArgs then Seq(classOf[Array[String]]) else Seq.empty
+    cls.getDeclaredMethods
+      .find { m =>
+        m.getName == "main" &&
+        !Modifier.isPrivate(m.getModifiers) &&
+        m.getReturnType == java.lang.Void.TYPE &&
+        m.getParameterTypes.toSeq == paramTypes
+      }
+      .orElse {
+        // Also search public methods inherited from superclasses (getMethod does that).
+        Try(
+          if hasArgs then cls.getMethod("main", classOf[Array[String]])
+          else cls.getMethod("main")
+        ).toOption.filter(m =>
+          !Modifier.isPrivate(m.getModifiers) && m.getReturnType == java.lang.Void.TYPE
+        )
+      }
   }
 }

--- a/modules/runner/src/test/scala/scala/cli/runner/RunnerTests.scala
+++ b/modules/runner/src/test/scala/scala/cli/runner/RunnerTests.scala
@@ -1,0 +1,69 @@
+package scala.cli.runner
+
+import munit.FunSuite
+
+class RunnerTests extends FunSuite {
+
+  private def run(className: String, args: Array[String] = Array.empty): String = {
+    val out = new java.io.ByteArrayOutputStream()
+    Console.withOut(out) {
+      Runner.invokeMain(Class.forName(className), args)
+    }
+    out.toString("UTF-8").trim
+  }
+
+  test("static main(String[])") {
+    assertEquals(run("scala.cli.runner.StaticWithArgs", Array("x")), "static-with-args:x")
+  }
+
+  test("static main()") {
+    assertEquals(run("scala.cli.runner.StaticNoArgs"), "static-no-args")
+  }
+
+  test("instance main(String[])") {
+    assertEquals(run("scala.cli.runner.InstanceWithArgs", Array("y")), "instance-with-args:y")
+  }
+
+  test("instance main()") {
+    assertEquals(run("scala.cli.runner.InstanceNoArgs"), "instance-no-args")
+  }
+
+  test("prefer main(String[]) over main()") {
+    assertEquals(run("scala.cli.runner.Both", Array("z")), "with-args:z")
+  }
+
+  test("reject instance main with private constructor") {
+    intercept[NoSuchMethodException] {
+      run("scala.cli.runner.PrivateCtor")
+    }
+  }
+}
+
+class StaticWithArgs
+object StaticWithArgs {
+  def main(args: Array[String]): Unit =
+    println(s"static-with-args:${args.mkString}")
+}
+
+class StaticNoArgs
+object StaticNoArgs {
+  def main(): Unit = println("static-no-args")
+}
+
+class InstanceWithArgs {
+  def main(args: Array[String]): Unit =
+    println(s"instance-with-args:${args.mkString}")
+}
+
+class InstanceNoArgs {
+  def main(): Unit = println("instance-no-args")
+}
+
+class Both {
+  def main(args: Array[String]): Unit = println(s"with-args:${args.mkString}")
+  def main(): Unit                    = println("no-args")
+}
+
+class PrivateCtor private () {
+  def main(): Unit = println("unreachable")
+}

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -93,6 +93,8 @@ object Java {
   def minimumBloopJava: Int    = 17
   def minimumScala38Java: Int  = 17
   def minimumInternalJava: Int = 16
+  def minimumJep512Java: Int        = 25
+  def minimumJep512PreviewJava: Int = 21
   def defaultJava: Int         = minimumBloopJava
   def cliKeyJavaVersions       = Seq(
     minimumBloopJava,


### PR DESCRIPTION
Closes #3886

Recognize and launch JEP 512 main methods (`static`/`instance`, with/without `String[]`) when targeting the JVM on JDK 25+ (or JDK 21+ with `--enable-preview`).

```scala
//> using jvm 25
class Hello {
  def main(): Unit =
    println("Hello from an instance main")
}
```

```scala
//> using jvm 21
//> using javaOpt --enable-preview
class Hello {
  def main(): Unit = println("Hello on JDK 21 preview")
}
```

Ofc, works with Java, too.

```java
//> using jvm 25
// Hello.java
void main() {
    System.out.println("Hello from a compact source");
}
```

```java
//> using jvm 25
// HelloWithExplicitClss.java
public class HelloWithExplicitClss {
    void main() {
        System.out.println("Hello from an instance main");
    }
}
```

Worth noting that on lower JDKs we still note those main classes down in the error, since detection works just fine, they're just not runnable.

```text
[error]  No main class found
Class Hello declares a main method that requires JDK 25 or newer (JEP 512); the current JVM is 17.
```

## LLM usage
extensively, Cursor / Claude

## Known limitations
- Default `package` / bootstrap cannot launch JEP-512 mains until coursier’s
  bootstrap launcher is updated; use `--assembly` or `--library`
- doesn't work with Scala.js / Scala Native for now