### PR TITLE
Switch `lts` tags to Scala 3.9 series

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -238,7 +238,7 @@ trait DocsTests extends CrossSbtModule with ScalaCliScalafixModule with LocatedI
 }
 
 object packager extends ScalaModule {
-  override def scalaVersion: T[String] = Scala.scala3Lts
+  override def scalaVersion: T[String] = Scala.scala3LegacyLts
   override def mvnDeps: T[Seq[Dep]]    = Seq(
     Deps.scalaPackagerCli
   )
@@ -537,7 +537,11 @@ trait Core extends ScalaCliCrossSbtModule
          |  def scala3NextRcVersion = "${Scala.scala3NextRc}"
          |  def scala3NextPrefix = "${Scala.scala3NextPrefix}"
          |  def scala3LtsPrefix = "${Scala.scala3LtsPrefix}"
-         |  def scala3Lts       = "${Scala.scala3Lts}"
+         |  def scala3LegacyLtsPrefix = "${Scala.scala3LegacyLtsPrefix}"
+         |  def scala3LegacyLts       = "${Scala.scala3LegacyLts}"
+         |  def scala3LtsPrefixes = Seq(${Scala.scala3LtsPrefixes
+          .map(p => s"\"$p\"")
+          .mkString(", ")})
          |  
          |  def scala38Versions = Seq(${Scala.scala38Versions
           .sorted
@@ -1016,7 +1020,7 @@ trait CliIntegration extends SbtModule
     with LocatedInModules {
   override def scalaVersion: T[String] = sv
 
-  def sv: String = Scala.scala3Lts
+  def sv: String = Scala.scala3LegacyLts
 
   def tmpDirBase: T[PathRef] = Task(persistent = true) {
     PathRef(Task.dest / "working-dir")
@@ -1080,6 +1084,11 @@ trait CliIntegration extends SbtModule
            |  def scala213                     = "${Scala.scala213}"
            |  def scala3LtsPrefix              = "${Scala.scala3LtsPrefix}"
            |  def scala3Lts                    = "${Scala.scala3Lts}"
+           |  def scala3LegacyLtsPrefix        = "${Scala.scala3LegacyLtsPrefix}"
+           |  def scala3LegacyLts              = "${Scala.scala3LegacyLts}"
+           |  def scala3LtsPrefixes            = Seq(${Scala.scala3LtsPrefixes
+            .map(p => s"\"$p\"")
+            .mkString(", ")})
            |  def scala3NextPrefix             = "${Scala.scala3NextPrefix}"
            |  def scala3NextRc                 = "${Scala.scala3NextRc}"
            |  def scala3NextRcAnnounced        = "${Scala.scala3NextRcAnnounced}"
@@ -1307,7 +1316,7 @@ trait CliIntegration extends SbtModule
 }
 
 trait CliIntegrationDocker extends SbtModule with ScalaCliPublishModule with HasTests {
-  override def scalaVersion: T[String] = Scala.scala3Lts
+  override def scalaVersion: T[String] = Scala.scala3LegacyLts
   override def mvnDeps: T[Seq[Dep]]    = super.mvnDeps() ++ Seq(
     Deps.osLib
   )

--- a/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
+++ b/modules/build/src/test/scala/scala/build/tests/BuildOptionsTests.scala
@@ -15,7 +15,7 @@ import scala.build.errors.{
   UnsupportedScalaVersionError
 }
 import scala.build.internal.Constants.*
-import scala.build.internal.Regexes.{scala2NightlyRegex, scala3LtsRegex}
+import scala.build.internal.Regexes.scala2NightlyRegex
 import scala.build.options.*
 import scala.build.tests.util.BloopServer
 import scala.build.{Build, BuildThreads, Directories, LocalRepo, Positioned, RepositoryUtils}
@@ -240,8 +240,8 @@ class BuildOptionsTests extends TestUtil.ScalaCliBuildSuite {
     )
     val scalaParams = options.scalaParams.orThrow.getOrElse(sys.error("should not happen"))
     assert(
-      scala3LtsRegex.unapplySeq(scalaParams.scalaVersion).isDefined,
-      "-S 3.lts argument does not lead to scala3 LTS"
+      scalaParams.scalaVersion.startsWith(s"$scala3LtsPrefix."),
+      "-S 3.lts argument does not lead to the latest scala3 LTS"
     )
   }
 

--- a/modules/cli/src/test/scala/cli/commands/tests/DocTests.scala
+++ b/modules/cli/src/test/scala/cli/commands/tests/DocTests.scala
@@ -23,17 +23,17 @@ class DocTests extends munit.FunSuite {
   }
 
   test("crossDocSubdirName: multiple groups, single platform uses only Scala version") {
-    val params = CrossBuildParams(Constants.scala3Lts, "jvm")
+    val params = CrossBuildParams(Constants.scala3LegacyLts, "jvm")
     expect(
       Doc.crossDocSubdirName(params, multipleCrossGroups = true, needsPlatformInSuffix = false) ==
-        Constants.scala3Lts
+        Constants.scala3LegacyLts
     )
   }
 
   test("crossDocSubdirName: multiple groups and platforms include platform in suffix") {
     val paramsJvm = CrossBuildParams(Constants.defaultScala213Version, "jvm")
     val paramsJs  = CrossBuildParams(Constants.defaultScala213Version, "js")
-    val paramsNat = CrossBuildParams(Constants.scala3Lts, "native")
+    val paramsNat = CrossBuildParams(Constants.scala3LegacyLts, "native")
     expect(
       Doc.crossDocSubdirName(paramsJvm, multipleCrossGroups = true, needsPlatformInSuffix = true) ==
         s"${Constants.defaultScala213Version}_jvm"
@@ -44,7 +44,7 @@ class DocTests extends munit.FunSuite {
     )
     expect(
       Doc.crossDocSubdirName(paramsNat, multipleCrossGroups = true, needsPlatformInSuffix = true) ==
-        s"${Constants.scala3Lts}_native"
+        s"${Constants.scala3LegacyLts}_native"
     )
   }
 
@@ -60,10 +60,10 @@ class DocTests extends munit.FunSuite {
       expect(mappingsArg.contains(s"scala-lang.org/api/${Constants.defaultScalaVersion}/"))
     }
 
-  test(s"correct external mappings for Scala 3 LTS (${Constants.scala3Lts})") {
-    val args        = Doc.defaultScaladocArgs(Constants.scala3Lts, Constants.defaultJavaVersion)
+  test(s"correct external mappings for Scala 3 LTS (${Constants.scala3LegacyLts})") {
+    val args = Doc.defaultScaladocArgs(Constants.scala3LegacyLts, Constants.defaultJavaVersion)
     val mappingsArg = args.find(_.startsWith("-external-mappings:")).get
-    expect(mappingsArg.contains(s"scala-lang.org/api/${Constants.scala3Lts}/"))
+    expect(mappingsArg.contains(s"scala-lang.org/api/${Constants.scala3LegacyLts}/"))
     expect(
       mappingsArg.contains(s"javase/${Constants.defaultJavaVersion}/docs/api/java.base/")
     )

--- a/modules/core/src/main/scala/scala/build/errors/ScalaVersionError.scala
+++ b/modules/core/src/main/scala/scala/build/errors/ScalaVersionError.scala
@@ -20,6 +20,9 @@ object ScalaVersionError {
        |In addition, you can request compilation with the last nightly versions of Scala,
        |by passing the 2.nightly, 2.12.nightly, 2.13.nightly, or 3.nightly arguments.
        |Specific Scala 2 or Scala 3 nightly versions are also accepted.
-       |You can also request the latest Scala 3 LTS by passing lts or 3.lts.
+       |You can also request the latest Scala 3 LTS (the $scala3LtsPrefix line) by passing lts or 3.lts.
+       |A particular LTS line can be requested with one of: ${scala3LtsPrefixes.map(p =>
+        s"$p.lts"
+      ).mkString(", ")}.
        |""".stripMargin
 }

--- a/modules/core/src/main/scala/scala/build/internals/Regexes.scala
+++ b/modules/core/src/main/scala/scala/build/internals/Regexes.scala
@@ -5,5 +5,4 @@ object Regexes {
   val scala3NightlyNicknameRegex = raw"""3\.([0-9]*)\.nightly""".r
   val scala3RcRegex              = raw"""3\.([0-9]*\.[0-9]*-[rR][cC][0-9]+)""".r
   val scala3RcNicknameRegex      = raw"""3\.([0-9]*)\.?[rR][cC]""".r
-  val scala3LtsRegex             = raw"""3\.3\.[0-9]+""".r
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTestDefinitions.scala
@@ -1027,7 +1027,7 @@ abstract class CompileTestDefinitions
             |""".stripMargin
       ).fromRoot { root =>
         // Signed dep built at 3.3 LTS (Sloth patches 3.0-3.7.x bytecode)
-        val signedJar = publishSignedLazyValsJar(Constants.scala3Lts, root, latestJava)
+        val signedJar = publishSignedLazyValsJar(Constants.scala3LegacyLts, root, latestJava)
 
         val r = os.proc(
           TestUtil.cli,
@@ -1107,7 +1107,7 @@ abstract class CompileTestDefinitions
       val expectedMessage = "Hello"
       TestInputs(
         os.rel / "Main.scala" ->
-          s"""//> using scala ${Constants.scala3Lts}
+          s"""//> using scala ${Constants.scala3LegacyLts}
              |//> using resourceDir resources
              |object Main {
              |  lazy val greeting: String = "$expectedMessage"

--- a/modules/integration/src/test/scala/scala/cli/integration/CompileTests213.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/CompileTests213.scala
@@ -52,14 +52,14 @@ class CompileTests213 extends CompileTestDefinitions with Test213 {
       val separator           = if (Properties.isWin) "\\" else "/"
       val graalVmVersion      = Constants.defaultGraalVMJavaVersion
       val legacyRunnerVersion = Constants.runnerScala2LegacyVersion
-      val ltsPrefix           = Constants.scala3LtsPrefix
+      val legacyLtsPrefix     = Constants.scala3LegacyLtsPrefix
 
       val expectedOutput =
         s"""|Compiling project (Scala $actualScalaVersion, JVM ($graalVmVersion))
             |Compiled project (Scala $actualScalaVersion, JVM ($graalVmVersion))
             |[warn] Scala $actualScalaVersion is no longer supported by the test-runner module.
             |[warn] Defaulting to a legacy test-runner module version: $legacyRunnerVersion.
-            |[warn] To use the latest test-runner, upgrade Scala to at least $ltsPrefix.
+            |[warn] To use the latest test-runner, upgrade Scala to at least $legacyLtsPrefix.
             |Compiling project (test, Scala $actualScalaVersion, JVM ($graalVmVersion))
             |[info] .${separator}Test.test.scala:6:5
             |[info] scala.Predef.ArrowAssoc[Int](1).->[String]("test")

--- a/modules/integration/src/test/scala/scala/cli/integration/DocSlothTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/DocSlothTestDefinitions.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 trait DocSlothTestDefinitions extends LazyValTests:
   this: DocTestDefinitions & TestScalaVersion =>
 
-  private val docScalaVersion = Constants.scala3Lts
+  private val docScalaVersion = Constants.scala3LegacyLts
 
   private def lazyValProjFile: String =
     s"""//> using scala $docScalaVersion

--- a/modules/integration/src/test/scala/scala/cli/integration/FixSlothTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixSlothTestDefinitions.scala
@@ -5,7 +5,7 @@ import com.eed3si9n.expecty.Expecty.expect
 trait FixSlothTestDefinitions extends LazyValTests:
   this: FixTestDefinitions & TestScalaVersion =>
 
-  private val fixScalaVersion = Constants.scala3Lts
+  private val fixScalaVersion = Constants.scala3LegacyLts
 
   private def expectScalafixClasspathContains(output: String, fragment: String): Unit =
     val cpOpt = output.split("--classpath ").lift(1).map(_.takeWhile(c => c != ' ' && c != '\n'))

--- a/modules/integration/src/test/scala/scala/cli/integration/PackageSlothTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PackageSlothTestDefinitions.scala
@@ -11,8 +11,8 @@ trait PackageSlothTestDefinitions extends LazyValTests:
   this: PackageTestDefinitions & TestScalaVersion =>
 
   private val latestJava             = Constants.allJavaVersions.max
-  private val assemblyScalaVersions  = Seq("3.0.2", Constants.scala3Lts)
-  private val ltsOnlyScalaVersion    = Constants.scala3Lts
+  private val assemblyScalaVersions  = Seq("3.0.2", Constants.scala3LegacyLts)
+  private val ltsOnlyScalaVersion    = Constants.scala3LegacyLts
   private val expectedMessage        = "Hello"
   private val slothAgentWarnFragment = "is not applicable to package"
 
@@ -461,7 +461,7 @@ trait PackageSlothTestDefinitions extends LazyValTests:
             |""".stripMargin
       ).fromRoot { root =>
         // Signed dep built at 3.3 LTS
-        val signedJar = publishSignedLazyValsJar(Constants.scala3Lts, root, latestJava)
+        val signedJar = publishSignedLazyValsJar(Constants.scala3LegacyLts, root, latestJava)
         val appJar    = root / "app.jar"
 
         os.proc(

--- a/modules/integration/src/test/scala/scala/cli/integration/PublishSlothTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/PublishSlothTestDefinitions.scala
@@ -86,7 +86,7 @@ trait PublishSlothTestDefinitions extends LazyValTests:
     }
 
     test(
-      s"publish reflects --sloth toggle for ${Constants.scala3Lts} lazy vals on JDK $latestJava"
+      s"publish reflects --sloth toggle for ${Constants.scala3LegacyLts} lazy vals on JDK $latestJava"
     ) {
       val ltsProjFile =
         s"""//> using publish.organization $testOrg
@@ -117,13 +117,18 @@ trait PublishSlothTestDefinitions extends LazyValTests:
           ).call(cwd = root, stderr = os.Pipe)
 
         val withSlothRepo = root / "test-repo-sloth"
-        publishToRepo(root, slothOptions, withSlothRepo, scalaVersionOverride = Constants.scala3Lts)
+        publishToRepo(
+          root,
+          slothOptions,
+          withSlothRepo,
+          scalaVersionOverride = Constants.scala3LegacyLts
+        )
         val withSloth = runPublished(withSlothRepo)
         expect(withSloth.out.trim().contains(expectedMessage))
         expect(!withSloth.err.trim().contains("sun.misc.Unsafe"))
 
         val withoutSlothRepo = root / "test-repo-no-sloth"
-        publishToRepo(root, Nil, withoutSlothRepo, scalaVersionOverride = Constants.scala3Lts)
+        publishToRepo(root, Nil, withoutSlothRepo, scalaVersionOverride = Constants.scala3LegacyLts)
         val withoutSloth = runPublished(withoutSlothRepo)
         expect(withoutSloth.out.trim().contains(expectedMessage))
         expect(withoutSloth.err.trim().contains("sun.misc.Unsafe"))
@@ -155,7 +160,7 @@ trait PublishSlothTestDefinitions extends LazyValTests:
 
     test("publish --sloth preserves user META-INF/MANIFEST.MF from resources") {
       val projFile =
-        s"""//> using scala ${Constants.scala3Lts}
+        s"""//> using scala ${Constants.scala3LegacyLts}
            |//> using resourceDir resources
            |//> using publish.organization $testOrg
            |//> using publish.name $testName

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTests3Lts.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTests3Lts.scala
@@ -4,34 +4,36 @@ import com.eed3si9n.expecty.Expecty.expect
 
 class ReplTests3Lts extends ReplTestDefinitions with Test3Lts
     with ReplJShellTestDefinitions {
-  import Constants.scala3LtsPrefix
-  if canRunInRepl then
-    for { ltsNightlyTag <- List("3.lts.nightly", "lts.nightly") }
+  import Constants.{scala3LtsPrefix, scala3LegacyLtsPrefix}
+  if canRunInRepl then {
+    val versionCode = s"""println($retrieveScalaVersionCode)"""
+
+    def replScalaVersion(tag: String)(check: String => Unit): Unit =
+      runInRepl(
+        versionCode,
+        cliOptions = Seq("-S", tag, "--with-compiler"),
+        skipScalaVersionArgs = true
+      )(r => check(r.out.trim()))
+
+    for {
+      (ltsNightlyTag, expectedPrefix) <- List(
+        "3.lts.nightly"                       -> scala3LtsPrefix,
+        "lts.nightly"                         -> scala3LtsPrefix,
+        s"$scala3LegacyLtsPrefix.lts.nightly" -> scala3LegacyLtsPrefix
+      ).distinct
+    }
       test(
-        s"$runInReplPrefix $ltsNightlyTag returns the same Scala version as $scala3LtsPrefix.nightly"
+        s"$runInReplPrefix $ltsNightlyTag returns the same Scala version as $expectedPrefix.nightly"
       ) {
-        val code = s"""println($retrieveScalaVersionCode)"""
-        runInRepl(
-          code,
-          cliOptions = Seq("-S", ltsNightlyTag, "--with-compiler"),
-          skipScalaVersionArgs = true
-        ) { r1 =>
-          val version1 = r1.out.trim()
+        replScalaVersion(ltsNightlyTag) { version1 =>
           System.err.println(s"$ltsNightlyTag returns the following nightly: $version1")
-          runInRepl(
-            code,
-            cliOptions = Seq("-S", s"$scala3LtsPrefix.nightly", "--with-compiler"),
-            skipScalaVersionArgs = true
-          ) { r2 =>
-            val version2 = r2.out.trim()
+          replScalaVersion(s"$expectedPrefix.nightly") { version2 =>
             expect(version1 == version2)
-            val major = version1.split('.').take(1).head.toInt
-            expect(major == 3)
-            val minor = version1.split('.').take(2).last.toInt
-            expect(minor >= scala3LtsPrefix.split('.').last.toInt)
+            expect(version1.startsWith(s"$expectedPrefix."))
             val patch = version1.split('.').take(3).last.takeWhile(_.isDigit).toInt
-            if minor == 3 then expect(patch >= 8) // new nightly repo
+            if expectedPrefix == "3.3" then expect(patch >= 8) // new nightly repo
           }
         }
       }
+  }
 }

--- a/modules/integration/src/test/scala/scala/cli/integration/ReplTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/ReplTestsDefault.scala
@@ -41,7 +41,7 @@ class ReplTestsDefault extends ReplTestDefinitions
       val expectedMessage = "Hello"
       val code            = "println(lazyvalslib.LazyValsLib.greeting)"
       TestInputs.empty.fromRoot { root =>
-        val (dep, repoDir) = publishLazyValsLib(Constants.scala3Lts, root)
+        val (dep, repoDir) = publishLazyValsLib(Constants.scala3LegacyLts, root)
         val res            = os.proc(
           TestUtil.cli,
           "repl",

--- a/modules/integration/src/test/scala/scala/cli/integration/RunLtsTagTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunLtsTagTestDefinitions.scala
@@ -1,0 +1,73 @@
+package scala.cli.integration
+
+import com.eed3si9n.expecty.Expecty.expect
+
+trait RunLtsTagTestDefinitions { this: RunTestDefinitions =>
+  protected val currentltsPrefix: String = Constants.scala3LtsPrefix
+  protected val currentLts: String       = Constants.scala3Lts
+  protected val legacyLtsPrefix: String  = Constants.scala3LegacyLtsPrefix
+  protected val legacyLts: String        = Constants.scala3LegacyLts
+
+  private val nonLtsPrefix: String = "3.8"
+
+  for {
+    (tag, expectedPrefix, expectedVersion) <- List(
+      ("lts", currentltsPrefix, currentLts),
+      ("3.lts", currentltsPrefix, currentLts),
+      (s"$currentltsPrefix.lts", currentltsPrefix, currentLts),
+      (s"$legacyLtsPrefix.lts", legacyLtsPrefix, legacyLts)
+    ).distinct
+  }
+    test(s"Scala $tag points to the latest stable $expectedPrefix version") {
+      TestInputs.empty.fromRoot { root =>
+        val version = getScalaVersion(tag, root)
+        expect(version.startsWith(s"$expectedPrefix."))
+        expect(version == expectedVersion)
+        expect(!version.exists(_.isLetter))
+      }
+    }
+
+  for {
+    (tag, expectedPrefix) <- List(
+      "lts.rc"                   -> currentltsPrefix,
+      "3.lts.rc"                 -> currentltsPrefix,
+      s"$legacyLtsPrefix.lts.rc" -> legacyLtsPrefix
+    ).distinct
+  }
+    test(s"Scala $tag points to the latest $expectedPrefix RC") {
+      TestInputs.empty.fromRoot { root =>
+        val version = getScalaVersion(tag, root)
+        expect(version.startsWith(s"$expectedPrefix."))
+        expect(version.contains("-RC"))
+        expect(!version.contains("NIGHTLY"))
+        expect(!version.contains("SNAPSHOT"))
+      }
+    }
+
+  test(s"Scala lts.nightly, 3.lts.nightly & $currentltsPrefix.nightly point to the same version") {
+    TestInputs.empty.fromRoot { root =>
+      val version = getScalaVersion("lts.nightly", root)
+      expect(version.startsWith(s"$currentltsPrefix."))
+      expect(version == getScalaVersion("3.lts.nightly", root))
+      expect(version == getScalaVersion(s"$currentltsPrefix.nightly", root))
+    }
+  }
+
+  test(s"Scala $legacyLtsPrefix.lts.nightly & $legacyLtsPrefix.nightly point to the same version") {
+    TestInputs.empty.fromRoot { root =>
+      val version = getScalaVersion(s"$legacyLtsPrefix.lts.nightly", root)
+      expect(version.startsWith(s"$legacyLtsPrefix."))
+      val patch = version.split('.').take(3).last.takeWhile(_.isDigit).toInt
+      if legacyLtsPrefix == "3.3" then expect(patch >= 8) // new nightly repo
+      expect(version == getScalaVersion(s"$legacyLtsPrefix.nightly", root))
+    }
+  }
+
+  test(s"Scala $nonLtsPrefix.lts is rejected, as $nonLtsPrefix is not an LTS series") {
+    TestInputs.empty.fromRoot { root =>
+      val output =
+        getScalaVersion(s"$nonLtsPrefix.lts", root, check = false, mergeErrIntoOut = true)
+      expect(output.contains(s"Cannot find matching Scala version for '$nonLtsPrefix.lts'"))
+    }
+  }
+}

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestDefinitions.scala
@@ -2876,7 +2876,8 @@ abstract class RunTestDefinitions
         TestUtil.retryOnCi() {
           testInputs.fromRoot { root =>
             // Scala 3.3 lib built on JDK 8 -> uses sun.misc.Unsafe lazy vals; sloth must patch it.
-            val (_, repoDir) = publishLazyValsLib(Constants.scala3Lts, root, buildJvm = Some("8"))
+            val (_, repoDir) =
+              publishLazyValsLib(Constants.scala3LegacyLts, root, buildJvm = Some("8"))
             if (shouldRestartBloop)
               os.proc(TestUtil.cli, "bloop", "exit", "--power").call(cwd = root)
             val processes = (0 until parallelInstancesCount).map { _ =>
@@ -3000,7 +3001,7 @@ abstract class RunTestDefinitions
             |""".stripMargin
       ).fromRoot { root =>
         // Signed dep built at 3.3 LTS (Sloth patches 3.0-3.7.x bytecode)
-        val signedJar = publishSignedLazyValsJar(Constants.scala3Lts, root, latestJava)
+        val signedJar = publishSignedLazyValsJar(Constants.scala3LegacyLts, root, latestJava)
 
         val r = os.proc(
           TestUtil.cli,

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTests3Lts.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTests3Lts.scala
@@ -6,21 +6,7 @@ import scala.cli.integration.TestUtil.ProcOps
 import scala.concurrent.duration.DurationInt
 import scala.util.Properties
 
-class RunTests3Lts extends RunTestDefinitions with Test3Lts {
-  import Constants.scala3LtsPrefix
-  for (ltsNightlyAlias <- List("lts.nightly", "3.lts.nightly"))
-    test(s"Scala $ltsNightlyAlias & $scala3LtsPrefix.nightly point to the same version") {
-      TestInputs.empty.fromRoot { root =>
-        val version1      = getScalaVersion(ltsNightlyAlias, root)
-        val nightlyPrefix = version1.split('.').take(2).mkString(".")
-        expect(nightlyPrefix == Constants.scala3LtsPrefix)
-        val nightlyPatch = version1.split('.').take(3).last.takeWhile(_.isDigit).toInt
-        if nightlyPrefix == "3.3" then expect(nightlyPatch >= 8) // new nightly repo
-        val version2 = getScalaVersion(s"${Constants.scala3LtsPrefix}.nightly", root)
-        expect(version1 == version2)
-      }
-    }
-
+class RunTests3Lts extends RunTestDefinitions with RunLtsTagTestDefinitions with Test3Lts {
   if (!Properties.isMac || !TestUtil.isCI)
     test(s"--sloth works correctly under --watch mode") {
       val expectedMessage1 = "Hello from lazy val"

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTests3NextRc.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTests3NextRc.scala
@@ -14,7 +14,7 @@ class RunTests3NextRc extends RunTestDefinitions with Test3NextRc {
     }
 
   for {
-    label <- List("rc", "3.rc", "3.lts.rc", "lts.rc", s"${Constants.scala3LtsPrefix}.rc", "3.7.rc")
+    label <- List("rc", "3.rc", s"${Constants.scala3LegacyLtsPrefix}.rc", "3.7.rc")
   }
     test(s"$label is valid and works as expected") {
       TestInputs.empty.fromRoot { root =>

--- a/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunTestsDefault.scala
@@ -42,7 +42,7 @@ class RunTestsDefault extends RunTestDefinitions
     .maxBy(_.coursierVersion)
   for slothFlag <- Seq("--sloth", "--sloth-agent") do
     lazyValsUnsafeTest(highest30, slothFlag)
-    lazyValsUnsafeTest(Constants.scala3Lts, slothFlag)
+    lazyValsUnsafeTest(Constants.scala3LegacyLts, slothFlag)
 
   test("--sloth and --sloth-agent together warn they are mutually redundant") {
     val expectedMessage = "Hello"
@@ -63,7 +63,7 @@ class RunTestsDefault extends RunTestDefinitions
   }
 
   test(
-    s"user code ${Constants.scala3Lts} lazy vals dont warn about sun.misc.Unsafe on JDK $latestJava (--sloth)"
+    s"user code ${Constants.scala3LegacyLts} lazy vals dont warn about sun.misc.Unsafe on JDK $latestJava (--sloth)"
   ) {
     val expectedMessage = "Hello from user code"
     TestInputs.empty.fromRoot { root =>
@@ -81,7 +81,7 @@ class RunTestsDefault extends RunTestDefinitions
         "--sloth",
         ".",
         "--scala",
-        Constants.scala3Lts,
+        Constants.scala3LegacyLts,
         "--jvm",
         latestJava
       ).call(cwd = root, mergeErrIntoOut = true)
@@ -91,7 +91,7 @@ class RunTestsDefault extends RunTestDefinitions
   }
 
   test(
-    s"run reflects --sloth toggle for ${Constants.scala3Lts} lazy vals on JDK $latestJava"
+    s"run reflects --sloth toggle for ${Constants.scala3LegacyLts} lazy vals on JDK $latestJava"
   ) {
     val expectedMessage = "Hello from toggle"
     TestInputs(
@@ -109,7 +109,7 @@ class RunTestsDefault extends RunTestDefinitions
         extraOptions,
         slothOptions,
         "--scala",
-        Constants.scala3Lts,
+        Constants.scala3LegacyLts,
         "--jvm",
         latestJava.toString,
         "."
@@ -123,7 +123,7 @@ class RunTestsDefault extends RunTestDefinitions
         "run",
         extraOptions,
         "--scala",
-        Constants.scala3Lts,
+        Constants.scala3LegacyLts,
         "--jvm",
         latestJava.toString,
         "."
@@ -136,7 +136,7 @@ class RunTestsDefault extends RunTestDefinitions
   test("run js --sloth warns that sloth is not applicable") {
     TestInputs(
       os.rel / "Main.scala" ->
-        s"""//> using scala ${Constants.scala3Lts}
+        s"""//> using scala ${Constants.scala3LegacyLts}
            |//> using platform scala-js
            |import scala.scalajs.js
            |
@@ -165,7 +165,7 @@ class RunTestsDefault extends RunTestDefinitions
     TestUtil.retryOnCi() {
       TestInputs(
         os.rel / "Main.scala" ->
-          s"""//> using scala ${Constants.scala3Lts}
+          s"""//> using scala ${Constants.scala3LegacyLts}
              |//> using platform scala-native
              |object Main {
              |  def main(args: Array[String]): Unit = println("Hello")
@@ -189,7 +189,7 @@ class RunTestsDefault extends RunTestDefinitions
   }
 
   test(
-    s"run --sloth preserves user META-INF/MANIFEST.MF for ${Constants.scala3Lts}"
+    s"run --sloth preserves user META-INF/MANIFEST.MF for ${Constants.scala3LegacyLts}"
   ) {
     val expectedMessage = "Hello with manifest"
     TestInputs(
@@ -209,7 +209,7 @@ class RunTestsDefault extends RunTestDefinitions
         extraOptions,
         slothOptions,
         "--scala",
-        Constants.scala3Lts,
+        Constants.scala3LegacyLts,
         "."
       ).call(cwd = root, stderr = os.Pipe)
       expect(r.out.trim().contains(expectedMessage))
@@ -229,7 +229,7 @@ class RunTestsDefault extends RunTestDefinitions
     ).fromRoot { root =>
       // Use a .zip suffix so the compiler accepts the archive on --classpath, while Sloth
       // must still recognize it by content rather than a `.jar` extension.
-      val lib = packageLazyValsLibrary(Constants.scala3Lts, root, root / "lib.zip")
+      val lib = packageLazyValsLibrary(Constants.scala3LegacyLts, root, root / "lib.zip")
       val r   = os.proc(
         TestUtil.cli,
         "--power",
@@ -259,7 +259,7 @@ class RunTestsDefault extends RunTestDefinitions
             |}
             |""".stripMargin
       ).fromRoot { root =>
-        val plainLib = packageLazyValsLibrary(Constants.scala3Lts, root, root / "lib.jar")
+        val plainLib = packageLazyValsLibrary(Constants.scala3LegacyLts, root, root / "lib.jar")
         val preamble =
           """#!/usr/bin/env sh
             |exec java -jar "$0" "$@"

--- a/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/SipScalaTests.scala
@@ -508,7 +508,7 @@ class SipScalaTests extends ScalaCliSuite
     anotherVersion =
       if (sv.startsWith("2.13")) Constants.scala212
       else if (sv.startsWith("2.12")) Constants.scala213
-      else Constants.scala3Lts
+      else Constants.scala3LegacyLts
   } {
     test(
       s"default Scala version overridden with $sv by a launcher parameter is respected when running a script"
@@ -871,7 +871,7 @@ class SipScalaTests extends ScalaCliSuite
 
   // this check is just to ensure this isn't being run for LTS RC jobs
   // should be adjusted when a new LTS line is released
-  if (!Constants.scala3NextRc.startsWith(Constants.scala3LtsPrefix))
+  if (!Constants.scala3NextRc.startsWith(Constants.scala3LegacyLtsPrefix))
     test("scalac help respects --cli-default-scala-version") {
       TestInputs.empty.fromRoot { root =>
         val sv                          = Constants.scala3NextRc

--- a/modules/integration/src/test/scala/scala/cli/integration/TestNativeImageOnScala3.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestNativeImageOnScala3.scala
@@ -42,7 +42,7 @@ class TestNativeImageOnScala3 extends ScalaCliSuite {
 
   for {
     scalaVersion <- TestUtil.legacyScalaVersionsOnePerMinor.sorted ++ Seq(
-      Constants.scala3Lts,
+      Constants.scala3LegacyLts,
       Constants.scala3Next,
       Constants.scala3NextRc
     )

--- a/modules/integration/src/test/scala/scala/cli/integration/TestScalaVersionArgs.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestScalaVersionArgs.scala
@@ -6,7 +6,7 @@ trait TestScalaVersionArgs extends ScalaCliSuite { this: TestScalaVersion =>
   override def group: ScalaCliSuite.TestGroup =
     if (actualScalaVersion.startsWith("2.12.")) ScalaCliSuite.TestGroup.Third
     else if (actualScalaVersion.startsWith("2.13.")) ScalaCliSuite.TestGroup.Second
-    else if (actualScalaVersion.startsWith(Constants.scala3LtsPrefix))
+    else if (actualScalaVersion.startsWith(Constants.scala3LegacyLtsPrefix))
       ScalaCliSuite.TestGroup.Fourth
     else if (actualScalaVersion.startsWith(Constants.scala3NextRc))
       ScalaCliSuite.TestGroup.Fifth
@@ -51,7 +51,7 @@ trait Test212 extends TestScalaVersion { this: TestScalaVersionArgs =>
   override lazy val scalaVersionOpt: Option[String] = Some(Constants.scala212)
 }
 trait Test3Lts extends TestScalaVersion { this: TestScalaVersionArgs =>
-  override lazy val scalaVersionOpt: Option[String] = Some(Constants.scala3Lts)
+  override lazy val scalaVersionOpt: Option[String] = Some(Constants.scala3LegacyLts)
 }
 trait Test3NextRc extends TestScalaVersion { this: TestScalaVersionArgs =>
   override lazy val scalaVersionOpt: Option[String] = Some(Constants.scala3NextRc)

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestsDefault.scala
@@ -59,13 +59,13 @@ class TestTestsDefault extends TestTestDefinitions with LazyValTests with TestDe
     .maxBy(_.coursierVersion)
   for slothFlag <- Seq("--sloth", "--sloth-agent") do
     testLazyValsUnsafe(highest30, slothFlag)
-    testLazyValsUnsafe(Constants.scala3Lts, slothFlag)
+    testLazyValsUnsafe(Constants.scala3LegacyLts, slothFlag)
 
   // project classes are only patched for Scala < 3.8, so the LTS version is what exercises
   // patching of the very class dirs the test runner scans for suites
   for slothFlag <- Seq("--sloth", "--sloth-agent") do
     test(
-      s"test user code ${Constants.scala3Lts} lazy vals dont warn about sun.misc.Unsafe on JDK $latestJava ($slothFlag)"
+      s"test user code ${Constants.scala3LegacyLts} lazy vals dont warn about sun.misc.Unsafe on JDK $latestJava ($slothFlag)"
     ) {
       val expectedMessage = "Hello from user test code"
       val marker          = "TEST_BODY_EXECUTED"
@@ -97,7 +97,7 @@ class TestTestsDefault extends TestTestDefinitions with LazyValTests with TestDe
           slothFlag,
           ".",
           "--scala",
-          Constants.scala3Lts,
+          Constants.scala3LegacyLts,
           "--jvm",
           latestJava
         ).call(cwd = root, stderr = os.Pipe)
@@ -112,7 +112,7 @@ class TestTestsDefault extends TestTestDefinitions with LazyValTests with TestDe
   test("test js --sloth warns that sloth is not applicable") {
     TestInputs(
       os.rel / "HelloTests.test.scala" ->
-        s"""//> using scala ${Constants.scala3Lts}
+        s"""//> using scala ${Constants.scala3LegacyLts}
            |//> using platform scala-js
            |//> using dep org.scalameta::munit::$munitVersion
            |
@@ -142,7 +142,7 @@ class TestTestsDefault extends TestTestDefinitions with LazyValTests with TestDe
     TestUtil.retryOnCi() {
       TestInputs(
         os.rel / "HelloTests.test.scala" ->
-          s"""//> using scala ${Constants.scala3Lts}
+          s"""//> using scala ${Constants.scala3LegacyLts}
              |//> using platform scala-native
              |//> using dep org.scalameta::munit::$munitVersion
              |

--- a/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestUtil.scala
@@ -29,7 +29,7 @@ object TestUtil {
   val debugPortOpt: Option[String]  = sys.props.get("test.scala-cli.debug.port")
   val detectCliPath: String         = if (TestUtil.isNativeCli) TestUtil.cliPath else "scala-cli"
   val cli: Seq[String]              = cliCommand(cliPath)
-  val ltsEqualsNext: Boolean        = Constants.scala3Lts equals Constants.scala3Next
+  val ltsEqualsNext: Boolean        = Constants.scala3LegacyLts equals Constants.scala3Next
 
   lazy val legacyScalaVersionsOnePerMinor: Seq[String] =
     Constants.legacyScala3Versions.sorted.reverse.distinctBy(_.split('.').take(2).mkString("."))

--- a/modules/options/src/main/scala/scala/build/Artifacts.scala
+++ b/modules/options/src/main/scala/scala/build/Artifacts.scala
@@ -163,7 +163,7 @@ object Artifacts {
     val shouldUseLegacyJava8Runners  = jvmVersion < Constants.scala38MinJavaVersion
     val shouldUseLegacyScala3Runners =
       scalaVersion.startsWith("3") &&
-      scalaVersion.coursierVersion < s"$scala3LtsPrefix.0".coursierVersion
+      scalaVersion.coursierVersion < s"$scala3LegacyLtsPrefix.0".coursierVersion
     val shouldUseLegacyScala2Runners = scalaVersion.startsWith("2")
     val shouldUseLegacyScalaRunners  = shouldUseLegacyScala3Runners || shouldUseLegacyScala2Runners
     val shouldUseLegacyRunners       = shouldUseLegacyScalaRunners || shouldUseLegacyJava8Runners
@@ -189,7 +189,7 @@ object Artifacts {
             )
             if shouldUseLegacyScalaRunners then
               logger.message(
-                s"$warnPrefix To use the latest test-runner, upgrade Scala to at least $scala3LtsPrefix."
+                s"$warnPrefix To use the latest test-runner, upgrade Scala to at least $scala3LegacyLtsPrefix."
               )
             if shouldUseLegacyJava8Runners then
               logger.message(
@@ -531,7 +531,7 @@ object Artifacts {
                 )
                 if shouldUseLegacyScalaRunners then
                   logger.message(
-                    s"$warnPrefix To use the latest runner, upgrade Scala to at least $scala3LtsPrefix."
+                    s"$warnPrefix To use the latest runner, upgrade Scala to at least $scala3LegacyLtsPrefix."
                   )
                 if shouldUseLegacyJava8Runners then
                   logger.message(
@@ -540,7 +540,7 @@ object Artifacts {
                 logger.message(
                   s"""$warnPrefix Scala $scalaVersion is no longer supported by the runner module.
                      |$warnPrefix Defaulting to a legacy runner module version: $runnerLegacyVersion.
-                     |$warnPrefix To use the latest runner, upgrade Scala to at least $scala3LtsPrefix."""
+                     |$warnPrefix To use the latest runner, upgrade Scala to at least $scala3LegacyLtsPrefix."""
                     .stripMargin
                 )
                 runnerLegacyVersion

--- a/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
+++ b/modules/options/src/main/scala/scala/build/options/BuildOptions.scala
@@ -379,12 +379,20 @@ final case class BuildOptions(
         case (Some(MaybeScalaVersion(Some(svInput))), _) =>
           val sv = value {
             svInput match {
-              case sv if ScalaVersionUtil.scala3Lts.contains(sv) =>
-                ScalaVersionUtil.validateStable(Constants.scala3LtsPrefix, cache, repositories)
+              case sv if ScalaVersionUtil.scala3Lts.contains(sv.toLowerCase) =>
+                ScalaVersionUtil.validateStable(
+                  Constants.scala3LtsPrefix,
+                  cache,
+                  repositories
+                )
+              case ScalaVersionUtil.VersionedLts(ltsPrefix) =>
+                ScalaVersionUtil.validateStable(ltsPrefix, cache, repositories)
               case sv if ScalaVersionUtil.scala3LatestRc.contains(sv.toLowerCase) =>
                 ScalaVersionUtil.validateRc("3", cache, repositories)
               case sv if ScalaVersionUtil.scala3LtsLatestRc.contains(sv.toLowerCase) =>
                 ScalaVersionUtil.validateRc(Constants.scala3LtsPrefix, cache, repositories)
+              case ScalaVersionUtil.VersionedLtsRc(ltsPrefix) =>
+                ScalaVersionUtil.validateRc(ltsPrefix, cache, repositories)
               case scala3RcRegex(threeSubBinarySuffix) =>
                 ScalaVersionUtil.validateRc(s"3.$threeSubBinarySuffix", cache, repositories)
               case scala3RcNicknameRegex(threeSubBinarySuffix) =>
@@ -404,6 +412,8 @@ final case class BuildOptions(
                   Constants.scala3LtsPrefix.split('.').last,
                   cache
                 )
+              case ScalaVersionUtil.VersionedLtsNightly(ltsPrefix) =>
+                ScalaVersionUtil.GetNightly.scala3X(ltsPrefix.split('.').last, cache)
               case scala3NightlyNicknameRegex(threeSubBinaryNum) =>
                 ScalaVersionUtil.GetNightly.scala3X(threeSubBinaryNum, cache)
               case vs if ScalaVersionUtil.scala213Nightly.contains(vs) =>

--- a/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
+++ b/modules/options/src/main/scala/scala/build/options/ScalaVersionUtil.scala
@@ -36,10 +36,25 @@ object ScalaVersionUtil {
   private def rcAlias(prefix: String) = s"$prefix.rc"
   def scala2LatestRc                  = List(rcAlias("2"), rcAlias("2.12"), rcAlias("2.13"))
   def scala3LatestRc                  = List("rc", rcAlias("3"))
-  def scala3LtsLatestRc = List(rcAlias("lts"), rcAlias("3.lts"), rcAlias(Constants.scala3LtsPrefix))
-  def scala3Lts         = List("3.lts", "lts")
+  def scala3LtsLatestRc               = List(rcAlias("lts"), rcAlias("3.lts"))
+  def scala3Lts                       = List("3.lts", "lts")
   // not valid versions, defined only for informative error messages
   def scala2Lts = List("2.13.lts", "2.12.lts", "2.lts")
+
+  /** Matches an LTS tag pinned to a particular series, e.g. `3.3.lts`, `3.3.lts.rc`. Only the
+    * series listed in [[Constants.scala3LtsPrefixes]] have such tags, extracting to the series
+    * prefix itself.
+    */
+  private def versionedLtsTag(suffix: String)(sv: String): Option[String] =
+    Constants.scala3LtsPrefixes.find(prefix => sv.equalsIgnoreCase(s"$prefix.lts$suffix"))
+
+  object VersionedLts:
+    def unapply(sv: String): Option[String] = versionedLtsTag("")(sv)
+  object VersionedLtsRc:
+    def unapply(sv: String): Option[String] = versionedLtsTag(".rc")(sv)
+  object VersionedLtsNightly:
+    def unapply(sv: String): Option[String] = versionedLtsTag(".nightly")(sv)
+
   extension (cache: FileCache[Task]) {
     def fileWithTtl0(artifact: Artifact): Either[ArtifactError, File] =
       cache.logger.use {
@@ -315,7 +330,7 @@ object ScalaVersionUtil {
 
   def isScala3Nightly(version: String): Boolean =
     (version.startsWith("3") && version.toLowerCase.endsWith("nightly")) ||
-    scala3Nightly.contains(version.toLowerCase) || scala3LtsNightly.contains(version)
+    scala3Nightly.contains(version.toLowerCase) || scala3LtsNightly.contains(version.toLowerCase)
   def isStable(version: String): Boolean =
     !version.exists(_.isLetter)
   def isRc(version: String): Boolean = {

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -13,19 +13,22 @@ object Cli {
 }
 
 object Scala {
-  def scala212         = "2.12.21"
-  def scala213         = "2.13.18"
-  def scala3LtsPrefix  = "3.3"                  // used for the LTS version tags
-  def scala3Lts        = s"$scala3LtsPrefix.8"  // the LTS version currently used in the build
-  def runnerScala3     = scala3Lts
-  def scala3NextPrefix = "3.9"
-  def scala3Next       = s"$scala3NextPrefix.0" // the newest/next version of Scala
+  def scala212              = "2.12.21"
+  def scala213              = "2.13.18"
+  def scala3LtsPrefix       = "3.9"                  // current LTS
+  def scala3Lts             = s"$scala3LtsPrefix.0"
+  def scala3LegacyLtsPrefix = "3.3"                  // old LTS, still used to build the CLI itself
+  def scala3LtsPrefixes     = Seq(scala3LegacyLtsPrefix, scala3LtsPrefix).distinct
+  def scala3LegacyLts       = s"$scala3LegacyLtsPrefix.8"
+  def runnerScala3          = scala3LegacyLts
+  def scala3NextPrefix      = "3.9"
+  def scala3Next            = s"$scala3NextPrefix.0" // the newest/next version of Scala
   def scala3NextAnnounced   = "3.8.4"     // the newest/next version of Scala that's been announced
   def scala3NextRc          = "3.9.0-RC6" // the latest RC version of Scala Next
   def scala3NextRcAnnounced = "3.9.0-RC6" // the latest announced RC version of Scala Next
 
   // The Scala version used to build the CLI itself.
-  def defaultInternal = sys.props.get("scala.version.internal").getOrElse(scala3Lts)
+  def defaultInternal = sys.props.get("scala.version.internal").getOrElse(scala3LegacyLts)
 
   // The Scala version used by default to compile user input.
   def defaultUser = sys.props.get("scala.version.user").getOrElse(scala3Next)
@@ -38,10 +41,10 @@ object Scala {
   // respectively
   def scala38Versions = Seq("3.8.0", "3.8.0-RC1", "3.8.0-RC1-bin-20250901-ca400bd-NIGHTLY")
 
-  val allScala2           = Seq(scala213, scala212)
-  val defaults            = Seq(defaultInternal, defaultUser).distinct
-  val allScala3           = Seq(scala3Lts, scala3Next, scala3NextAnnounced, scala3NextRc).distinct
-  val all                 = (allScala2 ++ allScala3 ++ defaults).distinct
+  val allScala2 = Seq(scala213, scala212)
+  val defaults  = Seq(defaultInternal, defaultUser).distinct
+  val allScala3 = Seq(scala3LegacyLts, scala3Next, scala3NextAnnounced, scala3NextRc).distinct
+  val all       = (allScala2 ++ allScala3 ++ defaults).distinct
   val scala3MainVersions  = (defaults ++ allScala3).distinct
   val runnerScalaVersions = (Seq(runnerScala3) ++ scala3MainVersions).distinct
 
@@ -60,7 +63,7 @@ object Scala {
     val max30  = 2
     val max31  = 3
     val max32  = 2
-    val max33  = patchVer(scala3Lts)
+    val max33  = patchVer(scala3LegacyLts)
     val max34  = 3
     val max35  = 2
     val max36  = 4
@@ -85,7 +88,7 @@ object Scala {
     listAll
       .filter(_.startsWith("3"))
       .distinct
-      .filter(minorVer(_) < minorVer(scala3Lts))
+      .filter(minorVer(_) < minorVer(scala3LegacyLts))
 
 }
 


### PR DESCRIPTION
```bash
scala-cli -e 'println(scala.util.Properties.versionNumberString)' -S lts
# Compiling project (Scala 3.9.0, JVM (23))
# Compiled project (Scala 3.9.0, JVM (23))
# 3.9.0
```
This switches existing `lts` tags (as passed to `-S <tag>` / `//> using scala <tag>`) from Scala 3.3 LTS to 3.9 LTS.

| Tag | Before | After |
| --- | --- | --- |
| `lts`, `3.lts` | 3.3.8 | 3.9.0 |
| `lts.rc`, `3.lts.rc` | latest 3.3 RC | latest 3.9 RC |
| `lts.nightly`, `3.lts.nightly` | 3.3 nightly | 3.9 nightly |
| `3.3.lts`, `3.3.lts.rc`, `3.3.lts.nightly` | not recognised | the 3.3 series |
| `3.9.lts`, `3.9.lts.rc`, `3.9.lts.nightly` | not recognised | the 3.9 series |
| `3.7.lts` (and other non-LTS `<prefix>.lts`) | not recognised | not recognised |

## Checklist
- [x] tested the solution locally and it works 
- [x] ran the code formatter (`scala-cli fmt .`)
- [x] ran `scalafix` (`./mill -i __.fix`)
- [x] ran reference docs auto-generation (`./mill -i 'generate-reference-doc[]'.run`)

## How much have your relied on LLM-based tools in this contribution?
extensively, Cursor + Claude

## How was the solution tested?
included automated tests