### PR TITLE
Bump Scala Next RC to 3.10.0-RC1

### DIFF
--- a/modules/integration/src/test/scala/scala/cli/integration/FixScalafixRulesTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixScalafixRulesTestDefinitions.scala
@@ -59,45 +59,47 @@ trait FixScalafixRulesTestDefinitions {
     }
   }
 
-  test("semantic rule") {
-    val unusedValueInputsContent: String =
-      s"""//> using options $scalafixUnusedRuleOption
-         |package foo
-         |
-         |object Hello {
-         |  def main(args: Array[String]): Unit = {
-         |    val name = "John"
-         |    println("Hello")
-         |  }
-         |}
-         |""".stripMargin
-    val semanticRuleInputs: TestInputs = TestInputs(
-      os.rel / scalafixConfFileName ->
-        s"""|rules = [
-            |  RemoveUnused
-            |]
-            |""".stripMargin,
-      os.rel / "Hello.scala" -> unusedValueInputsContent
-    )
-    val expectedContent: String = noCrLf {
-      s"""//> using options $scalafixUnusedRuleOption
-         |package foo
-         |
-         |object Hello {
-         |  def main(args: Array[String]): Unit = {
-         |    
-         |    println("Hello")
-         |  }
-         |}
-         |""".stripMargin
-    }
+  if !isScala310OrNewer then
+    // TODO https://github.com/scalacenter/scalafix/issues/2503 re-enable when fixed
+    test("semantic rule") {
+      val unusedValueInputsContent: String =
+        s"""//> using options $scalafixUnusedRuleOption
+           |package foo
+           |
+           |object Hello {
+           |  def main(args: Array[String]): Unit = {
+           |    val name = "John"
+           |    println("Hello")
+           |  }
+           |}
+           |""".stripMargin
+      val semanticRuleInputs: TestInputs = TestInputs(
+        os.rel / scalafixConfFileName ->
+          s"""|rules = [
+              |  RemoveUnused
+              |]
+              |""".stripMargin,
+        os.rel / "Hello.scala" -> unusedValueInputsContent
+      )
+      val expectedContent: String = noCrLf {
+        s"""//> using options $scalafixUnusedRuleOption
+           |package foo
+           |
+           |object Hello {
+           |  def main(args: Array[String]): Unit = {
+           |    
+           |    println("Hello")
+           |  }
+           |}
+           |""".stripMargin
+      }
 
-    semanticRuleInputs.fromRoot { root =>
-      os.proc(TestUtil.cli, "fix", "--power", ".", scalaVersionArgs).call(cwd = root)
-      val updatedContent = noCrLf(os.read(root / "Hello.scala"))
-      expect(updatedContent == expectedContent)
+      semanticRuleInputs.fromRoot { root =>
+        os.proc(TestUtil.cli, "fix", "--power", ".", scalaVersionArgs).call(cwd = root)
+        val updatedContent = noCrLf(os.read(root / "Hello.scala"))
+        expect(updatedContent == expectedContent)
+      }
     }
-  }
 
   test("--rules args") {
     val input = TestInputs(
@@ -315,6 +317,7 @@ trait FixScalafixRulesTestDefinitions {
       if (semanticDbOptions.nonEmpty) s" (${semanticDbOptions.mkString(" ")})"
       else ""
     verb = if (expectedSuccess) "run" else "fail"
+    if !isScala310OrNewer || !expectedSuccess
     if !Properties.isWin || expectedSuccess
   }
     test(

--- a/modules/integration/src/test/scala/scala/cli/integration/FixTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixTestDefinitions.scala
@@ -19,54 +19,56 @@ abstract class FixTestDefinitions
       s"--enable-built-in-rules=${enableBuiltIn.toString}"
     )
 
-  test("built-in + scalafix rules") {
-    val mainFileName         = "Main.scala"
-    val unusedValName        = "unused"
-    val directive1           = "//> using dep com.lihaoyi::os-lib:0.11.3"
-    val directive2           = "//> using dep com.lihaoyi::pprint:0.9.0"
-    val mergedDirective1And2 =
-      "using dependency com.lihaoyi::os-lib:0.11.3 com.lihaoyi::pprint:0.9.0"
-    val directive3 =
-      if (actualScalaVersion.startsWith("2")) "//> using options -Xlint:unused"
-      else "//> using options -Wunused:all"
-    TestInputs(
-      os.rel / "Foo.scala" ->
-        s"""$directive1
-           |object Foo {
-           |  def hello: String = "hello"
-           |}
-           |""".stripMargin,
-      os.rel / "Bar.scala" ->
-        s"""$directive2
-           |object Bar {
-           |  def world: String = "world"
-           |}
-           |""".stripMargin,
-      os.rel / mainFileName ->
-        s"""$directive3
-           |object Main {
-           |  def main(args: Array[String]): Unit = {
-           |    val unused = "unused"
-           |    pprint.pprintln(Foo.hello + Bar.world)
-           |    pprint.pprintln(os.pwd)
-           |  }
-           |}
-           |""".stripMargin,
-      os.rel / scalafixConfFileName ->
-        """rules = [
-          |  RemoveUnused
-          |]
-          |""".stripMargin
-    ).fromRoot { root =>
-      os.proc(TestUtil.cli, "fix", ".", extraOptions, "--power").call(cwd = root)
-      val projectFileContents = os.read(root / projectFileName)
-      expect(projectFileContents.contains(mergedDirective1And2))
-      expect(projectFileContents.contains(directive3))
-      val mainFileContents = os.read(root / mainFileName)
-      expect(!mainFileContents.contains(unusedValName))
-      os.proc(TestUtil.cli, "compile", ".", extraOptions).call(cwd = root)
+  if !isScala310OrNewer then
+    // TODO https://github.com/scalacenter/scalafix/issues/2503 re-enable when fixed
+    test("built-in + scalafix rules") {
+      val mainFileName         = "Main.scala"
+      val unusedValName        = "unused"
+      val directive1           = "//> using dep com.lihaoyi::os-lib:0.11.3"
+      val directive2           = "//> using dep com.lihaoyi::pprint:0.9.0"
+      val mergedDirective1And2 =
+        "using dependency com.lihaoyi::os-lib:0.11.3 com.lihaoyi::pprint:0.9.0"
+      val directive3 =
+        if (actualScalaVersion.startsWith("2")) "//> using options -Xlint:unused"
+        else "//> using options -Wunused:all"
+      TestInputs(
+        os.rel / "Foo.scala" ->
+          s"""$directive1
+             |object Foo {
+             |  def hello: String = "hello"
+             |}
+             |""".stripMargin,
+        os.rel / "Bar.scala" ->
+          s"""$directive2
+             |object Bar {
+             |  def world: String = "world"
+             |}
+             |""".stripMargin,
+        os.rel / mainFileName ->
+          s"""$directive3
+             |object Main {
+             |  def main(args: Array[String]): Unit = {
+             |    val unused = "unused"
+             |    pprint.pprintln(Foo.hello + Bar.world)
+             |    pprint.pprintln(os.pwd)
+             |  }
+             |}
+             |""".stripMargin,
+        os.rel / scalafixConfFileName ->
+          """rules = [
+            |  RemoveUnused
+            |]
+            |""".stripMargin
+      ).fromRoot { root =>
+        os.proc(TestUtil.cli, "fix", ".", extraOptions, "--power").call(cwd = root)
+        val projectFileContents = os.read(root / projectFileName)
+        expect(projectFileContents.contains(mergedDirective1And2))
+        expect(projectFileContents.contains(directive3))
+        val mainFileContents = os.read(root / mainFileName)
+        expect(!mainFileContents.contains(unusedValName))
+        os.proc(TestUtil.cli, "compile", ".", extraOptions).call(cwd = root)
+      }
     }
-  }
 
   test("sbt file in directory does not break fix") {
     TestInputs(

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaNativeTestDefinitions.scala
@@ -313,7 +313,8 @@ trait RunScalaNativeTestDefinitions { this: RunTestDefinitions =>
       useDirectives <- Seq(true, false)
       titleStr = if (useDirectives) "with directives" else "with command line args"
       explicitNativeVersion <-
-        Seq(Some(Constants.scalaNativeVersion04), Some(Constants.scalaNativeVersion05), None)
+        if isScala310OrNewer then Seq(Some(Constants.scalaNativeVersion05), None)
+        else Seq(Some(Constants.scalaNativeVersion04), Some(Constants.scalaNativeVersion05), None)
       nativeVersionStr  = explicitNativeVersion.map(v => s"explicit: $v").getOrElse("default")
       nativeVersionOpts = explicitNativeVersion.toSeq.flatMap(v => Seq("--native-version", v))
       nativeVersionDirectiveStr =

--- a/modules/integration/src/test/scala/scala/cli/integration/RunScalaPyTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/RunScalaPyTestDefinitions.scala
@@ -98,7 +98,8 @@ trait RunScalaPyTestDefinitions { this: RunTestDefinitions =>
 
   // disabled on Windows for now, for context, see
   // https://github.com/VirtusLab/scala-cli/pull/1270#issuecomment-1237904394
-  if (!Properties.isWin) {
+  // TODO enable for 3.10+ when ScalaPy adds support for Scala Native 0.5+
+  if !Properties.isWin && !isScala310OrNewer then {
     test("scalapy native with directives") {
       scalapyNativeTest(useDirectives = true)
     }

--- a/modules/integration/src/test/scala/scala/cli/integration/TestScalaVersionArgs.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestScalaVersionArgs.scala
@@ -27,6 +27,10 @@ trait TestScalaVersionArgs extends ScalaCliSuite { this: TestScalaVersion =>
   def isScala39OrNewer: Boolean =
     actualScalaVersion.coursierVersion >= "3.9.0-RC1".coursierVersion
 
+  /** Of note, Scala 3.10 and newer no longer support Scala Native 0.4 */
+  def isScala310OrNewer: Boolean =
+    actualScalaVersion.coursierVersion >= "3.10.0-RC1".coursierVersion
+
   /** Scaladoc only passes its own compiler context (and thus `-scalajs`) to the TASTy inspector
     * since Scala 3.6.3, which is what makes reading Scala.js TASTy work.
     */

--- a/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/TestTestDefinitions.scala
@@ -13,7 +13,10 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
   this: TestScalaVersion =>
   protected lazy val extraOptions: Seq[String] = scalaVersionArgs ++ TestUtil.extraOptions
   private val utestVersion                     = "0.8.3"
-  private val zioTestVersion                   = "2.1.17"
+  private def zioTestVersion                   = if isScala310OrNewer then "2.1.26" else "2.1.17"
+  private def zioSpecType                      =
+    if isScala310OrNewer then "Spec[TestEnvironment & Scope, Any]"
+    else "Spec[TestEnvironment with Scope, Any]"
 
   def successfulTestInputs(directivesString: String =
     s"//> using dep org.scalameta::munit::$munitVersion"): TestInputs = TestInputs(
@@ -98,20 +101,20 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
 
   val successfulScalaCheckFromCatsNativeInputs: TestInputs = TestInputs(
     os.rel / "MyTests.test.scala" ->
-      """//> using scala 2.13
-        |//> using platform native
-        |//> using nativeVersion 0.4.17
-        |//> using dep org.typelevel::cats-kernel-laws::2.8.0
-        |
-        |import org.scalacheck._
-        |import Prop.forAll
-        |
-        |class TestSpec extends Properties("spec") {
-        |  property("startsWith") = forAll { (a: String, b: String) =>
-        |    (a+b).startsWith(a)
-        |  }
-        |  println("Hello from " + "tests")
-        |}""".stripMargin
+      s"""//> using scala 2.13
+         |//> using platform native
+         |//> using nativeVersion ${Constants.scalaNativeVersion04}
+         |//> using dep org.typelevel::cats-kernel-laws::2.8.0
+         |
+         |import org.scalacheck._
+         |import Prop.forAll
+         |
+         |class TestSpec extends Properties("spec") {
+         |  property("startsWith") = forAll { (a: String, b: String) =>
+         |    (a+b).startsWith(a)
+         |  }
+         |  println("Hello from " + "tests")
+         |}""".stripMargin
   )
 
   val successfulJunitInputs: TestInputs = TestInputs(
@@ -561,14 +564,15 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
       expect(output.contains("Hello from tests"))
     }
 
-  test("scalacheck from cats") {
-    successfulScalaCheckFromCatsNativeInputs.fromRoot { root =>
-      val output = os.proc(TestUtil.cli, "test", extraOptions, ".", "--native")
-        .call(cwd = root)
-        .out.text()
-      expect(output.contains("Hello from tests"))
+  if !isScala310OrNewer then
+    test("scalacheck from cats") {
+      successfulScalaCheckFromCatsNativeInputs.fromRoot { root =>
+        val output = os.proc(TestUtil.cli, "test", extraOptions, ".", "--native")
+          .call(cwd = root)
+          .out.text()
+        expect(output.contains("Hello from tests"))
+      }
     }
-  }
 
   test("utest native") {
     TestUtil.retryOnCi()(utestNative())
@@ -747,7 +751,7 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
   val platforms: Seq[(String, Seq[String])] = {
     val maybeJs     = Seq("JS" -> Seq("--js"))
     val maybeNative =
-      if (actualScalaVersion.startsWith("2."))
+      if actualScalaVersion.startsWith("2.") && !isScala310OrNewer then
         Seq("native" -> Seq("--native"))
       else
         Nil
@@ -773,9 +777,9 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
         )
         inputs.fromRoot { root =>
           val scalaTestExtraArgs =
-            if (platformName == "native")
+            if platformName == "native" then
               // FIXME: revert to using default Scala Native version when scalatest supports 0.5.x
-              Seq("--native-version", "0.4.17")
+              Seq("--native-version", Constants.scalaNativeVersion04)
             else Nil
           val baseRes =
             os.proc(TestUtil.cli, "test", extraOptions, platformArgs, scalaTestExtraArgs, ".")
@@ -1098,7 +1102,7 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
            |import zio.test._
            |
            |object SimpleSpec extends ZIOSpecDefault {
-           |  override def spec: Spec[TestEnvironment with Scope, Any] =
+           |  override def spec: $zioSpecType =
            |    suite("SimpleSpec")(
            |      test("print hello and assert true") {
            |        for {
@@ -1136,7 +1140,7 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
              |import zio.test._
              |
              |object SimpleSpec extends ZIOSpecDefault {
-             |  override def spec: Spec[TestEnvironment with Scope, Any] =
+             |  override def spec: $zioSpecType =
              |    suite("SimpleSpec")(
              |      test("print hello and assert true") {
              |        for {
@@ -1202,7 +1206,7 @@ abstract class TestTestDefinitions extends ScalaCliSuite with TestScalaVersionAr
                |import zio.test._
                |
                |object SimpleSpec extends ZIOSpecDefault {
-               |  override def spec: Spec[TestEnvironment with Scope, Any] =
+               |  override def spec: $zioSpecType =
                |    suite("SimpleSpec")(
                |      test("print hello and assert true") {
                |        for {

--- a/project/deps/package.mill
+++ b/project/deps/package.mill
@@ -23,9 +23,9 @@ object Scala {
   def runnerScala3          = scala3LegacyLts
   def scala3NextPrefix      = "3.9"
   def scala3Next            = s"$scala3NextPrefix.0" // the newest/next version of Scala
-  def scala3NextAnnounced   = "3.8.4"     // the newest/next version of Scala that's been announced
-  def scala3NextRc          = "3.9.0-RC6" // the latest RC version of Scala Next
-  def scala3NextRcAnnounced = "3.9.0-RC6" // the latest announced RC version of Scala Next
+  def scala3NextAnnounced   = "3.8.4"      // the newest/next version of Scala that's been announced
+  def scala3NextRc          = "3.10.0-RC1" // the latest RC version of Scala Next
+  def scala3NextRcAnnounced = "3.9.0-RC6"  // the latest announced RC version of Scala Next
 
   // The Scala version used to build the CLI itself.
   def defaultInternal = sys.props.get("scala.version.internal").getOrElse(scala3LegacyLts)

--- a/project/settings/package.mill
+++ b/project/settings/package.mill
@@ -14,6 +14,7 @@ import build.project.utils
 import utils.isArmArchitecture
 import com.goyeau.mill.scalafix.ScalafixModule
 import coursier.Repository
+import coursier.version.Version
 import io.github.alexarchambault.millnativeimage.NativeImage
 import mill.*
 import mill.scalalib.*
@@ -804,6 +805,36 @@ trait FormatNativeImageConf extends JavaModule {
 trait ScalaCliScalafixModule extends ScalafixModule {
 
   override def semanticDbVersion: T[String] = Deps.Versions.scalaMeta
+
+  // TODO https://github.com/scalacenter/scalafix/issues/2503; remove when fixed
+  private def scalafixCompatible(sv: String): Boolean =
+    sv.startsWith("2.") ||
+    (Version(sv) >= Version("3.3.4") && Version(sv) < Version("3.10.0-RC1"))
+
+  // Cannot call `super.fix(args*)` from inside a Mill Task; delegate to fixAction directly.
+  override def fix(args: String*): Command[Unit] =
+    Task.Command {
+      val sv = scalaVersion()
+      if !scalafixCompatible(sv) then
+        Task.ctx().log.info(
+          s"Skipping scalafix for Scala $sv (https://github.com/scalacenter/scalafix/issues/2503)"
+        )
+        mill.api.Result.Success(())
+      else
+        ScalafixModule.fixAction(
+          Task.ctx().log,
+          scalafixRepositories(),
+          ScalafixModule.filesToFix(sources()).map(_.path),
+          classpath =
+            (compileClasspath() ++ localClasspath() ++ Seq(semanticDbData())).iterator.toSeq.map(_.path),
+          scalaVersion = sv,
+          scalacOptions = scalacOptions(),
+          scalafixIvyDeps = scalafixIvyDeps(),
+          scalafixConfig = scalafixConfig(),
+          args = args,
+          wd = BuildCtx.workspaceRoot
+        )
+    }
 
   def scalafixConfig: T[Option[os.Path]] = Task {
     if (scalaVersion().startsWith("2.")) super.scalafixConfig()


### PR DESCRIPTION
- https://github.com/scala/scala3/issues/26933
  - `scalafix` builds are temporarily disabled for Scala 3.10+ because of https://github.com/scalacenter/scalafix/issues/2503
  - Scala 3.10 drops support for Scala Native 0.4, so all relevant tests are gated appropriately