### PR TITLE
Auto detect user-created main methods in classes named with the `*$_` suffix

### DIFF
--- a/modules/build/src/main/scala/scala/build/Build.scala
+++ b/modules/build/src/main/scala/scala/build/Build.scala
@@ -66,16 +66,22 @@ object Build {
     def fullClassPath: Seq[os.Path]        = Seq(output) ++ dependencyClassPath
     def fullCompileClassPath: Seq[os.Path] = fullClassPath ++ dependencyCompileClassPath
     private lazy val mainClassCandidatesInProject: Seq[MainClass.MainClassCandidate] =
-      MainClass.find(output, logger).filterNot(isScriptWrapperUserCodeClass)
+      MainClass.find(output, logger)
+        .filterNot(c => scriptWrapperUserCodeClasses.contains(c.className))
     private lazy val mainClassCandidatesOnExtraClasspath: Seq[MainClass.MainClassCandidate] =
       options.classPathOptions.extraClassPath.flatMap(MainClass.find(_, logger))
     private lazy val mainClassesFoundInUserExtraDependencies: Seq[String] =
       artifacts.jarsForUserExtraDependencies.flatMap(MainClass.findInDependency).sorted
 
-    private def isScriptWrapperUserCodeClass(candidate: MainClass.MainClassCandidate): Boolean =
-      // ClassCodeWrapper puts user code in a class named `{script}$_`; its instance main must not
-      // surface as a selectable entry point alongside the real `{script}_sc` wrapper main.
-      candidate.className.endsWith("$_")
+    /** `ClassCodeWrapper` puts the script body in a `{script}$_` class next to the real
+      * `{script}_sc` main; only those generated classes must be hidden as entry points. A user
+      * class that merely happens to end with `$_` stays a legitimate main class.
+      */
+    private lazy val scriptWrapperUserCodeClasses: Set[String] =
+      generatedSources.flatMap(_.wrapperParamsOpt.map(_.mainClass)).collect {
+        case wrapperMainClass if wrapperMainClass.endsWith("_sc") =>
+          s"${wrapperMainClass.stripSuffix("_sc")}$$_"
+      }.toSet
 
     private lazy val hasEnablePreview: Boolean =
       options.javaOptions.javaOpts.toSeq.exists(_.value.value == "--enable-preview")

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -1257,6 +1257,21 @@ abstract class RunTestDefinitions
     }
   }
 
+  test("run an object with a dollar-underscore suffixed name") {
+    TestUtil.retryOnCi() {
+      TestInputs(
+        os.rel / "Test.scala" ->
+          """object `Test$_` {
+            |  def main(args: Array[String]): Unit = println("hello from a user class")
+            |}
+            |""".stripMargin
+      ).fromRoot { root =>
+        val res = os.proc(TestUtil.cli, "run", ".", extraOptions).call(cwd = root)
+        expect(res.out.trim() == "hello from a user class")
+      }
+    }
+  }
+
   for (javaVersion <- Constants.allJavaVersions.filter(_ >= Constants.jep512MinJavaVersion)) {
     test(s"run a Scala class with a no-arg main method on JDK $javaVersion") {
       TestUtil.retryOnCi() {
@@ -1317,6 +1332,28 @@ abstract class RunTestDefinitions
               "--runner"
             ).call(cwd = root)
             expect(res.out.trim() == "1")
+          }
+        }
+      }
+
+    if actualScalaVersion.startsWith("3") then
+      test(s"do not list the dollar-underscore script wrapper class on JDK $javaVersion") {
+        TestUtil.retryOnCi() {
+          TestInputs(
+            os.rel / "hello.sc" -> "def main(): Unit = println(1)"
+          ).fromRoot { root =>
+            val res = os.proc(
+              TestUtil.cli,
+              "run",
+              ".",
+              extraOptions,
+              "--jvm",
+              javaVersion,
+              "--main-class-ls"
+            ).call(cwd = root, mergeErrIntoOut = true)
+            val out = res.out.text()
+            expect(out.contains("hello_sc"))
+            expect(!out.contains("hello$_"))
           }
         }
       }


### PR DESCRIPTION
Follow-up to https://github.com/VirtusLab/scala-cli/pull/4418#discussion_r3758403448

Now this was easier than expected. We'll only filter out the classes in the generated script wrappers, and still detect user-created ones with main methods and the `*$_` suffix.
Why we'd need this is beyond me - why not is the likely answer.

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Cursor

## How was the solution tested?
automated test included