### PR TITLE
Package `--library` JAR files when `-d` is set to a `*.jar` path

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -194,8 +194,8 @@ final case class SharedOptions(
   @Name("destination")
   @Name("compileOutput")
   @Name("compileOut")
-  @HelpMessage("Copy compilation results to output directory using either relative or absolute path")
-  @ValueDescription("/example/path")
+  @HelpMessage("Copy compilation results to output directory, or package them as a library JAR when the path ends with .jar")
+  @ValueDescription("/example/path|/example/path.jar")
   @Tag(tags.must)
     compilationOutput: Option[String] = None,
   @Group(HelpGroup.Scala.toString)

--- a/modules/cli/src/main/scala/scala/cli/commands/util/BuildCommandHelpers.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/util/BuildCommandHelpers.scala
@@ -6,6 +6,7 @@ import scala.build.{Build, Builds, CrossBuildParams, Logger, Os}
 import scala.cli.commands.ScalaCommand
 import scala.cli.commands.shared.SharedOptions
 import scala.cli.commands.util.ScalacOptionsUtil.*
+import scala.cli.packaging.Library
 
 trait BuildCommandHelpers { self: ScalaCommand[?] =>
   extension (b: Seq[Build.Successful]) {
@@ -41,6 +42,11 @@ object BuildCommandHelpers {
   extension (successfulBuild: Build.Successful) {
 
     /** -O -d defaults to --compile-output; if both are defined, --compile-output takes precedence.
+      *
+      * When the destination path ends with `.jar`, compilation results are packaged as a library
+      * JAR (same logic as `package --library`), matching `scalac -d out.jar` behaviour. Otherwise
+      * class files are copied into the destination directory.
+      *
       * When `--sloth` is enabled, the destination is patched unless the source build output was
       * already patched in this process (e.g. by `compile`), so the same bytes are not scanned
       * twice.
@@ -50,26 +56,39 @@ object BuildCommandHelpers {
         .orElse(sharedOptions.scalacOptions.getScalacOption("-d"))
         .filter(_.nonEmpty)
         .map(os.Path(_, Os.pwd)).foreach { output =>
-          os.copy(
-            successfulBuild.output,
-            output,
-            createFolders = true,
-            mergeFolders = true,
-            replaceExisting = true
-          )
-          if SlothPatcher.wasPatchedInThisProcess(successfulBuild.output) then
-            logger.debug(
-              s"Skipping Sloth patch of $output: source ${successfulBuild.output} already patched"
-            )
-          else
-            for
-              ex <- SlothPatcher.patchClassDirInPlace(
-                output,
-                successfulBuild.options,
-                logger,
-                shouldPatch = SlothPatcher.shouldPatchProjectClasses(Seq(successfulBuild))
-              ).left
-            do logger.exit(ex)
+          if output.last.endsWith(".jar") then copyOutputAsJar(output, logger)
+          else copyOutputAsDirectory(output, logger)
         }
+
+    private def copyOutputAsJar(output: os.Path, logger: Logger): Unit =
+      val mainClassOpt = successfulBuild.options.mainClass.filter(_.nonEmpty)
+      val libraryJar0  = Library.libraryJar(Seq(successfulBuild), mainClassOpt)
+      val libraryJar   = SlothPatcher.patchJarFile(libraryJar0, successfulBuild.options, logger)
+        .fold(logger.exit, identity)
+      if os.exists(output) then
+        logger.log(s"Overwriting existing destination $output")
+      os.copy.over(libraryJar, output, createFolders = true)
+
+    private def copyOutputAsDirectory(output: os.Path, logger: Logger): Unit =
+      os.copy(
+        successfulBuild.output,
+        output,
+        createFolders = true,
+        mergeFolders = true,
+        replaceExisting = true
+      )
+      if SlothPatcher.wasPatchedInThisProcess(successfulBuild.output) then
+        logger.debug(
+          s"Skipping Sloth patch of $output: source ${successfulBuild.output} already patched"
+        )
+      else
+        for
+          ex <- SlothPatcher.patchClassDirInPlace(
+            output,
+            successfulBuild.options,
+            logger,
+            shouldPatch = SlothPatcher.shouldPatchProjectClasses(Seq(successfulBuild))
+          ).left
+        do logger.exit(ex)
   }
 }

--- a/modules/cli/src/test/scala/cli/tests/CopyOutputJarTests.scala
+++ b/modules/cli/src/test/scala/cli/tests/CopyOutputJarTests.scala
@@ -1,0 +1,162 @@
+package cli.tests
+
+import bloop.rifle.BloopRifleConfig
+import com.eed3si9n.expecty.Expecty.expect
+
+import java.util.jar.Manifest as JarManifest
+import java.util.zip.ZipFile
+
+import scala.build.Ops.*
+import scala.build.options.{BuildOptions, InternalOptions}
+import scala.build.tests.util.BloopServer
+import scala.build.tests.{TestInputs, TestLogger}
+import scala.build.{BuildThreads, Directories, LocalRepo}
+import scala.cli.commands.shared.SharedOptions
+import scala.cli.commands.util.BuildCommandHelpers.copyOutput
+import scala.jdk.CollectionConverters.*
+import scala.util.Using
+
+class CopyOutputJarTests extends TestUtil.ScalaCliSuite {
+  val buildThreads: BuildThreads    = BuildThreads.create()
+  def bloopConfig: BloopRifleConfig = BloopServer.bloopConfig
+
+  val extraRepoTmpDir: os.Path = os.temp.dir(prefix = "scala-cli-tests-copy-output-jar-")
+  val directories: Directories = Directories.under(extraRepoTmpDir)
+
+  val defaultOptions = BuildOptions(
+    internal = InternalOptions(
+      localRepository = LocalRepo.localRepo(directories.localRepoDir, TestLogger())
+    )
+  )
+
+  test("-d out.jar produces a JAR file with class entries and Main-Class") {
+    TestInputs().fromRoot { root =>
+      val options = defaultOptions.copy(mainClass = Some("Hello"))
+      val inputs  = TestInputs(
+        files = Seq(
+          os.rel / "Hello.scala" ->
+            """object Hello {
+              |  def main(args: Array[String]): Unit = println("Hello")
+              |}
+              |""".stripMargin
+        ),
+        forceCwd = Some(root)
+      )
+      inputs.withBuild(options, buildThreads, Some(bloopConfig)) {
+        (_, _, maybeBuild) =>
+          val build  = maybeBuild.orThrow.successfulOpt.get
+          val outJar = root / "out.jar"
+          build.copyOutput(
+            SharedOptions(compilationOutput = Some(outJar.toString)),
+            TestLogger()
+          )
+          expect(os.isFile(outJar))
+          Using.resource(ZipFile(outJar.toIO)) { zf =>
+            val entries = zf.entries().asScala.map(_.getName).toSeq
+            expect(entries.exists(_.endsWith("Hello.class")))
+            expect(entries.exists(_ == "META-INF/MANIFEST.MF"))
+            val manifest = JarManifest(zf.getInputStream(zf.getEntry("META-INF/MANIFEST.MF")))
+            expect(manifest.getMainAttributes.getValue("Main-Class") == "Hello")
+          }
+      }
+    }
+  }
+
+  test("-d out.jar preserves user META-INF/MANIFEST.MF from resources") {
+    TestInputs().fromRoot { root =>
+      val options = defaultOptions.copy(mainClass = Some("Hello"))
+      val inputs  = TestInputs(
+        files = Seq(
+          os.rel / "Hello.scala" ->
+            """//> using resourceDir resources
+              |
+              |object Hello {
+              |  def main(args: Array[String]): Unit = println("Hello")
+              |}
+              |""".stripMargin,
+          os.rel / "resources" / "META-INF" / "MANIFEST.MF" ->
+            """Manifest-Version: 1.0
+              |X-Custom: yes
+              |""".stripMargin
+        ),
+        inputArgs = Seq("."),
+        forceCwd = Some(root)
+      )
+      inputs.withBuild(options, buildThreads, Some(bloopConfig), fromDirectory = true) {
+        (_, _, maybeBuild) =>
+          val build  = maybeBuild.orThrow.successfulOpt.get
+          val outJar = root / "out.jar"
+          build.copyOutput(
+            SharedOptions(compilationOutput = Some(outJar.toString)),
+            TestLogger()
+          )
+          expect(os.isFile(outJar))
+          Using.resource(ZipFile(outJar.toIO)) { zf =>
+            val entries = zf.entries().asScala.map(_.getName).toSeq
+            expect(entries.count(_ == "META-INF/MANIFEST.MF") == 1)
+            val manifest = JarManifest(zf.getInputStream(zf.getEntry("META-INF/MANIFEST.MF")))
+            expect(manifest.getMainAttributes.getValue("X-Custom") == "yes")
+            expect(manifest.getMainAttributes.getValue("Main-Class") == "Hello")
+          }
+      }
+    }
+  }
+
+  test("-d out.jar overwrites an existing JAR") {
+    TestInputs().fromRoot { root =>
+      val inputs = TestInputs(
+        files = Seq(
+          os.rel / "Hello.scala" ->
+            """object Hello {
+              |  def main(args: Array[String]): Unit = println("Hello")
+              |}
+              |""".stripMargin
+        ),
+        forceCwd = Some(root)
+      )
+      inputs.withBuild(defaultOptions, buildThreads, Some(bloopConfig)) {
+        (_, _, maybeBuild) =>
+          val build  = maybeBuild.orThrow.successfulOpt.get
+          val outJar = root / "out.jar"
+          os.write(outJar, Array[Byte](0, 1, 2, 3))
+          expect(os.isFile(outJar))
+          val previousSize = os.size(outJar)
+          build.copyOutput(
+            SharedOptions(compilationOutput = Some(outJar.toString)),
+            TestLogger()
+          )
+          expect(os.isFile(outJar))
+          expect(os.size(outJar) != previousSize)
+          Using.resource(ZipFile(outJar.toIO)) { zf =>
+            expect(zf.entries().asScala.exists(_.getName.endsWith("Hello.class")))
+          }
+      }
+    }
+  }
+
+  test("-d outDir still produces a directory of class files") {
+    TestInputs().fromRoot { root =>
+      val inputs = TestInputs(
+        files = Seq(
+          os.rel / "Hello.scala" ->
+            """object Hello {
+              |  def main(args: Array[String]): Unit = println("Hello")
+              |}
+              |""".stripMargin
+        ),
+        forceCwd = Some(root)
+      )
+      inputs.withBuild(defaultOptions, buildThreads, Some(bloopConfig)) {
+        (_, _, maybeBuild) =>
+          val build  = maybeBuild.orThrow.successfulOpt.get
+          val outDir = root / "outDir"
+          build.copyOutput(
+            SharedOptions(compilationOutput = Some(outDir.toString)),
+            TestLogger()
+          )
+          expect(os.isDir(outDir))
+          expect(os.walk(outDir).exists(_.last.endsWith("Hello.class")))
+      }
+    }
+  }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileScalacCompatTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileScalacCompatTestDefinitions.scala
@@ -6,6 +6,34 @@ import scala.util.Properties
 
 /** For the `run` counterpart, refer to [[RunScalacCompatTestDefinitions]] */
 trait CompileScalacCompatTestDefinitions { this: CompileTestDefinitions =>
+
+  test("compile-destination-jar-usable-as-classpath") {
+    val expectedOutput = "Hello"
+    TestInputs(
+      os.rel / "Lib.scala"  -> "case class Message(value: String)",
+      os.rel / "Main.scala" ->
+        s"""object Main {
+           |  def main(args: Array[String]): Unit = println(Message("$expectedOutput").value)
+           |}
+           |""".stripMargin
+    ).fromRoot { root =>
+      val outputJar = root / "out.jar"
+      os.proc(TestUtil.cli, "compile", "Lib.scala", "-d", outputJar.toString, extraOptions)
+        .call(cwd = root)
+      // must be a file, not a directory named out.jar (the mistake PR #2943 made)
+      expect(os.isFile(outputJar))
+      val runRes = os.proc(
+        TestUtil.cli,
+        "run",
+        "Main.scala",
+        "-cp",
+        outputJar.toString,
+        extraOptions
+      ).call(cwd = root)
+      expect(runRes.out.trim() == expectedOutput)
+    }
+  }
+
   if (actualScalaVersion.startsWith("3"))
     test("consecutive -language:* flags are not ignored") {
       val sourceFileName = "example.scala"

--- a/website/docs/commands/compile.md
+++ b/website/docs/commands/compile.md
@@ -306,6 +306,15 @@ Those include:
 - `-classpath` being redirected to `--classpath`
 - `-d` being redirected to `--compilation-output`
 
+When the destination passed to `-d` / `--compilation-output` ends with `.jar`, Scala CLI packages the
+compilation results as a library JAR (same contents as `package --library`), matching `scalac -d out.jar`
+behaviour. An existing file at that path is overwritten. Otherwise, class files are copied into the
+destination directory.
+
+```bash
+scala-cli compile Hello.scala -d out.jar
+```
+
 ### Scala compiler help
 
 Certain compiler options allow to view relevant help. Inputs aren't required when those are passed.

--- a/website/docs/reference/cli-options.md
+++ b/website/docs/reference/cli-options.md
@@ -1692,7 +1692,7 @@ Should include Scala CLI runner on the runtime ClassPath. Runner is added by def
 
 Aliases: `--compile-out`, `--compile-output`, `-d`, `--destination`, `--output-directory`
 
-Copy compilation results to output directory using either relative or absolute path
+Copy compilation results to output directory, or package them as a library JAR when the path ends with .jar
 
 ### `--with-toolkit`
 

--- a/website/docs/reference/scala-command/cli-options.md
+++ b/website/docs/reference/scala-command/cli-options.md
@@ -1184,7 +1184,7 @@ Aliases: `--compile-out`, `--compile-output`, `-d`, `--destination`, `--output-d
 
 `MUST have` per Scala Runner specification
 
-Copy compilation results to output directory using either relative or absolute path
+Copy compilation results to output directory, or package them as a library JAR when the path ends with .jar
 
 ### `--with-toolkit`
 

--- a/website/docs/reference/scala-command/runner-specification.md
+++ b/website/docs/reference/scala-command/runner-specification.md
@@ -122,7 +122,7 @@ Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
-Copy compilation results to output directory using either relative or absolute path
+Copy compilation results to output directory, or package them as a library JAR when the path ends with .jar
 
 Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
@@ -937,7 +937,7 @@ Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
-Copy compilation results to output directory using either relative or absolute path
+Copy compilation results to output directory, or package them as a library JAR when the path ends with .jar
 
 Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
@@ -1568,7 +1568,7 @@ Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
-Copy compilation results to output directory using either relative or absolute path
+Copy compilation results to output directory, or package them as a library JAR when the path ends with .jar
 
 Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
@@ -2223,7 +2223,7 @@ Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
-Copy compilation results to output directory using either relative or absolute path
+Copy compilation results to output directory, or package them as a library JAR when the path ends with .jar
 
 Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
@@ -2893,7 +2893,7 @@ Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
-Copy compilation results to output directory using either relative or absolute path
+Copy compilation results to output directory, or package them as a library JAR when the path ends with .jar
 
 Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
@@ -3551,7 +3551,7 @@ Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
-Copy compilation results to output directory using either relative or absolute path
+Copy compilation results to output directory, or package them as a library JAR when the path ends with .jar
 
 Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
@@ -4228,7 +4228,7 @@ Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
-Copy compilation results to output directory using either relative or absolute path
+Copy compilation results to output directory, or package them as a library JAR when the path ends with .jar
 
 Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
@@ -4977,7 +4977,7 @@ Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
-Copy compilation results to output directory using either relative or absolute path
+Copy compilation results to output directory, or package them as a library JAR when the path ends with .jar
 
 Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 
@@ -5976,7 +5976,7 @@ Aliases: `--with-scala-compiler` ,`-with-compiler`
 
 **--compilation-output**
 
-Copy compilation results to output directory using either relative or absolute path
+Copy compilation results to output directory, or package them as a library JAR when the path ends with .jar
 
 Aliases: `-d` ,`--output-directory` ,`--destination` ,`--compile-output` ,`--compile-out`
 


### PR DESCRIPTION
Closes https://github.com/VirtusLab/scala-cli/issues/2804

This effectively means that `-d` set to a `(...)/*.jar` path is equivalent to using the `package` sub-command with `--library` (and works under all the same restrictions).
As this is done to mimic `scalac` behaviour (which also produces a JAR in these circumstances, even if by far less customisable), this does not require the `--power` toggle to be set, even though `package` is still a restricted feature.

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Cursor

## How was the solution tested?
Included automated tests