### PR TITLE
Strip -scalajs from scaladoc invocation

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
@@ -276,9 +276,16 @@ object Doc extends ScalaCommand[DocOptions] with BuildCommandHelpers {
         // scaladoc has its own `-scalajs` flag, but passing it on triggers JS backend
         // codegen phases (e.g. JUnitBootstrappers) that crash on otherwise valid code
         // (VirtusLab/scala-cli#3006). The doc content is platform-agnostic, so drop it.
+        val (scalaJsScalacOptions, otherScalacOptions) = builds.head.project.scalaCompiler
+          .map(_.scalacOptions).getOrElse(Nil)
+          .partition(_ == "-scalajs")
+        if scalaJsScalacOptions.nonEmpty then
+          logger.log(
+            s"Not passing ${scalaJsScalacOptions.mkString(", ")} to scaladoc, " +
+              "as it can cause it to crash on valid code (VirtusLab/scala-cli#3006)"
+          )
         val args = baseArgs ++
-          builds.head.project.scalaCompiler.map(_.scalacOptions).getOrElse(Nil)
-            .filterNot(_ == "-scalajs") ++
+          otherScalacOptions ++
           extraArgs ++
           defaultArgs ++
           builds.map(_.output.toString)

--- a/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
@@ -273,8 +273,12 @@ object Doc extends ScalaCommand[DocOptions] with BuildCommandHelpers {
               .getOrElse(true)
           then defaultScaladocArgs(scalaParams.scalaVersion, javaVersion)
           else Nil
+        // scaladoc has its own `-scalajs` flag, but passing it on triggers JS backend
+        // codegen phases (e.g. JUnitBootstrappers) that crash on otherwise valid code
+        // (VirtusLab/scala-cli#3006). The doc content is platform-agnostic, so drop it.
         val args = baseArgs ++
-          builds.head.project.scalaCompiler.map(_.scalacOptions).getOrElse(Nil) ++
+          builds.head.project.scalaCompiler.map(_.scalacOptions).getOrElse(Nil)
+            .filterNot(_ == "-scalajs") ++
           extraArgs ++
           defaultArgs ++
           builds.map(_.output.toString)

--- a/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
@@ -190,4 +190,26 @@ abstract class DocTestDefinitions
       }
     }
   }
+
+  //`-scalajs` triggers JS codegen phases (e.g. JUnitBootstrappers) that crash on valid code
+  if (!actualScalaVersion.startsWith("2."))
+    test("generate scala doc for a Scala.js project") {
+      val dest = os.rel / "doc-js"
+      TestInputs(
+        os.rel / "Hello.scala" ->
+          """/** Greeter. */
+            |object Hello {
+            |  def greet: String = "hi"
+            |}
+            |""".stripMargin
+      ).fromRoot { root =>
+        os.proc(TestUtil.cli, "doc", extraOptions, "--js", ".", "-o", dest).call(
+          cwd = root,
+          stdin = os.Inherit,
+          stdout = os.Inherit
+        )
+        expect(os.isDir(root / dest))
+        expect(os.list(root / dest).exists(_.last.endsWith(".html")))
+      }
+    }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
@@ -191,7 +191,7 @@ abstract class DocTestDefinitions
     }
   }
 
-  //`-scalajs` triggers JS codegen phases (e.g. JUnitBootstrappers) that crash on valid code
+  // `-scalajs` triggers JS codegen phases (e.g. JUnitBootstrappers) that crash on valid code
   if (!actualScalaVersion.startsWith("2."))
     test("generate scala doc for a Scala.js project") {
       val dest = os.rel / "doc-js"


### PR DESCRIPTION
scaladoc inherits the full project scalacOptions, including -scalajs for Scala.js builds. That flag makes scaladoc run JS backend codegen phases (e.g. JUnitBootstrappers), which crash on otherwise valid code (#3006). The generated doc content is platform-agnostic, so drop the flag before invoking scaladoc.

<!-- Fixes #XYZ (where XYZ is the issue number from the issue tracker) -->

Fixes #3006)

<!-- TODO description of the change -->

<!-- if the PR is still a WIP, create it as a draft PR (or convert it into one) -->

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have you relied on LLM-based tools in this contribution?

extensively, I've reviewed the output
<!-- 
  State clearly in the pull request description, 
  whether LLM-based tools were used and to what extent 

  (extensively/moderately/minimally/not at all)
-->

<!--
  Refer to our [LLM usage policy](https://github.com/scala/scala3/blob/main/LLM_POLICY.md) for rules and guidelines
  regarding usage of LLM-based tools in contributions.
-->

## How was the solution tested?

a new integration test added
<!-- 
  If automated tests are included, mention it.
  If they are not, explain why and how the solution was tested.
-->

## Additional notes

Current workaround: https://github.com/halotukozak-com/made/blob/main/.github/workflows/publish.yml

<!-- Placeholder for any extra context regarding this contribution. -->

<!-- When in doubt, check[our contribution guide](https://github.com/VirtusLab/scala-cli/blob/main/CONTRIBUTING.md) -->
