### PR TITLE
Revert #4431 & add gated test for Scala 3.6.3+

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/doc/Doc.scala
@@ -273,19 +273,8 @@ object Doc extends ScalaCommand[DocOptions] with BuildCommandHelpers {
               .getOrElse(true)
           then defaultScaladocArgs(scalaParams.scalaVersion, javaVersion)
           else Nil
-        // scaladoc has its own `-scalajs` flag, but passing it on triggers JS backend
-        // codegen phases (e.g. JUnitBootstrappers) that crash on otherwise valid code
-        // (VirtusLab/scala-cli#3006). The doc content is platform-agnostic, so drop it.
-        val (scalaJsScalacOptions, otherScalacOptions) = builds.head.project.scalaCompiler
-          .map(_.scalacOptions).getOrElse(Nil)
-          .partition(_ == "-scalajs")
-        if scalaJsScalacOptions.nonEmpty then
-          logger.log(
-            s"Not passing ${scalaJsScalacOptions.mkString(", ")} to scaladoc, " +
-              "as it can cause it to crash on valid code (VirtusLab/scala-cli#3006)"
-          )
         val args = baseArgs ++
-          otherScalacOptions ++
+          builds.head.project.scalaCompiler.map(_.scalacOptions).getOrElse(Nil) ++
           extraArgs ++
           defaultArgs ++
           builds.map(_.output.toString)

--- a/modules/integration/src/test/scala/scala/cli/integration/DocScalaJsTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DocScalaJsTestDefinitions.scala
@@ -1,0 +1,57 @@
+package scala.cli.integration
+
+import com.eed3si9n.expecty.Expecty.expect
+
+trait DocScalaJsTestDefinitions { this: DocTestDefinitions & TestScalaVersion =>
+
+  // Scala 2 + Scala.js goes through the Scala 2 scaladoc, a different code path.
+  if !actualScalaVersion.startsWith("2.") then
+    test("generate scala doc for a Scala.js project") {
+      val dest = os.rel / "doc-js"
+      TestInputs(
+        os.rel / "Hello.scala" ->
+          """/** Greeter. */
+            |object Hello {
+            |  def greet: String = "hi"
+            |}
+            |""".stripMargin
+      ).fromRoot { root =>
+        os.proc(TestUtil.cli, "doc", extraOptions, "--js", ".", "-o", dest).call(
+          cwd = root,
+          stdin = os.Inherit,
+          stdout = os.Inherit
+        )
+        expect(os.isDir(root / dest))
+        expect(os.list(root / dest).exists(_.last.endsWith(".html")))
+      }
+    }
+
+  // Unlike the smoke test above, this one calls a Scala.js API (`js.Promise.then`) whose erased
+  // signature contains a pseudo-union (`js.UndefOr`). Such signatures only match what is recorded
+  // in TASTy when `-scalajs` is passed on, so this is what actually detects the flag being dropped.
+  // Scaladoc only honours `-scalajs` in its TASTy-reading run since 3.6.3, so on older versions
+  // (including 3.3 LTS) this fails regardless of what Scala CLI passes.
+  if !actualScalaVersion.startsWith("2.") && isScala363OrNewer then
+    test("generate scala doc for a Scala.js project using a pseudo-union API") {
+      val dest = os.rel / "doc-js-tasty"
+      TestInputs(
+        os.rel / "Promises.scala" ->
+          """import scala.scalajs.js.Promise
+            |
+            |/** Promise helpers. */
+            |object Promises:
+            |  /** Prints the resolved value. */
+            |  def printResolved(): Unit = Promise.resolve(25).`then`(println(_))
+            |""".stripMargin
+      ).fromRoot { root =>
+        val res = os.proc(TestUtil.cli, "doc", extraOptions, "--js", ".", "-o", dest)
+          .call(cwd = root, check = false, mergeErrIntoOut = true)
+        val output = res.out.text()
+        expect(!output.contains("at readTasty"))
+        expect(!output.contains("undefined:"))
+        expect(res.exitCode == 0)
+        expect(os.isDir(root / dest))
+        expect(os.list(root / dest).exists(_.last.endsWith(".html")))
+      }
+    }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DocTestDefinitions.scala
@@ -6,7 +6,7 @@ import org.jsoup.*
 import scala.jdk.CollectionConverters.*
 
 abstract class DocTestDefinitions
-    extends ScalaCliSuite with TestScalaVersionArgs {
+    extends ScalaCliSuite with TestScalaVersionArgs with DocScalaJsTestDefinitions {
   this: TestScalaVersion =>
   protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
 
@@ -190,26 +190,4 @@ abstract class DocTestDefinitions
       }
     }
   }
-
-  // `-scalajs` triggers JS codegen phases (e.g. JUnitBootstrappers) that crash on valid code
-  if (!actualScalaVersion.startsWith("2."))
-    test("generate scala doc for a Scala.js project") {
-      val dest = os.rel / "doc-js"
-      TestInputs(
-        os.rel / "Hello.scala" ->
-          """/** Greeter. */
-            |object Hello {
-            |  def greet: String = "hi"
-            |}
-            |""".stripMargin
-      ).fromRoot { root =>
-        os.proc(TestUtil.cli, "doc", extraOptions, "--js", ".", "-o", dest).call(
-          cwd = root,
-          stdin = os.Inherit,
-          stdout = os.Inherit
-        )
-        expect(os.isDir(root / dest))
-        expect(os.list(root / dest).exists(_.last.endsWith(".html")))
-      }
-    }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/TestScalaVersionArgs.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestScalaVersionArgs.scala
@@ -27,6 +27,12 @@ trait TestScalaVersionArgs extends ScalaCliSuite { this: TestScalaVersion =>
   def isScala39OrNewer: Boolean =
     actualScalaVersion.coursierVersion >= "3.9.0-RC1".coursierVersion
 
+  /** Scaladoc only passes its own compiler context (and thus `-scalajs`) to the TASTy inspector
+    * since Scala 3.6.3, which is what makes reading Scala.js TASTy work.
+    */
+  def isScala363OrNewer: Boolean =
+    actualScalaVersion.coursierVersion >= "3.6.3".coursierVersion
+
   def hasLatestRunnerModule: Boolean = actualScalaVersion.coursierVersion > "3.3.0".coursierVersion
 
   def retrieveScalaVersionCode: String =


### PR DESCRIPTION
So I may have been trigger happy when merging #4431 (cc @halotukozak)
It hasn't been a proper fix for  https://github.com/VirtusLab/scala-cli/issues/3006 - quite the opposite, it introduced a regression for Scala 3.6.3+

The proper handling for `-scalajs` options got fixed in Scala 3.6.3. So it's no wonder it doesn't work for earlier versions. In fact, those options are strictly necessary for newer Scala.

I reverted the change and covered this with a proper test.
What could be considered is to bisect the changes in the compiler and back port them to Scala 3.3 LTS in the compiler repo (@halotukozak, feel free to try if you care about this).
This is still broken at Scala 3.3.8.

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Cursor

## How was the solution tested?
included new automated tests
