### PR TITLE
Re-enable `scalafix` for Scala 3.10+

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -2,7 +2,8 @@
 //| mvnDeps:
 //| - io.github.alexarchambault.mill::mill-native-image::0.2.6
 //| - io.github.alexarchambault.mill::mill-native-image-upload:0.2.6
-//| - com.goyeau::mill-scalafix::0.6.0
+//| - com.goyeau::mill-scalafix::0.6.2
+//| - ch.epfl.scala:scalafix-interfaces:0.14.8
 //| - com.lumidion::sonatype-central-client-requests:0.6.0
 //| - io.get-coursier:coursier-launcher_2.13:2.1.25-M26
 //| - org.eclipse.jgit:org.eclipse.jgit:7.5.0.202512021534-r

--- a/modules/integration/src/test/scala/scala/cli/integration/FixScalafixRulesTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixScalafixRulesTestDefinitions.scala
@@ -312,9 +312,9 @@ trait FixScalafixRulesTestDefinitions {
       Seq("--semanticdb=false") -> false
     )
     semanticDbOptionsDescription =
-      if (semanticDbOptions.nonEmpty) s" (${semanticDbOptions.mkString(" ")})"
-      else ""
-    verb = if (expectedSuccess) "run" else "fail"
+      if semanticDbOptions.nonEmpty then s" (${semanticDbOptions.mkString(" ")})" else ""
+    verb = if expectedSuccess then "run" else "fail"
+    if !isScala310OrNewer || !expectedSuccess // TODO re-enable when fixed for 3.10+
     if !Properties.isWin || expectedSuccess
   }
     test(

--- a/modules/integration/src/test/scala/scala/cli/integration/FixScalafixRulesTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixScalafixRulesTestDefinitions.scala
@@ -59,47 +59,45 @@ trait FixScalafixRulesTestDefinitions {
     }
   }
 
-  if !isScala310OrNewer then
-    // TODO https://github.com/scalacenter/scalafix/issues/2503 re-enable when fixed
-    test("semantic rule") {
-      val unusedValueInputsContent: String =
-        s"""//> using options $scalafixUnusedRuleOption
-           |package foo
-           |
-           |object Hello {
-           |  def main(args: Array[String]): Unit = {
-           |    val name = "John"
-           |    println("Hello")
-           |  }
-           |}
-           |""".stripMargin
-      val semanticRuleInputs: TestInputs = TestInputs(
-        os.rel / scalafixConfFileName ->
-          s"""|rules = [
-              |  RemoveUnused
-              |]
-              |""".stripMargin,
-        os.rel / "Hello.scala" -> unusedValueInputsContent
-      )
-      val expectedContent: String = noCrLf {
-        s"""//> using options $scalafixUnusedRuleOption
-           |package foo
-           |
-           |object Hello {
-           |  def main(args: Array[String]): Unit = {
-           |    
-           |    println("Hello")
-           |  }
-           |}
-           |""".stripMargin
-      }
-
-      semanticRuleInputs.fromRoot { root =>
-        os.proc(TestUtil.cli, "fix", "--power", ".", scalaVersionArgs).call(cwd = root)
-        val updatedContent = noCrLf(os.read(root / "Hello.scala"))
-        expect(updatedContent == expectedContent)
-      }
+  test("semantic rule") {
+    val unusedValueInputsContent: String =
+      s"""//> using options $scalafixUnusedRuleOption
+         |package foo
+         |
+         |object Hello {
+         |  def main(args: Array[String]): Unit = {
+         |    val name = "John"
+         |    println("Hello")
+         |  }
+         |}
+         |""".stripMargin
+    val semanticRuleInputs: TestInputs = TestInputs(
+      os.rel / scalafixConfFileName ->
+        s"""|rules = [
+            |  RemoveUnused
+            |]
+            |""".stripMargin,
+      os.rel / "Hello.scala" -> unusedValueInputsContent
+    )
+    val expectedContent: String = noCrLf {
+      s"""//> using options $scalafixUnusedRuleOption
+         |package foo
+         |
+         |object Hello {
+         |  def main(args: Array[String]): Unit = {
+         |    
+         |    println("Hello")
+         |  }
+         |}
+         |""".stripMargin
     }
+
+    semanticRuleInputs.fromRoot { root =>
+      os.proc(TestUtil.cli, "fix", "--power", ".", scalaVersionArgs).call(cwd = root)
+      val updatedContent = noCrLf(os.read(root / "Hello.scala"))
+      expect(updatedContent == expectedContent)
+    }
+  }
 
   test("--rules args") {
     val input = TestInputs(
@@ -317,7 +315,6 @@ trait FixScalafixRulesTestDefinitions {
       if (semanticDbOptions.nonEmpty) s" (${semanticDbOptions.mkString(" ")})"
       else ""
     verb = if (expectedSuccess) "run" else "fail"
-    if !isScala310OrNewer || !expectedSuccess
     if !Properties.isWin || expectedSuccess
   }
     test(

--- a/modules/integration/src/test/scala/scala/cli/integration/FixTestDefinitions.scala
+++ b/modules/integration/src/test/scala/scala/cli/integration/FixTestDefinitions.scala
@@ -19,56 +19,54 @@ abstract class FixTestDefinitions
       s"--enable-built-in-rules=${enableBuiltIn.toString}"
     )
 
-  if !isScala310OrNewer then
-    // TODO https://github.com/scalacenter/scalafix/issues/2503 re-enable when fixed
-    test("built-in + scalafix rules") {
-      val mainFileName         = "Main.scala"
-      val unusedValName        = "unused"
-      val directive1           = "//> using dep com.lihaoyi::os-lib:0.11.3"
-      val directive2           = "//> using dep com.lihaoyi::pprint:0.9.0"
-      val mergedDirective1And2 =
-        "using dependency com.lihaoyi::os-lib:0.11.3 com.lihaoyi::pprint:0.9.0"
-      val directive3 =
-        if (actualScalaVersion.startsWith("2")) "//> using options -Xlint:unused"
-        else "//> using options -Wunused:all"
-      TestInputs(
-        os.rel / "Foo.scala" ->
-          s"""$directive1
-             |object Foo {
-             |  def hello: String = "hello"
-             |}
-             |""".stripMargin,
-        os.rel / "Bar.scala" ->
-          s"""$directive2
-             |object Bar {
-             |  def world: String = "world"
-             |}
-             |""".stripMargin,
-        os.rel / mainFileName ->
-          s"""$directive3
-             |object Main {
-             |  def main(args: Array[String]): Unit = {
-             |    val unused = "unused"
-             |    pprint.pprintln(Foo.hello + Bar.world)
-             |    pprint.pprintln(os.pwd)
-             |  }
-             |}
-             |""".stripMargin,
-        os.rel / scalafixConfFileName ->
-          """rules = [
-            |  RemoveUnused
-            |]
-            |""".stripMargin
-      ).fromRoot { root =>
-        os.proc(TestUtil.cli, "fix", ".", extraOptions, "--power").call(cwd = root)
-        val projectFileContents = os.read(root / projectFileName)
-        expect(projectFileContents.contains(mergedDirective1And2))
-        expect(projectFileContents.contains(directive3))
-        val mainFileContents = os.read(root / mainFileName)
-        expect(!mainFileContents.contains(unusedValName))
-        os.proc(TestUtil.cli, "compile", ".", extraOptions).call(cwd = root)
-      }
+  test("built-in + scalafix rules") {
+    val mainFileName         = "Main.scala"
+    val unusedValName        = "unused"
+    val directive1           = "//> using dep com.lihaoyi::os-lib:0.11.3"
+    val directive2           = "//> using dep com.lihaoyi::pprint:0.9.0"
+    val mergedDirective1And2 =
+      "using dependency com.lihaoyi::os-lib:0.11.3 com.lihaoyi::pprint:0.9.0"
+    val directive3 =
+      if (actualScalaVersion.startsWith("2")) "//> using options -Xlint:unused"
+      else "//> using options -Wunused:all"
+    TestInputs(
+      os.rel / "Foo.scala" ->
+        s"""$directive1
+           |object Foo {
+           |  def hello: String = "hello"
+           |}
+           |""".stripMargin,
+      os.rel / "Bar.scala" ->
+        s"""$directive2
+           |object Bar {
+           |  def world: String = "world"
+           |}
+           |""".stripMargin,
+      os.rel / mainFileName ->
+        s"""$directive3
+           |object Main {
+           |  def main(args: Array[String]): Unit = {
+           |    val unused = "unused"
+           |    pprint.pprintln(Foo.hello + Bar.world)
+           |    pprint.pprintln(os.pwd)
+           |  }
+           |}
+           |""".stripMargin,
+      os.rel / scalafixConfFileName ->
+        """rules = [
+          |  RemoveUnused
+          |]
+          |""".stripMargin
+    ).fromRoot { root =>
+      os.proc(TestUtil.cli, "fix", ".", extraOptions, "--power").call(cwd = root)
+      val projectFileContents = os.read(root / projectFileName)
+      expect(projectFileContents.contains(mergedDirective1And2))
+      expect(projectFileContents.contains(directive3))
+      val mainFileContents = os.read(root / mainFileName)
+      expect(!mainFileContents.contains(unusedValName))
+      os.proc(TestUtil.cli, "compile", ".", extraOptions).call(cwd = root)
     }
+  }
 
   test("sbt file in directory does not break fix") {
     TestInputs(

--- a/project/settings/package.mill
+++ b/project/settings/package.mill
@@ -14,7 +14,6 @@ import build.project.utils
 import utils.isArmArchitecture
 import com.goyeau.mill.scalafix.ScalafixModule
 import coursier.Repository
-import coursier.version.Version
 import io.github.alexarchambault.millnativeimage.NativeImage
 import mill.*
 import mill.scalalib.*
@@ -805,36 +804,6 @@ trait FormatNativeImageConf extends JavaModule {
 trait ScalaCliScalafixModule extends ScalafixModule {
 
   override def semanticDbVersion: T[String] = Deps.Versions.scalaMeta
-
-  // TODO https://github.com/scalacenter/scalafix/issues/2503; remove when fixed
-  private def scalafixCompatible(sv: String): Boolean =
-    sv.startsWith("2.") ||
-    (Version(sv) >= Version("3.3.4") && Version(sv) < Version("3.10.0-RC1"))
-
-  // Cannot call `super.fix(args*)` from inside a Mill Task; delegate to fixAction directly.
-  override def fix(args: String*): Command[Unit] =
-    Task.Command {
-      val sv = scalaVersion()
-      if !scalafixCompatible(sv) then
-        Task.ctx().log.info(
-          s"Skipping scalafix for Scala $sv (https://github.com/scalacenter/scalafix/issues/2503)"
-        )
-        mill.api.Result.Success(())
-      else
-        ScalafixModule.fixAction(
-          Task.ctx().log,
-          scalafixRepositories(),
-          ScalafixModule.filesToFix(sources()).map(_.path),
-          classpath =
-            (compileClasspath() ++ localClasspath() ++ Seq(semanticDbData())).iterator.toSeq.map(_.path),
-          scalaVersion = sv,
-          scalacOptions = scalacOptions(),
-          scalafixIvyDeps = scalafixIvyDeps(),
-          scalafixConfig = scalafixConfig(),
-          args = args,
-          wd = BuildCtx.workspaceRoot
-        )
-    }
 
   def scalafixConfig: T[Option[os.Path]] = Task {
     if (scalaVersion().startsWith("2.")) super.scalafixConfig()


### PR DESCRIPTION
This mostly reverts gating for running `scalafix` with Scala 3.10+, since https://github.com/scalacenter/scalafix/issues/2503 has been resolved in the last bump