### PR TITLE
Fix REPL on JDK 24+ for Scala versions with split JLine modules

### DIFF
--- a/modules/build/src/main/scala/scala/build/ReplArtifacts.scala
+++ b/modules/build/src/main/scala/scala/build/ReplArtifacts.scala
@@ -6,6 +6,7 @@ import coursier.util.Task
 import dependency.*
 
 import java.io.File
+import java.nio.file.Paths
 
 import scala.build.EitherCps.{either, value}
 import scala.build.errors.BuildException
@@ -87,26 +88,7 @@ object ReplArtifacts {
       replArtifacts
         .map(_._2.toString)
         .filter(_.contains("jline"))
-    val jlineJavaOpts: Seq[String] =
-      if javaVersion >= 24 && jlineArtifacts.nonEmpty then {
-        val modulePath    = Seq("--module-path", jlineArtifacts.mkString(File.pathSeparator))
-        val remainingOpts =
-          if isScala2 then
-            Seq(
-              "--add-modules",
-              "org.jline",
-              "--enable-native-access=org.jline"
-            )
-          else
-            Seq(
-              "--add-modules",
-              "org.jline.terminal",
-              "--enable-native-access=org.jline.nativ"
-            )
-        modulePath ++ remainingOpts
-      }
-      else Seq.empty
-    val replJavaOpts = defaultReplJavaOpts ++ jlineJavaOpts
+    val replJavaOpts = defaultReplJavaOpts ++ jlineJavaOpts(jlineArtifacts, javaVersion)
     ReplArtifacts(
       replArtifacts = replArtifacts,
       depArtifacts = depArtifacts,
@@ -117,4 +99,29 @@ object ReplArtifacts {
       addSourceJars = false
     )
   }
+
+  /** Puts JLine on the module path, to avoid restricted method warnings on JDK 24+.
+    *
+    * Scala ships JLine either as the `org.jline:jline` uber-jar (module `org.jline`, 2.13.18 and
+    * earlier) or as the individual modules (Scala 3, 2.13.19+), so no single module name works for
+    * `--add-modules`; `ALL-MODULE-PATH` adds whatever is on the module path instead, see
+    * https://openjdk.org/jeps/261. `--enable-native-access` has no equivalent, hence the check.
+    */
+  private[build] def jlineJavaOpts(
+    jlineArtifacts: Seq[String],
+    javaVersion: Int
+  ): Seq[String] =
+    if javaVersion >= 24 && jlineArtifacts.nonEmpty then {
+      val hasSplitModules =
+        jlineArtifacts.exists(Paths.get(_).getFileName.toString.startsWith("jline-native"))
+      val nativeAccessModule = if hasSplitModules then "org.jline.nativ" else "org.jline"
+      Seq(
+        "--module-path",
+        jlineArtifacts.mkString(File.pathSeparator),
+        "--add-modules",
+        "ALL-MODULE-PATH",
+        s"--enable-native-access=$nativeAccessModule"
+      )
+    }
+    else Seq.empty
 }

--- a/modules/build/src/main/scala/scala/build/ReplArtifacts.scala
+++ b/modules/build/src/main/scala/scala/build/ReplArtifacts.scala
@@ -112,9 +112,9 @@ object ReplArtifacts {
     javaVersion: Int
   ): Seq[String] =
     if javaVersion >= 24 && jlineArtifacts.nonEmpty then {
-      val hasSplitModules =
+      val hasJLineNative =
         jlineArtifacts.exists(Paths.get(_).getFileName.toString.startsWith("jline-native"))
-      val nativeAccessModule = if hasSplitModules then "org.jline.nativ" else "org.jline"
+      val nativeAccessModule = if hasJLineNative then "org.jline.nativ" else "org.jline"
       Seq(
         "--module-path",
         jlineArtifacts.mkString(File.pathSeparator),

--- a/modules/build/src/test/scala/scala/build/tests/ReplArtifactsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/ReplArtifactsTests.scala
@@ -1,0 +1,39 @@
+package scala.build.tests
+
+import com.eed3si9n.expecty.Expecty.expect
+
+import java.io.File
+
+import scala.build.ReplArtifacts
+
+class ReplArtifactsTests extends TestUtil.ScalaCliBuildSuite {
+
+  test("uber-jar JLine") {
+    val artifacts = Seq("/cs/org/jline/jline/3.29.0/jline-3.29.0-jdk8.jar")
+    expect(
+      ReplArtifacts.jlineJavaOpts(artifacts, javaVersion = 24) == Seq(
+        "--module-path",
+        artifacts.mkString(File.pathSeparator),
+        "--add-modules",
+        "ALL-MODULE-PATH",
+        "--enable-native-access=org.jline"
+      )
+    )
+  }
+
+  test("split JLine modules") {
+    val artifacts = Seq(
+      "/cs/org/jline/jline-terminal/3.30.16/jline-terminal-3.30.16.jar",
+      "/cs/org/jline/jline-native/3.30.16/jline-native-3.30.16.jar"
+    )
+    expect(
+      ReplArtifacts.jlineJavaOpts(artifacts, javaVersion = 24) == Seq(
+        "--module-path",
+        artifacts.mkString(File.pathSeparator),
+        "--add-modules",
+        "ALL-MODULE-PATH",
+        "--enable-native-access=org.jline.nativ"
+      )
+    )
+  }
+}


### PR DESCRIPTION
The Scala 2 branch passed `--add-modules org.jline`, which is the automatic
module name of the `org.jline:jline` uber-jar. Scala 2.13.19 switches to the
individual JLine modules (as Scala 3 already did), where no `org.jline` module
exists, so the REPL dies with:

  java.lang.module.FindException: Module org.jline not found

https://github.com/scala/scala/pull/11275

Use `--add-modules ALL-MODULE-PATH` instead of naming a module. The module path
assembled here only ever holds JLine artifacts, so this works for both shapes
and needs no per-Scala-version logic; the Scala 2 and Scala 3 branches collapse
into one. `--enable-native-access` still needs a real module name, picked from
whether the split-out `jline-native` artifact is present.

Extracted as `jlineJavaOpts` so it can be unit tested.