### PR TITLE
fix: reject malformed toolkit coordinates

### DIFF
--- a/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/DirectiveTests.scala
@@ -8,6 +8,7 @@ import scala.build.errors.{
   CompositeBuildException,
   DependencyFormatError,
   FetchingDependenciesError,
+  MalformedInputError,
   ToolkitDirectiveMissingVersionError
 }
 import scala.build.options.{
@@ -18,6 +19,7 @@ import scala.build.options.{
   ScalacOpt,
   Scope
 }
+import scala.build.preprocessing.directives.Toolkit
 import scala.build.tests.util.BloopServer
 import scala.build.{Build, BuildThreads, Directories, LocalRepo, Position, Positioned}
 
@@ -136,6 +138,20 @@ class DirectiveTests extends TestUtil.ScalaCliBuildSuite {
             case _ => sys.error("should not happen")
       }
     }
+
+  for (
+    toolkitCoords <-
+      Seq("", ":1.0.0", "scala:", "scala:1.0.0:extra", "scala", "typelevel", "org.typelevel")
+  )
+    test(s"reject malformed toolkit coordinates '$toolkitCoords'") {
+      Toolkit.resolveDependenciesWithRequirements(Positioned.commandLine(toolkitCoords)) match
+        case Left(error: MalformedInputError) =>
+          expect(error.input == toolkitCoords)
+          expect(error.expectedShape == "version or flavor:version")
+        case result =>
+          fail(s"Expected malformed toolkit coordinates error, got $result")
+    }
+
   for (scope <- Scope.all) {
     def withProjectFile[T](projectFileContent: String)(f: (Build, Boolean) => T): T = TestInputs(
       os.rel / "project.scala"    -> projectFileContent,

--- a/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/shared/SharedOptions.scala
@@ -399,11 +399,12 @@ final case class SharedOptions(
         Keys.suppressDeprecatedFeatureWarning
       )
       val (resolvedToolkitDependency, toolkitMaxDefaultScalaNativeVersions) =
-        SharedOptions.resolveToolkitDependencyAndScalaNativeVersionReqs(
-          withToolkit,
-          shouldSuppressDeprecatedWarnings.getOrElse(false),
-          logger
-        )
+        value:
+          SharedOptions.resolveToolkitDependencyAndScalaNativeVersionReqs(
+            withToolkit,
+            shouldSuppressDeprecatedWarnings.getOrElse(false),
+            logger
+          )
       val scalapyMaxDefaultScalaNativeVersions =
         if sharedPython.python.contains(true) then
           List(Constants.scalaPyMaxScalaNative -> Python.maxScalaNativeWarningMsg)
@@ -828,7 +829,7 @@ object SharedOptions {
     toolkitVersion: Option[String],
     shouldSuppressDeprecatedWarnings: Boolean,
     logger: Logger
-  ): (Seq[Positioned[AnyDependency]], Seq[(String, String)]) = {
+  ): Either[BuildException, (Seq[Positioned[AnyDependency]], Seq[(String, String)])] = either:
     if (
       !shouldSuppressDeprecatedWarnings &&
       (toolkitVersion.contains("latest")
@@ -842,10 +843,14 @@ object SharedOptions {
       )
     )
 
-    val (dependencies, toolkitDefinitions) =
-      toolkitVersion.toList.map(Positioned.commandLine)
-        .flatMap(Toolkit.resolveDependenciesWithRequirements(_).map((wbr, td) => wbr.value -> td))
-        .unzip
+    val resolvedDependencies = value:
+      toolkitVersion
+        .map(Positioned.commandLine)
+        .map(Toolkit.resolveDependenciesWithRequirements)
+        .sequence
+    val (dependencies, toolkitDefinitions) = resolvedDependencies.toList.flatten
+      .map((wbr, td) => wbr.value -> td)
+      .unzip
     val maxScalaNativeVersions =
       toolkitDefinitions.flatMap {
         case Toolkit.ToolkitDefinitions(
@@ -881,5 +886,4 @@ object SharedOptions {
           st ++ tlt
       }
     dependencies -> maxScalaNativeVersions
-  }
 }

--- a/modules/cli/src/test/scala/cli/commands/tests/RunOptionsTests.scala
+++ b/modules/cli/src/test/scala/cli/commands/tests/RunOptionsTests.scala
@@ -2,6 +2,7 @@ package scala.cli.commands.tests
 
 import com.eed3si9n.expecty.Expecty.assert as expect
 
+import scala.build.errors.MalformedInputError
 import scala.cli.commands.run.{Run, RunOptions}
 import scala.cli.commands.shared.{SharedOptions, SharedPythonOptions}
 
@@ -49,6 +50,14 @@ class RunOptionsTests extends munit.FunSuite {
     expect(toolkitDep.organization == "org.typelevel")
     expect(toolkitDep.name == "toolkit")
     expect(toolkitDep.version == "latest.release")
+  }
+
+  test("reject malformed toolkit coordinates") {
+    SharedOptions(withToolkit = Some("scala:")).buildOptions() match
+      case Left(error: MalformedInputError) =>
+        expect(error.input == "scala:")
+      case result =>
+        fail(s"Expected malformed toolkit coordinates error, got $result")
   }
 
   test("sloth option") {

--- a/modules/directives/src/main/scala/scala/build/preprocessing/directives/Toolkit.scala
+++ b/modules/directives/src/main/scala/scala/build/preprocessing/directives/Toolkit.scala
@@ -5,7 +5,7 @@ import dependency.*
 
 import scala.build.Positioned
 import scala.build.directives.*
-import scala.build.errors.BuildException
+import scala.build.errors.{BuildException, MalformedInputError}
 import scala.build.internal.Constants
 import scala.build.options.*
 import scala.build.options.WithBuildRequirements.*
@@ -64,22 +64,47 @@ object Toolkit {
     typelevelToolkitExplicitVersion: Option[String] = None
   )
 
+  private val knownFlavors =
+    Set(scala, typelevel, Constants.toolkitOrganization, Constants.typelevelOrganization)
+
+  private def parseFlavorAndVersion(
+    toolkitCoords: Positioned[String]
+  ): Either[BuildException, (Option[String], String)] =
+    toolkitCoords.value.split(":", -1).toList match
+      // e.g. //> using toolkit typelevel would otherwise be treated as version `typelevel`
+      // and fail during resolution with a cryptic error, so we reject it early
+      case version :: Nil if version.nonEmpty && !knownFlavors.contains(version) =>
+        Right(None -> version)
+      case flavor :: version :: Nil if flavor.nonEmpty && version.nonEmpty =>
+        Right(Some(flavor) -> version)
+      case _ =>
+        Left(
+          new MalformedInputError(
+            "toolkit",
+            input = toolkitCoords.value,
+            expectedShape = "version or flavor:version",
+            positions = toolkitCoords.positions
+          )
+        )
+
   /** @param toolkitCoords
     *   the toolkit coordinates
     * @return
     *   the `toolkit` and `toolkit-test` dependencies with the appropriate build requirements
     */
-  def resolveDependenciesWithRequirements(toolkitCoords: Positioned[String]): List[(
-    WithBuildRequirements[Positioned[DependencyLike[NameAttributes, NameAttributes]]],
-    ToolkitDefinitions
-  )] =
-    toolkitCoords match
-      case Positioned(positions, coords) =>
-        val tokens            = coords.split(':')
-        val rawVersion        = tokens.last
+  def resolveDependenciesWithRequirements(
+    toolkitCoords: Positioned[String]
+  ): Either[
+    BuildException,
+    List[(
+      WithBuildRequirements[Positioned[DependencyLike[NameAttributes, NameAttributes]]],
+      ToolkitDefinitions
+    )]
+  ] =
+    parseFlavorAndVersion(toolkitCoords).map:
+      case (flavor, rawVersion) =>
         def isDefault         = rawVersion == "default"
         val notDefaultVersion = if rawVersion == "latest" then "latest.release" else rawVersion
-        val flavor            = tokens.dropRight(1).headOption
         val (org, v, trv: ToolkitDefinitions) = flavor match {
           case TypelevelToolkit() =>
             val typelevelToolkitVersion =
@@ -112,9 +137,9 @@ object Toolkit {
           case Some(org) => (org, notDefaultVersion, ToolkitDefinitions())
         }
         List(
-          Positioned(positions, dep"$org::${Constants.toolkitName}::$v,toolkit")
+          Positioned(toolkitCoords.positions, dep"$org::${Constants.toolkitName}::$v,toolkit")
             .withEmptyRequirements -> trv,
-          Positioned(positions, dep"$org::${Constants.toolkitTestName}::$v,toolkit")
+          Positioned(toolkitCoords.positions, dep"$org::${Constants.toolkitTestName}::$v,toolkit")
             .withScopeRequirement(Scope.Test) -> trv
         )
   val handler: DirectiveHandler[Toolkit] = DirectiveHandler.derive
@@ -140,9 +165,20 @@ object Toolkit {
   private def buildOptionsWithScopeRequirement(
     t: Option[Positioned[String]],
     defaultScope: Option[Scope]
-  ): List[Either[BuildException, WithBuildRequirements[BuildOptions]]] = t
-    .toList
-    .flatMap(resolveDependenciesWithRequirements) // resolve dependencies
+  ): List[Either[BuildException, WithBuildRequirements[BuildOptions]]] =
+    t.toList.flatMap: toolkitCoords =>
+      resolveDependenciesWithRequirements(toolkitCoords).fold(
+        error => List(Left(error)),
+        buildOptionsForResolvedDependencies(_, defaultScope)
+      )
+
+  private def buildOptionsForResolvedDependencies(
+    resolvedDependencies: List[(
+      WithBuildRequirements[Positioned[DependencyLike[NameAttributes, NameAttributes]]],
+      ToolkitDefinitions
+    )],
+    defaultScope: Option[Scope]
+  ): List[Either[BuildException, WithBuildRequirements[BuildOptions]]] = resolvedDependencies
     .map {
       case (
             WithBuildRequirements(requirements, positionedDep),


### PR DESCRIPTION
Malformed toolkit coordinates such as `:`, `::`, `a:b:c` used to pass and resulted in a weird behaviour. This PR fixes this, and makes it that toolkit only accepts `version` or `flavour:version`.

Related: https://github.com/scala/scala3/pull/26788

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?

Moderately

## How was the solution tested?

Automated tests